### PR TITLE
fix: Publish watch rediscovery transactionally

### DIFF
--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -2,7 +2,7 @@ use std::{
     cell::RefCell,
     collections::{HashMap, HashSet},
     ops::DerefMut,
-    sync::{Arc, RwLock},
+    sync::Arc,
 };
 
 use notify::Event;
@@ -19,7 +19,7 @@ use turborepo_repository::{
         ChangeMapper, GlobalDepsPackageChangeMapper, LockfileContents, PackageChanges,
     },
     package_graph::{PackageGraph, PackageGraphBuilder, PackageName, WorkspacePackage},
-    package_json::PackageJson,
+    package_json::{self, PackageJson},
     toolchain::{EcosystemAdapter, WatchSpec},
 };
 use turborepo_scm::GitHashes;
@@ -123,7 +123,7 @@ struct Subscriber {
     changed_files: Mutex<RefCell<ChangedFiles>>,
     repo_root: AbsoluteSystemPathBuf,
     repository_ignore: RepositoryIgnore,
-    watch_spec: Arc<RwLock<WatchSpec>>,
+    watch_spec: WatchSpec,
     package_change_events_tx: broadcast::Sender<PackageChangeEvent>,
     hash_watcher: Arc<HashWatcher>,
     custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
@@ -368,7 +368,7 @@ impl Subscriber {
             file_events,
             changed_files: Default::default(),
             repository_ignore,
-            watch_spec: Arc::new(RwLock::new(watch_spec)),
+            watch_spec,
             package_change_events_tx,
             hash_watcher,
             custom_turbo_json_path: normalized_custom_path,
@@ -379,15 +379,24 @@ impl Subscriber {
     }
 
     async fn initialize_repo_state(&self) -> Option<RepoState> {
-        let Ok(root_package_json) =
-            PackageJson::load(&self.repo_root.join_component("package.json"))
-        else {
-            tracing::debug!("no package.json found, package watcher not available");
-            return None;
+        let package_json_path = self.repo_root.join_component("package.json");
+        let root_package_json = match PackageJson::load(&package_json_path) {
+            Ok(package_json) => Some(package_json),
+            Err(package_json::Error::Io(error))
+                if error.kind() == std::io::ErrorKind::NotFound
+                    && !self.ecosystem_adapters.is_empty() =>
+            {
+                None
+            }
+            Err(error) => {
+                tracing::debug!(%error, "package watcher root package unavailable");
+                return None;
+            }
         };
-        let mut builder = PackageGraphBuilder::new(&self.repo_root, root_package_json.clone())
-            .with_single_package_mode(self.single_package)
-            .with_allow_no_package_manager(self.allow_no_package_manager);
+        let mut builder =
+            PackageGraphBuilder::new_optional(&self.repo_root, root_package_json.clone())
+                .with_single_package_mode(self.single_package)
+                .with_allow_no_package_manager(self.allow_no_package_manager);
         for adapter in &self.ecosystem_adapters {
             builder = builder.with_ecosystem_adapter(adapter.clone());
         }
@@ -418,6 +427,10 @@ impl Subscriber {
 
         let reader = TurboJsonReader::new(self.repo_root.clone());
         let root_turbo_json = if self.single_package {
+            let Some(root_package_json) = root_package_json else {
+                tracing::debug!("single-package watching requires a root package.json");
+                return None;
+            };
             UnifiedTurboJsonLoader::single_package(reader, config_path, root_package_json)
         } else {
             UnifiedTurboJsonLoader::workspace(reader, config_path, pkg_dep_graph.packages())
@@ -425,12 +438,6 @@ impl Subscriber {
         .load(&PackageName::Root)
         .ok()
         .cloned();
-
-        *self
-            .watch_spec
-            .write()
-            .unwrap_or_else(|poisoned| poisoned.into_inner()) =
-            pkg_dep_graph.toolchains().watch_spec();
 
         Some(RepoState {
             root_turbo_json,
@@ -471,13 +478,15 @@ impl Subscriber {
         true
     }
 
-    /// Send a Rediscover event and reinitialize repo state. Returns the new
-    /// state tuple on success, or `None` if the caller should break.
+    /// Build a replacement repository state and publish Rediscover only after
+    /// it succeeds. A failed candidate leaves the current state active so a
+    /// later file event can retry.
     async fn rediscover_and_reinit(&self) -> Option<RepoState> {
+        let state = self.initialize_repo_state().await?;
         let _ = self
             .package_change_events_tx
             .send(PackageChangeEvent::Rediscover);
-        self.initialize_repo_state().await
+        Some(state)
     }
 
     async fn watch(self, exit_rx: oneshot::Receiver<()>) {
@@ -510,9 +519,6 @@ impl Subscriber {
                 let Ok(path) = repo_root.anchor(&absolute_path) else {
                     return false;
                 };
-                let watch_spec = watch_spec
-                    .read()
-                    .unwrap_or_else(|poisoned| poisoned.into_inner());
                 let in_ignored_prefix = watch_spec.ignore_prefixes.iter().any(|prefix| {
                     path.components()
                         .next()
@@ -646,7 +652,7 @@ impl Subscriber {
             macro_rules! rediscover {
                 ($self:expr, $repo_state:ident, $change_mapper:ident) => {{
                     let Some(new_state) = $self.rediscover_and_reinit().await else {
-                        break;
+                        continue;
                     };
                     $repo_state = new_state;
                     $change_mapper = match $repo_state.get_change_mapper() {
@@ -677,14 +683,13 @@ impl Subscriber {
                     continue;
                 };
 
-                let watch_spec = repo_state.pkg_dep_graph.toolchains().watch_spec();
                 let action = classify_changed_files(
                     &trie,
                     &self.repo_root,
                     &self.repository_ignore,
                     self.custom_turbo_json_path.as_ref(),
                     &change_mapper,
-                    &watch_spec,
+                    &self.watch_spec,
                 );
                 tracing::debug!(?action, "classified file changes");
 
@@ -771,10 +776,11 @@ mod test {
         hash_watcher::HashWatcher, NotifyError, OptionalWatch, WatchEventSender, WatchSource,
     };
     use turborepo_repository::{
+        cargo::CargoAdapter,
         change_mapper::{ChangeMapper, GlobalDepsPackageChangeMapper, PackageChanges},
         package_graph::{PackageGraph, PackageGraphBuilder},
         package_json::PackageJson,
-        toolchain::WatchSpec,
+        toolchain::{EcosystemAdapter, WatchSpec},
     };
     use turborepo_scm::SCM;
 
@@ -1383,6 +1389,20 @@ mod test {
         single_package: bool,
         allow_no_package_manager: bool,
     ) -> TestWatcherHandle {
+        create_test_watcher_with_adapters(
+            repo_root,
+            single_package,
+            allow_no_package_manager,
+            Vec::new(),
+        )
+    }
+
+    fn create_test_watcher_with_adapters(
+        repo_root: &AbsoluteSystemPathBuf,
+        single_package: bool,
+        allow_no_package_manager: bool,
+        ecosystem_adapters: Vec<Arc<dyn EcosystemAdapter>>,
+    ) -> TestWatcherHandle {
         let (file_events_tx, file_events) = WatchSource::channel_for_root(repo_root.as_std_path());
 
         // Keep the discovery sender alive so the HashWatcher doesn't busy-loop
@@ -1410,7 +1430,7 @@ mod test {
             None,
             single_package,
             allow_no_package_manager,
-            Vec::new(),
+            ecosystem_adapters,
         );
 
         TestWatcherHandle {
@@ -1443,6 +1463,81 @@ mod test {
             matches!(event, Some(PackageChangeEvent::Rediscover)),
             "expected Rediscover, got {:?}",
             event
+        );
+    }
+
+    #[tokio::test]
+    async fn cargo_only_watcher_initializes_from_adapter() {
+        let (_tmp, repo_root) = setup_git_repo();
+        std::fs::remove_file(repo_root.join_component("package.json").as_std_path()).unwrap();
+        std::fs::remove_file(repo_root.join_component("package-lock.json").as_std_path()).unwrap();
+        let crate_dir = repo_root.join_components(&["crates", "app"]);
+        crate_dir.join_component("src").create_dir_all().unwrap();
+        let workspace_manifest = b"[workspace]\nmembers = [\"crates/*\"]\nresolver = \"2\"\n\n[workspace.metadata]\nname = \"fixture\"\n";
+        let workspace_manifest_path = repo_root.join_component("Cargo.toml");
+        repo_root
+            .join_component("Cargo.toml")
+            .create_with_contents(workspace_manifest)
+            .unwrap();
+        crate_dir
+            .join_component("Cargo.toml")
+            .create_with_contents(
+                b"[package]\nname = \"app\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+            )
+            .unwrap();
+        crate_dir
+            .join_components(&["src", "lib.rs"])
+            .create_with_contents(b"")
+            .unwrap();
+        repo_root
+            .join_component("Cargo.lock")
+            .create_with_contents(
+                b"version = 4\n\n[[package]]\nname = \"app\"\nversion = \"0.1.0\"\n",
+            )
+            .unwrap();
+
+        let handle = create_test_watcher_with_adapters(
+            &repo_root,
+            false,
+            false,
+            vec![CargoAdapter::new(repo_root.clone())],
+        );
+        let mut rx = handle.watcher.package_change_events_rx.resubscribe();
+
+        let event = recv_event(&mut rx, Duration::from_secs(2)).await;
+        assert!(
+            matches!(event, Some(PackageChangeEvent::Rediscover)),
+            "expected Cargo-only watcher initialization, got {event:?}"
+        );
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        workspace_manifest_path
+            .create_with_contents(b"[workspace\nmembers = [")
+            .unwrap();
+        handle
+            .file_events_tx
+            .send(Ok(make_notify_event_from(&[&workspace_manifest_path])))
+            .unwrap();
+        assert!(
+            recv_event(&mut rx, Duration::from_millis(500))
+                .await
+                .is_none(),
+            "failed repository candidates must not be published"
+        );
+
+        workspace_manifest_path
+            .create_with_contents(workspace_manifest)
+            .unwrap();
+        handle
+            .file_events_tx
+            .send(Ok(make_notify_event_from(&[&workspace_manifest_path])))
+            .unwrap();
+        assert!(
+            matches!(
+                recv_event(&mut rx, Duration::from_secs(2)).await,
+                Some(PackageChangeEvent::Rediscover)
+            ),
+            "watcher must retry after a failed repository candidate"
         );
     }
 

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -1326,12 +1326,6 @@ impl Toolchain for CargoToolchain {
         )
     }
 
-    // Compatibility runtime hook. Watch interests move fully onto the adapter
-    // in the follow-up watcher transaction change.
-    fn watch_spec(&self) -> toolchain::WatchSpec {
-        watch_spec()
-    }
-
     /// Prune the Cargo workspace machinery around the kept crates:
     ///
     /// * `Cargo.lock` is subset to the closure of the kept crates, so `cargo

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -149,15 +149,17 @@ topological (`^`) dependencies.
 #### Toolchains (`crates/turborepo-repository/src/toolchain.rs`)
 
 The package graph is generic over ecosystems. An `EcosystemAdapter` is a
-reusable graph-construction input: each contribution contains discovered
-packages plus a fresh graph-local compatibility runtime. Core validates
-ecosystem identity, package names and paths, and duplicate registrations before
-committing that runtime to the resulting graph. `Toolchain` remains the runtime
-compatibility surface while its behavioral callbacks move into contribution
-data. All runtime lookups go through the `ToolchainRegistry` (carried by the
-`PackageGraph`); `ToolchainId` is an open string identifier, not a closed enum;
-and trait methods are coarse-grained and data-in/data-out, keeping the door open
-to out-of-process plugin adapters. JavaScript is the first, production implementation: its
+stateless, reusable graph-construction input: each contribution contains
+discovered packages plus a fresh immutable `Toolchain` behavior runtime. Core
+validates ecosystem identity, package names and paths, and duplicate
+registrations before committing the prepared runtime to the resulting graph. A
+failed build publishes nothing, and watcher rediscovery cannot mutate earlier
+graphs. A `Toolchain` answers behavioral questions —
+what command a task runs and what hash wiring it derives. All lookups go through the
+`ToolchainRegistry` (carried by the `PackageGraph`); `ToolchainId` is an
+open string identifier, not a closed enum; and trait methods are
+coarse-grained and data-in/data-out, keeping the door open to out-of-process
+plugin adapters. JavaScript is the first, production implementation: its
 discovery, script command construction, and phantom-task detection flow
 through the trait. Machinery that predates the abstraction and has no trait
 surface yet (package-manager resolution for dependency splitting, the JS
@@ -316,8 +318,8 @@ whether anything changed; Cargo decides how and in what order to build.**
   requested process, and library artifacts have no stable final path to restore.
   An explicit turbo.json `cache` setting overrides the toolchain default.
 
-- **Watch mode** (`Toolchain::watch_spec`, consumed by
-  `turborepo-lib/src/package_changes_watcher.rs`): each toolchain declares
+- **Watch mode** (`EcosystemAdapter::watch_spec`, consumed by
+  `turborepo-lib/src/package_changes_watcher.rs`): each adapter declares
   its workspace-definition files and build-byproduct directories. For
   Cargo, any `Cargo.toml` or the root `Cargo.lock` triggers full
   rediscovery (the crate set or its edges may have changed), while events
@@ -325,10 +327,12 @@ whether anything changed; Cargo decides how and in what order to build.**
   continuously during builds, and the feedback loop must not depend on a
   `.gitignore` entry (`Cargo.toml` files under `target/` are build
   byproducts, not workspace definition). The watcher builds its package
-  graph with the same toolchains a run would register, so watch sees the
+  graph with the same adapters a run would register, so watch sees the
   same package set. JavaScript declares nothing extra: workspace
   redefinition is caught by the change mapper's conservative
-  all-packages fallback. Known gap: the hash watcher's content-hash dedup
+  all-packages fallback. Watch builds a complete replacement graph before
+  publishing a rediscovery event; invalid candidates retain the current graph
+  and later filesystem events retry. Known gap: the hash watcher's content-hash dedup
   is JS-glob-based, so a no-op save inside a crate re-runs its tasks as a
   fast cache hit rather than being suppressed.
 


### PR DESCRIPTION
## Stack

3 of 3 in the core-owned toolchain contribution stack.

- Depends on #13436
- Depends on #13437

## Motivation

Graph-local Cargo state prevents one repository generation from mutating another, but watch still announces rediscovery before its replacement graph succeeds. Consumers can tear down running tasks and attempt a run against an invalid candidate even though the watcher retains its old graph. Watch interests also still flow backward from compatibility runtimes instead of remaining adapter input data.

Core should construct a complete candidate first, publish only successful repository state, and keep the current snapshot active when native manifests are temporarily invalid.

## Changes

- keep watch interests owned by ecosystem adapters for the full watcher lifecycle
- build replacement repository state before broadcasting `Rediscover`
- retain the current graph after failed candidates and retry on later filesystem events
- allow Cargo-only watch initialization without a root `package.json`
- remove the Cargo runtime watch compatibility hook
- add Cargo-only startup and invalid-manifest recovery coverage

## Testing

- `cargo test -p turborepo-lib package_changes_watcher --lib`
- `cargo test -p turborepo-lib cargo_only_watcher_initializes_from_adapter --lib`
- `cargo fmt --package turborepo-repository --package turborepo-lib --package turbo --check`