### PR TITLE
test: Characterize JavaScript package discovery

### DIFF
--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -1020,7 +1020,7 @@ impl PackageInfo {
 
 #[cfg(test)]
 mod test {
-    use std::{assert_matches, collections::HashMap};
+    use std::collections::HashMap;
 
     use turborepo_errors::Spanned;
 
@@ -1042,6 +1042,121 @@ mod test {
         ) -> Result<crate::discovery::DiscoveryResponse, crate::discovery::Error> {
             self.discover_packages().await
         }
+    }
+
+    #[tokio::test]
+    async fn javascript_packages_have_canonical_identities_paths_and_root_scope() {
+        let root =
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+
+        for root_name in [Some("named-root"), None] {
+            let package_jsons = HashMap::from([
+                (
+                    root.join_components(&["apps", "app", "package.json"]),
+                    PackageJson {
+                        name: Some(Spanned::new("app".into())),
+                        ..Default::default()
+                    },
+                ),
+                (
+                    root.join_components(&["packages", "group", "nested", "package.json"]),
+                    PackageJson {
+                        name: Some(Spanned::new("@scope/nested".into())),
+                        ..Default::default()
+                    },
+                ),
+                (
+                    root.join_components(&["packages", "unnamed", "package.json"]),
+                    PackageJson::default(),
+                ),
+            ]);
+            let root_package_json = PackageJson {
+                name: root_name.map(|name| Spanned::new(name.to_string())),
+                ..Default::default()
+            };
+
+            let graph = PackageGraphBuilder::new(&root, root_package_json)
+                .with_package_discovery(MockDiscovery)
+                .with_package_jsons(Some(package_jsons))
+                .build()
+                .await
+                .unwrap();
+
+            let mut packages = graph
+                .packages()
+                .map(|(name, info)| {
+                    (
+                        name.as_str().to_string(),
+                        info.package_path().to_unix().to_string(),
+                        info.package_json_path().to_unix().to_string(),
+                        info.package_name(),
+                    )
+                })
+                .collect::<Vec<_>>();
+            packages.sort();
+
+            assert_eq!(
+                packages,
+                vec![
+                    (
+                        "//".to_string(),
+                        "".to_string(),
+                        "package.json".to_string(),
+                        root_name.map(str::to_string),
+                    ),
+                    (
+                        "@scope/nested".to_string(),
+                        "packages/group/nested".to_string(),
+                        "packages/group/nested/package.json".to_string(),
+                        Some("@scope/nested".to_string()),
+                    ),
+                    (
+                        "app".to_string(),
+                        "apps/app".to_string(),
+                        "apps/app/package.json".to_string(),
+                        Some("app".to_string()),
+                    ),
+                ]
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn single_package_mode_exposes_only_the_canonical_root_scope() {
+        let root =
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+        let graph = PackageGraphBuilder::new(
+            &root,
+            PackageJson {
+                name: Some(Spanned::new("user-facing-root-name".into())),
+                ..Default::default()
+            },
+        )
+        .with_single_package_mode(true)
+        .with_package_discovery(MockDiscovery)
+        .build()
+        .await
+        .unwrap();
+
+        let packages = graph.packages().collect::<Vec<_>>();
+        assert_eq!(packages.len(), 1);
+        assert_eq!(packages[0].0, &PackageName::Root);
+        assert_eq!(
+            graph
+                .package_dir(&PackageName::Root)
+                .unwrap()
+                .to_unix()
+                .to_string(),
+            ""
+        );
+        assert_eq!(
+            packages[0].1.package_json_path().to_unix().to_string(),
+            "package.json"
+        );
+        assert_eq!(
+            packages[0].1.package_name().as_deref(),
+            Some("user-facing-root-name")
+        );
     }
 
     // Regression test: connect_internal_dependencies must produce correct
@@ -1696,14 +1811,14 @@ mod test {
         .with_package_jsons(Some({
             let mut map = HashMap::new();
             map.insert(
-                root.join_component("a"),
+                root.join_components(&["packages", "a", "package.json"]),
                 PackageJson {
                     name: Some(Spanned::new("foo".into())),
                     ..Default::default()
                 },
             );
             map.insert(
-                root.join_component("b"),
+                root.join_components(&["packages", "b", "package.json"]),
                 PackageJson {
                     name: Some(Spanned::new("foo".into())),
                     ..Default::default()
@@ -1711,7 +1826,23 @@ mod test {
             );
             map
         }));
-        assert_matches!(builder.build().await, Err(Error::DuplicateWorkspace { .. }));
+        let error = builder.build().await.unwrap_err();
+        let Error::DuplicateWorkspace {
+            name,
+            path,
+            existing_path,
+        } = error
+        else {
+            panic!("expected duplicate workspace error, got {error:?}");
+        };
+        let mut paths = [path.replace('\\', "/"), existing_path.replace('\\', "/")];
+        paths.sort();
+
+        assert_eq!(name, "foo");
+        assert_eq!(
+            paths,
+            ["packages/a/package.json", "packages/b/package.json"]
+        );
     }
 
     #[test]

--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -1484,6 +1484,83 @@ mod tests {
     }
 
     #[test]
+    fn workspace_discovery_is_consistent_across_javascript_package_managers() {
+        let (_dir, repo_root) = temp_repo_root().unwrap();
+        std::fs::write(
+            repo_root.join_component("package.json").as_std_path(),
+            r#"{"workspaces":["packages/**"]}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            repo_root
+                .join_component(pnpm::WORKSPACE_CONFIGURATION_PATH)
+                .as_std_path(),
+            "packages:\n  - packages/**\n",
+        )
+        .unwrap();
+        std::fs::write(
+            repo_root
+                .join_component(aube::WORKSPACE_CONFIGURATION_PATH)
+                .as_std_path(),
+            "packages:\n  - packages/**\n",
+        )
+        .unwrap();
+
+        for (components, name) in [
+            (&["packages", "app"][..], "app"),
+            (&["packages", "group", "nested"][..], "@scope/nested"),
+        ] {
+            let directory = repo_root.join_components(components);
+            std::fs::create_dir_all(directory.as_std_path()).unwrap();
+            std::fs::write(
+                directory.join_component("package.json").as_std_path(),
+                format!(r#"{{"name":"{name}"}}"#),
+            )
+            .unwrap();
+        }
+        // A matching directory without a manifest is not a package.
+        std::fs::create_dir_all(
+            repo_root
+                .join_components(&["packages", "missing"])
+                .as_std_path(),
+        )
+        .unwrap();
+
+        let package_managers = [
+            PackageManager::Npm,
+            PackageManager::Pnpm9,
+            PackageManager::Yarn,
+            PackageManager::Berry,
+            PackageManager::Bun,
+            PackageManager::Nub {
+                lockfile: Box::new(PackageManager::Npm),
+            },
+            PackageManager::Aube {
+                lockfile: Box::new(PackageManager::Npm),
+            },
+        ];
+
+        for package_manager in package_managers {
+            let mut manifests = package_manager
+                .get_package_jsons(&repo_root)
+                .unwrap()
+                .map(|path| repo_root.anchor(path).unwrap().to_unix().to_string())
+                .collect::<Vec<_>>();
+            manifests.sort();
+
+            assert_eq!(
+                manifests,
+                [
+                    "packages/app/package.json",
+                    "packages/group/nested/package.json",
+                ],
+                "{} workspace discovery",
+                package_manager.name()
+            );
+        }
+    }
+
+    #[test]
     fn test_get_workspace_ignores() {
         let root = repo_root();
         let fixtures = root.join_components(&[

--- a/crates/turborepo/tests/invalid_package_json_test.rs
+++ b/crates/turborepo/tests/invalid_package_json_test.rs
@@ -83,9 +83,13 @@ fn test_malformed_package_json() {
 
     let output = run_turbo(tempdir.path(), &["build"]);
     assert!(!output.status.success());
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stderr = String::from_utf8_lossy(&output.stderr).replace('\\', "/");
     assert!(
         stderr.contains("package_json_parse_error"),
         "expected parse error: {stderr}"
+    );
+    assert!(
+        stderr.contains("apps/my-app/package.json"),
+        "expected malformed manifest path: {stderr}"
     );
 }

--- a/crates/turborepo/tests/invalid_package_json_test.rs
+++ b/crates/turborepo/tests/invalid_package_json_test.rs
@@ -88,8 +88,9 @@ fn test_malformed_package_json() {
         stderr.contains("package_json_parse_error"),
         "expected parse error: {stderr}"
     );
+    let compact_stderr = stderr.split_whitespace().collect::<String>();
     assert!(
-        stderr.contains("apps/my-app/package.json"),
+        compact_stderr.contains("apps/my-app/package.json"),
         "expected malformed manifest path: {stderr}"
     );
 }


### PR DESCRIPTION
### Description

Part 1 of the package/scope knowledge migration stack.

- Characterize canonical package identities, directories, native definition paths, root scope behavior, unnamed workspaces, duplicate diagnostics, and single-package mode.
- Assert workspace discovery parity across npm, pnpm, Yarn, Berry, Bun, Nub, and Aube.
- Preserve malformed-manifest source paths in observable diagnostics.
- Make no production behavior changes.

Current producers are JavaScript package discovery, `DiscoveryResponse`, `WorkspaceData`, `JavaScriptToolchain::discover_packages`, and package graph `BuildState`. Package/scope consumers include graph assembly, filtering, configuration loading, boundaries, devtools, query, and microfrontends.

Phase 1 deletion checkpoint: package identity/path consumers no longer read `PackageJson`; native definition paths are not universally named `package_json_path`; repository root, root execution scope, aggregate scopes, and graph sentinel are distinct; the old package/scope producer and temporary projections are deleted.

Stack: #13440 -> #13441 -> #13442 -> #13447 -> #13448 -> #13443

### Testing Instructions

- `cargo test -p turborepo-repository`
- `cargo test -p turbo --test invalid_package_json_test`
- `cargo test -p turbo --test unnamed_packages_test --test single_package_graph_test`
- `pnpm run format`