### PR TITLE
refactor: Separate package graph node assembly

### DIFF
--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -1020,7 +1020,7 @@ impl PackageInfo {
 
 #[cfg(test)]
 mod test {
-    use std::{assert_matches, collections::HashMap};
+    use std::collections::HashMap;
 
     use turborepo_errors::Spanned;
 
@@ -1042,6 +1042,121 @@ mod test {
         ) -> Result<crate::discovery::DiscoveryResponse, crate::discovery::Error> {
             self.discover_packages().await
         }
+    }
+
+    #[tokio::test]
+    async fn javascript_packages_have_canonical_identities_paths_and_root_scope() {
+        let root =
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+
+        for root_name in [Some("named-root"), None] {
+            let package_jsons = HashMap::from([
+                (
+                    root.join_components(&["apps", "app", "package.json"]),
+                    PackageJson {
+                        name: Some(Spanned::new("app".into())),
+                        ..Default::default()
+                    },
+                ),
+                (
+                    root.join_components(&["packages", "group", "nested", "package.json"]),
+                    PackageJson {
+                        name: Some(Spanned::new("@scope/nested".into())),
+                        ..Default::default()
+                    },
+                ),
+                (
+                    root.join_components(&["packages", "unnamed", "package.json"]),
+                    PackageJson::default(),
+                ),
+            ]);
+            let root_package_json = PackageJson {
+                name: root_name.map(|name| Spanned::new(name.to_string())),
+                ..Default::default()
+            };
+
+            let graph = PackageGraphBuilder::new(&root, root_package_json)
+                .with_package_discovery(MockDiscovery)
+                .with_package_jsons(Some(package_jsons))
+                .build()
+                .await
+                .unwrap();
+
+            let mut packages = graph
+                .packages()
+                .map(|(name, info)| {
+                    (
+                        name.as_str().to_string(),
+                        info.package_path().to_unix().to_string(),
+                        info.package_json_path().to_unix().to_string(),
+                        info.package_name(),
+                    )
+                })
+                .collect::<Vec<_>>();
+            packages.sort();
+
+            assert_eq!(
+                packages,
+                vec![
+                    (
+                        "//".to_string(),
+                        "".to_string(),
+                        "package.json".to_string(),
+                        root_name.map(str::to_string),
+                    ),
+                    (
+                        "@scope/nested".to_string(),
+                        "packages/group/nested".to_string(),
+                        "packages/group/nested/package.json".to_string(),
+                        Some("@scope/nested".to_string()),
+                    ),
+                    (
+                        "app".to_string(),
+                        "apps/app".to_string(),
+                        "apps/app/package.json".to_string(),
+                        Some("app".to_string()),
+                    ),
+                ]
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn single_package_mode_exposes_only_the_canonical_root_scope() {
+        let root =
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+        let graph = PackageGraphBuilder::new(
+            &root,
+            PackageJson {
+                name: Some(Spanned::new("user-facing-root-name".into())),
+                ..Default::default()
+            },
+        )
+        .with_single_package_mode(true)
+        .with_package_discovery(MockDiscovery)
+        .build()
+        .await
+        .unwrap();
+
+        let packages = graph.packages().collect::<Vec<_>>();
+        assert_eq!(packages.len(), 1);
+        assert_eq!(packages[0].0, &PackageName::Root);
+        assert_eq!(
+            graph
+                .package_dir(&PackageName::Root)
+                .unwrap()
+                .to_unix()
+                .to_string(),
+            ""
+        );
+        assert_eq!(
+            packages[0].1.package_json_path().to_unix().to_string(),
+            "package.json"
+        );
+        assert_eq!(
+            packages[0].1.package_name().as_deref(),
+            Some("user-facing-root-name")
+        );
     }
 
     // Regression test: connect_internal_dependencies must produce correct
@@ -1696,14 +1811,14 @@ mod test {
         .with_package_jsons(Some({
             let mut map = HashMap::new();
             map.insert(
-                root.join_component("a"),
+                root.join_components(&["packages", "a", "package.json"]),
                 PackageJson {
                     name: Some(Spanned::new("foo".into())),
                     ..Default::default()
                 },
             );
             map.insert(
-                root.join_component("b"),
+                root.join_components(&["packages", "b", "package.json"]),
                 PackageJson {
                     name: Some(Spanned::new("foo".into())),
                     ..Default::default()
@@ -1711,7 +1826,23 @@ mod test {
             );
             map
         }));
-        assert_matches!(builder.build().await, Err(Error::DuplicateWorkspace { .. }));
+        let error = builder.build().await.unwrap_err();
+        let Error::DuplicateWorkspace {
+            name,
+            path,
+            existing_path,
+        } = error
+        else {
+            panic!("expected duplicate workspace error, got {error:?}");
+        };
+        let mut paths = [path.replace('\\', "/"), existing_path.replace('\\', "/")];
+        paths.sort();
+
+        assert_eq!(name, "foo");
+        assert_eq!(
+            paths,
+            ["packages/a/package.json", "packages/b/package.json"]
+        );
     }
 
     #[test]

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -279,11 +279,7 @@ where
 struct BuildState<'a, S, T> {
     repo_root: &'a AbsoluteSystemPath,
     single: bool,
-    workspaces: HashMap<PackageName, PackageInfo>,
-    workspace_graph: Graph<PackageNode, DependencyKind>,
-    root_node_index: NodeIndex,
-    root_workspace_index: NodeIndex,
-    node_lookup: HashMap<PackageNode, NodeIndex>,
+    assembler: PackageGraphAssembler,
     /// The root `package.json`, absent for a pure Cargo workspace. See
     /// [`PackageGraphBuilder::root_package_json`].
     root_package_json: Option<PackageJson>,
@@ -303,6 +299,88 @@ struct BuildState<'a, S, T> {
     toolchains: ToolchainRegistry,
 }
 
+struct PackageGraphAssembler {
+    workspaces: HashMap<PackageName, PackageInfo>,
+    workspace_graph: Graph<PackageNode, DependencyKind>,
+    root_node_index: NodeIndex,
+    root_workspace_index: NodeIndex,
+    node_lookup: HashMap<PackageNode, NodeIndex>,
+}
+
+struct PackageGraphAssembly {
+    workspaces: HashMap<PackageName, PackageInfo>,
+    workspace_graph: Graph<PackageNode, DependencyKind>,
+    root_node_index: NodeIndex,
+    root_workspace_index: NodeIndex,
+    node_lookup: HashMap<PackageNode, NodeIndex>,
+}
+
+impl PackageGraphAssembler {
+    fn new(root_package_info: PackageInfo) -> Self {
+        let mut workspaces = HashMap::new();
+        workspaces.insert(PackageName::Root, root_package_info);
+
+        let mut workspace_graph = Graph::new();
+        let root_node_index = workspace_graph.add_node(PackageNode::Root);
+        let root_workspace = PackageNode::Workspace(PackageName::Root);
+        let root_workspace_index = workspace_graph.add_node(root_workspace.clone());
+        workspace_graph.add_edge(
+            root_workspace_index,
+            root_node_index,
+            DependencyKind::Production,
+        );
+
+        let mut node_lookup = HashMap::new();
+        node_lookup.insert(PackageNode::Root, root_node_index);
+        node_lookup.insert(root_workspace, root_workspace_index);
+
+        Self {
+            workspaces,
+            workspace_graph,
+            root_node_index,
+            root_workspace_index,
+            node_lookup,
+        }
+    }
+
+    fn reserve(&mut self, additional: usize) {
+        self.workspaces.reserve(additional);
+        self.node_lookup.reserve(additional);
+    }
+
+    fn add_package(&mut self, name: PackageName, info: PackageInfo) -> Result<(), Error> {
+        match self.workspaces.entry(name) {
+            std::collections::hash_map::Entry::Vacant(vacant) => {
+                let name = vacant.key().clone();
+                vacant.insert(info);
+                let node = PackageNode::Workspace(name);
+                let idx = self.workspace_graph.add_node(node.clone());
+                self.node_lookup.insert(node, idx);
+                Ok(())
+            }
+            std::collections::hash_map::Entry::Occupied(occupied) => {
+                let existing_path = occupied.get().package_json_path.to_string();
+                let name = occupied.key().to_string();
+                Err(Error::DuplicateWorkspace {
+                    name,
+                    path: info.package_json_path.to_string(),
+                    existing_path,
+                })
+            }
+        }
+    }
+
+    fn finish(self) -> PackageGraphAssembly {
+        PackageGraphAssembly {
+            workspaces: self.workspaces,
+            workspace_graph: self.workspace_graph,
+            root_node_index: self.root_node_index,
+            root_workspace_index: self.root_workspace_index,
+            node_lookup: self.node_lookup,
+        }
+    }
+}
+
 // Allows us to perform workspace discovery and parse package jsons
 enum ResolvedPackageManager {}
 
@@ -311,14 +389,6 @@ enum ResolvedWorkspaces {}
 
 // Allows us to collect all transitive deps
 enum ResolvedLockfile {}
-
-impl<S, T> BuildState<'_, S, T> {
-    fn add_node(&mut self, node: PackageNode) -> NodeIndex {
-        let idx = self.workspace_graph.add_node(node.clone());
-        self.node_lookup.insert(node, idx);
-        idx
-    }
-}
 
 impl<'a, T> BuildState<'a, ResolvedPackageManager, T>
 where
@@ -348,7 +418,6 @@ where
         // registered nor queried for a package manager. The graph is built
         // entirely from the extra toolchains (Cargo).
         let no_javascript = root_package_json.is_none();
-        let mut workspaces = HashMap::new();
         let root_package_info = PackageInfo {
             // The root node always needs a descriptor; a pure Cargo workspace
             // has none, so it gets an empty one. The graph's public
@@ -357,21 +426,7 @@ where
             package_json_path: AnchoredSystemPathBuf::from_raw("package.json")?,
             ..Default::default()
         };
-        workspaces.insert(PackageName::Root, root_package_info);
-
-        let mut workspace_graph = Graph::new();
-        let root_node_index = workspace_graph.add_node(PackageNode::Root);
-        let root_workspace = PackageNode::Workspace(PackageName::Root);
-        let root_workspace_index = workspace_graph.add_node(root_workspace.clone());
-        workspace_graph.add_edge(
-            root_workspace_index,
-            root_node_index,
-            DependencyKind::Production,
-        );
-
-        let mut node_lookup = HashMap::new();
-        node_lookup.insert(PackageNode::Root, root_node_index);
-        node_lookup.insert(root_workspace, root_workspace_index);
+        let assembler = PackageGraphAssembler::new(root_package_info);
 
         // The discovery strategy is shared (via the JavaScript toolchain)
         // between package discovery and package-manager resolution; the
@@ -399,13 +454,9 @@ where
             repo_root,
             single,
 
-            workspaces,
+            assembler,
             lockfile,
             package_jsons,
-            workspace_graph,
-            root_node_index,
-            root_workspace_index,
-            node_lookup,
             root_package_json,
             defer_closures,
             closure_hasher,
@@ -453,23 +504,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             transitive_dependencies,
             ..Default::default()
         };
-        match self.workspaces.entry(name) {
-            std::collections::hash_map::Entry::Vacant(vacant) => {
-                let name = vacant.key().clone();
-                vacant.insert(entry);
-                self.add_node(PackageNode::Workspace(name));
-                Ok(())
-            }
-            std::collections::hash_map::Entry::Occupied(occupied) => {
-                let existing_path = occupied.get().package_json_path.to_string();
-                let name = occupied.key().to_string();
-                Err(Error::DuplicateWorkspace {
-                    name,
-                    path: entry.package_json_path.to_string(),
-                    existing_path,
-                })
-            }
-        }
+        self.assembler.add_package(name, entry)
     }
 
     // need our own type
@@ -501,8 +536,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             discovered.extend(packages.into_iter().map(|package| (id.clone(), package)));
         }
 
-        self.workspaces.reserve(discovered.len());
-        self.node_lookup.reserve(discovered.len());
+        self.assembler.reserve(discovered.len());
 
         let _span = tracing::info_span!("add_packages").entered();
         for (toolchain, package) in discovered {
@@ -523,11 +557,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
         let Self {
             repo_root,
             single,
-            workspaces,
-            workspace_graph,
-            root_node_index,
-            root_workspace_index,
-            node_lookup,
+            assembler,
             root_package_json,
             lockfile,
             javascript,
@@ -539,11 +569,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
         Ok(BuildState {
             repo_root,
             single,
-            workspaces,
-            workspace_graph,
-            root_node_index,
-            root_workspace_index,
-            node_lookup,
+            assembler,
             root_package_json,
             lockfile,
             javascript,
@@ -558,11 +584,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
     async fn build_single_package_graph(self) -> Result<PackageGraph, discovery::Error> {
         let Self {
             single,
-            workspaces,
-            workspace_graph,
-            root_node_index,
-            root_workspace_index,
-            node_lookup,
+            assembler,
             root_package_json,
             lockfile,
             javascript,
@@ -570,6 +592,13 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             repo_root,
             ..
         } = self;
+        let PackageGraphAssembly {
+            workspaces,
+            workspace_graph,
+            root_node_index,
+            root_workspace_index,
+            node_lookup,
+        } = assembler.finish();
 
         let package_manager = match &javascript {
             Some(javascript) => {
@@ -611,7 +640,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
         &mut self,
         package_manager: Option<&PackageManager>,
     ) -> Result<(), Error> {
-        let path_index = WorkspacePathIndex::new(&self.workspaces);
+        let path_index = WorkspacePathIndex::new(&self.assembler.workspaces);
         // Compute once — for pnpm/Berry this reads a config file from disk.
         // Without hoisting, the par_iter below would redundantly read the
         // same file N times (once per workspace). A pure Cargo workspace has
@@ -626,7 +655,8 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
         // so this is safe. Graph mutation stays sequential below.
         let split_deps = {
             use rayon::prelude::*;
-            self.workspaces
+            self.assembler
+                .workspaces
                 .par_iter()
                 .map(|(name, entry)| {
                     (
@@ -634,7 +664,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
                         Dependencies::new(
                             self.repo_root,
                             &entry.package_json_path,
-                            &self.workspaces,
+                            &self.assembler.workspaces,
                             link_workspace_packages,
                             entry.package_json.dependencies_with_kind(),
                             &path_index,
@@ -646,28 +676,36 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
         };
         for (name, deps) in split_deps {
             let entry = self
+                .assembler
                 .workspaces
                 .get_mut(&name)
                 .expect("workspace present in ");
             let Dependencies { internal, external } = deps;
             let node_idx = self
+                .assembler
                 .node_lookup
                 .get(&PackageNode::Workspace(name))
                 .expect("unable to find workspace node index");
             if internal.is_empty() {
                 let root_idx = self
+                    .assembler
                     .node_lookup
                     .get(&PackageNode::Root)
                     .expect("root node should have index");
-                self.workspace_graph
-                    .add_edge(*node_idx, *root_idx, DependencyKind::Production);
+                self.assembler.workspace_graph.add_edge(
+                    *node_idx,
+                    *root_idx,
+                    DependencyKind::Production,
+                );
             }
             for (dependency, kind) in internal {
                 let dependency_idx = self
+                    .assembler
                     .node_lookup
                     .get(&PackageNode::Workspace(dependency))
                     .expect("unable to find workspace node index");
-                self.workspace_graph
+                self.assembler
+                    .workspace_graph
                     .add_edge(*node_idx, *dependency_idx, kind);
             }
             entry.unresolved_external_dependencies = Some(external);
@@ -686,7 +724,8 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
             None => {
                 let lockfile = package_manager.read_lockfile(
                     self.repo_root,
-                    self.workspaces
+                    self.assembler
+                        .workspaces
                         .get(&PackageName::Root)
                         .as_ref()
                         .map(|e| &e.package_json)
@@ -748,11 +787,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
         let Self {
             repo_root,
             single,
-            workspaces,
-            workspace_graph,
-            root_node_index,
-            root_workspace_index,
-            node_lookup,
+            assembler,
             root_package_json,
             javascript,
             toolchains,
@@ -763,11 +798,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
         Ok(BuildState {
             repo_root,
             single,
-            workspaces,
-            workspace_graph,
-            root_node_index,
-            root_workspace_index,
-            node_lookup,
+            assembler,
             root_package_json,
             lockfile,
             defer_closures,
@@ -793,7 +824,8 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
     fn all_external_dependencies(
         &self,
     ) -> Result<HashMap<String, BTreeMap<String, String>>, Error> {
-        self.workspaces
+        self.assembler
+            .workspaces
             .values()
             // Only JavaScript packages participate in the JS lockfile's
             // external-dependency closures. This map is keyed by directory,
@@ -842,7 +874,7 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             .as_ref()
             .map(|hasher| hasher(&closures))
             .unwrap_or_default();
-        for entry in self.workspaces.values_mut() {
+        for entry in self.assembler.workspaces.values_mut() {
             // Mirror of the filter in all_external_dependencies: a non-JS
             // package sharing a directory with a JS package must not steal
             // its closure.
@@ -928,16 +960,19 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             None => None,
         };
         let Self {
-            workspaces,
-            workspace_graph,
-            root_node_index,
-            root_workspace_index,
-            node_lookup,
+            assembler,
             root_package_json,
             toolchains,
             repo_root,
             ..
         } = self;
+        let PackageGraphAssembly {
+            workspaces,
+            workspace_graph,
+            root_node_index,
+            root_workspace_index,
+            node_lookup,
+        } = assembler.finish();
         Ok(PackageGraph {
             graph: workspace_graph,
             root_node_index,

--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -1484,6 +1484,83 @@ mod tests {
     }
 
     #[test]
+    fn workspace_discovery_is_consistent_across_javascript_package_managers() {
+        let (_dir, repo_root) = temp_repo_root().unwrap();
+        std::fs::write(
+            repo_root.join_component("package.json").as_std_path(),
+            r#"{"workspaces":["packages/**"]}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            repo_root
+                .join_component(pnpm::WORKSPACE_CONFIGURATION_PATH)
+                .as_std_path(),
+            "packages:\n  - packages/**\n",
+        )
+        .unwrap();
+        std::fs::write(
+            repo_root
+                .join_component(aube::WORKSPACE_CONFIGURATION_PATH)
+                .as_std_path(),
+            "packages:\n  - packages/**\n",
+        )
+        .unwrap();
+
+        for (components, name) in [
+            (&["packages", "app"][..], "app"),
+            (&["packages", "group", "nested"][..], "@scope/nested"),
+        ] {
+            let directory = repo_root.join_components(components);
+            std::fs::create_dir_all(directory.as_std_path()).unwrap();
+            std::fs::write(
+                directory.join_component("package.json").as_std_path(),
+                format!(r#"{{"name":"{name}"}}"#),
+            )
+            .unwrap();
+        }
+        // A matching directory without a manifest is not a package.
+        std::fs::create_dir_all(
+            repo_root
+                .join_components(&["packages", "missing"])
+                .as_std_path(),
+        )
+        .unwrap();
+
+        let package_managers = [
+            PackageManager::Npm,
+            PackageManager::Pnpm9,
+            PackageManager::Yarn,
+            PackageManager::Berry,
+            PackageManager::Bun,
+            PackageManager::Nub {
+                lockfile: Box::new(PackageManager::Npm),
+            },
+            PackageManager::Aube {
+                lockfile: Box::new(PackageManager::Npm),
+            },
+        ];
+
+        for package_manager in package_managers {
+            let mut manifests = package_manager
+                .get_package_jsons(&repo_root)
+                .unwrap()
+                .map(|path| repo_root.anchor(path).unwrap().to_unix().to_string())
+                .collect::<Vec<_>>();
+            manifests.sort();
+
+            assert_eq!(
+                manifests,
+                [
+                    "packages/app/package.json",
+                    "packages/group/nested/package.json",
+                ],
+                "{} workspace discovery",
+                package_manager.name()
+            );
+        }
+    }
+
+    #[test]
     fn test_get_workspace_ignores() {
         let root = repo_root();
         let fixtures = root.join_components(&[

--- a/crates/turborepo/tests/invalid_package_json_test.rs
+++ b/crates/turborepo/tests/invalid_package_json_test.rs
@@ -83,9 +83,13 @@ fn test_malformed_package_json() {
 
     let output = run_turbo(tempdir.path(), &["build"]);
     assert!(!output.status.success());
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stderr = String::from_utf8_lossy(&output.stderr).replace('\\', "/");
     assert!(
         stderr.contains("package_json_parse_error"),
         "expected parse error: {stderr}"
+    );
+    assert!(
+        stderr.contains("apps/my-app/package.json"),
+        "expected malformed manifest path: {stderr}"
     );
 }

--- a/crates/turborepo/tests/invalid_package_json_test.rs
+++ b/crates/turborepo/tests/invalid_package_json_test.rs
@@ -88,8 +88,9 @@ fn test_malformed_package_json() {
         stderr.contains("package_json_parse_error"),
         "expected parse error: {stderr}"
     );
+    let compact_stderr = stderr.split_whitespace().collect::<String>();
     assert!(
-        stderr.contains("apps/my-app/package.json"),
+        compact_stderr.contains("apps/my-app/package.json"),
         "expected malformed manifest path: {stderr}"
     );
 }


### PR DESCRIPTION
### Why this PR exists

`PackageGraphBuilder` currently owns two different jobs at the same time:

1. **Observe native repository state**: discover workspaces, parse manifests, resolve package-manager behavior, and prepare package metadata.
2. **Maintain graph structure**: create the root/sentinel nodes, insert package nodes, reject duplicate names, and keep the package map, petgraph nodes, and lookup indexes synchronized.

That coupling is manageable while `PackageJson` is the source of package identity and paths. It becomes a blocker for the next PR, where parser-neutral repository knowledge must become authoritative. If we introduce that knowledge directly into the existing builder, the same change would simultaneously alter discovery, package identity, path ownership, duplicate handling, and graph mutation. A regression would be difficult to localize, and reviewers could not tell whether changed graph output came from the new observation model or from rewritten graph assembly.

We need a narrow boundary where already-observed package facts can be handed to graph-owned code:

```text
Before

native discovery + manifest parsing + package facts + graph invariants
                         all inside BuildState

After this PR

native discovery + manifest parsing
                |
                v
     package facts / compatibility payload
                |
                v
      PackageGraphAssembler
      - root and sentinel setup
      - package node insertion
      - duplicate validation
      - lookup/index maintenance
```

The next PR can therefore replace the source of package facts without also redesigning how graph nodes are assembled. This is the strangler seam: new repository knowledge will feed the assembler, while graph topology remains core-owned and behaviorally unchanged.

### Why these fields move together

The package map, petgraph graph, root indexes, and node lookup are one invariant set. Adding a package must update all of them together; otherwise graph traversal and package lookup can disagree. `PackageGraphAssembler` gives that invariant one owner instead of leaving the fields directly mutable throughout `BuildState`.

It also makes the distinction between these two existing concepts explicit in one place:

- `PackageNode::Root`: the graph implementation sentinel.
- `PackageNode::Workspace(PackageName::Root)`: the root execution scope.

That distinction matters once repository roots, package roots, and aggregate scopes become separate knowledge concepts.

### What changes

This PR extracts a private, graph-owned assembler responsible for:

- Root and root-workspace node initialization.
- Structural root edge creation.
- Package node insertion.
- Duplicate package-name diagnostics.
- Capacity reservation and lookup-table maintenance.
- Returning the assembled graph state when construction finishes.

`BuildState` remains the caller, so construction order and graph output remain unchanged.

### What deliberately does not change

This is a mechanical prerequisite, not the package-knowledge cutover. It does not change:

- Workspace discovery.
- Manifest parsing or `PackageJson` compatibility data.
- Package identity or path semantics.
- Dependency splitting or relationship edges.
- Package-manager or lockfile behavior.
- External dependency closure calculation.
- Filtering, task graph, hashing, caching, watch, or prune behavior.

The temporary `PackageInfo` payload is still present here. The following PR changes package identity/path authority to parser-neutral repository knowledge; doing that here would defeat the purpose of separating the two independently reviewable moves.

### Review guidance

The expected result is structural equivalence. Useful review questions are:

- Are root/sentinel nodes and their structural edge initialized exactly once?
- Does every package insertion update the package map, graph, and node lookup together?
- Are duplicate diagnostics preserved?
- Did relationship and lockfile logic remain in its previous phase?
- Does `finish()` transfer the same graph-owned state into `PackageGraph`?

Stack: #13440 -> #13441 -> #13442 -> #13447 -> #13448 -> #13443

### Testing Instructions

- `cargo test -p turborepo-repository`
- `cargo lint`
- `pnpm run format`