### PR TITLE
refactor: Add authoritative package knowledge

### DIFF
--- a/crates/turborepo-engine/src/builder/test.rs
+++ b/crates/turborepo-engine/src/builder/test.rs
@@ -145,21 +145,23 @@ impl Toolchain for StubIOToolchain {
 
     fn discover_packages(&self) -> DiscoverPackagesFuture<'_> {
         Box::pin(async move {
-            let package = |name: &str, dependencies: &[(&str, &str)]| DiscoveredPackage {
-                descriptor: PackageJson {
-                    name: Some(Spanned::new(name.to_string())),
-                    dependencies: Some(
-                        dependencies
-                            .iter()
-                            .map(|(name, version)| (name.to_string(), version.to_string()))
-                            .collect(),
-                    ),
-                    ..Default::default()
-                },
-                manifest_path: self
-                    .repo_root
-                    .join_components(&["packages", name, "stub.json"]),
-                external_dependencies: Some(HashSet::new()),
+            let package = |name: &str, dependencies: &[(&str, &str)]| {
+                DiscoveredPackage::package(
+                    Some(name.to_string()),
+                    PackageJson {
+                        name: Some(Spanned::new(name.to_string())),
+                        dependencies: Some(
+                            dependencies
+                                .iter()
+                                .map(|(name, version)| (name.to_string(), version.to_string()))
+                                .collect(),
+                        ),
+                        ..Default::default()
+                    },
+                    self.repo_root
+                        .join_components(&["packages", name, "stub.json"]),
+                    Some(HashSet::new()),
+                )
             };
             Ok(vec![
                 package("app", &[("lib", "workspace:*")]),

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -40,7 +40,6 @@ use std::{
 
 use serde::Deserialize;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
-use turborepo_errors::Spanned;
 
 use crate::{
     package_json::PackageJson,
@@ -1699,15 +1698,15 @@ impl Toolchain for CargoToolchain {
                     .chain(std::iter::once(rustc.clone()))
                     .collect();
                 crate_names.push(cargo_crate.name.clone());
-                packages.push(DiscoveredPackage {
-                    descriptor: PackageJson {
-                        name: Some(Spanned::new(cargo_crate.name)),
+                packages.push(DiscoveredPackage::package(
+                    Some(cargo_crate.name.clone()),
+                    PackageJson {
                         dependencies: Some(dependencies),
                         ..Default::default()
                     },
-                    manifest_path: cargo_crate.manifest_path,
-                    external_dependencies: Some(external_dependencies),
-                });
+                    cargo_crate.manifest_path,
+                    Some(external_dependencies),
+                ));
             }
 
             // The synthetic workspace package, anchored at the root
@@ -1729,17 +1728,17 @@ impl Toolchain for CargoToolchain {
                     .into_iter()
                     .map(|name| (name, "workspace:*".to_string()))
                     .collect();
-                packages.push(DiscoveredPackage {
-                    descriptor: PackageJson {
-                        name: Some(Spanned::new(workspace_name)),
+                packages.push(DiscoveredPackage::aggregate(
+                    workspace_name,
+                    PackageJson {
                         dependencies: Some(dependencies),
                         ..Default::default()
                     },
-                    manifest_path: self.repo_root.join_component(CARGO_TOML),
+                    self.repo_root.join_component(CARGO_TOML),
                     // Workspace-scoped verbs run every crate, so the union
                     // of all closures is this package's external surface.
-                    external_dependencies: Some(workspace_externals),
-                });
+                    Some(workspace_externals),
+                ));
             }
 
             Ok(packages)
@@ -2445,6 +2444,7 @@ struct ResolvedMetadataPackage {
 #[cfg(test)]
 mod test {
     use turbopath::{AbsoluteSystemPathBuf, IntoUnix};
+    use turborepo_errors::Spanned;
 
     use super::*;
 
@@ -3640,7 +3640,13 @@ release: 1.96.0-nightly\n",
         let toolchain = CargoToolchain::new(root.clone());
         assert_eq!(toolchain.id(), ToolchainId::RUST);
 
-        let mut packages = toolchain.discover_packages().await.unwrap();
+        let mut packages: Vec<_> = toolchain
+            .discover_packages()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(DiscoveredPackage::into_parts)
+            .collect();
         packages.sort_by(|a, b| {
             a.descriptor
                 .name

--- a/crates/turborepo-repository/src/knowledge.rs
+++ b/crates/turborepo-repository/src/knowledge.rs
@@ -1,0 +1,223 @@
+//! Immutable, parser-neutral facts observed about a repository.
+//!
+//! This module deliberately contains no package manifests or native metadata.
+//! Those remain compatibility inputs for relationship and task construction;
+//! package identity, ownership boundaries, and definition sources live here.
+
+use std::collections::HashMap;
+
+use turbopath::{
+    AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPath, AnchoredSystemPathBuf,
+};
+
+use crate::toolchain::ToolchainId;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ScopeKind {
+    Package,
+    Aggregate,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ScopeKnowledge {
+    identity: String,
+    directory: AnchoredSystemPathBuf,
+    definition_path: AnchoredSystemPathBuf,
+    toolchain: ToolchainId,
+    kind: ScopeKind,
+}
+
+impl ScopeKnowledge {
+    pub(crate) fn identity(&self) -> &str {
+        &self.identity
+    }
+
+    pub(crate) fn user_facing_name(&self) -> &str {
+        &self.identity
+    }
+
+    pub(crate) fn directory(&self) -> &AnchoredSystemPath {
+        &self.directory
+    }
+
+    pub(crate) fn definition_path(&self) -> &AnchoredSystemPath {
+        &self.definition_path
+    }
+
+    pub(crate) fn toolchain(&self) -> &ToolchainId {
+        &self.toolchain
+    }
+
+    pub(crate) fn kind(&self) -> ScopeKind {
+        self.kind
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RootJavaScriptScope {
+    user_facing_name: Option<String>,
+    definition_path: AnchoredSystemPathBuf,
+    toolchain: ToolchainId,
+}
+
+impl RootJavaScriptScope {
+    pub(crate) fn user_facing_name(&self) -> Option<&str> {
+        self.user_facing_name.as_deref()
+    }
+
+    pub(crate) fn definition_path(&self) -> &AnchoredSystemPath {
+        &self.definition_path
+    }
+
+    pub(crate) fn toolchain(&self) -> &ToolchainId {
+        &self.toolchain
+    }
+}
+
+/// One immutable generation of package and execution-scope facts.
+#[derive(Debug)]
+pub(crate) struct RepositoryKnowledge {
+    repository_root: AbsoluteSystemPathBuf,
+    repository_directory: AnchoredSystemPathBuf,
+    root_javascript_scope: Option<RootJavaScriptScope>,
+    scopes: Vec<ScopeKnowledge>,
+    scope_lookup: HashMap<String, usize>,
+}
+
+impl RepositoryKnowledge {
+    pub(crate) fn repository_root(&self) -> &AbsoluteSystemPath {
+        &self.repository_root
+    }
+
+    pub(crate) fn repository_directory(&self) -> &AnchoredSystemPath {
+        &self.repository_directory
+    }
+
+    pub(crate) fn root_javascript_scope(&self) -> Option<&RootJavaScriptScope> {
+        self.root_javascript_scope.as_ref()
+    }
+
+    pub(crate) fn packages(&self) -> impl Iterator<Item = &ScopeKnowledge> {
+        self.scopes
+            .iter()
+            .filter(|scope| scope.kind == ScopeKind::Package)
+    }
+
+    pub(crate) fn aggregate_scopes(&self) -> impl Iterator<Item = &ScopeKnowledge> {
+        self.scopes
+            .iter()
+            .filter(|scope| scope.kind == ScopeKind::Aggregate)
+    }
+
+    pub(crate) fn scope(&self, identity: &str) -> Option<&ScopeKnowledge> {
+        self.scope_lookup
+            .get(identity)
+            .map(|index| &self.scopes[*index])
+    }
+
+    pub(crate) fn build(
+        repository_root: &AbsoluteSystemPath,
+        root_javascript_name: Option<Option<String>>,
+        observations: &[PackageScopeObservation],
+    ) -> Result<Self, Error> {
+        let root_definition_path = AnchoredSystemPathBuf::from_raw("package.json")?;
+        let root_javascript_scope =
+            root_javascript_name.map(|user_facing_name| RootJavaScriptScope {
+                user_facing_name,
+                definition_path: root_definition_path,
+                toolchain: ToolchainId::JAVASCRIPT,
+            });
+
+        let mut scopes = Vec::with_capacity(observations.len());
+        let mut scope_lookup = HashMap::with_capacity(observations.len());
+        let mut definitions = HashMap::<String, AnchoredSystemPathBuf>::new();
+
+        for observation in observations {
+            if !definition_is_contained(repository_root, &observation.definition_path) {
+                return Err(Error::DefinitionOutsideRepository {
+                    path: observation.definition_path.clone(),
+                    repository_root: repository_root.to_owned(),
+                });
+            }
+            let Some(identity) = observation.identity.as_ref() else {
+                continue;
+            };
+            let definition_path = AnchoredSystemPathBuf::relative_path_between(
+                repository_root,
+                &observation.definition_path,
+            );
+            if let Some(existing_path) =
+                definitions.insert(identity.clone(), definition_path.clone())
+            {
+                return Err(Error::DuplicateScope {
+                    name: identity.clone(),
+                    path: definition_path,
+                    existing_path,
+                });
+            }
+            let directory = definition_path
+                .parent()
+                .map(AnchoredSystemPath::to_owned)
+                .unwrap_or_default();
+            scope_lookup.insert(identity.clone(), scopes.len());
+            scopes.push(ScopeKnowledge {
+                identity: identity.clone(),
+                directory,
+                definition_path,
+                toolchain: observation.toolchain.clone(),
+                kind: observation.scope_kind,
+            });
+        }
+
+        Ok(Self {
+            repository_root: repository_root.to_owned(),
+            repository_directory: AnchoredSystemPathBuf::default(),
+            root_javascript_scope,
+            scopes,
+            scope_lookup,
+        })
+    }
+}
+
+fn definition_is_contained(
+    repository_root: &AbsoluteSystemPath,
+    definition_path: &AbsoluteSystemPath,
+) -> bool {
+    if !repository_root.contains(definition_path) {
+        return false;
+    }
+
+    match (
+        dunce::canonicalize(repository_root.as_std_path()),
+        dunce::canonicalize(definition_path.as_std_path()),
+    ) {
+        (Ok(repository_root), Ok(definition_path)) => definition_path.starts_with(repository_root),
+        // Discovery and watcher tests may supply definitions that do not exist
+        // yet. Preserve lexical containment when either side cannot be observed.
+        _ => true,
+    }
+}
+
+pub(crate) struct PackageScopeObservation {
+    pub identity: Option<String>,
+    pub definition_path: AbsoluteSystemPathBuf,
+    pub toolchain: ToolchainId,
+    pub scope_kind: ScopeKind,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum Error {
+    #[error("duplicate package or aggregate scope {name}")]
+    DuplicateScope {
+        name: String,
+        path: AnchoredSystemPathBuf,
+        existing_path: AnchoredSystemPathBuf,
+    },
+    #[error("package definition {path} is outside repository root {repository_root}")]
+    DefinitionOutsideRepository {
+        path: AbsoluteSystemPathBuf,
+        repository_root: AbsoluteSystemPathBuf,
+    },
+    #[error(transparent)]
+    Path(#[from] turbopath::PathError),
+}

--- a/crates/turborepo-repository/src/lib.rs
+++ b/crates/turborepo-repository/src/lib.rs
@@ -15,6 +15,7 @@ pub mod cargo;
 pub mod change_mapper;
 pub mod discovery;
 pub mod inference;
+mod knowledge;
 mod manifest_parser;
 pub mod package_graph;
 pub mod package_json;

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -20,10 +20,12 @@ use crate::{
         self, CachingPackageDiscovery, LocalPackageDiscoveryBuilder, PackageDiscovery,
         PackageDiscoveryBuilder,
     },
+    knowledge::{PackageScopeObservation, RepositoryKnowledge, ScopeKind},
     package_json::{DependencyKind, PackageJson},
     package_manager::{PackageManager, pnpm::PnpmCatalogs},
     toolchain::{
-        DiscoveredPackage, JavaScriptToolchain, Toolchain, ToolchainId, ToolchainRegistry,
+        DiscoveredPackage, DiscoveredPackageParts, DiscoveredScopeKind, JavaScriptToolchain,
+        Toolchain, ToolchainId, ToolchainRegistry,
     },
 };
 
@@ -69,6 +71,17 @@ pub enum Error {
     PackageJson(#[from] crate::package_json::Error),
     #[error("package.json must have a name field:\n{0}")]
     PackageJsonMissingName(AbsoluteSystemPathBuf),
+    #[error("package definition {path} is outside repository root {repository_root}")]
+    DefinitionOutsideRepository {
+        path: AbsoluteSystemPathBuf,
+        repository_root: AbsoluteSystemPathBuf,
+    },
+    #[error("missing compatibility projection for discovered scope {name}")]
+    MissingCompatibilityProjection { name: String },
+    #[error("compatibility projection {name} has no authoritative discovered scope")]
+    UnexpectedCompatibilityProjection { name: String },
+    #[error("repository package knowledge was not constructed")]
+    MissingRepositoryKnowledge,
     #[error(transparent)]
     Lockfile(#[from] turborepo_lockfiles::Error),
     #[error(transparent)]
@@ -87,6 +100,30 @@ impl From<crate::toolchain::Error> for Error {
             crate::toolchain::Error::Discovery(err) => Error::Discovery(err),
             crate::toolchain::Error::Descriptor(err) => Error::PackageJson(err),
             crate::toolchain::Error::Failed(err) => Error::Toolchain(err),
+        }
+    }
+}
+
+impl From<crate::knowledge::Error> for Error {
+    fn from(error: crate::knowledge::Error) -> Self {
+        match error {
+            crate::knowledge::Error::DuplicateScope {
+                name,
+                path,
+                existing_path,
+            } => Error::DuplicateWorkspace {
+                name,
+                path: path.to_string(),
+                existing_path: existing_path.to_string(),
+            },
+            crate::knowledge::Error::DefinitionOutsideRepository {
+                path,
+                repository_root,
+            } => Error::DefinitionOutsideRepository {
+                path,
+                repository_root,
+            },
+            crate::knowledge::Error::Path(error) => Error::Path(error),
         }
     }
 }
@@ -280,6 +317,7 @@ struct BuildState<'a, S, T> {
     repo_root: &'a AbsoluteSystemPath,
     single: bool,
     assembler: PackageGraphAssembler,
+    knowledge: Option<Arc<RepositoryKnowledge>>,
     /// The root `package.json`, absent for a pure Cargo workspace. See
     /// [`PackageGraphBuilder::root_package_json`].
     root_package_json: Option<PackageJson>,
@@ -370,6 +408,42 @@ impl PackageGraphAssembler {
         }
     }
 
+    fn add_knowledge(
+        &mut self,
+        knowledge: &RepositoryKnowledge,
+        compatibility: Vec<(String, PackageInfo)>,
+    ) -> Result<(), Error> {
+        let mut compatibility: HashMap<_, _> = compatibility.into_iter().collect();
+        self.reserve(knowledge.packages().count() + knowledge.aggregate_scopes().count());
+
+        for package in knowledge.packages() {
+            let name = package.identity();
+            let mut info = compatibility.remove(name).ok_or_else(|| {
+                Error::MissingCompatibilityProjection {
+                    name: name.to_string(),
+                }
+            })?;
+            info.package_json_path = package.definition_path().to_owned();
+            info.toolchain = package.toolchain().clone();
+            self.add_package(PackageName::Other(name.to_string()), info)?;
+        }
+        for aggregate in knowledge.aggregate_scopes() {
+            let name = aggregate.identity();
+            let mut info = compatibility.remove(name).ok_or_else(|| {
+                Error::MissingCompatibilityProjection {
+                    name: name.to_string(),
+                }
+            })?;
+            info.package_json_path = aggregate.definition_path().to_owned();
+            info.toolchain = aggregate.toolchain().clone();
+            self.add_package(PackageName::Other(name.to_string()), info)?;
+        }
+        if let Some(name) = compatibility.keys().next() {
+            return Err(Error::UnexpectedCompatibilityProjection { name: name.clone() });
+        }
+        Ok(())
+    }
+
     fn finish(self) -> PackageGraphAssembly {
         PackageGraphAssembly {
             workspaces: self.workspaces,
@@ -455,6 +529,7 @@ where
             single,
 
             assembler,
+            knowledge: None,
             lockfile,
             package_jsons,
             root_package_json,
@@ -468,24 +543,20 @@ where
 }
 
 impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManager, T> {
-    fn add_package(
-        &mut self,
+    fn observe_package(
+        &self,
         toolchain: ToolchainId,
         package: DiscoveredPackage,
-    ) -> Result<(), Error> {
-        let DiscoveredPackage {
+    ) -> Result<(PackageScopeObservation, Option<(String, PackageInfo)>), Error> {
+        let DiscoveredPackageParts {
+            name,
+            scope_kind,
             descriptor: json,
             manifest_path,
             external_dependencies,
-        } = package;
+        } = package.into_parts();
         let relative_json_path =
             AnchoredSystemPathBuf::relative_path_between(self.repo_root, &manifest_path);
-        let name = PackageName::Other(
-            json.name
-                .clone()
-                .ok_or(Error::PackageJsonMissingName(manifest_path))?
-                .into_inner(),
-        );
         // Toolchain-resolved external identities (e.g. Cargo's per-crate
         // lockfile closures), in the sorted representation the JS lockfile
         // phase produces. That phase later fills this for JavaScript
@@ -500,11 +571,27 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
         let entry = PackageInfo {
             package_json: json,
             package_json_path: relative_json_path,
-            toolchain,
+            toolchain: toolchain.clone(),
             transitive_dependencies,
             ..Default::default()
         };
-        self.assembler.add_package(name, entry)
+        let observation = PackageScopeObservation {
+            identity: name.clone(),
+            definition_path: manifest_path.clone(),
+            toolchain,
+            scope_kind: match scope_kind {
+                DiscoveredScopeKind::Package => ScopeKind::Package,
+                DiscoveredScopeKind::Aggregate => ScopeKind::Aggregate,
+            },
+        };
+        let compatibility = name.map(|name| (name, entry));
+        if compatibility.is_none() {
+            tracing::debug!(
+                "ignoring package definition at {} since it has no name",
+                manifest_path
+            );
+        }
+        Ok((observation, compatibility))
     }
 
     // need our own type
@@ -523,11 +610,12 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
                 discovered.extend(jsons.into_iter().map(|(path, json)| {
                     (
                         ToolchainId::JAVASCRIPT,
-                        DiscoveredPackage {
-                            descriptor: json,
-                            manifest_path: path,
-                            external_dependencies: None,
-                        },
+                        DiscoveredPackage::package(
+                            json.name.as_ref().map(|name| name.as_inner().clone()),
+                            json,
+                            path,
+                            None,
+                        ),
                     )
                 }));
                 continue;
@@ -536,28 +624,35 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             discovered.extend(packages.into_iter().map(|package| (id.clone(), package)));
         }
 
-        self.assembler.reserve(discovered.len());
-
         let _span = tracing::info_span!("add_packages").entered();
+        let mut observations = Vec::with_capacity(discovered.len());
+        let mut compatibility = Vec::with_capacity(discovered.len());
         for (toolchain, package) in discovered {
-            match self.add_package(toolchain, package) {
-                Ok(()) => {}
-                Err(Error::PackageJsonMissingName(path)) => {
-                    // previous implementations of turbo would silently ignore package.json files
-                    // that didn't have a name field (well, actually, if two or more had the same
-                    // name, it would throw a 'name clash' error, but that's a different story)
-                    //
-                    // let's try to match that behavior, but log a debug message
-                    tracing::debug!("ignoring package.json at {} since it has no name", path);
-                }
-                Err(err) => return Err(err),
+            let (observation, projection) = self.observe_package(toolchain, package)?;
+            observations.push(observation);
+            if let Some(projection) = projection {
+                compatibility.push(projection);
             }
         }
+        let root_name = self.root_package_json.as_ref().map(|package_json| {
+            package_json
+                .name
+                .as_ref()
+                .map(|name| name.as_inner().clone())
+        });
+        let knowledge = Arc::new(RepositoryKnowledge::build(
+            self.repo_root,
+            root_name,
+            &observations,
+        )?);
+        self.assembler.add_knowledge(&knowledge, compatibility)?;
+        self.knowledge = Some(knowledge);
 
         let Self {
             repo_root,
             single,
             assembler,
+            knowledge,
             root_package_json,
             lockfile,
             javascript,
@@ -570,6 +665,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             repo_root,
             single,
             assembler,
+            knowledge,
             root_package_json,
             lockfile,
             javascript,
@@ -581,10 +677,11 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
         })
     }
 
-    async fn build_single_package_graph(self) -> Result<PackageGraph, discovery::Error> {
+    async fn build_single_package_graph(self) -> Result<PackageGraph, Error> {
         let Self {
             single,
             assembler,
+            knowledge,
             root_package_json,
             lockfile,
             javascript,
@@ -592,6 +689,18 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             repo_root,
             ..
         } = self;
+        let knowledge = match knowledge {
+            Some(knowledge) => knowledge,
+            None => {
+                let root_name = root_package_json.as_ref().map(|package_json| {
+                    package_json
+                        .name
+                        .as_ref()
+                        .map(|name| name.as_inner().clone())
+                });
+                Arc::new(RepositoryKnowledge::build(repo_root, root_name, &[])?)
+            }
+        };
         let PackageGraphAssembly {
             workspaces,
             workspace_graph,
@@ -625,7 +734,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             packages: workspaces,
             lockfile: lockfile.map(Arc::from),
             package_manager,
-            repo_root: repo_root.to_owned(),
+            knowledge,
             deferred_closures: std::sync::Mutex::new(None),
             external_dep_to_internal_dependents: std::sync::OnceLock::new(),
             root_internal_dependencies: std::sync::OnceLock::new(),
@@ -788,6 +897,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
             repo_root,
             single,
             assembler,
+            knowledge,
             root_package_json,
             javascript,
             toolchains,
@@ -799,6 +909,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
             repo_root,
             single,
             assembler,
+            knowledge,
             root_package_json,
             lockfile,
             defer_closures,
@@ -961,11 +1072,14 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
         };
         let Self {
             assembler,
+            knowledge,
             root_package_json,
             toolchains,
-            repo_root,
             ..
         } = self;
+        let knowledge = knowledge.ok_or(discovery::Error::Failed(Box::new(
+            Error::MissingRepositoryKnowledge,
+        )))?;
         let PackageGraphAssembly {
             workspaces,
             workspace_graph,
@@ -982,7 +1096,7 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             packages: workspaces,
             package_manager,
             lockfile: arc_lockfile,
-            repo_root: repo_root.to_owned(),
+            knowledge,
             deferred_closures: std::sync::Mutex::new(deferred_closures),
             external_dep_to_internal_dependents: std::sync::OnceLock::new(),
             root_internal_dependencies: std::sync::OnceLock::new(),
@@ -1117,6 +1231,46 @@ mod test {
                 .await
                 .unwrap();
 
+            let knowledge = graph.repository_knowledge();
+            assert_eq!(knowledge.repository_root(), root.as_ref());
+            let root_scope = knowledge
+                .root_javascript_scope()
+                .expect("a root package.json creates a JavaScript execution scope");
+            assert_eq!(root_scope.user_facing_name(), root_name);
+            assert_eq!(
+                graph
+                    .package_dir(&PackageName::Root)
+                    .expect("root graph scope has a directory")
+                    .to_unix()
+                    .as_str(),
+                ""
+            );
+            assert_eq!(
+                root_scope.definition_path().to_unix().as_str(),
+                "package.json"
+            );
+            assert_eq!(knowledge.packages().count(), 2);
+            assert!(knowledge.scope("//").is_none());
+            assert!(knowledge.scope("unnamed").is_none());
+            assert_eq!(knowledge.aggregate_scopes().count(), 0);
+            assert_ne!(
+                PackageNode::Root,
+                PackageNode::Workspace(PackageName::Root),
+                "the graph sentinel and root execution scope node are distinct"
+            );
+
+            for package in knowledge.packages() {
+                let graph_name = PackageName::from(package.identity());
+                assert_eq!(graph.package_dir(&graph_name), Some(package.directory()));
+                assert_eq!(
+                    graph
+                        .package_info(&graph_name)
+                        .expect("knowledge package is assembled into the graph")
+                        .package_json_path(),
+                    package.definition_path()
+                );
+            }
+
             let mut packages = graph
                 .packages()
                 .map(|(name, info)| {
@@ -1172,6 +1326,17 @@ mod test {
         .build()
         .await
         .unwrap();
+
+        let retained_generation = graph.knowledge.clone();
+        assert!(Arc::ptr_eq(&retained_generation, &graph.knowledge));
+        assert_eq!(
+            retained_generation
+                .root_javascript_scope()
+                .expect("single-package mode retains the root execution scope")
+                .user_facing_name(),
+            Some("user-facing-root-name")
+        );
+        assert_eq!(retained_generation.packages().count(), 0);
 
         let packages = graph.packages().collect::<Vec<_>>();
         assert_eq!(packages.len(), 1);
@@ -1878,6 +2043,77 @@ mod test {
             paths,
             ["packages/a/package.json", "packages/b/package.json"]
         );
+    }
+
+    #[tokio::test]
+    async fn package_definition_outside_repository_is_a_typed_error() {
+        let root =
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+        let outside = AbsoluteSystemPathBuf::new(if cfg!(windows) {
+            r"C:\outside\package.json"
+        } else {
+            "/outside/package.json"
+        })
+        .unwrap();
+        let result = PackageGraphBuilder::new(&root, PackageJson::default())
+            .with_package_discovery(MockDiscovery)
+            .with_package_jsons(Some(HashMap::from([(
+                outside.clone(),
+                PackageJson {
+                    name: Some(Spanned::new("escaped".into())),
+                    ..Default::default()
+                },
+            )])))
+            .build()
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(Error::DefinitionOutsideRepository {
+                path,
+                repository_root,
+            }) if path == outside && repository_root == root
+        ));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn package_definition_escaping_through_symlink_is_a_typed_error() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let repository = tempdir.path().join("repository");
+        let outside = tempdir.path().join("outside");
+        std::fs::create_dir_all(repository.join("packages")).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        std::fs::write(outside.join("package.json"), "{}").unwrap();
+        std::os::unix::fs::symlink(&outside, repository.join("packages/escaped")).unwrap();
+
+        let root = AbsoluteSystemPathBuf::new(
+            dunce::canonicalize(&repository)
+                .unwrap()
+                .to_string_lossy()
+                .into_owned(),
+        )
+        .unwrap();
+        let definition = root.join_components(&["packages", "escaped", "package.json"]);
+        let result = PackageGraphBuilder::new(&root, PackageJson::default())
+            .with_package_discovery(MockDiscovery)
+            .with_package_jsons(Some(HashMap::from([(
+                definition.clone(),
+                PackageJson {
+                    name: Some(Spanned::new("escaped".into())),
+                    ..Default::default()
+                },
+            )])))
+            .build()
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(Error::DefinitionOutsideRepository {
+                path,
+                repository_root,
+            }) if path == definition && repository_root == root
+        ));
     }
 
     #[test]

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -11,14 +11,12 @@ use petgraph::{
 };
 use serde::Serialize;
 use tracing::debug;
-use turbopath::{
-    AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPath, AnchoredSystemPathBuf,
-};
+use turbopath::{AbsoluteSystemPath, AnchoredSystemPath, AnchoredSystemPathBuf};
 use turborepo_lockfiles::Lockfile;
 
 use crate::{
-    discovery::LocalPackageDiscoveryBuilder, package_json::PackageJson,
-    package_manager::PackageManager,
+    discovery::LocalPackageDiscoveryBuilder, knowledge::RepositoryKnowledge,
+    package_json::PackageJson, package_manager::PackageManager,
 };
 
 pub mod builder;
@@ -53,7 +51,7 @@ pub struct PackageGraph {
     root_package_json: Option<PackageJson>,
     package_manager: Option<PackageManager>,
     lockfile: Option<Arc<dyn Lockfile>>,
-    repo_root: AbsoluteSystemPathBuf,
+    knowledge: Arc<RepositoryKnowledge>,
     /// Receiver for background transitive-closure computation when the graph
     /// was built with deferred closures. Consumed (exactly once) by
     /// [`Self::ensure_transitive_closures`].
@@ -94,13 +92,13 @@ impl WorkspacePackage {
     }
 }
 
-/// PackageInfo represents a package within the workspace.
+/// Compatibility data retained for relationship and task consumers.
+///
+/// Package identity, directory ownership, definition source, and provenance
+/// are authoritative in [`RepositoryKnowledge`], not in this projection.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct PackageInfo {
-    /// The toolchain-neutral package descriptor (see
-    /// [`crate::toolchain::DiscoveredPackage`]). For JavaScript packages
-    /// this is the parsed `package.json`; other toolchains synthesize one
-    /// from their native manifest.
+    /// A temporary compatibility descriptor for relationships and tasks.
     pub package_json: PackageJson,
     /// Path to the package's native manifest, anchored to the repo root.
     pub package_json_path: AnchoredSystemPathBuf,
@@ -228,17 +226,18 @@ impl PackageGraph {
     /// missing a `name` field in its package.json.
     #[tracing::instrument(skip(self))]
     pub fn validate(&self) -> Result<(), Error> {
-        for (package_name, info) in self.packages.iter() {
-            if matches!(package_name, PackageName::Root) {
-                continue;
+        for package in self.knowledge.packages() {
+            if package.user_facing_name().is_empty() {
+                return Err(Error::PackageJsonMissingName(
+                    self.repo_root().resolve(package.definition_path()),
+                ));
             }
-            let name = info.package_json.name.as_ref().map(|name| name.as_str());
-            match name {
-                Some("") | None => {
-                    let package_json_path = self.repo_root.resolve(info.package_json_path());
-                    return Err(Error::PackageJsonMissingName(package_json_path));
-                }
-                Some(_) => continue,
+        }
+        for aggregate in self.knowledge.aggregate_scopes() {
+            if aggregate.user_facing_name().is_empty() {
+                return Err(Error::PackageJsonMissingName(
+                    self.repo_root().resolve(aggregate.definition_path()),
+                ));
             }
         }
 
@@ -384,7 +383,90 @@ impl PackageGraph {
     }
 
     pub fn repo_root(&self) -> &AbsoluteSystemPath {
-        &self.repo_root
+        self.knowledge.repository_root()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn repository_knowledge(&self) -> &RepositoryKnowledge {
+        &self.knowledge
+    }
+
+    /// Whether a root `package.json` contributed a JavaScript execution scope.
+    pub fn has_root_javascript_scope(&self) -> bool {
+        self.knowledge.root_javascript_scope().is_some()
+    }
+
+    /// The root JavaScript scope's user-facing package name. The outer option
+    /// distinguishes no JavaScript scope (pure Cargo) from an unnamed root
+    /// JavaScript scope.
+    pub fn root_javascript_scope_name(&self) -> Option<Option<&str>> {
+        self.knowledge
+            .root_javascript_scope()
+            .map(|scope| scope.user_facing_name())
+    }
+
+    /// User-facing identities of real packages, excluding root and aggregate
+    /// execution scopes.
+    pub fn real_package_names(&self) -> impl Iterator<Item = &str> {
+        self.knowledge.packages().map(|scope| scope.identity())
+    }
+
+    /// User-facing identities of non-package aggregate execution scopes.
+    pub fn aggregate_scope_names(&self) -> impl Iterator<Item = &str> {
+        self.knowledge
+            .aggregate_scopes()
+            .map(|scope| scope.identity())
+    }
+
+    /// Native definition path for a package or execution scope. A pure Cargo
+    /// repository's compatibility root node has no native definition.
+    pub fn package_definition_path(&self, package: &PackageName) -> Option<&AnchoredSystemPath> {
+        match package {
+            PackageName::Root => self
+                .knowledge
+                .root_javascript_scope()
+                .map(|scope| scope.definition_path()),
+            PackageName::Other(name) => self
+                .knowledge
+                .scope(name)
+                .map(|scope| scope.definition_path()),
+        }
+    }
+
+    /// Toolchain provenance for a package or execution scope.
+    pub fn package_toolchain(
+        &self,
+        package: &PackageName,
+    ) -> Option<&crate::toolchain::ToolchainId> {
+        match package {
+            PackageName::Root => self
+                .knowledge
+                .root_javascript_scope()
+                .map(|scope| scope.toolchain()),
+            PackageName::Other(name) => self.knowledge.scope(name).map(|scope| scope.toolchain()),
+        }
+    }
+
+    pub fn is_real_package(&self, package: &PackageName) -> bool {
+        matches!(
+            package,
+            PackageName::Other(name)
+                if self
+                    .knowledge
+                    .scope(name)
+                    .is_some_and(|scope| scope.kind() == crate::knowledge::ScopeKind::Package)
+        )
+    }
+
+    pub fn is_aggregate_scope(&self, package: &PackageName) -> bool {
+        matches!(
+            package,
+            PackageName::Other(name)
+                if self
+                    .knowledge
+                    .scope(name)
+                    .is_some_and(|scope| scope.kind() == crate::knowledge::ScopeKind::Aggregate)
+        )
     }
 
     pub fn lockfile(&self) -> Option<&dyn Lockfile> {
@@ -437,13 +519,10 @@ impl PackageGraph {
     }
 
     pub fn package_dir(&self, package: &PackageName) -> Option<&AnchoredSystemPath> {
-        let entry = self.packages.get(package)?;
-        Some(
-            entry
-                .package_json_path()
-                .parent()
-                .unwrap_or_else(|| AnchoredSystemPath::new("").unwrap()),
-        )
+        match package {
+            PackageName::Root => Some(self.knowledge.repository_directory()),
+            PackageName::Other(name) => self.knowledge.scope(name).map(|scope| scope.directory()),
+        }
     }
 
     pub fn package_info(&self, package: &PackageName) -> Option<&PackageInfo> {
@@ -960,6 +1039,7 @@ mod test {
     use std::{fs, path::Path, process::Command};
 
     use serde_json::json;
+    use turbopath::AbsoluteSystemPathBuf;
     use turborepo_errors::Spanned;
 
     use super::*;
@@ -1991,6 +2071,31 @@ version = "0.1.0"
             let workspace_pkg = pkg_graph.package_info(&PackageName::from("acme")).unwrap();
             assert_eq!(workspace_pkg.toolchain, crate::toolchain::ToolchainId::RUST);
 
+            let knowledge = pkg_graph.repository_knowledge();
+            let cargo_app = knowledge.scope("app").expect("Cargo crate is a package");
+            assert_eq!(
+                cargo_app.definition_path().to_unix().as_str(),
+                "rust/app/Cargo.toml"
+            );
+            assert_eq!(cargo_app.toolchain(), &crate::toolchain::ToolchainId::RUST);
+            assert_eq!(cargo_app.kind(), crate::knowledge::ScopeKind::Package);
+            let cargo_workspace = knowledge
+                .scope("acme")
+                .expect("Cargo workspace compatibility package is an aggregate scope");
+            assert_eq!(
+                cargo_workspace.kind(),
+                crate::knowledge::ScopeKind::Aggregate
+            );
+            assert_eq!(cargo_workspace.directory().to_unix().as_str(), "");
+            assert_eq!(
+                cargo_workspace.definition_path().to_unix().as_str(),
+                "Cargo.toml"
+            );
+            assert_eq!(
+                pkg_graph.package_dir(&PackageName::from("acme")),
+                Some(cargo_workspace.directory())
+            );
+
             // Crate path dependencies became graph edges.
             let app_deps = pkg_graph
                 .immediate_dependencies(&PackageNode::Workspace(PackageName::from("app")))
@@ -2054,6 +2159,24 @@ version = "0.1.0"
             .unwrap();
 
         assert!(pkg_graph.validate().is_ok());
+
+        assert!(
+            pkg_graph
+                .repository_knowledge()
+                .root_javascript_scope()
+                .is_none(),
+            "a pure Cargo repository has no root JavaScript execution scope"
+        );
+        assert!(!pkg_graph.has_root_javascript_scope());
+        assert_eq!(pkg_graph.package_definition_path(&PackageName::Root), None);
+        assert_eq!(pkg_graph.package_toolchain(&PackageName::Root), None);
+        assert!(
+            pkg_graph
+                .repository_knowledge()
+                .scope("acme")
+                .is_some_and(|scope| scope.kind() == crate::knowledge::ScopeKind::Aggregate),
+            "existing workspace-scoped Cargo behavior is represented as an aggregate"
+        );
 
         // No JavaScript project: no package manager, no root manifest.
         assert!(

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -447,6 +447,8 @@ impl PackageGraph {
         }
     }
 
+    /// Whether this identity represents a real package rather than an
+    /// execution-only scope.
     pub fn is_real_package(&self, package: &PackageName) -> bool {
         matches!(
             package,
@@ -458,6 +460,7 @@ impl PackageGraph {
         )
     }
 
+    /// Whether this identity represents a non-package aggregate scope.
     pub fn is_aggregate_scope(&self, package: &PackageName) -> bool {
         matches!(
             package,

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -47,6 +47,7 @@
 use std::{borrow::Cow, ffi::OsString, fmt, future::Future, pin::Pin, sync::Arc};
 
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
+use turborepo_errors::Spanned;
 
 use crate::{
     discovery::{self, PackageDiscovery},
@@ -94,20 +95,25 @@ impl fmt::Display for ToolchainId {
     }
 }
 
-/// A package discovered by a toolchain.
+/// Compatibility output from native package discovery.
 ///
-/// `descriptor` is the toolchain-neutral package descriptor. [`PackageJson`]
-/// serves as that descriptor for every toolchain: JavaScript packages parse
-/// theirs from disk, while other toolchains synthesize one from their native
-/// manifest (only the fields they populate — at minimum `name` and internal
-/// dependencies — are meaningful).
+/// Identity and source facts feed [`crate::knowledge::RepositoryKnowledge`].
+/// `descriptor` remains temporarily for relationship and task consumers:
+/// JavaScript packages retain their parsed manifest while other toolchains
+/// synthesize only the compatibility fields those consumers need.
 #[derive(Debug, Clone)]
 pub struct DiscoveredPackage {
-    /// The toolchain-neutral package descriptor.
-    pub descriptor: PackageJson,
+    /// Real user-facing identity, extracted by the native producer. `None`
+    /// preserves JavaScript's historical unnamed-package suppression.
+    name: Option<String>,
+    /// Whether this is a real package or an execution-only aggregate scope.
+    scope_kind: DiscoveredScopeKind,
+    /// Temporary relationship/task compatibility data; never identity or path
+    /// authority.
+    descriptor: PackageJson,
     /// Absolute path to the package's native manifest (`package.json`,
     /// `Cargo.toml`, ...).
-    pub manifest_path: AbsoluteSystemPathBuf,
+    manifest_path: AbsoluteSystemPathBuf,
     /// External-dependency identities for this package, when the toolchain
     /// resolves them at discovery time. They feed the package's
     /// external-dependency hash: a task's hash changes exactly when an
@@ -120,7 +126,78 @@ pub struct DiscoveredPackage {
     /// builder's lockfile phase — deliberately concurrent with run setup —
     /// rather than through this field; folding that in requires a
     /// deferred-aware trait surface.
+    external_dependencies: Option<std::collections::HashSet<turborepo_lockfiles::Package>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DiscoveredScopeKind {
+    Package,
+    Aggregate,
+}
+
+pub(crate) struct DiscoveredPackageParts {
+    pub name: Option<String>,
+    pub scope_kind: DiscoveredScopeKind,
+    pub descriptor: PackageJson,
+    pub manifest_path: AbsoluteSystemPathBuf,
     pub external_dependencies: Option<std::collections::HashSet<turborepo_lockfiles::Package>>,
+}
+
+impl DiscoveredPackage {
+    /// Construct a real package observation. The compatibility descriptor's
+    /// name is normalized to the authoritative identity, making divergence
+    /// structurally impossible. `None` preserves unnamed JavaScript package
+    /// suppression.
+    pub fn package(
+        name: Option<String>,
+        mut descriptor: PackageJson,
+        manifest_path: AbsoluteSystemPathBuf,
+        external_dependencies: Option<std::collections::HashSet<turborepo_lockfiles::Package>>,
+    ) -> Self {
+        descriptor.name = name.clone().map(Spanned::new);
+        Self {
+            name,
+            scope_kind: DiscoveredScopeKind::Package,
+            descriptor,
+            manifest_path,
+            external_dependencies,
+        }
+    }
+
+    /// Construct a named aggregate execution scope and normalize its temporary
+    /// compatibility descriptor to the same identity.
+    pub fn aggregate(
+        name: String,
+        mut descriptor: PackageJson,
+        manifest_path: AbsoluteSystemPathBuf,
+        external_dependencies: Option<std::collections::HashSet<turborepo_lockfiles::Package>>,
+    ) -> Self {
+        descriptor.name = Some(Spanned::new(name.clone()));
+        Self {
+            name: Some(name),
+            scope_kind: DiscoveredScopeKind::Aggregate,
+            descriptor,
+            manifest_path,
+            external_dependencies,
+        }
+    }
+
+    pub(crate) fn into_parts(self) -> DiscoveredPackageParts {
+        let Self {
+            name,
+            scope_kind,
+            descriptor,
+            manifest_path,
+            external_dependencies,
+        } = self;
+        DiscoveredPackageParts {
+            name,
+            scope_kind,
+            descriptor,
+            manifest_path,
+            external_dependencies,
+        }
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -880,14 +957,16 @@ impl<P: PackageDiscovery + Send + Sync> Toolchain for JavaScriptToolchain<P> {
                     .into_par_iter()
                     .map(|workspace| {
                         let descriptor = PackageJson::load(&workspace.package_json)?;
-                        Ok(DiscoveredPackage {
+                        let name = descriptor.name.as_ref().map(|name| name.as_inner().clone());
+                        Ok(DiscoveredPackage::package(
+                            name,
                             descriptor,
-                            manifest_path: workspace.package_json,
+                            workspace.package_json,
                             // JavaScript closures come from the builder's
                             // (deliberately concurrent) lockfile phase; see
                             // the field docs.
-                            external_dependencies: None,
-                        })
+                            None,
+                        ))
                     })
                     .collect::<Result<Vec<_>, Error>>()
             })
@@ -911,6 +990,51 @@ mod tests {
         assert_eq!(custom.to_string(), "gleam");
         let dynamic = ToolchainId::new(String::from("python-uv"));
         assert_eq!(dynamic.as_str(), "python-uv");
+    }
+
+    #[test]
+    fn discovered_package_constructor_enforces_one_identity() {
+        let path = AbsoluteSystemPathBuf::new(if cfg!(windows) {
+            r"C:\repo\package.json"
+        } else {
+            "/repo/package.json"
+        })
+        .unwrap();
+        let mismatched = PackageJson {
+            name: Some(Spanned::new("payload-name".to_string())),
+            ..Default::default()
+        };
+
+        let package = DiscoveredPackage::package(
+            Some("authoritative-name".to_string()),
+            mismatched.clone(),
+            path.clone(),
+            None,
+        )
+        .into_parts();
+        assert_eq!(package.name.as_deref(), Some("authoritative-name"));
+        assert_eq!(
+            package.descriptor.name.as_ref().map(|name| name.as_str()),
+            Some("authoritative-name")
+        );
+
+        let unnamed = DiscoveredPackage::package(None, mismatched, path.clone(), None).into_parts();
+        assert_eq!(unnamed.name, None);
+        assert_eq!(unnamed.descriptor.name, None);
+
+        let aggregate = DiscoveredPackage::aggregate(
+            "workspace".to_string(),
+            PackageJson::default(),
+            path,
+            None,
+        )
+        .into_parts();
+        assert_eq!(aggregate.name.as_deref(), Some("workspace"));
+        assert_eq!(aggregate.scope_kind, DiscoveredScopeKind::Aggregate);
+        assert_eq!(
+            aggregate.descriptor.name.as_ref().map(|name| name.as_str()),
+            Some("workspace")
+        );
     }
 
     #[test]

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -146,8 +146,10 @@ Represents the workspace structure and package dependencies:
 `RepositoryKnowledge` is the crate-private authority for package identity and
 paths during node assembly, and the resulting `PackageGraph` retains that exact
 immutable generation. Consumers migrate incrementally through narrow
-knowledge-backed graph queries and may temporarily use derived `PackageInfo`
-compatibility projections. Native manifests and metadata do not enter repository
+knowledge-backed graph queries and may temporarily use `PackageInfo`
+compatibility projections. Their identity, path, scope kind, and provenance are
+knowledge-backed; relationship and task payloads remain associated native
+compatibility data. Native manifests and metadata do not enter repository
 knowledge. Native definition paths must remain within the repository, including
 after resolving existing symlinks.
 

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -135,10 +135,20 @@ Represents the workspace structure and package dependencies:
 
 - Identifies the JavaScript package manager, when present
 - Discovers packages in workspace
+- Builds one immutable `RepositoryKnowledge` generation containing repository
+  root, root JavaScript execution scope, real package identities and source
+  boundaries, native definition paths, provenance, and required aggregate scopes
 - Performs ecosystem-specific lockfile analysis
 - Builds dependency relationships between workspace packages
 - Validates that all non-root packages have a `name` field
   (`PackageGraph::validate()`)
+
+`RepositoryKnowledge` is the crate-private authority for package identity and
+paths during node assembly, and the resulting `PackageGraph` retains that exact
+immutable generation. Consumers use narrow knowledge-backed graph queries
+rather than accessing its storage. `PackageInfo` remains a compatibility
+projection for relationship and task behavior; native manifests and metadata do
+not enter repository knowledge.
 
 The package graph intentionally allows cyclic dependencies between packages —
 this aligns with how npm, pnpm, and yarn handle cyclic workspace deps. Cycle
@@ -148,10 +158,10 @@ topological (`^`) dependencies.
 
 #### Toolchains (`crates/turborepo-repository/src/toolchain.rs`)
 
-The package graph is generic over language toolchains. A `Toolchain` answers
-ecosystem-specific questions — which packages exist, what command a task
-runs, what hash wiring a task derives — so graph construction and execution
-never branch on a specific ecosystem. All lookups go through the
+The package graph is generic over language toolchains. Native discovery output
+contributes package/scope observations to repository knowledge, while a
+`Toolchain` continues to answer ecosystem-specific behavioral questions such as
+what command a task runs and what hash wiring a task derives. All lookups go through the
 `ToolchainRegistry` (carried by the `PackageGraph`); `ToolchainId` is an
 open string identifier, not a closed enum; and trait methods are
 coarse-grained and data-in/data-out, keeping the door open to out-of-process
@@ -208,8 +218,9 @@ whether anything changed; Cargo decides how and in what order to build.**
   workspace's deliverables. *Libraries* exist in the package graph and expose
   filtered build and verification tasks. Unfiltered builds prefer entrypoints
   because Cargo builds their library dependency closures implicitly. A synthetic
-  *workspace* package — named by the user via `[workspace.metadata] name` in
-  the root Cargo.toml, a hard requirement — depends on every crate and hosts
+  *workspace* scope — named by the user via `[workspace.metadata] name` in
+  the root Cargo.toml, a hard requirement — is an aggregate in repository
+  knowledge. Its compatibility package depends on every crate and hosts
   workspace-scoped verification verbs.
 - **Execution and entrypoint selection** (`Toolchain::task_command` and
   `Toolchain::select_task_entrypoints`): crate-scoped build and verification

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -145,10 +145,11 @@ Represents the workspace structure and package dependencies:
 
 `RepositoryKnowledge` is the crate-private authority for package identity and
 paths during node assembly, and the resulting `PackageGraph` retains that exact
-immutable generation. Consumers use narrow knowledge-backed graph queries
-rather than accessing its storage. `PackageInfo` remains a compatibility
-projection for relationship and task behavior; native manifests and metadata do
-not enter repository knowledge.
+immutable generation. Consumers migrate incrementally through narrow
+knowledge-backed graph queries and may temporarily use derived `PackageInfo`
+compatibility projections. Native manifests and metadata do not enter repository
+knowledge. Native definition paths must remain within the repository, including
+after resolving existing symlinks.
 
 The package graph intentionally allows cyclic dependencies between packages —
 this aligns with how npm, pnpm, and yarn handle cyclic workspace deps. Cycle


### PR DESCRIPTION
### Why this PR exists

Package identity and path ownership currently remain entangled with `PackageJson` compatibility data. That makes JavaScript manifest structure an accidental core package model and prevents Cargo or future ecosystems from contributing equivalent package facts without synthesizing JavaScript descriptors.

This PR introduces one immutable, parser-neutral package/scope generation and makes it authoritative for graph assembly. The package graph retains the exact generation used to create its nodes, so consumers cannot observe package facts from a different repository snapshot.

### What changes

- Add crate-private `RepositoryKnowledge` for repository root, root JavaScript execution scope, package and aggregate identities, directories, native definition paths, and open `ToolchainId` provenance.
- Build package/scope knowledge once from existing JavaScript discovery and the current Cargo compatibility output.
- Use that knowledge as the authority for package graph node assembly.
- Retain `PackageInfo` only as temporary relationship/task compatibility data. Its package identity, path, scope kind, and provenance are projected from knowledge.
- Keep one identity between discovery facts and temporary descriptors.
- Reject native definition paths outside the repository, including symlink escapes.
- Expose narrow knowledge-backed `PackageGraph` queries for later consumer migrations.
- Update architecture documentation for the package/scope cutover.

### What does not change

This PR does not introduce workspace-root uniqueness, nested workspace detection, relationship projections, external resolution, task knowledge, watch generations, or prune behavior. Those concerns move in their own stack layers or later phases.

Stack: #13440 -> #13441 -> #13442 -> #13447 -> #13448 -> #13443

### Testing Instructions

- `cargo test -p turborepo-repository`
- `cargo test -p turborepo-engine`
- `cargo test -p turborepo-lib`
- `cargo test -p turbo --test cargo_workspace_test`
- `cargo test -p turbo --test final_hash_contract`
- `cargo lint`
- `pnpm run format`