### PR TITLE
fix: Verify version after attempting codemod upgrade

### DIFF
--- a/packages/turbo-codemod/__tests__/migrate.test.ts
+++ b/packages/turbo-codemod/__tests__/migrate.test.ts
@@ -431,13 +431,11 @@ describe("migrate", () => {
       .mockReturnValue(undefined);
     const mockedGetCurrentVersion = jest
       .spyOn(getCurrentVersion, "getCurrentVersion")
-      .mockReturnValue("1.3.0");
+      .mockReturnValueOnce("1.3.0")
+      .mockReturnValueOnce("1.3.1");
     const mockedGetLatestVersion = jest
       .spyOn(getLatestVersion, "getLatestVersion")
       .mockResolvedValue("1.3.1");
-    const mockedGetInstalledVersion = jest
-      .spyOn(getCurrentVersion, "getInstalledVersion")
-      .mockReturnValue("1.3.1");
     const mockedGetTurboUpgradeCommand = jest
       .spyOn(getTurboUpgradeCommand, "getTurboUpgradeCommand")
       .mockResolvedValue("npm install turbo@1.3.1");
@@ -487,7 +485,6 @@ describe("migrate", () => {
     mockedCheckGitStatus.mockRestore();
     mockedGetCurrentVersion.mockRestore();
     mockedGetLatestVersion.mockRestore();
-    mockedGetInstalledVersion.mockRestore();
     mockedGetTurboUpgradeCommand.mockRestore();
     mockedGetWorkspaceDetails.mockRestore();
     mockedExecSync.mockRestore();
@@ -507,13 +504,11 @@ describe("migrate", () => {
       .mockReturnValue(undefined);
     const mockedGetCurrentVersion = jest
       .spyOn(getCurrentVersion, "getCurrentVersion")
-      .mockReturnValue("1.0.0");
+      .mockReturnValueOnce("1.0.0")
+      .mockReturnValueOnce("1.7.0");
     const mockedGetLatestVersion = jest
       .spyOn(getLatestVersion, "getLatestVersion")
       .mockResolvedValue("1.7.0");
-    const mockedGetInstalledVersion = jest
-      .spyOn(getCurrentVersion, "getInstalledVersion")
-      .mockReturnValue("1.7.0");
     const mockedGetTurboUpgradeCommand = jest
       .spyOn(getTurboUpgradeCommand, "getTurboUpgradeCommand")
       .mockResolvedValue("pnpm install -g turbo@1.7.0");
@@ -597,7 +592,6 @@ describe("migrate", () => {
     mockedCheckGitStatus.mockRestore();
     mockedGetCurrentVersion.mockRestore();
     mockedGetLatestVersion.mockRestore();
-    mockedGetInstalledVersion.mockRestore();
     mockedGetTurboUpgradeCommand.mockRestore();
     mockedGetAvailablePackageManagers.mockRestore();
     mockedGetWorkspaceDetails.mockRestore();
@@ -621,9 +615,6 @@ describe("migrate", () => {
     const mockedGetLatestVersion = jest
       .spyOn(getLatestVersion, "getLatestVersion")
       .mockResolvedValue("2.9.3");
-    const mockedGetInstalledVersion = jest
-      .spyOn(getCurrentVersion, "getInstalledVersion")
-      .mockReturnValue("2.8.0");
     const mockedGetTurboUpgradeCommand = jest
       .spyOn(getTurboUpgradeCommand, "getTurboUpgradeCommand")
       .mockResolvedValue("pnpm add turbo@latest --save-dev -w");
@@ -648,12 +639,11 @@ describe("migrate", () => {
 
     expect(mockExit.exit).toHaveBeenCalledWith(1);
     expect(readJson("turbo.json")).toStrictEqual(turboJson);
-    expect(mockedGetInstalledVersion).toHaveBeenCalled();
+    expect(mockedGetCurrentVersion).toHaveBeenCalledTimes(2);
 
     mockedCheckGitStatus.mockRestore();
     mockedGetCurrentVersion.mockRestore();
     mockedGetLatestVersion.mockRestore();
-    mockedGetInstalledVersion.mockRestore();
     mockedGetTurboUpgradeCommand.mockRestore();
     mockedGetWorkspaceDetails.mockRestore();
     mockedExecSync.mockRestore();

--- a/packages/turbo-codemod/__tests__/migrate.test.ts
+++ b/packages/turbo-codemod/__tests__/migrate.test.ts
@@ -435,6 +435,9 @@ describe("migrate", () => {
     const mockedGetLatestVersion = jest
       .spyOn(getLatestVersion, "getLatestVersion")
       .mockResolvedValue("1.3.1");
+    const mockedGetInstalledVersion = jest
+      .spyOn(getCurrentVersion, "getInstalledVersion")
+      .mockReturnValue("1.3.1");
     const mockedGetTurboUpgradeCommand = jest
       .spyOn(getTurboUpgradeCommand, "getTurboUpgradeCommand")
       .mockResolvedValue("npm install turbo@1.3.1");
@@ -484,6 +487,7 @@ describe("migrate", () => {
     mockedCheckGitStatus.mockRestore();
     mockedGetCurrentVersion.mockRestore();
     mockedGetLatestVersion.mockRestore();
+    mockedGetInstalledVersion.mockRestore();
     mockedGetTurboUpgradeCommand.mockRestore();
     mockedGetWorkspaceDetails.mockRestore();
     mockedExecSync.mockRestore();
@@ -507,6 +511,9 @@ describe("migrate", () => {
     const mockedGetLatestVersion = jest
       .spyOn(getLatestVersion, "getLatestVersion")
       .mockResolvedValue("1.7.0");
+    const mockedGetInstalledVersion = jest
+      .spyOn(getCurrentVersion, "getInstalledVersion")
+      .mockReturnValue("1.7.0");
     const mockedGetTurboUpgradeCommand = jest
       .spyOn(getTurboUpgradeCommand, "getTurboUpgradeCommand")
       .mockResolvedValue("pnpm install -g turbo@1.7.0");
@@ -590,43 +597,36 @@ describe("migrate", () => {
     mockedCheckGitStatus.mockRestore();
     mockedGetCurrentVersion.mockRestore();
     mockedGetLatestVersion.mockRestore();
+    mockedGetInstalledVersion.mockRestore();
     mockedGetTurboUpgradeCommand.mockRestore();
     mockedGetAvailablePackageManagers.mockRestore();
     mockedGetWorkspaceDetails.mockRestore();
     mockedExecSync.mockRestore();
   });
 
-  it("fails gracefully when the correct upgrade command cannot be found", async () => {
+  it("fails when the package manager does not install the expected version", async () => {
     const { root, readJson } = useFixture({
-      fixture: "old-turbo"
+      fixture: "turbo-2"
     });
 
     const packageManager = "pnpm";
-    const packageManagerVersion = "1.2.3";
+    const turboJson = readJson("turbo.json");
 
-    // setup mocks
     const mockedCheckGitStatus = jest
       .spyOn(checkGitStatus, "checkGitStatus")
       .mockReturnValue(undefined);
     const mockedGetCurrentVersion = jest
       .spyOn(getCurrentVersion, "getCurrentVersion")
-      .mockReturnValue("1.0.0");
+      .mockReturnValue("2.8.0");
     const mockedGetLatestVersion = jest
       .spyOn(getLatestVersion, "getLatestVersion")
-      .mockResolvedValue("1.7.0");
+      .mockResolvedValue("2.9.3");
+    const mockedGetInstalledVersion = jest
+      .spyOn(getCurrentVersion, "getInstalledVersion")
+      .mockReturnValue("2.8.0");
     const mockedGetTurboUpgradeCommand = jest
       .spyOn(getTurboUpgradeCommand, "getTurboUpgradeCommand")
-      .mockResolvedValue(undefined);
-    const mockedGetAvailablePackageManagers = jest
-      .spyOn(turboUtils, "getAvailablePackageManagers")
-      .mockResolvedValue({
-        pnpm: packageManagerVersion,
-        npm: undefined,
-        yarn: undefined,
-        bun: undefined,
-        nub: undefined,
-        aube: undefined
-      });
+      .mockResolvedValue("pnpm add turbo@latest --save-dev -w");
     const mockedGetWorkspaceDetails = jest
       .spyOn(turboWorkspaces, "getWorkspaceDetails")
       .mockResolvedValue(
@@ -646,27 +646,62 @@ describe("migrate", () => {
       install: true
     });
 
-    expect(readJson("package.json")).toStrictEqual(
-      expectedPackageJsonWithPackageManager({
-        name: "no-turbo-json",
-        turboVersion: "1.0.0"
-      })
-    );
-    expect(readJson("turbo.json")).toStrictEqual({
-      $schema: "https://turborepo.dev/schema.json",
-      pipeline: {
-        build: {
-          outputs: [".next/**", "!.next/cache/**"]
-        },
-        dev: {
-          cache: false
-        },
-        lint: {},
-        test: {
-          outputs: ["dist/**", "build/**"]
-        }
-      }
+    expect(mockExit.exit).toHaveBeenCalledWith(1);
+    expect(readJson("turbo.json")).toStrictEqual(turboJson);
+    expect(mockedGetInstalledVersion).toHaveBeenCalled();
+
+    mockedCheckGitStatus.mockRestore();
+    mockedGetCurrentVersion.mockRestore();
+    mockedGetLatestVersion.mockRestore();
+    mockedGetInstalledVersion.mockRestore();
+    mockedGetTurboUpgradeCommand.mockRestore();
+    mockedGetWorkspaceDetails.mockRestore();
+    mockedExecSync.mockRestore();
+  });
+
+  it("fails gracefully when the correct upgrade command cannot be found", async () => {
+    const { root, readJson } = useFixture({
+      fixture: "old-turbo"
     });
+
+    const packageManager = "pnpm";
+    const packageJson = readJson("package.json");
+    const turboJson = readJson("turbo.json");
+
+    // setup mocks
+    const mockedCheckGitStatus = jest
+      .spyOn(checkGitStatus, "checkGitStatus")
+      .mockReturnValue(undefined);
+    const mockedGetCurrentVersion = jest
+      .spyOn(getCurrentVersion, "getCurrentVersion")
+      .mockReturnValue("1.0.0");
+    const mockedGetLatestVersion = jest
+      .spyOn(getLatestVersion, "getLatestVersion")
+      .mockResolvedValue("1.7.0");
+    const mockedGetTurboUpgradeCommand = jest
+      .spyOn(getTurboUpgradeCommand, "getTurboUpgradeCommand")
+      .mockResolvedValue(undefined);
+    const mockedGetWorkspaceDetails = jest
+      .spyOn(turboWorkspaces, "getWorkspaceDetails")
+      .mockResolvedValue(
+        getWorkspaceDetailsMockReturnValue({
+          root,
+          packageManager
+        })
+      );
+    const mockedExecSync = jest
+      .spyOn(childProcess, "execSync")
+      .mockReturnValue("installed");
+
+    await migrate(root, {
+      force: false,
+      dryRun: false,
+      print: false,
+      install: true
+    });
+
+    expect(readJson("package.json")).toStrictEqual(packageJson);
+    expect(readJson("turbo.json")).toStrictEqual(turboJson);
 
     expect(mockExit.exit).toHaveBeenCalledWith(1);
 
@@ -675,7 +710,6 @@ describe("migrate", () => {
     expect(mockedGetCurrentVersion).toHaveBeenCalled();
     expect(mockedGetLatestVersion).toHaveBeenCalled();
     expect(mockedGetTurboUpgradeCommand).toHaveBeenCalled();
-    expect(mockedGetAvailablePackageManagers).toHaveBeenCalled();
     expect(mockedGetWorkspaceDetails).toHaveBeenCalled();
     expect(mockedExecSync).toHaveBeenCalledTimes(2);
     expect(mockedExecSync).toHaveBeenNthCalledWith(1, "turbo bin", {
@@ -692,7 +726,6 @@ describe("migrate", () => {
     mockedGetCurrentVersion.mockRestore();
     mockedGetLatestVersion.mockRestore();
     mockedGetTurboUpgradeCommand.mockRestore();
-    mockedGetAvailablePackageManagers.mockRestore();
     mockedGetWorkspaceDetails.mockRestore();
     mockedExecSync.mockRestore();
   });
@@ -841,7 +874,6 @@ describe("migrate", () => {
     });
 
     const packageManager = "pnpm";
-    const packageManagerVersion = "1.2.3";
 
     // setup mocks
     const mockedCheckGitStatus = jest
@@ -853,16 +885,9 @@ describe("migrate", () => {
     const mockedGetLatestVersion = jest
       .spyOn(getLatestVersion, "getLatestVersion")
       .mockResolvedValue("1.7.0");
-    const mockedGetAvailablePackageManagers = jest
-      .spyOn(turboUtils, "getAvailablePackageManagers")
-      .mockResolvedValue({
-        pnpm: packageManagerVersion,
-        npm: undefined,
-        yarn: undefined,
-        bun: undefined,
-        nub: undefined,
-        aube: undefined
-      });
+    const mockedGetTurboUpgradeCommand = jest
+      .spyOn(getTurboUpgradeCommand, "getTurboUpgradeCommand")
+      .mockResolvedValue("pnpm add turbo@latest --save-dev -w");
     const mockedGetWorkspaceDetails = jest
       .spyOn(turboWorkspaces, "getWorkspaceDetails")
       .mockResolvedValue(
@@ -885,14 +910,14 @@ describe("migrate", () => {
     expect(mockedCheckGitStatus).not.toHaveBeenCalled();
     expect(mockedGetCurrentVersion).toHaveBeenCalled();
     expect(mockedGetLatestVersion).toHaveBeenCalled();
-    expect(mockedGetAvailablePackageManagers).toHaveBeenCalled();
+    expect(mockedGetTurboUpgradeCommand).toHaveBeenCalled();
     expect(mockedGetWorkspaceDetails).toHaveBeenCalled();
 
     // restore mocks
     mockedCheckGitStatus.mockRestore();
     mockedGetCurrentVersion.mockRestore();
     mockedGetLatestVersion.mockRestore();
-    mockedGetAvailablePackageManagers.mockRestore();
+    mockedGetTurboUpgradeCommand.mockRestore();
     mockedGetWorkspaceDetails.mockRestore();
   });
 

--- a/packages/turbo-codemod/src/commands/migrate/index.ts
+++ b/packages/turbo-codemod/src/commands/migrate/index.ts
@@ -10,10 +10,7 @@ import { Runner } from "../../runner/runner";
 import { looksLikeRepo } from "../../utils/looks-like-repo";
 import type { TransformerResults } from "../../runner";
 import { transformer as updateVersionedSchema } from "../../transforms/update-versioned-schema-json";
-import {
-  getCurrentVersion,
-  getInstalledVersion
-} from "./steps/get-current-version";
+import { getCurrentVersion } from "./steps/get-current-version";
 import { getLatestVersion } from "./steps/get-latest-version";
 import { getTransformsForMigration } from "./steps/get-transforms-for-migration";
 import { getTurboUpgradeCommand } from "./steps/get-turbo-upgrade-command";
@@ -253,7 +250,10 @@ export async function migrate(
         });
       }
 
-      const installedVersion = getInstalledVersion(project);
+      const installedVersion = getCurrentVersion(project, {
+        ...options,
+        from: undefined
+      });
       if (installedVersion !== toVersion) {
         return endMigration({
           success: false,

--- a/packages/turbo-codemod/src/commands/migrate/index.ts
+++ b/packages/turbo-codemod/src/commands/migrate/index.ts
@@ -10,7 +10,10 @@ import { Runner } from "../../runner/runner";
 import { looksLikeRepo } from "../../utils/looks-like-repo";
 import type { TransformerResults } from "../../runner";
 import { transformer as updateVersionedSchema } from "../../transforms/update-versioned-schema-json";
-import { getCurrentVersion } from "./steps/get-current-version";
+import {
+  getCurrentVersion,
+  getInstalledVersion
+} from "./steps/get-current-version";
 import { getLatestVersion } from "./steps/get-latest-version";
 import { getTransformsForMigration } from "./steps/get-transforms-for-migration";
 import { getTurboUpgradeCommand } from "./steps/get-turbo-upgrade-command";
@@ -179,6 +182,96 @@ export async function migrate(
     os.EOL
   );
 
+  // Check if turbo uses a catalog reference (e.g. "turbo": "catalog:" in package.json).
+  // If so, update the version in the catalog file instead of letting the package
+  // manager overwrite the catalog reference with a literal version.
+  let catalogInfo: CatalogInfo | undefined;
+  if (project) {
+    catalogInfo = detectCatalog({
+      root: project.paths.root,
+      packageManager: project.packageManager
+    });
+  }
+
+  if (catalogInfo) {
+    if (options.dryRun) {
+      logger.log(
+        `Would update turbo version in catalog file ${picocolors.dim(
+          catalogInfo.catalogFile
+        )} ${picocolors.dim("(dry run)")}`,
+        os.EOL
+      );
+    } else {
+      const updated = updateCatalogVersion({
+        catalogInfo,
+        version: toVersion
+      });
+      if (updated) {
+        logger.log(
+          `Updated turbo version to ${picocolors.bold(
+            toVersion
+          )} in ${picocolors.dim(catalogInfo.catalogFile)}`,
+          os.EOL
+        );
+      }
+    }
+  }
+
+  // Find the upgrade command and run it before changing project configuration.
+  const upgradeCommand = await getTurboUpgradeCommand({
+    project,
+    to: options.to,
+    catalogInfo
+  });
+
+  if (!upgradeCommand) {
+    return endMigration({
+      success: false,
+      message: "Unable to determine upgrade command"
+    });
+  }
+
+  if (options.install) {
+    if (options.dryRun) {
+      logger.log(
+        `Upgrading turbo with ${picocolors.bold(
+          upgradeCommand
+        )} ${picocolors.dim("(dry run)")}`,
+        os.EOL
+      );
+    } else {
+      logger.log(
+        `Upgrading turbo with ${picocolors.bold(upgradeCommand)}`,
+        os.EOL
+      );
+      try {
+        execSync(upgradeCommand, { stdio: "pipe", cwd: project.paths.root });
+      } catch (err: unknown) {
+        return endMigration({
+          success: false,
+          message: `Unable to upgrade turbo: ${String(err)}`
+        });
+      }
+
+      const installedVersion = getInstalledVersion(project);
+      if (installedVersion !== toVersion) {
+        return endMigration({
+          success: false,
+          message: [
+            "The package manager did not install the expected version of Turbo.",
+            "",
+            `Expected: ${toVersion}`,
+            `Installed: ${installedVersion ?? "unknown"}`,
+            "",
+            "No codemods or schema updates were applied."
+          ].join(os.EOL)
+        });
+      }
+    }
+  } else {
+    logger.log(`Upgrade turbo with ${picocolors.bold(upgradeCommand)}`, os.EOL);
+  }
+
   const results: Array<TransformerResults> = [];
   for (const [idx, codemod] of codemods.entries()) {
     logger.log(
@@ -222,84 +315,6 @@ export async function migrate(
       message:
         "Could not complete migration due to codemod errors. Please fix the errors and try again."
     });
-  }
-
-  // step 5
-
-  // Check if turbo uses a catalog reference (e.g. "turbo": "catalog:" in package.json).
-  // If so, update the version in the catalog file instead of letting the package
-  // manager overwrite the catalog reference with a literal version.
-  let catalogInfo: CatalogInfo | undefined;
-  if (project) {
-    catalogInfo = detectCatalog({
-      root: project.paths.root,
-      packageManager: project.packageManager
-    });
-  }
-
-  if (catalogInfo) {
-    if (options.dryRun) {
-      logger.log(
-        `Would update turbo version in catalog file ${picocolors.dim(
-          catalogInfo.catalogFile
-        )} ${picocolors.dim("(dry run)")}`,
-        os.EOL
-      );
-    } else {
-      const updated = updateCatalogVersion({
-        catalogInfo,
-        version: toVersion
-      });
-      if (updated) {
-        logger.log(
-          `Updated turbo version to ${picocolors.bold(
-            toVersion
-          )} in ${picocolors.dim(catalogInfo.catalogFile)}`,
-          os.EOL
-        );
-      }
-    }
-  }
-
-  // find the upgrade command, and run it
-  const upgradeCommand = await getTurboUpgradeCommand({
-    project,
-    to: options.to,
-    catalogInfo
-  });
-
-  if (!upgradeCommand) {
-    return endMigration({
-      success: false,
-      message: "Unable to determine upgrade command"
-    });
-  }
-
-  // install
-  if (options.install) {
-    if (options.dryRun) {
-      logger.log(
-        `Upgrading turbo with ${picocolors.bold(
-          upgradeCommand
-        )} ${picocolors.dim("(dry run)")}`,
-        os.EOL
-      );
-    } else {
-      logger.log(
-        `Upgrading turbo with ${picocolors.bold(upgradeCommand)}`,
-        os.EOL
-      );
-      try {
-        execSync(upgradeCommand, { stdio: "pipe", cwd: project.paths.root });
-      } catch (err: unknown) {
-        return endMigration({
-          success: false,
-          message: `Unable to upgrade turbo: ${String(err)}`
-        });
-      }
-    }
-  } else {
-    logger.log(`Upgrade turbo with ${picocolors.bold(upgradeCommand)}`, os.EOL);
   }
 
   endMigration({ success: true });

--- a/packages/turbo-codemod/src/commands/migrate/steps/get-current-version.ts
+++ b/packages/turbo-codemod/src/commands/migrate/steps/get-current-version.ts
@@ -2,15 +2,7 @@ import { type Project } from "@turbo/workspaces";
 import { exec } from "../utils";
 import type { MigrateCommandOptions } from "../types";
 
-export function getCurrentVersion(
-  project: Project,
-  opts: MigrateCommandOptions
-): string | undefined {
-  const { from } = opts;
-  if (from) {
-    return from;
-  }
-
+export function getInstalledVersion(project: Project): string | undefined {
   // try global first
   const turboVersionFromGlobal = exec(`turbo --version`, {
     cwd: project.paths.root
@@ -29,4 +21,16 @@ export function getCurrentVersion(
   }
 
   return exec(`npm exec -c 'turbo --version'`, { cwd: project.paths.root });
+}
+
+export function getCurrentVersion(
+  project: Project,
+  opts: MigrateCommandOptions
+): string | undefined {
+  const { from } = opts;
+  if (from) {
+    return from;
+  }
+
+  return getInstalledVersion(project);
 }

--- a/packages/turbo-codemod/src/commands/migrate/steps/get-current-version.ts
+++ b/packages/turbo-codemod/src/commands/migrate/steps/get-current-version.ts
@@ -2,7 +2,15 @@ import { type Project } from "@turbo/workspaces";
 import { exec } from "../utils";
 import type { MigrateCommandOptions } from "../types";
 
-export function getInstalledVersion(project: Project): string | undefined {
+export function getCurrentVersion(
+  project: Project,
+  opts: MigrateCommandOptions
+): string | undefined {
+  const { from } = opts;
+  if (from) {
+    return from;
+  }
+
   // try global first
   const turboVersionFromGlobal = exec(`turbo --version`, {
     cwd: project.paths.root
@@ -21,16 +29,4 @@ export function getInstalledVersion(project: Project): string | undefined {
   }
 
   return exec(`npm exec -c 'turbo --version'`, { cwd: project.paths.root });
-}
-
-export function getCurrentVersion(
-  project: Project,
-  opts: MigrateCommandOptions
-): string | undefined {
-  const { from } = opts;
-  if (from) {
-    return from;
-  }
-
-  return getInstalledVersion(project);
 }


### PR DESCRIPTION
## Summary

- install Turbo before applying migration codemods or schema updates
- verify the installed Turbo version matches the migration target
- fail with the expected and installed versions when a package manager exits successfully without upgrading
- add regression coverage for successful no-op installs

## Testing

- `pnpm --filter @turbo/codemod exec jest __tests__/migrate.test.ts --runInBand --coverage=false`
- `pnpm --filter @turbo/codemod check-types`
- `pnpm turbo run build --filter=@turbo/codemod`
- pre-push format and TOML checks

Fixes #13445