### PR TITLE
feat: Select runnable task entrypoints

### DIFF
--- a/apps/docs/content/docs/reference/configuration.mdx
+++ b/apps/docs/content/docs/reference/configuration.mdx
@@ -441,6 +441,44 @@ In this example, `--filter=[main]` would not select `build` for a package if onl
   selected, regardless of individual task `inputs`.
 </Callout>
 
+#### `strictTaskEntrypointSelection`
+
+Default: `false`
+
+Select requested tasks according to whether they resolve a command in the
+repository. When at least one package can run a requested task, packages
+without a command do not become entrypoints and their dependencies are not
+included merely because the task was requested.
+
+```jsonc title="./turbo.json"
+{
+  "futureFlags": {
+    "strictTaskEntrypointSelection": true,
+  },
+  "tasks": {
+    "test": {
+      "dependsOn": ["build"],
+    },
+  },
+}
+```
+
+If `web` has a `test` command and `docs` does not, `turbo run test` starts from
+`web#test` but not `docs#test`. Missing tasks reached from retained tasks remain
+in the Task Graph, preserving Transit Nodes and cache invalidation.
+
+When no package resolves a command for a configured or implicitly registered
+task, it remains available for graph-only orchestration. For example, a
+scriptless `ci:checks` task can continue to run its configured dependencies.
+When any of those dependency branches reaches a runnable command, branches that
+never reach runnable work are removed. A fully scriptless graph is preserved
+when none of its branches contains a runnable command.
+
+This flag is independent of [`filterUsingTasks`](#filterusingtasks). When both
+are enabled, a plain task-level filter drops a matching task without a command,
+while `...` can explicitly select executable dependencies or dependents through
+that missing task node.
+
 #### `globalConfiguration`
 
 Default: `false`

--- a/crates/turborepo-engine/src/lib.rs
+++ b/crates/turborepo-engine/src/lib.rs
@@ -497,6 +497,19 @@ impl<T: TaskDefinitionInfo + Clone> Engine<Built, T> {
         self.prune_to_reachable(&reachable, false)
     }
 
+    /// Retains exactly the given task nodes and any dependency edges between
+    /// them. Unlike `retain_filtered_tasks`, this does not add transitive
+    /// dependencies.
+    pub fn retain_task_subset(self, retained_tasks: &HashSet<TaskId>) -> Self {
+        let mut retained: HashSet<_> = retained_tasks
+            .iter()
+            .filter_map(|task| self.task_lookup.get(task))
+            .copied()
+            .collect();
+        retained.insert(self.root_index);
+        self.prune_to_reachable(&retained, false)
+    }
+
     /// Computes the full reachable set from seed nodes: reverse DFS for
     /// transitive dependents, then forward DFS for transitive dependencies.
     /// Root is always included so `prune_to_reachable` can recover it.

--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -10,6 +10,7 @@ pub use turborepo_engine::{
     Built, ExecuteError, ExecutionOptions, Message, TaskDefinitionInfo, TaskNode,
 };
 use turborepo_repository::package_graph::{PackageGraph, PackageName};
+use turborepo_task_id::TaskId;
 use turborepo_types::{TaskDefinition, UIMode};
 
 /// Type alias for Engine specialized with TaskDefinition.
@@ -70,6 +71,31 @@ pub trait EngineExt {
     ) -> Result<(), Vec<ValidateError>>;
 }
 
+pub(crate) fn task_has_command(
+    engine: &Engine<Built>,
+    package_graph: &PackageGraph,
+    task: &TaskId<'static>,
+) -> bool {
+    if task.task() == "proxy" {
+        return true;
+    }
+
+    let Some(info) = package_graph.package_info(&PackageName::from(task.package())) else {
+        return false;
+    };
+    match engine
+        .task_definition(task)
+        .and_then(|definition| definition.command.as_ref())
+    {
+        Some(turborepo_types::TaskCommandOverride::Argv(_)) => true,
+        Some(turborepo_types::TaskCommandOverride::OptOut) => false,
+        None => package_graph
+            .toolchains()
+            .get(&info.toolchain)
+            .is_some_and(|toolchain| toolchain.defines_task(info, task.task())),
+    }
+}
+
 impl EngineExt for Engine<Built> {
     fn tasks_with_command(&self, pkg_graph: &PackageGraph) -> Vec<String> {
         self.tasks()
@@ -77,9 +103,7 @@ impl EngineExt for Engine<Built> {
                 TaskNode::Root => None,
                 TaskNode::Task(task) => Some(task),
             })
-            .filter_map(|task| {
-                let pkg_name = PackageName::from(task.package());
-                let info = pkg_graph.package_info(&pkg_name)?;
+            .filter(|task| {
                 // Ask the package's toolchain whether the task resolves to a
                 // runnable command — the same authority execution uses. For
                 // JS packages this is the package.json scripts lookup; for
@@ -88,19 +112,9 @@ impl EngineExt for Engine<Built> {
                 // override is authoritative in both directions: an argv
                 // executes even where the toolchain defines nothing, and an
                 // opt-out never executes even where it does.
-                let has_command = match self
-                    .task_definition(task)
-                    .and_then(|def| def.command.as_ref())
-                {
-                    Some(turborepo_types::TaskCommandOverride::Argv(_)) => true,
-                    Some(turborepo_types::TaskCommandOverride::OptOut) => false,
-                    None => pkg_graph
-                        .toolchains()
-                        .get(&info.toolchain)
-                        .is_some_and(|toolchain| toolchain.defines_task(info, task.task())),
-                };
-                (task.task() == "proxy" || has_command).then(|| task.to_string())
+                task_has_command(self, pkg_graph, task)
             })
+            .map(ToString::to_string)
             .collect()
     }
 

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -43,9 +43,17 @@ type FilteredPackages = (
     HashSet<PackageName>,
 );
 
+#[derive(Default)]
+struct TaskEntrypointSelection {
+    candidates: HashSet<TaskId<'static>>,
+    selected: HashSet<TaskId<'static>>,
+    excluded: HashSet<TaskId<'static>>,
+    orchestration: HashMap<String, HashSet<TaskId<'static>>>,
+}
+
 use crate::{
     commands::CommandBase,
-    engine::{Engine, EngineBuilder, EngineExt},
+    engine::{task_has_command, Engine, EngineBuilder, EngineExt},
     microfrontends::MicrofrontendsConfigs,
     opts::Opts,
     run::{
@@ -903,6 +911,18 @@ impl RunBuilder {
 
         // Task-level filter: resolve --filter and/or --affected against the task graph.
         if use_task_level_filter {
+            let task_entrypoints = self
+                .opts
+                .future_flags
+                .strict_task_entrypoint_selection
+                .then(|| {
+                    self.command_task_entrypoints(
+                        &engine,
+                        &pkg_dep_graph,
+                        &all_pkgs.iter().cloned().collect(),
+                    )
+                });
+            let excluded_entrypoints = HashSet::new();
             let selectors: Vec<turborepo_scope::TargetSelector> = self
                 .opts
                 .scope_opts
@@ -943,6 +963,15 @@ impl RunBuilder {
                 super::task_filter::TaskFilterConstraints {
                     affected: affected_constraint.as_ref(),
                     always_include: &package_tasks,
+                    entrypoints: task_entrypoints
+                        .as_ref()
+                        .map(|selection| &selection.candidates),
+                    excluded_entrypoints: task_entrypoints
+                        .as_ref()
+                        .map_or(&excluded_entrypoints, |selection| &selection.excluded),
+                    orchestration_entrypoints: task_entrypoints
+                        .as_ref()
+                        .map(|selection| &selection.orchestration),
                 },
                 &pkg_dep_graph,
                 &scm,
@@ -963,6 +992,23 @@ impl RunBuilder {
 
         if needs_all_packages {
             engine = self.select_engine_task_entrypoints(engine, &pkg_dep_graph, &filter_mode);
+        }
+
+        if self.opts.future_flags.strict_task_entrypoint_selection
+            && !use_task_level_filter
+            && !self.add_all_tasks
+        {
+            let task_entrypoints = self.command_task_entrypoints(
+                &engine,
+                &pkg_dep_graph,
+                &unqualified_entrypoint_packages,
+            );
+            engine = super::task_filter::retain_strict_task_graph(
+                engine,
+                &pkg_dep_graph,
+                task_entrypoints.selected,
+                &task_entrypoints.orchestration,
+            );
         }
 
         // Validate after all filtering so the persistent task count reflects
@@ -1191,6 +1237,65 @@ impl RunBuilder {
                 )
             })
             .collect()
+    }
+
+    fn command_task_entrypoints(
+        &self,
+        engine: &Engine,
+        pkg_dep_graph: &PackageGraph,
+        candidate_packages: &HashSet<PackageName>,
+    ) -> TaskEntrypointSelection {
+        let mut selection = TaskEntrypointSelection::default();
+
+        for requested in &self.opts.run_opts.tasks {
+            let task = TaskName::from(requested.as_str());
+            if let Some(task_id) = task.task_id().map(TaskId::into_owned) {
+                if engine.task_definition(&task_id).is_some() {
+                    selection.candidates.insert(task_id.clone());
+                    selection.selected.insert(task_id.clone());
+                    if !task_has_command(engine, pkg_dep_graph, &task_id) {
+                        selection
+                            .orchestration
+                            .entry(task.to_string())
+                            .or_default()
+                            .insert(task_id);
+                    }
+                }
+                continue;
+            }
+
+            let has_command = pkg_dep_graph.packages().any(|(_, package)| {
+                pkg_dep_graph
+                    .toolchains()
+                    .get(&package.toolchain)
+                    .is_some_and(|toolchain| toolchain.defines_task(package, task.task()))
+            }) || engine.task_ids().any(|task_id| {
+                task_id.task() == task.task() && task_has_command(engine, pkg_dep_graph, task_id)
+            });
+
+            for package in candidate_packages {
+                let task_id = TaskId::new(package.as_ref(), task.task()).into_owned();
+                if engine.task_definition(&task_id).is_none() {
+                    continue;
+                }
+
+                selection.candidates.insert(task_id.clone());
+                if !has_command || task_has_command(engine, pkg_dep_graph, &task_id) {
+                    selection.selected.insert(task_id.clone());
+                    if !has_command {
+                        selection
+                            .orchestration
+                            .entry(task.task().to_string())
+                            .or_default()
+                            .insert(task_id);
+                    }
+                } else {
+                    selection.excluded.insert(task_id);
+                }
+            }
+        }
+
+        selection
     }
 
     fn task_entrypoint_exclusions_for_task(

--- a/crates/turborepo-lib/src/run/task_filter.rs
+++ b/crates/turborepo-lib/src/run/task_filter.rs
@@ -15,7 +15,7 @@
 //! and `crate::task_change_detector::affected_task_ids`, sharing code with
 //! `--affected` + `affectedUsingTaskInputs`.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf};
 use turborepo_repository::package_graph::{PackageGraph, PackageName};
@@ -24,7 +24,7 @@ use turborepo_scope::{target_selector::GitRange, TargetSelector};
 use turborepo_task_id::TaskId;
 use wax::Program;
 
-use crate::engine::Engine;
+use crate::engine::{task_has_command, Engine, TaskNode};
 
 /// Resolves an `--affected` range to the set of task IDs that are affected
 /// (changed + dependents). Used by the builder to compute an intersection
@@ -55,12 +55,16 @@ pub fn resolve_affected_tasks(
         scm,
         repo_root,
         global_deps,
+        None,
     )
 }
 
 pub(crate) struct TaskFilterConstraints<'a> {
     pub affected: Option<&'a HashSet<TaskId<'static>>>,
     pub always_include: &'a HashSet<TaskId<'static>>,
+    pub entrypoints: Option<&'a HashSet<TaskId<'static>>>,
+    pub excluded_entrypoints: &'a HashSet<TaskId<'static>>,
+    pub orchestration_entrypoints: Option<&'a HashMap<String, HashSet<TaskId<'static>>>>,
 }
 
 /// Filters an engine down to only the tasks matching the given selectors.
@@ -79,12 +83,16 @@ pub fn filter_engine_to_tasks(
     global_deps: &[String],
 ) -> Result<Engine, crate::run::error::Error> {
     let always_include = HashSet::new();
+    let excluded_entrypoints = HashSet::new();
     filter_engine_to_tasks_with_inclusions(
         engine,
         selectors,
         TaskFilterConstraints {
             affected: affected_constraint,
             always_include: &always_include,
+            entrypoints: None,
+            excluded_entrypoints: &excluded_entrypoints,
+            orchestration_entrypoints: None,
         },
         pkg_dep_graph,
         scm,
@@ -114,13 +122,16 @@ pub(crate) fn filter_engine_to_tasks_with_inclusions(
             scm,
             repo_root,
             global_deps,
+            constraints.entrypoints,
         )?;
         included_tasks.extend(matched);
     }
 
     // If there were no include selectors (only excludes), start with all tasks.
     if include.is_empty() {
-        included_tasks = engine.task_ids().cloned().collect();
+        included_tasks = constraints
+            .entrypoints
+            .map_or_else(|| engine.task_ids().cloned().collect(), HashSet::clone);
     }
 
     if let Some(affected) = constraints.affected {
@@ -135,11 +146,23 @@ pub(crate) fn filter_engine_to_tasks_with_inclusions(
             scm,
             repo_root,
             global_deps,
+            constraints.entrypoints,
         )?;
         included_tasks.retain(|t| !to_exclude.contains(t));
     }
 
+    included_tasks.retain(|task| !constraints.excluded_entrypoints.contains(task));
+
     included_tasks.extend(constraints.always_include.iter().cloned());
+
+    if let Some(orchestration_entrypoints) = constraints.orchestration_entrypoints {
+        return Ok(retain_strict_task_graph(
+            engine,
+            pkg_dep_graph,
+            included_tasks,
+            orchestration_entrypoints,
+        ));
+    }
 
     if included_tasks.is_empty() {
         return Ok(engine.retain_filtered_tasks(&included_tasks));
@@ -169,6 +192,7 @@ fn resolve_selector_to_tasks(
     scm: &SCM,
     repo_root: &AbsoluteSystemPath,
     global_deps: &[String],
+    entrypoints: Option<&HashSet<TaskId<'static>>>,
 ) -> Result<HashSet<TaskId<'static>>, crate::run::error::Error> {
     if selector.match_dependencies {
         return resolve_match_dependencies(
@@ -178,11 +202,19 @@ fn resolve_selector_to_tasks(
             scm,
             repo_root,
             global_deps,
+            entrypoints,
         );
     }
 
-    let base_tasks =
-        resolve_base_tasks(engine, selector, pkg_dep_graph, scm, repo_root, global_deps)?;
+    let base_tasks = resolve_base_tasks(
+        engine,
+        selector,
+        pkg_dep_graph,
+        scm,
+        repo_root,
+        global_deps,
+        entrypoints,
+    )?;
 
     let mut result = HashSet::new();
 
@@ -225,19 +257,24 @@ fn resolve_base_tasks(
     scm: &SCM,
     repo_root: &AbsoluteSystemPath,
     global_deps: &[String],
+    entrypoints: Option<&HashSet<TaskId<'static>>>,
 ) -> Result<HashSet<TaskId<'static>>, crate::run::error::Error> {
     let tasks_from_packages = resolve_name_and_dir(engine, selector, pkg_dep_graph);
     let tasks_from_git_range =
         resolve_git_range(engine, selector, pkg_dep_graph, scm, repo_root, global_deps)?;
 
-    match (tasks_from_packages, tasks_from_git_range) {
+    let mut tasks = match (tasks_from_packages, tasks_from_git_range) {
         (Some(pkg_tasks), Some(git_tasks)) => {
             // Intersection: task must match both name/dir AND git range.
-            Ok(pkg_tasks.intersection(&git_tasks).cloned().collect())
+            pkg_tasks.intersection(&git_tasks).cloned().collect()
         }
-        (Some(tasks), None) | (None, Some(tasks)) => Ok(tasks),
-        (None, None) => Ok(HashSet::new()),
+        (Some(tasks), None) | (None, Some(tasks)) => tasks,
+        (None, None) => HashSet::new(),
+    };
+    if let Some(entrypoints) = entrypoints {
+        tasks.retain(|task| entrypoints.contains(task));
     }
+    Ok(tasks)
 }
 
 /// Matches tasks by package name pattern and/or directory.
@@ -347,6 +384,7 @@ fn resolve_match_dependencies(
     scm: &SCM,
     repo_root: &AbsoluteSystemPath,
     global_deps: &[String],
+    entrypoints: Option<&HashSet<TaskId<'static>>>,
 ) -> Result<HashSet<TaskId<'static>>, crate::run::error::Error> {
     let git_range = match &selector.git_range {
         Some(range) => range,
@@ -355,7 +393,10 @@ fn resolve_match_dependencies(
 
     // Find all tasks in the named packages
     let matching_packages = find_matching_packages(selector, pkg_dep_graph);
-    let package_tasks = engine.task_ids_for_packages(&matching_packages);
+    let mut package_tasks = engine.task_ids_for_packages(&matching_packages);
+    if let Some(entrypoints) = entrypoints {
+        package_tasks.retain(|task| entrypoints.contains(task));
+    }
 
     // Expand to include all task-graph dependencies
     let mut candidate_tasks = engine.collect_task_dependencies(&package_tasks);
@@ -413,7 +454,7 @@ fn get_changed_files(
 /// When `retain_filtered_tasks` prunes the engine via forward DFS, edge-less
 /// `with` siblings are unreachable and get dropped. This function closes that
 /// gap by expanding the retained set before pruning.
-fn expand_with_siblings(
+pub(crate) fn expand_with_siblings(
     engine: &Engine,
     tasks: HashSet<TaskId<'static>>,
 ) -> HashSet<TaskId<'static>> {
@@ -451,6 +492,83 @@ fn expand_with_siblings(
     result
 }
 
+pub(crate) fn retain_strict_task_graph(
+    engine: Engine,
+    pkg_dep_graph: &PackageGraph,
+    selected: HashSet<TaskId<'static>>,
+    orchestration: &HashMap<String, HashSet<TaskId<'static>>>,
+) -> Engine {
+    let orchestration_tasks: HashSet<_> = orchestration
+        .values()
+        .flatten()
+        .filter(|task| selected.contains(*task))
+        .cloned()
+        .collect();
+    let command_entrypoints: HashSet<_> =
+        selected.difference(&orchestration_tasks).cloned().collect();
+    let command_entrypoints = expand_with_siblings(&engine, command_entrypoints);
+    let mut retained = command_entrypoints.clone();
+    retained.extend(engine.collect_task_dependencies(&command_entrypoints));
+
+    for entrypoints in orchestration.values() {
+        let selected_entrypoints: HashSet<_> =
+            entrypoints.intersection(&selected).cloned().collect();
+        if selected_entrypoints.is_empty() {
+            continue;
+        }
+
+        let has_command_path = entrypoints
+            .iter()
+            .any(|entrypoint| orchestration_branch(&engine, pkg_dep_graph, entrypoint).is_some());
+        let mut paths_to_commands = HashSet::new();
+        for entrypoint in &selected_entrypoints {
+            if let Some(branch) = orchestration_branch(&engine, pkg_dep_graph, entrypoint) {
+                paths_to_commands.extend(branch);
+            }
+        }
+
+        if !has_command_path {
+            retained.extend(selected_entrypoints.iter().cloned());
+            retained.extend(engine.collect_task_dependencies(&selected_entrypoints));
+        } else {
+            retained.extend(paths_to_commands);
+        }
+    }
+
+    let expanded = expand_with_siblings(&engine, retained);
+    let mut retained = expanded.clone();
+    retained.extend(engine.collect_task_dependencies(&expanded));
+    engine.retain_task_subset(&retained)
+}
+
+fn orchestration_branch(
+    engine: &Engine,
+    pkg_dep_graph: &PackageGraph,
+    task_id: &TaskId<'static>,
+) -> Option<HashSet<TaskId<'static>>> {
+    if task_has_command(engine, pkg_dep_graph, task_id) {
+        let entrypoint = HashSet::from([task_id.clone()]);
+        let mut retained = entrypoint.clone();
+        retained.extend(engine.collect_task_dependencies(&entrypoint));
+        return Some(retained);
+    }
+
+    let mut retained = HashSet::new();
+    for dependency in engine.dependencies(task_id).into_iter().flatten() {
+        let TaskNode::Task(dependency) = dependency else {
+            continue;
+        };
+        if let Some(branch) = orchestration_branch(engine, pkg_dep_graph, dependency) {
+            retained.extend(branch);
+        }
+    }
+
+    (!retained.is_empty()).then(|| {
+        retained.insert(task_id.clone());
+        retained
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::{HashMap, HashSet};
@@ -463,7 +581,7 @@ mod tests {
         package_manager::PackageManager,
     };
     use turborepo_task_id::TaskId;
-    use turborepo_types::{TaskDefinition, TaskInputs};
+    use turborepo_types::{TaskCommandOverride, TaskDefinition, TaskInputs};
 
     use crate::engine::{Building, Engine};
 
@@ -530,6 +648,104 @@ mod tests {
             },
             ..Default::default()
         }
+    }
+
+    fn command_def() -> TaskDefinition {
+        TaskDefinition {
+            command: Some(TaskCommandOverride::Argv(vec!["run".to_string()])),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn strict_orchestration_retains_only_paths_to_commands() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
+        let pkg_graph = make_pkg_graph(root, &["app", "lib"]).await;
+
+        let app_checks = TaskId::new("app", "checks");
+        let app_package_types = TaskId::new("app", "package:types");
+        let lib_checks = TaskId::new("lib", "checks");
+        let lib_package_types = TaskId::new("lib", "package:types");
+        let engine = make_engine(
+            &[
+                (app_checks.clone(), TaskDefinition::default()),
+                (app_package_types.clone(), TaskDefinition::default()),
+                (lib_checks.clone(), TaskDefinition::default()),
+                (lib_package_types.clone(), command_def()),
+            ],
+            &[
+                (app_checks.clone(), app_package_types),
+                (lib_checks.clone(), lib_package_types.clone()),
+            ],
+        );
+        let selected = HashSet::from([app_checks.clone(), lib_checks.clone()]);
+        let orchestration = HashMap::from([(
+            "checks".to_string(),
+            HashSet::from([app_checks, lib_checks.clone()]),
+        )]);
+
+        let result = super::retain_strict_task_graph(engine, &pkg_graph, selected, &orchestration);
+        let remaining: HashSet<_> = result.task_ids().cloned().collect();
+
+        assert_eq!(remaining, HashSet::from([lib_checks, lib_package_types]));
+    }
+
+    #[tokio::test]
+    async fn strict_orchestration_preserves_fully_scriptless_graph() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
+        let pkg_graph = make_pkg_graph(root, &["app", "lib"]).await;
+
+        let app_topo = TaskId::new("app", "topo");
+        let lib_topo = TaskId::new("lib", "topo");
+        let engine = make_engine(
+            &[
+                (app_topo.clone(), TaskDefinition::default()),
+                (lib_topo.clone(), TaskDefinition::default()),
+            ],
+            &[(app_topo.clone(), lib_topo.clone())],
+        );
+        let selected = HashSet::from([app_topo.clone(), lib_topo.clone()]);
+        let orchestration = HashMap::from([("topo".to_string(), selected.clone())]);
+
+        let result = super::retain_strict_task_graph(engine, &pkg_graph, selected, &orchestration);
+        let remaining: HashSet<_> = result.task_ids().cloned().collect();
+
+        assert_eq!(remaining, HashSet::from([app_topo, lib_topo]));
+    }
+
+    #[tokio::test]
+    async fn strict_orchestration_filter_drops_selected_dead_branch() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
+        let pkg_graph = make_pkg_graph(root, &["app", "lib"]).await;
+
+        let app_checks = TaskId::new("app", "checks");
+        let app_package_types = TaskId::new("app", "package:types");
+        let lib_checks = TaskId::new("lib", "checks");
+        let lib_package_types = TaskId::new("lib", "package:types");
+        let engine = make_engine(
+            &[
+                (app_checks.clone(), TaskDefinition::default()),
+                (app_package_types.clone(), TaskDefinition::default()),
+                (lib_checks.clone(), TaskDefinition::default()),
+                (lib_package_types.clone(), command_def()),
+            ],
+            &[
+                (app_checks.clone(), app_package_types),
+                (lib_checks.clone(), lib_package_types),
+            ],
+        );
+        let selected = HashSet::from([app_checks.clone()]);
+        let orchestration = HashMap::from([(
+            "checks".to_string(),
+            HashSet::from([app_checks, lib_checks]),
+        )]);
+
+        let result = super::retain_strict_task_graph(engine, &pkg_graph, selected, &orchestration);
+
+        assert!(result.task_ids().next().is_none());
     }
 
     /// `--filter=web...` should pick up cross-package task deps.
@@ -651,7 +867,7 @@ mod tests {
         };
 
         let tasks =
-            super::resolve_selector_to_tasks(&engine, &selector, &pkg_graph, &scm, root, &[])
+            super::resolve_selector_to_tasks(&engine, &selector, &pkg_graph, &scm, root, &[], None)
                 .unwrap();
 
         assert!(tasks.contains(&web_build));
@@ -687,7 +903,7 @@ mod tests {
         };
 
         let tasks =
-            super::resolve_selector_to_tasks(&engine, &selector, &pkg_graph, &scm, root, &[])
+            super::resolve_selector_to_tasks(&engine, &selector, &pkg_graph, &scm, root, &[], None)
                 .unwrap();
 
         assert!(
@@ -698,6 +914,96 @@ mod tests {
             tasks.contains(&schema_gen),
             "schema#gen should be included via task graph traversal: {tasks:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn plain_filter_drops_missing_requested_task_and_implicit_dependencies() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
+        let pkg_graph = make_pkg_graph(root, &["web"]).await;
+        let scm = turborepo_scm::SCM::new(root);
+
+        let web_test = TaskId::new("web", "test");
+        let web_build = TaskId::new("web", "build");
+        let engine = make_engine(
+            &[
+                (web_test.clone(), TaskDefinition::default()),
+                (web_build.clone(), TaskDefinition::default()),
+            ],
+            &[(web_test.clone(), web_build.clone())],
+        );
+        let entrypoints = HashSet::from([web_test.clone()]);
+        let excluded_entrypoints = HashSet::from([web_test]);
+        let always_include = HashSet::new();
+        let selector = turborepo_scope::TargetSelector {
+            name_pattern: "web".to_string(),
+            ..Default::default()
+        };
+
+        let result = super::filter_engine_to_tasks_with_inclusions(
+            engine,
+            &[selector],
+            super::TaskFilterConstraints {
+                affected: None,
+                always_include: &always_include,
+                entrypoints: Some(&entrypoints),
+                excluded_entrypoints: &excluded_entrypoints,
+                orchestration_entrypoints: None,
+            },
+            &pkg_graph,
+            &scm,
+            root,
+            &[],
+        )
+        .unwrap();
+
+        assert!(result.task_ids().next().is_none());
+    }
+
+    #[tokio::test]
+    async fn dependency_filter_keeps_tasks_beyond_missing_requested_task() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
+        let pkg_graph = make_pkg_graph(root, &["web"]).await;
+        let scm = turborepo_scm::SCM::new(root);
+
+        let web_test = TaskId::new("web", "test");
+        let web_build = TaskId::new("web", "build");
+        let engine = make_engine(
+            &[
+                (web_test.clone(), TaskDefinition::default()),
+                (web_build.clone(), TaskDefinition::default()),
+            ],
+            &[(web_test.clone(), web_build.clone())],
+        );
+        let entrypoints = HashSet::from([web_test.clone()]);
+        let excluded_entrypoints = HashSet::from([web_test]);
+        let always_include = HashSet::new();
+        let selector = turborepo_scope::TargetSelector {
+            name_pattern: "web".to_string(),
+            include_dependencies: true,
+            ..Default::default()
+        };
+
+        let result = super::filter_engine_to_tasks_with_inclusions(
+            engine,
+            &[selector],
+            super::TaskFilterConstraints {
+                affected: None,
+                always_include: &always_include,
+                entrypoints: Some(&entrypoints),
+                excluded_entrypoints: &excluded_entrypoints,
+                orchestration_entrypoints: None,
+            },
+            &pkg_graph,
+            &scm,
+            root,
+            &[],
+        )
+        .unwrap();
+        let remaining: HashSet<_> = result.task_ids().cloned().collect();
+
+        assert_eq!(remaining, HashSet::from([web_build]));
     }
 
     /// resolve_selector_to_tasks with include_dependents traverses
@@ -727,7 +1033,7 @@ mod tests {
         };
 
         let tasks =
-            super::resolve_selector_to_tasks(&engine, &selector, &pkg_graph, &scm, root, &[])
+            super::resolve_selector_to_tasks(&engine, &selector, &pkg_graph, &scm, root, &[], None)
                 .unwrap();
 
         assert!(
@@ -1093,7 +1399,7 @@ mod tests {
         };
 
         let tasks =
-            super::resolve_selector_to_tasks(&engine, &selector, &pkg_graph, &scm, root, &[])
+            super::resolve_selector_to_tasks(&engine, &selector, &pkg_graph, &scm, root, &[], None)
                 .unwrap();
 
         assert!(
@@ -1133,7 +1439,7 @@ mod tests {
         };
 
         let tasks =
-            super::resolve_selector_to_tasks(&engine, &selector, &pkg_graph, &scm, root, &[])
+            super::resolve_selector_to_tasks(&engine, &selector, &pkg_graph, &scm, root, &[], None)
                 .unwrap();
 
         assert!(

--- a/crates/turborepo-schema-gen/src/main.rs
+++ b/crates/turborepo-schema-gen/src/main.rs
@@ -795,6 +795,15 @@ export interface FutureFlags {
    */
   filterUsingTasks?: boolean;
   /**
+   * Select requested task entrypoints according to whether the task resolves
+   * a command in the repository. When any package can run a requested task,
+   * packages without a command are skipped as entrypoints. Tasks with no
+   * command anywhere remain available for graph-only orchestration.
+   *
+   * @defaultValue `false`
+   */
+  strictTaskEntrypointSelection?: boolean;
+  /**
    * Move global configuration keys under a top-level `global` key.
    *
    * When enabled, keys like `globalDependencies`, `globalEnv`, `ui`,

--- a/crates/turborepo-turbo-json/src/future_flags.rs
+++ b/crates/turborepo-turbo-json/src/future_flags.rs
@@ -74,6 +74,13 @@ pub struct FutureFlags {
     /// traverse the task graph in addition to the package graph.
     #[serde(default)]
     pub filter_using_tasks: bool,
+    /// Select requested task entrypoints according to whether the task resolves
+    /// a command in the repository. When any package can run a requested task,
+    /// packages without a command are not used as entrypoints. Tasks with no
+    /// command anywhere remain available for graph-only orchestration, and
+    /// missing tasks reached as dependencies remain in the Task Graph.
+    #[serde(default)]
+    pub strict_task_entrypoint_selection: bool,
     /// Move global configuration keys (like `globalDependencies`, `ui`,
     /// `envMode`, etc.) under a top-level `global` key for clarity.
     ///
@@ -152,16 +159,18 @@ impl TS for FutureFlags {
     fn inline() -> String {
         "{ errorsOnlyShowHash?: boolean, experimentalObservability?: boolean, longerSignatureKey?: \
          boolean, affectedUsingTaskInputs?: boolean, watchUsingTaskInputs?: boolean, \
-         pruneIncludesGlobalFiles?: boolean, filterUsingTasks?: boolean, globalConfiguration?: \
-         boolean, experimentalCargoWorkspaces?: boolean, experimentalTaskCommand?: boolean }"
+         pruneIncludesGlobalFiles?: boolean, filterUsingTasks?: boolean, \
+         strictTaskEntrypointSelection?: boolean, globalConfiguration?: boolean, \
+         experimentalCargoWorkspaces?: boolean, experimentalTaskCommand?: boolean }"
             .to_string()
     }
 
     fn inline_flattened() -> String {
         "{ errorsOnlyShowHash?: boolean, experimentalObservability?: boolean, longerSignatureKey?: \
          boolean, affectedUsingTaskInputs?: boolean, watchUsingTaskInputs?: boolean, \
-         pruneIncludesGlobalFiles?: boolean, filterUsingTasks?: boolean, globalConfiguration?: \
-         boolean, experimentalCargoWorkspaces?: boolean, experimentalTaskCommand?: boolean }"
+         pruneIncludesGlobalFiles?: boolean, filterUsingTasks?: boolean, \
+         strictTaskEntrypointSelection?: boolean, globalConfiguration?: boolean, \
+         experimentalCargoWorkspaces?: boolean, experimentalTaskCommand?: boolean }"
             .to_string()
     }
 
@@ -169,8 +178,8 @@ impl TS for FutureFlags {
         "type FutureFlags = { errorsOnlyShowHash?: boolean, experimentalObservability?: boolean, \
          longerSignatureKey?: boolean, affectedUsingTaskInputs?: boolean, watchUsingTaskInputs?: \
          boolean, pruneIncludesGlobalFiles?: boolean, filterUsingTasks?: boolean, \
-         globalConfiguration?: boolean, experimentalCargoWorkspaces?: boolean, \
-         experimentalTaskCommand?: boolean };"
+         strictTaskEntrypointSelection?: boolean, globalConfiguration?: boolean, \
+         experimentalCargoWorkspaces?: boolean, experimentalTaskCommand?: boolean };"
             .to_string()
     }
 
@@ -178,8 +187,8 @@ impl TS for FutureFlags {
         "type FutureFlags = { errorsOnlyShowHash?: boolean, experimentalObservability?: boolean, \
          longerSignatureKey?: boolean, affectedUsingTaskInputs?: boolean, watchUsingTaskInputs?: \
          boolean, pruneIncludesGlobalFiles?: boolean, filterUsingTasks?: boolean, \
-         globalConfiguration?: boolean, experimentalCargoWorkspaces?: boolean, \
-         experimentalTaskCommand?: boolean };"
+         strictTaskEntrypointSelection?: boolean, globalConfiguration?: boolean, \
+         experimentalCargoWorkspaces?: boolean, experimentalTaskCommand?: boolean };"
             .to_string()
     }
 

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -440,6 +440,34 @@ The core task graph consists of:
   execution-only compile-cache environment injection likewise apply only to
   native toolchain-resolved commands.
 
+#### Run Entrypoint Selection (`crates/turborepo-lib/src/run/builder.rs`)
+
+- This behavior is gated by
+  `futureFlags.strictTaskEntrypointSelection` and is independent of
+  `futureFlags.filterUsingTasks`.
+- Requested task names that resolve a command anywhere in the repository start
+  only in scoped packages where that task resolves a command. A missing task is
+  therefore not allowed to pull its configured dependencies into a run merely
+  because another package implements the requested task.
+- When no package resolves a command for a configured or toolchain-registered
+  task, its scoped package nodes remain entrypoints so graph-only orchestration
+  tasks continue to fan out to their configured dependencies. If any branch
+  reaches a runnable command, only paths to runnable work are retained; when no
+  branch is runnable, the fully scriptless graph remains intact.
+- Entrypoint selection happens independently from dependency traversal. Missing
+  tasks reached from a retained task stay in the graph for ordering and hash
+  propagation. Explicitly requesting another task unions its retained graph, so
+  `turbo run build test` still runs every selected `build` command.
+- With `filterUsingTasks`, package and git selectors start from the requested
+  task nodes rather than every dependency task already present in the package.
+  Missing requested nodes are dropped after selector expansion: a plain filter
+  runs nothing for a missing command, while trailing or leading `...` may retain
+  executable tasks reached through that node in the Task Graph.
+- Native package scripts, resolved `command` overrides, and toolchain-provided
+  commands all count as executable definitions. Toolchain-specific entrypoint
+  selection, including Cargo workspace/crate selection, remains authoritative
+  and is composed with this generic command-aware pruning.
+
 #### Engine Execution (`crates/turborepo-lib/src/engine/execute.rs`)
 
 - Orchestrates task execution in topological order

--- a/crates/turborepo/tests/cargo_workspace_test.rs
+++ b/crates/turborepo/tests/cargo_workspace_test.rs
@@ -1821,6 +1821,15 @@ fn test_pure_cargo_workspace_filtered_execution() {
 fn test_unfiltered_cargo_verification_runs_once_at_workspace_scope() {
     let tempdir = cargo_tempdir();
     setup_cargo_monorepo(tempdir.path());
+    let turbo_json_path = tempdir.path().join("turbo.json");
+    let mut turbo_json: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&turbo_json_path).unwrap()).unwrap();
+    turbo_json["futureFlags"]["strictTaskEntrypointSelection"] = true.into();
+    fs::write(
+        turbo_json_path,
+        serde_json::to_string_pretty(&turbo_json).unwrap(),
+    )
+    .unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "test", "--dry-run=json"]);
     assert!(output.status.success(), "dry run failed: {output:?}");
@@ -1881,7 +1890,8 @@ fn test_cargo_verification_works_with_task_level_filters() {
   "$schema": "https://turborepo.dev/schema.json",
   "futureFlags": {
     "experimentalCargoWorkspaces": true,
-    "filterUsingTasks": true
+    "filterUsingTasks": true,
+    "strictTaskEntrypointSelection": true
   },
   "tasks": {}
 }"#,

--- a/crates/turborepo/tests/task_entrypoints_test.rs
+++ b/crates/turborepo/tests/task_entrypoints_test.rs
@@ -1,0 +1,233 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
+mod common;
+
+use std::{collections::HashSet, fs, path::Path};
+
+use common::{git, run_turbo, setup};
+
+fn setup_fixture(dir: &Path, strict_entrypoints: bool, filter_using_tasks: bool) {
+    setup::setup_integration_test(dir, "basic_monorepo", "npm@10.5.0", false).unwrap();
+
+    let mut app: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(dir.join("apps/my-app/package.json")).unwrap())
+            .unwrap();
+    app["scripts"]["test"] = "echo testing".into();
+    app["scripts"]["test-transit"] = "echo testing transit".into();
+    fs::write(
+        dir.join("apps/my-app/package.json"),
+        serde_json::to_string_pretty(&app).unwrap(),
+    )
+    .unwrap();
+
+    let mut another: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(dir.join("packages/another/package.json")).unwrap(),
+    )
+    .unwrap();
+    another["scripts"]["build"] = "echo building".into();
+    another["scripts"]["package:types"] = "echo checking package".into();
+    fs::write(
+        dir.join("packages/another/package.json"),
+        serde_json::to_string_pretty(&another).unwrap(),
+    )
+    .unwrap();
+
+    let future_flags = serde_json::json!({
+        "strictTaskEntrypointSelection": strict_entrypoints,
+        "filterUsingTasks": filter_using_tasks
+    });
+    let turbo_json = serde_json::json!({
+        "futureFlags": future_flags,
+        "tasks": {
+            "build": { "dependsOn": ["^build"] },
+            "test": { "dependsOn": ["build"] },
+            "checks": { "dependsOn": ["build"] },
+            "package-checks": { "dependsOn": ["package:types"] },
+            "package:types": {},
+            "transit": { "dependsOn": ["^transit"] },
+            "topo": { "dependsOn": ["^topo"] },
+            "test-transit": { "dependsOn": ["transit"] }
+        }
+    });
+    fs::write(
+        dir.join("turbo.json"),
+        serde_json::to_string_pretty(&turbo_json).unwrap(),
+    )
+    .unwrap();
+    git(dir, &["add", "."]);
+    git(dir, &["commit", "-m", "entrypoint fixture", "--quiet"]);
+}
+
+fn dry_tasks(dir: &Path, args: &[&str]) -> HashSet<String> {
+    let mut command = vec!["run"];
+    command.extend_from_slice(args);
+    command.push("--dry=json");
+    let output = run_turbo(dir, &command);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "dry run failed: stdout={stdout}, stderr={stderr}"
+    );
+    let summary: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    summary["tasks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|task| task["taskId"].as_str().unwrap().to_string())
+        .collect()
+}
+
+#[test]
+fn requested_task_starts_only_where_it_has_a_command() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_fixture(tempdir.path(), true, false);
+
+    let tasks = dry_tasks(tempdir.path(), &["test"]);
+
+    assert_eq!(
+        tasks,
+        HashSet::from([
+            "my-app#test".to_string(),
+            "my-app#build".to_string(),
+            "util#build".to_string(),
+        ])
+    );
+}
+
+#[test]
+fn task_without_commands_remains_an_orchestration_task() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_fixture(tempdir.path(), true, false);
+
+    let tasks = dry_tasks(tempdir.path(), &["checks"]);
+
+    assert!(tasks.contains("my-app#checks"));
+    assert!(tasks.contains("util#checks"));
+    assert!(tasks.contains("another#checks"));
+    assert!(tasks.contains("my-app#build"));
+    assert!(tasks.contains("util#build"));
+    assert!(tasks.contains("another#build"));
+}
+
+#[test]
+fn orchestration_task_prunes_branches_without_runnable_work() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_fixture(tempdir.path(), true, false);
+
+    let tasks = dry_tasks(tempdir.path(), &["package-checks"]);
+
+    assert_eq!(
+        tasks,
+        HashSet::from([
+            "another#package-checks".to_string(),
+            "another#package:types".to_string(),
+        ])
+    );
+}
+
+#[test]
+fn task_filter_selects_only_orchestration_branches_with_runnable_work() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_fixture(tempdir.path(), true, true);
+
+    let tasks = dry_tasks(tempdir.path(), &["package-checks", "--filter=another"]);
+    assert_eq!(
+        tasks,
+        HashSet::from([
+            "another#package-checks".to_string(),
+            "another#package:types".to_string(),
+        ])
+    );
+
+    let tasks = dry_tasks(tempdir.path(), &["package-checks", "--filter=my-app"]);
+    assert!(tasks.is_empty());
+}
+
+#[test]
+fn fully_scriptless_orchestration_graph_is_preserved() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_fixture(tempdir.path(), true, false);
+
+    let tasks = dry_tasks(tempdir.path(), &["topo"]);
+
+    assert!(tasks.contains("my-app#topo"));
+    assert!(tasks.contains("util#topo"));
+    assert!(tasks.contains("another#topo"));
+}
+
+#[test]
+fn explicitly_requested_dependency_task_still_runs_everywhere() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_fixture(tempdir.path(), true, false);
+
+    let tasks = dry_tasks(tempdir.path(), &["build", "test"]);
+
+    assert!(tasks.contains("another#build"));
+    assert!(!tasks.contains("another#test"));
+    assert!(!tasks.contains("util#test"));
+}
+
+#[test]
+fn missing_transit_tasks_remain_inside_a_runnable_task_graph() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_fixture(tempdir.path(), true, false);
+
+    let tasks = dry_tasks(tempdir.path(), &["test-transit"]);
+
+    assert!(tasks.contains("my-app#transit"));
+    assert!(tasks.contains("util#transit"));
+}
+
+#[test]
+fn task_filter_skips_a_missing_command_without_dependency_expansion() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_fixture(tempdir.path(), true, true);
+
+    let tasks = dry_tasks(tempdir.path(), &["test", "--filter=another"]);
+
+    assert!(tasks.is_empty());
+}
+
+#[test]
+fn package_filter_skips_a_missing_command_and_its_dependencies() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_fixture(tempdir.path(), true, false);
+
+    let tasks = dry_tasks(tempdir.path(), &["test", "--filter=another"]);
+
+    assert!(tasks.is_empty());
+}
+
+#[test]
+fn task_filter_explicitly_selects_dependencies_through_a_missing_command() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_fixture(tempdir.path(), true, true);
+
+    let tasks = dry_tasks(tempdir.path(), &["test", "--filter=another..."]);
+
+    assert_eq!(tasks, HashSet::from(["another#build".to_string()]));
+}
+
+#[test]
+fn missing_task_branches_remain_without_the_future_flag() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_fixture(tempdir.path(), false, false);
+
+    let tasks = dry_tasks(tempdir.path(), &["test"]);
+
+    assert!(tasks.contains("another#test"));
+    assert!(tasks.contains("another#build"));
+    assert!(tasks.contains("util#test"));
+}
+
+#[test]
+fn filter_using_tasks_does_not_enable_strict_entrypoint_selection() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_fixture(tempdir.path(), false, true);
+
+    let tasks = dry_tasks(tempdir.path(), &["test", "--filter=another"]);
+
+    assert!(tasks.contains("another#test"));
+    assert!(tasks.contains("another#build"));
+}

--- a/packages/turbo-types/schemas/schema.json
+++ b/packages/turbo-types/schemas/schema.json
@@ -330,6 +330,11 @@
           "default": false,
           "type": "boolean"
         },
+        "strictTaskEntrypointSelection": {
+          "description": "Select requested task entrypoints according to whether the task resolves a command in the repository. When any package can run a requested task, packages without a command are not used as entrypoints. Tasks with no command anywhere remain available for graph-only orchestration, and missing tasks reached as dependencies remain in the Task Graph.",
+          "default": false,
+          "type": "boolean"
+        },
         "watchUsingTaskInputs": {
           "description": "Use task-level `inputs` globs to determine which tasks to re-run when files change in `turbo watch`. When enabled, only tasks whose declared inputs match the changed files are re-executed, rather than re-running all tasks in changed packages.",
           "default": false,

--- a/packages/turbo-types/schemas/schema.ts
+++ b/packages/turbo-types/schemas/schema.ts
@@ -293,6 +293,15 @@ export interface FutureFlags {
    */
   filterUsingTasks?: boolean;
   /**
+   * Select requested task entrypoints according to whether the task resolves
+   * a command in the repository. When any package can run a requested task,
+   * packages without a command are skipped as entrypoints. Tasks with no
+   * command anywhere remain available for graph-only orchestration.
+   *
+   * @defaultValue `false`
+   */
+  strictTaskEntrypointSelection?: boolean;
+  /**
    * Move global configuration keys under a top-level `global` key.
    *
    * When enabled, keys like `globalDependencies`, `globalEnv`, `ui`,

--- a/packages/turbo-types/schemas/schema.v2.json
+++ b/packages/turbo-types/schemas/schema.v2.json
@@ -310,6 +310,11 @@
           "description": "Resolve `--filter` at the task level instead of the package level. Git-range filters (e.g. `--filter=[main]`) will match against task `inputs` globs, and the `...` dependency/dependent syntax will traverse the task graph in addition to the package graph.",
           "default": false,
           "type": "boolean"
+        },
+        "strictTaskEntrypointSelection": {
+          "description": "Select requested task entrypoints according to whether the task resolves a command in the repository. When any package can run a requested task, packages without a command are skipped as entrypoints. Tasks with no command anywhere remain available for graph-only orchestration.",
+          "default": false,
+          "type": "boolean"
         }
       }
     },

--- a/packages/turbo-types/src/types/config-v2.ts
+++ b/packages/turbo-types/src/types/config-v2.ts
@@ -293,6 +293,15 @@ export interface FutureFlags {
    */
   filterUsingTasks?: boolean;
   /**
+   * Select requested task entrypoints according to whether the task resolves
+   * a command in the repository. When any package can run a requested task,
+   * packages without a command are skipped as entrypoints. Tasks with no
+   * command anywhere remain available for graph-only orchestration.
+   *
+   * @defaultValue `false`
+   */
+  strictTaskEntrypointSelection?: boolean;
+  /**
    * Move global configuration keys under a top-level `global` key.
    *
    * When enabled, keys like `globalDependencies`, `globalEnv`, `ui`,

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,8 @@
   "noUpdateNotifier": true,
   "futureFlags": {
     "experimentalCargoWorkspaces": true,
-    "experimentalTaskCommand": true
+    "experimentalTaskCommand": true,
+    "strictTaskEntrypointSelection": true
   },
   // The following are used by tools such as pnpm, gh actions to setup pnpm, etc.
   "globalPassThroughEnv": [

--- a/turbo.json
+++ b/turbo.json
@@ -4,8 +4,7 @@
   "noUpdateNotifier": true,
   "futureFlags": {
     "experimentalCargoWorkspaces": true,
-    "experimentalTaskCommand": true,
-    "strictTaskEntrypointSelection": true
+    "experimentalTaskCommand": true
   },
   // The following are used by tools such as pnpm, gh actions to setup pnpm, etc.
   "globalPassThroughEnv": [


### PR DESCRIPTION
## Summary

- Fixes #937 
- Add the `futureFlags.strictTaskEntrypointSelection` opt-in
- Use command-bearing package tasks as requested entrypoints while retaining internal transit tasks
- Preserve scriptless orchestration graphs and prune orchestration branches that cannot reach runnable work
- Support task-level filter traversal, implicit Cargo tasks, command overrides, and proxy tasks
- Update schemas, types, docs, and architecture notes

## Enable the flag

```jsonc
{
  "$schema": "https://turborepo.dev/schema.json",
  "futureFlags": {
    "strictTaskEntrypointSelection": true
  },
  "tasks": {
    "build": {
      "dependsOn": ["^build"]
    },
    "test": {
      "dependsOn": ["build"]
    }
  }
}
```

## Behavior examples

### Requested tasks start where they can run

Given `app` has a `test` script and `lib` does not:

```console
$ turbo run test --dry
```

Before enabling the flag, both `app#test` and `lib#test` can be task entrypoints. With the flag enabled, only `app#test` is an entrypoint. Its configured dependencies, including scriptless transit tasks needed for ordering and hashing, remain in the graph.

### Scriptless orchestration reaches runnable work

Given this configuration:

```jsonc
{
  "tasks": {
    "package-checks": {
      "dependsOn": ["package:types"]
    },
    "package:types": {}
  }
}
```

If only `pkg-a` defines a `package:types` command, then:

```console
$ turbo run package-checks --dry
```

retains `pkg-a#package-checks -> pkg-a#package:types` and removes package branches that cannot reach runnable work. If no package defines a command anywhere in the requested graph, the fully scriptless orchestration graph is preserved.

### Filters do not manufacture missing entrypoints

If `@repo/types` has no `test` command:

```console
$ turbo run test --filter=@repo/types --dry
```

selects no tasks. Explicit dependency traversal can still cross a missing requested task:

```console
$ turbo run test --filter=@repo/types... --dry
```

and retain runnable dependencies reached through it.

## Testing
- `cargo lint`
- `cargo fmt --all -- --check`
- `cargo check -p turborepo-lib -p turborepo-engine -p turbo --tests`
- `cargo test -p turborepo-lib run::task_filter::tests`
- `cargo test -p turbo --test task_entrypoints_test`
- `cargo test -p turbo --test cargo_workspace_test cargo_verification`
- `pnpm --filter @turbo/types verify-schema`
- local-binary dry runs for `test`, `package-checks`, `package:types`, `topo`, `quality`, and filtered mixed-task runs