### PR TITLE
fix: Second order command injection in validate trimmedDirectory

### DIFF
--- a/packages/turbo-utils/src/validate-directory.ts
+++ b/packages/turbo-utils/src/validate-directory.ts
@@ -11,11 +11,14 @@ export function validateDirectory(directory: string): {
 } {
   // Basic sanity checks on the provided directory string to prevent
   // unsafe paths from flowing into tooling that invokes git or other CLIs.
+  const trimmedDirectory =
+    typeof directory === "string" ? directory.trim() : "";
   if (
     !directory ||
     typeof directory !== "string" ||
-    directory.trim() === "" ||
-    directory.includes("\0")
+    trimmedDirectory === "" ||
+    directory.includes("\0") ||
+    trimmedDirectory.startsWith("-")
   ) {
     const safeDirectory = typeof directory === "string" ? directory : "";
     return {


### PR DESCRIPTION
some shell commands, like `turbo` link , can execute arbitrary commands if a user provides a malicious URL that starts with `--upload-pack`. This can be used to execute arbitrary code on the server. fixes ensure untrusted path-like values passed to git cannot be interpreted as options, and harden early validation where user input is first accepted.

Best single fix without changing intended functionality:
1. In `packages/turbo-utils/src/examples.ts`, update the `git clone` invocation to insert `--` before positional arguments (`repo` and destination path). This is the canonical way to terminate option parsing in CLI tools and directly mitigates `--upload-pack`/option injection interpretation for subsequent args.
2. In `packages/turbo-utils/src/validate-directory.ts`, strengthen validation to reject directory inputs that **look like git options after normalization** (leading `-` remains already checked on `root`; keep and tighten by rejecting trimmed raw input starting with `-` too). This reduces taint entering downstream code paths and helps cover alert variants sourced from `directory` and `createProject` inputs.


[remote](https://git-scm.com/docs/git-ls-remote/2.22.0#Documentation/git-ls-remote.txt---upload-packltexecgt)
CWE-78
CWE-88