### PR TITLE
refactor: Expose knowledge-backed package scope views

### DIFF
--- a/crates/turborepo-repository/src/change_mapper/mod.rs
+++ b/crates/turborepo-repository/src/change_mapper/mod.rs
@@ -275,18 +275,18 @@ impl<'a, PD: PackageChangeMapper> ChangeMapper<'a, PD> {
             .map(|package| package.name.clone())
             .collect();
         for dependency in directly_changed {
-            let Some(info) = self.pkg_graph.package_info(&dependency) else {
+            let Some(view) = self.pkg_graph.package_view(&dependency) else {
                 continue;
             };
-            let Some(toolchain) = self.pkg_graph.toolchains().get(&info.toolchain) else {
+            let Some(toolchain_id) = view.toolchain() else {
+                continue;
+            };
+            let Some(toolchain) = self.pkg_graph.toolchains().get(toolchain_id) else {
                 continue;
             };
             for affected in toolchain.additional_affected_packages(dependency.as_str()) {
                 let name = PackageName::Other(affected);
-                let Some(info) = self.pkg_graph.package_info(&name) else {
-                    continue;
-                };
-                let Some(path) = info.package_json_path.parent() else {
+                let Some(path) = self.pkg_graph.package_dir(&name) else {
                     continue;
                 };
                 changed_packages

--- a/crates/turborepo-repository/src/change_mapper/package.rs
+++ b/crates/turborepo-repository/src/change_mapper/package.rs
@@ -4,7 +4,9 @@ use wax::{BuildError, Program};
 
 use crate::{
     change_mapper::{AllPackageChangeReason, PackageInclusionReason},
-    package_graph::{PackageGraph, PackageName, WorkspacePackage},
+    package_graph::{
+        PackageGraph, PackageGraphNodeKind, PackageName, PackageNode, WorkspacePackage,
+    },
     package_manager::PackageManager,
 };
 
@@ -61,28 +63,40 @@ impl<'a> DefaultPackageChangeMapper<'a> {
 
 impl PackageChangeMapper for DefaultPackageChangeMapper<'_> {
     fn detect_package(&self, file: &AnchoredSystemPath) -> PackageMapping {
-        for (name, entry) in self.pkg_dep_graph.packages() {
-            if name == &PackageName::Root {
-                continue;
-            }
-            if let Some(package_path) = entry.package_json_path.parent()
-                // A package whose directory is the repo root would vacuously
-                // match every file — the component zip below has nothing to
-                // compare. Only the Root package may claim root-level files,
-                // via the fallback.
-                && package_path.components().next().is_some()
-                && Self::is_file_in_package(file, package_path)
-            {
-                return PackageMapping::Package((
-                    WorkspacePackage {
-                        name: name.clone(),
-                        path: package_path.to_owned(),
-                    },
-                    PackageInclusionReason::FileChanged {
-                        file: file.to_owned(),
-                    },
-                ));
-            }
+        let package = self
+            .pkg_dep_graph
+            .node_views()
+            .filter_map(|(node, view)| {
+                let PackageNode::Workspace(name @ PackageName::Other(_)) = node else {
+                    return None;
+                };
+                let package_path = view.directory()?;
+                (view.kind() == PackageGraphNodeKind::Package
+                    // A package whose directory is the repo root would
+                    // vacuously match every file. Only the Root package may
+                    // claim root-level files, via the fallback.
+                    && package_path.components().next().is_some()
+                    && Self::is_file_in_package(file, package_path))
+                .then_some((name, package_path))
+            })
+            .max_by(|(left_name, left_path), (right_name, right_path)| {
+                left_path
+                    .components()
+                    .count()
+                    .cmp(&right_path.components().count())
+                    .then_with(|| right_name.cmp(left_name))
+            });
+
+        if let Some((name, package_path)) = package {
+            return PackageMapping::Package((
+                WorkspacePackage {
+                    name,
+                    path: package_path.to_owned(),
+                },
+                PackageInclusionReason::FileChanged {
+                    file: file.to_owned(),
+                },
+            ));
         }
 
         PackageMapping::All(AllPackageChangeReason::GlobalDepsChanged {
@@ -195,7 +209,10 @@ mod tests {
     use tempfile::tempdir;
     use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
 
-    use super::{DefaultPackageChangeMapper, GlobalDepsPackageChangeMapper};
+    use super::{
+        DefaultPackageChangeMapper, GlobalDepsPackageChangeMapper, PackageChangeMapper,
+        PackageMapping,
+    };
     use crate::{
         change_mapper::{
             AllPackageChangeReason, ChangeMapper, LockfileContents, PackageChanges,
@@ -225,6 +242,71 @@ mod tests {
         ) -> Result<discovery::DiscoveryResponse, discovery::Error> {
             self.discover_packages().await
         }
+    }
+
+    #[tokio::test]
+    async fn nested_package_owns_its_files() -> Result<(), anyhow::Error> {
+        let repo_root = tempdir()?;
+        let root = AbsoluteSystemPath::from_std_path(repo_root.path())?;
+        let parent_manifest = root.join_components(&["packages", "parent", "package.json"]);
+        let child_manifest = root.join_components(&["packages", "parent", "child", "package.json"]);
+        parent_manifest.ensure_dir()?;
+        parent_manifest.create_with_contents(r#"{"name":"parent"}"#)?;
+        child_manifest.ensure_dir()?;
+        child_manifest.create_with_contents(r#"{"name":"child"}"#)?;
+
+        struct NestedDiscovery {
+            parent_manifest: AbsoluteSystemPathBuf,
+            child_manifest: AbsoluteSystemPathBuf,
+        }
+        impl PackageDiscovery for NestedDiscovery {
+            async fn discover_packages(
+                &self,
+            ) -> Result<discovery::DiscoveryResponse, discovery::Error> {
+                Ok(discovery::DiscoveryResponse {
+                    package_manager: PackageManager::Npm,
+                    // Parent first reproduces the observation order that used
+                    // to make it incorrectly claim the child's files.
+                    workspaces: vec![
+                        discovery::WorkspaceData {
+                            package_json: self.parent_manifest.clone(),
+                            turbo_json: None,
+                        },
+                        discovery::WorkspaceData {
+                            package_json: self.child_manifest.clone(),
+                            turbo_json: None,
+                        },
+                    ],
+                })
+            }
+
+            async fn discover_packages_blocking(
+                &self,
+            ) -> Result<discovery::DiscoveryResponse, discovery::Error> {
+                self.discover_packages().await
+            }
+        }
+
+        let graph = PackageGraphBuilder::new(root, PackageJson::default())
+            .with_package_discovery(NestedDiscovery {
+                parent_manifest,
+                child_manifest,
+            })
+            .build()
+            .await?;
+        let file = AnchoredSystemPathBuf::from_raw(
+            ["packages", "parent", "child", "src", "index.ts"].join(std::path::MAIN_SEPARATOR_STR),
+        )?;
+
+        let PackageMapping::Package((package, _)) =
+            DefaultPackageChangeMapper::new(&graph).detect_package(&file)
+        else {
+            panic!("expected a package mapping");
+        };
+        assert_eq!(package.name.as_ref(), "child");
+        assert_eq!(package.path.to_unix().as_str(), "packages/parent/child");
+
+        Ok(())
     }
 
     /// A package whose directory is the repository root must never claim

--- a/crates/turborepo-repository/src/knowledge.rs
+++ b/crates/turborepo-repository/src/knowledge.rs
@@ -157,6 +157,10 @@ impl RepositoryKnowledge {
             .filter(|scope| scope.kind == ScopeKind::Aggregate)
     }
 
+    pub(crate) fn scopes(&self) -> impl Iterator<Item = &ScopeKnowledge> {
+        self.scopes.iter()
+    }
+
     pub(crate) fn scope(&self, identity: &str) -> Option<&ScopeKnowledge> {
         self.scope_lookup
             .get(identity)

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -835,7 +835,11 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
         &mut self,
         package_manager: Option<&PackageManager>,
     ) -> Result<(), Error> {
-        let path_index = WorkspacePathIndex::new(&self.assembler.workspaces);
+        let knowledge = self
+            .knowledge
+            .as_deref()
+            .ok_or(Error::MissingRepositoryKnowledge)?;
+        let path_index = WorkspacePathIndex::from_knowledge(knowledge);
         // Compute once — for pnpm/Berry this reads a config file from disk.
         // Without hoisting, the par_iter below would redundantly read the
         // same file N times (once per workspace). A pure Cargo workspace has
@@ -1017,13 +1021,31 @@ pub type ClosureHasher = Arc<
         + Sync,
 >;
 
+fn scope_directory_and_toolchain<'a>(
+    knowledge: &'a RepositoryKnowledge,
+    name: &PackageName,
+) -> Option<(&'a AnchoredSystemPath, &'a ToolchainId)> {
+    match name {
+        PackageName::Root => knowledge
+            .root_javascript_scope()
+            .map(|scope| (knowledge.repository_directory(), scope.toolchain())),
+        PackageName::Other(name) => knowledge
+            .scope(name)
+            .map(|scope| (scope.directory(), scope.toolchain())),
+    }
+}
+
 impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
     fn all_external_dependencies(
         &self,
     ) -> Result<HashMap<String, BTreeMap<String, String>>, Error> {
+        let knowledge = self
+            .knowledge
+            .as_deref()
+            .ok_or(Error::MissingRepositoryKnowledge)?;
         self.assembler
             .workspaces
-            .values()
+            .iter()
             // Only JavaScript packages participate in the JS lockfile's
             // external-dependency closures. This map is keyed by directory,
             // and a non-JS package can share a directory with a JS one (the
@@ -1031,13 +1053,12 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             // the root package) — including both would let HashMap iteration
             // order decide which entry survives, flipping the root's
             // external-dependency hash run to run.
-            .filter(|entry| entry.toolchain == ToolchainId::JAVASCRIPT)
-            .map(|entry| {
-                let workspace_path = entry
-                    .package_json_path
-                    .parent()
-                    .unwrap_or(AnchoredSystemPath::new("")?)
-                    .to_unix();
+            .filter_map(|(name, entry)| {
+                let (directory, toolchain) = scope_directory_and_toolchain(knowledge, name)?;
+                (toolchain == &ToolchainId::JAVASCRIPT).then_some((directory, entry))
+            })
+            .map(|(directory, entry)| {
+                let workspace_path = directory.to_unix();
                 let workspace_string = workspace_path.as_str();
                 let external_deps = entry
                     .unresolved_external_dependencies
@@ -1071,14 +1092,22 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             .as_ref()
             .map(|hasher| hasher(&closures))
             .unwrap_or_default();
-        for entry in self.assembler.workspaces.values_mut() {
+        let knowledge = self
+            .knowledge
+            .as_deref()
+            .ok_or(Error::MissingRepositoryKnowledge)?;
+        for (name, entry) in &mut self.assembler.workspaces {
             // Mirror of the filter in all_external_dependencies: a non-JS
             // package sharing a directory with a JS package must not steal
             // its closure.
-            if entry.toolchain != ToolchainId::JAVASCRIPT {
+            let Some((directory, toolchain)) = scope_directory_and_toolchain(knowledge, name)
+            else {
+                continue;
+            };
+            if toolchain != &ToolchainId::JAVASCRIPT {
                 continue;
             }
-            let dir = entry.unix_dir_str()?;
+            let dir = directory.to_unix().to_string();
             entry.transitive_dependencies = closures.remove(&dir);
             entry.external_deps_hash = hashes.remove(&dir);
         }
@@ -1242,17 +1271,6 @@ impl Dependencies {
     }
 }
 
-impl PackageInfo {
-    fn unix_dir_str(&self) -> Result<String, Error> {
-        let unix = self
-            .package_json_path
-            .parent()
-            .unwrap_or_else(|| AnchoredSystemPath::new("").expect("empty path is anchored"))
-            .to_unix();
-        Ok(unix.to_string())
-    }
-}
-
 #[cfg(test)]
 mod test {
     use std::collections::HashMap;
@@ -1404,6 +1422,53 @@ mod test {
                 PackageNode::Workspace(PackageName::Root),
                 "the graph sentinel and root execution scope node are distinct"
             );
+            assert_eq!(graph.root_javascript_scope_name(), Some(root_name));
+            let sentinel = graph
+                .node_view(&PackageNode::Root)
+                .expect("the graph sentinel is always present");
+            assert_eq!(
+                sentinel.kind(),
+                super::super::PackageGraphNodeKind::GraphSentinel
+            );
+            assert_eq!(sentinel.directory(), None);
+            assert_eq!(sentinel.definition_path(), None);
+            assert_eq!(sentinel.toolchain(), None);
+
+            let root_view = graph
+                .node_view(&PackageNode::Workspace(PackageName::Root))
+                .expect("a package.json contributes the root JavaScript scope");
+            assert_eq!(
+                root_view.kind(),
+                super::super::PackageGraphNodeKind::RootJavaScript
+            );
+            assert_eq!(
+                root_view.directory(),
+                Some(knowledge.repository_directory())
+            );
+            assert_eq!(
+                root_view
+                    .definition_path()
+                    .map(|path| path.to_unix().to_string()),
+                Some("package.json".to_string())
+            );
+            assert_eq!(root_view.toolchain(), Some(&ToolchainId::JAVASCRIPT));
+
+            let app_view = graph
+                .node_view(&PackageNode::Workspace(PackageName::from("app")))
+                .expect("the real package has an authoritative view");
+            assert_eq!(app_view.kind(), super::super::PackageGraphNodeKind::Package);
+            assert_eq!(
+                app_view.directory().map(|path| path.to_unix().to_string()),
+                Some("apps/app".to_string())
+            );
+            assert_eq!(
+                app_view
+                    .definition_path()
+                    .map(|path| path.to_unix().to_string()),
+                Some("apps/app/package.json".to_string())
+            );
+            assert_eq!(app_view.toolchain(), Some(&ToolchainId::JAVASCRIPT));
+            assert_eq!(graph.node_views().count(), 4);
 
             for package in knowledge.packages() {
                 let graph_name = PackageName::from(package.identity());

--- a/crates/turborepo-repository/src/package_graph/dep_splitter.rs
+++ b/crates/turborepo-repository/src/package_graph/dep_splitter.rs
@@ -6,7 +6,7 @@ use turbopath::{
 };
 
 use super::{PackageInfo, PackageName};
-use crate::package_manager::pnpm::PnpmCatalogs;
+use crate::{knowledge::RepositoryKnowledge, package_manager::pnpm::PnpmCatalogs};
 
 /// Reverse index from package path to package name, built once and shared
 /// across all `DependencySplitter` instances.
@@ -15,15 +15,44 @@ use crate::package_manager::pnpm::PnpmCatalogs;
 /// specifiers can never target them, and the synthetic Cargo workspace
 /// package lives at the repo root, which would otherwise collide with the
 /// Root package's path.
-pub struct WorkspacePathIndex<'a>(HashMap<&'a AnchoredSystemPath, &'a PackageName>);
+pub struct WorkspacePathIndex<'a>(HashMap<&'a AnchoredSystemPath, PackageName>);
 
 impl<'a> WorkspacePathIndex<'a> {
+    #[cfg(test)]
     pub fn new(workspaces: &'a HashMap<PackageName, PackageInfo>) -> Self {
         Self(
             workspaces
                 .iter()
                 .filter(|(_, info)| info.toolchain == crate::toolchain::ToolchainId::JAVASCRIPT)
-                .map(|(name, info)| (info.package_path(), name))
+                .map(|(name, info)| (info.package_path(), name.clone()))
+                .collect(),
+        )
+    }
+
+    /// Builds the production index from authoritative package/scope paths and
+    /// provenance rather than compatibility `PackageInfo` fields.
+    pub(crate) fn from_knowledge(knowledge: &'a RepositoryKnowledge) -> Self {
+        let root = knowledge.root_javascript_scope().map(|scope| {
+            (
+                knowledge.repository_directory(),
+                PackageName::Root,
+                scope.toolchain(),
+            )
+        });
+        let scopes = knowledge.scopes().map(|scope| {
+            (
+                scope.directory(),
+                PackageName::Other(scope.identity().to_string()),
+                scope.toolchain(),
+            )
+        });
+        Self(
+            root.into_iter()
+                .chain(scopes)
+                .filter(|(_, _, toolchain)| {
+                    *toolchain == &crate::toolchain::ToolchainId::JAVASCRIPT
+                })
+                .map(|(directory, name, _)| (directory, name))
                 .collect(),
         )
     }

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -184,6 +184,49 @@ impl PackageNode {
     }
 }
 
+/// The role of an identity-bearing scope or structural node in the package
+/// graph. In particular, the graph sentinel and the root JavaScript execution
+/// scope are separate nodes even though both have historically been called
+/// "root".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PackageGraphNodeKind {
+    Package,
+    Aggregate,
+    RootJavaScript,
+    GraphSentinel,
+}
+
+/// Manifest-independent facts about a package graph node.
+///
+/// Paths and provenance come from the graph's immutable repository knowledge,
+/// not from the [`PackageInfo`] compatibility projection. The graph sentinel
+/// has no directory, native definition, or toolchain provenance.
+#[derive(Debug, Clone, Copy)]
+pub struct PackageGraphNodeView<'a> {
+    kind: PackageGraphNodeKind,
+    directory: Option<&'a AnchoredSystemPath>,
+    definition_path: Option<&'a AnchoredSystemPath>,
+    toolchain: Option<&'a crate::toolchain::ToolchainId>,
+}
+
+impl<'a> PackageGraphNodeView<'a> {
+    pub fn kind(&self) -> PackageGraphNodeKind {
+        self.kind
+    }
+
+    pub fn directory(&self) -> Option<&'a AnchoredSystemPath> {
+        self.directory
+    }
+
+    pub fn definition_path(&self) -> Option<&'a AnchoredSystemPath> {
+        self.definition_path
+    }
+
+    pub fn toolchain(&self) -> Option<&'a crate::toolchain::ToolchainId> {
+        self.toolchain
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct ExternalDependencyChange {
     pub package: WorkspacePackage,
@@ -405,6 +448,77 @@ impl PackageGraph {
             .map(|scope| scope.user_facing_name())
     }
 
+    /// Looks up manifest-independent facts for an identity-bearing scope or
+    /// the structural graph sentinel. In a pure Cargo repository,
+    /// `Workspace(Root)` has no corresponding scope and therefore returns
+    /// `None`; `Root` still returns the graph sentinel view.
+    pub fn node_view(&self, node: &PackageNode) -> Option<PackageGraphNodeView<'_>> {
+        match node {
+            PackageNode::Root => Some(PackageGraphNodeView {
+                kind: PackageGraphNodeKind::GraphSentinel,
+                directory: None,
+                definition_path: None,
+                toolchain: None,
+            }),
+            PackageNode::Workspace(package) => self.package_view(package),
+        }
+    }
+
+    /// Looks up manifest-independent facts for a compatibility package
+    /// identity. Unlike [`Self::package_dir`], this returns `None` for the
+    /// synthetic root workspace when no root JavaScript scope exists.
+    pub fn package_view(&self, package: &PackageName) -> Option<PackageGraphNodeView<'_>> {
+        match package {
+            PackageName::Root => {
+                let scope = self.knowledge.root_javascript_scope()?;
+                Some(PackageGraphNodeView {
+                    kind: PackageGraphNodeKind::RootJavaScript,
+                    directory: Some(self.knowledge.repository_directory()),
+                    definition_path: Some(scope.definition_path()),
+                    toolchain: Some(scope.toolchain()),
+                })
+            }
+            PackageName::Other(name) => {
+                let scope = self.knowledge.scope(name)?;
+                let kind = match scope.kind() {
+                    crate::knowledge::ScopeKind::Package => PackageGraphNodeKind::Package,
+                    crate::knowledge::ScopeKind::Aggregate => PackageGraphNodeKind::Aggregate,
+                };
+                Some(PackageGraphNodeView {
+                    kind,
+                    directory: Some(scope.directory()),
+                    definition_path: Some(scope.definition_path()),
+                    toolchain: Some(scope.toolchain()),
+                })
+            }
+        }
+    }
+
+    /// Iterates the structural graph sentinel followed by every authoritative
+    /// execution scope. The root JavaScript scope is omitted when no root
+    /// `package.json` exists.
+    pub fn node_views(&self) -> impl Iterator<Item = (PackageNode, PackageGraphNodeView<'_>)> + '_ {
+        std::iter::once((PackageNode::Root, self.node_view(&PackageNode::Root)))
+            .chain(std::iter::once((
+                PackageNode::Workspace(PackageName::Root),
+                self.node_view(&PackageNode::Workspace(PackageName::Root)),
+            )))
+            .chain(self.knowledge.scopes().map(|scope| {
+                let node = PackageNode::Workspace(PackageName::Other(scope.identity().to_string()));
+                let view = PackageGraphNodeView {
+                    kind: match scope.kind() {
+                        crate::knowledge::ScopeKind::Package => PackageGraphNodeKind::Package,
+                        crate::knowledge::ScopeKind::Aggregate => PackageGraphNodeKind::Aggregate,
+                    },
+                    directory: Some(scope.directory()),
+                    definition_path: Some(scope.definition_path()),
+                    toolchain: Some(scope.toolchain()),
+                };
+                (node, Some(view))
+            }))
+            .filter_map(|(node, view)| view.map(|view| (node, view)))
+    }
+
     /// User-facing identities of real packages, excluding root and aggregate
     /// execution scopes.
     pub fn real_package_names(&self) -> impl Iterator<Item = &str> {
@@ -421,16 +535,7 @@ impl PackageGraph {
     /// Native definition path for a package or execution scope. A pure Cargo
     /// repository's compatibility root node has no native definition.
     pub fn package_definition_path(&self, package: &PackageName) -> Option<&AnchoredSystemPath> {
-        match package {
-            PackageName::Root => self
-                .knowledge
-                .root_javascript_scope()
-                .map(|scope| scope.definition_path()),
-            PackageName::Other(name) => self
-                .knowledge
-                .scope(name)
-                .map(|scope| scope.definition_path()),
-        }
+        self.package_view(package)?.definition_path()
     }
 
     /// Toolchain provenance for a package or execution scope.
@@ -438,38 +543,20 @@ impl PackageGraph {
         &self,
         package: &PackageName,
     ) -> Option<&crate::toolchain::ToolchainId> {
-        match package {
-            PackageName::Root => self
-                .knowledge
-                .root_javascript_scope()
-                .map(|scope| scope.toolchain()),
-            PackageName::Other(name) => self.knowledge.scope(name).map(|scope| scope.toolchain()),
-        }
+        self.package_view(package)?.toolchain()
     }
 
     /// Whether this identity represents a real package rather than an
     /// execution-only scope.
     pub fn is_real_package(&self, package: &PackageName) -> bool {
-        matches!(
-            package,
-            PackageName::Other(name)
-                if self
-                    .knowledge
-                    .scope(name)
-                    .is_some_and(|scope| scope.kind() == crate::knowledge::ScopeKind::Package)
-        )
+        self.package_view(package)
+            .is_some_and(|view| view.kind() == PackageGraphNodeKind::Package)
     }
 
     /// Whether this identity represents a non-package aggregate scope.
     pub fn is_aggregate_scope(&self, package: &PackageName) -> bool {
-        matches!(
-            package,
-            PackageName::Other(name)
-                if self
-                    .knowledge
-                    .scope(name)
-                    .is_some_and(|scope| scope.kind() == crate::knowledge::ScopeKind::Aggregate)
-        )
+        self.package_view(package)
+            .is_some_and(|view| view.kind() == PackageGraphNodeKind::Aggregate)
     }
 
     pub fn lockfile(&self) -> Option<&dyn Lockfile> {
@@ -494,15 +581,27 @@ impl PackageGraph {
                 mut closures,
                 mut hashes,
             })) => {
-                for info in self.packages.values_mut() {
+                let knowledge = &self.knowledge;
+                for (name, info) in &mut self.packages {
                     // Mirror of the filter in the inline path
                     // (`populate_transitive_dependencies`): a non-JS package
                     // sharing a directory with a JS package must not steal
                     // its closure.
-                    if info.toolchain != crate::toolchain::ToolchainId::JAVASCRIPT {
+                    let facts = match name {
+                        PackageName::Root => knowledge
+                            .root_javascript_scope()
+                            .map(|scope| (knowledge.repository_directory(), scope.toolchain())),
+                        PackageName::Other(name) => knowledge
+                            .scope(name)
+                            .map(|scope| (scope.directory(), scope.toolchain())),
+                    };
+                    let Some((directory, toolchain)) = facts else {
+                        continue;
+                    };
+                    if toolchain != &crate::toolchain::ToolchainId::JAVASCRIPT {
                         continue;
                     }
-                    let dir = info.package_path().to_unix();
+                    let dir = directory.to_unix();
                     info.transitive_dependencies = closures.remove(dir.as_str());
                     info.external_deps_hash = hashes.remove(dir.as_str());
                 }
@@ -523,8 +622,11 @@ impl PackageGraph {
 
     pub fn package_dir(&self, package: &PackageName) -> Option<&AnchoredSystemPath> {
         match package {
+            // Compatibility: the synthetic root workspace has historically
+            // had the repository directory even when no JavaScript scope
+            // exists. `node_view` is the API that distinguishes those cases.
             PackageName::Root => Some(self.knowledge.repository_directory()),
-            PackageName::Other(name) => self.knowledge.scope(name).map(|scope| scope.directory()),
+            PackageName::Other(_) => self.package_view(package)?.directory(),
         }
     }
 
@@ -826,15 +928,15 @@ impl PackageGraph {
 
         let external_deps = self
             .packages()
-            .filter_map(|(_name, info)| {
-                info.unresolved_external_dependencies.as_ref().map(|dep| {
-                    (
-                        info.package_path().to_unix().to_string(),
-                        dep.iter()
-                            .map(|(name, version)| (name.to_owned(), version.to_owned()))
-                            .collect(),
-                    )
-                })
+            .filter_map(|(name, info)| {
+                let dep = info.unresolved_external_dependencies.as_ref()?;
+                let directory = self.package_dir(name)?;
+                Some((
+                    directory.to_unix().to_string(),
+                    dep.iter()
+                        .map(|(name, version)| (name.to_owned(), version.to_owned()))
+                        .collect(),
+                ))
             })
             .collect::<HashMap<_, BTreeMap<_, _>>>();
 
@@ -854,7 +956,8 @@ impl PackageGraph {
             self.packages
                 .iter()
                 .filter_map(|(name, info)| {
-                    let previous_closure = closures.get(info.package_path().to_unix().as_str());
+                    let package_dir = self.package_dir(name)?;
+                    let previous_closure = closures.get(package_dir.to_unix().as_str());
                     // Both closures are sorted by (key, version), so `Vec`
                     // equality is set equality here.
                     let not_equal = previous_closure != info.transitive_dependencies.as_ref();
@@ -883,17 +986,17 @@ impl PackageGraph {
                             .map(|pkg| (*pkg).clone())
                             .sorted()
                             .collect::<Vec<_>>();
-                        Some((name, info, added, removed))
+                        Some((name, package_dir, added, removed))
                     } else {
                         None
                     }
                 })
-                .map(|(name, info, added, removed)| match name {
+                .map(|(name, package_dir, added, removed)| match name {
                     PackageName::Other(n) => {
                         let w_name = PackageName::Other(n.to_owned());
                         let package = WorkspacePackage {
                             name: w_name.clone(),
-                            path: info.package_path().to_owned(),
+                            path: package_dir.to_owned(),
                         };
                         Some(ExternalDependencyChange {
                             package,
@@ -911,16 +1014,17 @@ impl PackageGraph {
         Ok(changed.unwrap_or_else(|| {
             self.packages
                 .iter()
-                .map(|(name, info)| {
+                .filter_map(|(name, _info)| {
+                    let path = self.package_dir(name)?.to_owned();
                     let package = WorkspacePackage {
                         name: name.clone(),
-                        path: info.package_path().to_owned(),
+                        path,
                     };
-                    ExternalDependencyChange {
+                    Some(ExternalDependencyChange {
                         package,
                         added: Vec::new(),
                         removed: Vec::new(),
-                    }
+                    })
                 })
                 .collect()
         }))
@@ -2082,6 +2186,26 @@ version = "0.1.0"
             );
             assert_eq!(cargo_app.toolchain(), &crate::toolchain::ToolchainId::RUST);
             assert_eq!(cargo_app.kind(), crate::knowledge::ScopeKind::Package);
+            let cargo_app_view = pkg_graph
+                .package_view(&PackageName::from("app"))
+                .expect("Cargo contributes a real package");
+            assert_eq!(cargo_app_view.kind(), PackageGraphNodeKind::Package);
+            assert_eq!(
+                cargo_app_view
+                    .directory()
+                    .map(|path| path.to_unix().to_string()),
+                Some("rust/app".to_string())
+            );
+            assert_eq!(
+                cargo_app_view
+                    .definition_path()
+                    .map(|path| path.to_unix().to_string()),
+                Some("rust/app/Cargo.toml".to_string())
+            );
+            assert_eq!(
+                cargo_app_view.toolchain(),
+                Some(&crate::toolchain::ToolchainId::RUST)
+            );
             let cargo_workspace = knowledge
                 .scope("acme")
                 .expect("Cargo workspace compatibility package is an aggregate scope");
@@ -2097,6 +2221,20 @@ version = "0.1.0"
             assert_eq!(
                 pkg_graph.package_dir(&PackageName::from("acme")),
                 Some(cargo_workspace.directory())
+            );
+            let cargo_workspace_view = pkg_graph
+                .node_view(&PackageNode::Workspace(PackageName::from("acme")))
+                .expect("Cargo contributes an aggregate execution scope");
+            assert_eq!(cargo_workspace_view.kind(), PackageGraphNodeKind::Aggregate);
+            assert_eq!(
+                cargo_workspace_view
+                    .definition_path()
+                    .map(|path| path.to_unix().to_string()),
+                Some("Cargo.toml".to_string())
+            );
+            assert_eq!(
+                cargo_workspace_view.toolchain(),
+                Some(&crate::toolchain::ToolchainId::RUST)
             );
 
             // Crate path dependencies became graph edges.
@@ -2173,6 +2311,23 @@ version = "0.1.0"
         assert!(!pkg_graph.has_root_javascript_scope());
         assert_eq!(pkg_graph.package_definition_path(&PackageName::Root), None);
         assert_eq!(pkg_graph.package_toolchain(&PackageName::Root), None);
+        assert!(
+            pkg_graph
+                .node_view(&PackageNode::Workspace(PackageName::Root))
+                .is_none(),
+            "the compatibility root workspace is not a JavaScript scope"
+        );
+        assert_eq!(
+            pkg_graph
+                .node_view(&PackageNode::Root)
+                .map(|view| view.kind()),
+            Some(PackageGraphNodeKind::GraphSentinel)
+        );
+        assert!(
+            pkg_graph
+                .node_views()
+                .all(|(_, view)| view.kind() != PackageGraphNodeKind::RootJavaScript)
+        );
         assert!(
             pkg_graph
                 .repository_knowledge()

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -1013,8 +1013,8 @@ impl PackageGraph {
 
         Ok(changed.unwrap_or_else(|| {
             self.packages
-                .iter()
-                .filter_map(|(name, _info)| {
+                .keys()
+                .filter_map(|name| {
                     let path = self.package_dir(name)?.to_owned();
                     let package = WorkspacePackage {
                         name: name.clone(),


### PR DESCRIPTION
### Description

Part 1 of the package/scope knowledge completion stack.

Expose manifest-independent graph views for real packages, aggregate scopes, the root JavaScript scope, and the graph sentinel. Repository-owned path indexing, closure attribution, and change mapping now use those views, including deterministic deepest-package ownership.

### Testing Instructions

- `cargo test -p turborepo-repository`
- `cargo lint`