### PR TITLE
refactor: Use package knowledge for run scope enumeration

### DIFF
--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -1331,12 +1331,12 @@ impl RunBuilder {
             let toolchain_id = toolchain.id();
             let candidate_names: Vec<_> = candidates
                 .iter()
-                .filter_map(|name| {
+                .filter(|name| {
                     pkg_dep_graph
                         .package_toolchain(name)
                         .is_some_and(|candidate_toolchain| candidate_toolchain == &toolchain_id)
-                        .then(|| name.as_str().to_string())
                 })
+                .map(|name| name.as_str().to_string())
                 .collect();
             let prefer_workspace = match filter_mode {
                 FilterMode::AllPackages => true,
@@ -1352,12 +1352,12 @@ impl RunBuilder {
             exclusions.extend(
                 exclusion_candidates
                     .iter()
-                    .filter_map(|name| {
+                    .filter(|name| {
                         pkg_dep_graph
                             .package_toolchain(name)
                             .is_some_and(|candidate_toolchain| candidate_toolchain == &toolchain_id)
-                            .then(|| name.as_str().to_string())
                     })
+                    .map(|name| name.as_str().to_string())
                     .filter(|name| !selected.contains(name))
                     .map(|name| TaskId::new(&name, task.task()).into_owned()),
             );

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -344,8 +344,10 @@ impl RunBuilder {
     /// - **No filter** (`AllPackages`): root tasks defined in `turbo.json` are
     ///   included automatically.
     /// - **Exclude-only** (`ExcludeOnly`): semantically "all packages minus
-    ///   excluded ones" — root tasks are still included unless the root package
-    ///   itself was explicitly excluded (e.g. `--filter=!//`).
+    ///   excluded ones" — root tasks are still included unless the root Turbo
+    ///   namespace itself was explicitly excluded (e.g. `--filter=!//` or
+    ///   `--filter=!{.}`). Root-directory syntax addresses this namespace even
+    ///   when no root JavaScript package exists.
     /// - **Explicit selection** (`ExplicitSelection`): the user opted into
     ///   specific packages — root tasks are not auto-injected.
     ///
@@ -819,10 +821,21 @@ impl RunBuilder {
                 &root_turbo_json,
             )?
         };
+        // The root Turbo task namespace exists independently of a root
+        // JavaScript package scope. Non-root namespaces, including aggregate
+        // scopes, come from authoritative repository knowledge.
+        let task_namespace_packages: Vec<_> = std::iter::once(PackageName::Root)
+            .chain(
+                pkg_dep_graph
+                    .package_scope_directories()
+                    .map(|(name, _)| name)
+                    .filter(|name| name != &PackageName::Root),
+            )
+            .collect();
         let mut scoped_entrypoint_exclusions = self.task_entrypoint_exclusions(
             &pkg_dep_graph,
             unqualified_entrypoint_packages.iter(),
-            pkg_dep_graph.packages().map(|(name, _)| name),
+            task_namespace_packages.iter(),
             &filter_mode,
         );
         let explicitly_requested_tasks: HashSet<_> = self
@@ -870,10 +883,7 @@ impl RunBuilder {
         // by package-level scope resolution can still be matched. The
         // task-level filter (below) does the pruning when needed.
         let all_pkgs: Vec<PackageName> = if needs_all_packages {
-            pkg_dep_graph
-                .packages()
-                .map(|(name, _)| name.clone())
-                .collect()
+            task_namespace_packages
         } else {
             Vec::new()
         };
@@ -1323,9 +1333,9 @@ impl RunBuilder {
                 .iter()
                 .filter_map(|name| {
                     pkg_dep_graph
-                        .package_info(name)
-                        .filter(|info| info.toolchain == toolchain_id)
-                        .map(|_| name.as_str().to_string())
+                        .package_toolchain(name)
+                        .is_some_and(|candidate_toolchain| candidate_toolchain == &toolchain_id)
+                        .then(|| name.as_str().to_string())
                 })
                 .collect();
             let prefer_workspace = match filter_mode {
@@ -1344,9 +1354,9 @@ impl RunBuilder {
                     .iter()
                     .filter_map(|name| {
                         pkg_dep_graph
-                            .package_info(name)
-                            .filter(|info| info.toolchain == toolchain_id)
-                            .map(|_| name.as_str().to_string())
+                            .package_toolchain(name)
+                            .is_some_and(|candidate_toolchain| candidate_toolchain == &toolchain_id)
+                            .then(|| name.as_str().to_string())
                     })
                     .filter(|name| !selected.contains(name))
                     .map(|name| TaskId::new(&name, task.task()).into_owned()),

--- a/crates/turborepo-lib/src/run/task_filter.rs
+++ b/crates/turborepo-lib/src/run/task_filter.rs
@@ -309,19 +309,23 @@ fn find_matching_packages(
             if parent_dir.as_str() == "." {
                 packages.insert(PackageName::Root);
             } else {
-                for (name, info) in pkg_dep_graph.packages() {
-                    if globber.is_match(info.package_path().as_path()) {
-                        packages.insert(name.clone());
+                for (name, directory) in pkg_dep_graph.package_scope_directories() {
+                    if globber.is_match(directory.as_path()) {
+                        packages.insert(name);
                     }
                 }
             }
         }
     } else {
-        // Start with all packages when only name pattern is used
-        packages = pkg_dep_graph
-            .packages()
-            .map(|(name, _)| name.clone())
-            .collect();
+        // Root is also a Turbo task namespace even when there is no root
+        // JavaScript package. Keep it available for name matching without
+        // pretending that it owns the repository directory.
+        packages.insert(PackageName::Root);
+        packages.extend(
+            pkg_dep_graph
+                .package_scope_directories()
+                .map(|(name, _)| name),
+        );
     }
 
     // Name pattern matching
@@ -655,6 +659,83 @@ mod tests {
             command: Some(TaskCommandOverride::Argv(vec!["run".to_string()])),
             ..Default::default()
         }
+    }
+
+    #[tokio::test]
+    async fn package_matching_uses_scope_names_and_directories() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
+        let pkg_graph = make_pkg_graph(root, &["web", "api"]).await;
+
+        let packages = super::find_matching_packages(
+            &turborepo_scope::TargetSelector {
+                parent_dir: Some(AnchoredSystemPathBuf::from_raw("packages/*").unwrap()),
+                ..Default::default()
+            },
+            &pkg_graph,
+        );
+        assert_eq!(
+            packages,
+            HashSet::from([PackageName::from("web"), PackageName::from("api")])
+        );
+
+        let root_directory = super::find_matching_packages(
+            &turborepo_scope::TargetSelector {
+                parent_dir: Some(AnchoredSystemPathBuf::from_raw(".").unwrap()),
+                ..Default::default()
+            },
+            &pkg_graph,
+        );
+        assert_eq!(root_directory, HashSet::from([PackageName::Root]));
+
+        let root_namespace = super::find_matching_packages(
+            &turborepo_scope::TargetSelector {
+                name_pattern: "//".to_string(),
+                ..Default::default()
+            },
+            &pkg_graph,
+        );
+        assert_eq!(root_namespace, HashSet::from([PackageName::Root]));
+    }
+
+    #[tokio::test]
+    async fn native_only_matching_keeps_root_namespace_without_root_package() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
+        let pkg_graph = PackageGraph::builder_optional(root, None)
+            .with_package_discovery(MockDiscovery)
+            .with_package_jsons(Some(HashMap::new()))
+            .build()
+            .await
+            .unwrap();
+
+        assert!(!pkg_graph.has_root_javascript_scope());
+
+        let root_directory = super::find_matching_packages(
+            &turborepo_scope::TargetSelector {
+                parent_dir: Some(AnchoredSystemPathBuf::from_raw(".").unwrap()),
+                ..Default::default()
+            },
+            &pkg_graph,
+        );
+        assert_eq!(
+            root_directory,
+            HashSet::from([PackageName::Root]),
+            "{{.}} selects the root Turbo namespace without a root package"
+        );
+
+        let root_namespace = super::find_matching_packages(
+            &turborepo_scope::TargetSelector {
+                name_pattern: "//".to_string(),
+                ..Default::default()
+            },
+            &pkg_graph,
+        );
+        assert_eq!(
+            root_namespace,
+            HashSet::from([PackageName::Root]),
+            "root Turbo tasks remain addressable without a root package"
+        );
     }
 
     #[tokio::test]

--- a/crates/turborepo-scope/src/change_detector.rs
+++ b/crates/turborepo-scope/src/change_detector.rs
@@ -18,6 +18,27 @@ use turborepo_scm::{Error as ScmError, SCM, git::InvalidRange};
 
 use crate::ResolutionError;
 
+/// Expands an all-packages change to the root Turbo task namespace and every
+/// authoritative non-root execution scope.
+///
+/// The root namespace exists even when a pure native repository has no root
+/// JavaScript package. Package and aggregate identities still come exclusively
+/// from repository knowledge.
+pub(crate) fn all_package_changes(
+    pkg_graph: &PackageGraph,
+    reason: AllPackageChangeReason,
+) -> HashMap<PackageName, PackageInclusionReason> {
+    std::iter::once(PackageName::Root)
+        .chain(
+            pkg_graph
+                .package_scope_directories()
+                .map(|(name, _)| name)
+                .filter(|name| name != &PackageName::Root),
+        )
+        .map(|name| (name, PackageInclusionReason::All(reason.clone())))
+        .collect()
+}
+
 /// Given two git refs, determine which packages have changed between them.
 pub trait GitChangeDetector {
     /// Determine which packages have changed between two git refs.
@@ -119,37 +140,22 @@ impl<'a> GitChangeDetector for ScopeChangeDetector<'a> {
             Ok(Ok(changed_files)) => changed_files,
             Ok(Err(InvalidRange { from_ref, to_ref })) => {
                 debug!("invalid ref range, defaulting to all packages changed");
-                return Ok(self
-                    .pkg_graph
-                    .packages()
-                    .map(|(name, _)| {
-                        (
-                            name.to_owned(),
-                            PackageInclusionReason::All(AllPackageChangeReason::GitRefNotFound {
-                                from_ref: from_ref.clone(),
-                                to_ref: to_ref.clone(),
-                            }),
-                        )
-                    })
-                    .collect());
+                return Ok(all_package_changes(
+                    self.pkg_graph,
+                    AllPackageChangeReason::GitRefNotFound { from_ref, to_ref },
+                ));
             }
             Err(ScmError::Path(err, _)) => {
                 warn!(
                     "SCM path error while detecting changed files: {err}. Defaulting to all \
                      packages changed."
                 );
-                return Ok(self
-                    .pkg_graph
-                    .packages()
-                    .map(|(name, _)| {
-                        (
-                            name.to_owned(),
-                            PackageInclusionReason::All(AllPackageChangeReason::ScmError {
-                                error: err.to_string(),
-                            }),
-                        )
-                    })
-                    .collect());
+                return Ok(all_package_changes(
+                    self.pkg_graph,
+                    AllPackageChangeReason::ScmError {
+                        error: err.to_string(),
+                    },
+                ));
             }
             Err(err) => return Err(err.into()),
         };
@@ -167,11 +173,7 @@ impl<'a> GitChangeDetector for ScopeChangeDetector<'a> {
         {
             PackageChanges::All(reason) => {
                 debug!("all packages changed: {:?}", reason);
-                Ok(self
-                    .pkg_graph
-                    .packages()
-                    .map(|(name, _)| (name.to_owned(), PackageInclusionReason::All(reason.clone())))
-                    .collect())
+                Ok(all_package_changes(self.pkg_graph, reason))
             }
             PackageChanges::Some(packages) => {
                 debug!(

--- a/crates/turborepo-scope/src/filter.rs
+++ b/crates/turborepo-scope/src/filter.rs
@@ -55,9 +55,11 @@ impl PackageInference {
         let mut best_match: Option<(String, AnchoredSystemPathBuf)> = None;
         let mut found_package_below = false;
 
-        for package_name in pkg_graph.real_package_names() {
-            let graph_name = PackageName::Other(package_name.to_string());
-            let Some(package_path) = pkg_graph.package_dir(&graph_name) else {
+        for (graph_name, package_path) in pkg_graph.package_scope_directories() {
+            if !pkg_graph.is_real_package(&graph_name) {
+                continue;
+            }
+            let PackageName::Other(package_name) = graph_name else {
                 continue;
             };
             let pkg_path = turbo_root.resolve(package_path);
@@ -70,14 +72,14 @@ impl PackageInference {
             if inferred_path_is_below && (&pkg_path as &AbsoluteSystemPath) != turbo_root {
                 // This package contains the inference path. Track it if it's a better
                 // (longer/more specific) match than what we've found so far.
-                let pkg_path_len = package_path.as_str().len();
+                let package_depth = package_path.components().count();
                 let is_better_match = match &best_match {
                     None => true,
-                    Some((_, existing_path)) => pkg_path_len > existing_path.as_str().len(),
+                    Some((_, existing_path)) => package_depth > existing_path.components().count(),
                 };
 
                 if is_better_match {
-                    best_match = Some((package_name.to_string(), package_path.to_owned()));
+                    best_match = Some((package_name, package_path.to_owned()));
                 }
             }
 
@@ -335,7 +337,7 @@ impl<'a, T: GitChangeDetector> FilterResolver<'a, T> {
         if pattern_selectors.iter().all(|s| s.exclude) {
             let root_excluded = pattern_selectors
                 .iter()
-                .any(|s| Self::selector_matches_root(s));
+                .any(|s| self.selector_matches_root(s));
             FilterMode::ExcludeOnly { root_excluded }
         } else {
             FilterMode::ExplicitSelection
@@ -346,7 +348,7 @@ impl<'a, T: GitChangeDetector> FilterResolver<'a, T> {
     ///
     /// Uses the same glob matching as `match_package_names` for name
     /// patterns, and checks `parent_dir` for the repo root directory.
-    fn selector_matches_root(selector: &TargetSelector) -> bool {
+    fn selector_matches_root(&self, selector: &TargetSelector) -> bool {
         if !selector.name_pattern.is_empty()
             && let Ok(matcher) = SimpleGlob::new(&selector.name_pattern)
             && matcher.is_match(PackageName::Root.as_ref())
@@ -608,10 +610,16 @@ impl<'a, T: GitChangeDetector> FilterResolver<'a, T> {
                 .as_ref()
                 .zip(parent_dir_matcher.as_ref())
             {
-                let matches = self
-                    .pkg_graph
-                    .package_dir(&name)
-                    .is_some_and(|path| matcher.is_match(path.as_path()));
+                let matches = if name == PackageName::Root {
+                    // Root-directory selectors address the root Turbo task
+                    // namespace even when no root JavaScript scope exists.
+                    matcher.matched(&Path::new(".").into()).is_some()
+                } else {
+                    self.pkg_graph
+                        .package_view(&name)
+                        .and_then(|view| view.directory())
+                        .is_some_and(|path| matcher.is_match(path.as_path()))
+                };
 
                 if matches {
                     entry_packages.insert(
@@ -723,15 +731,15 @@ impl<'a, T: GitChangeDetector> FilterResolver<'a, T> {
             selector_valid = true;
             let changed_packages = self.packages_changed_in_range(git_range)?;
             let package_path_lookup = self
-                .selectable_packages()
-                .filter_map(|name| self.pkg_graph.package_dir(&name).map(|path| (name, path)))
+                .pkg_graph
+                .package_scope_directories()
                 .collect::<HashMap<_, _>>();
 
             for (package, reason) in changed_packages {
                 if let Some(parent_dir_globber) = parent_dir_globber.as_ref() {
                     if package == PackageName::Root {
-                        // The root package changed, only add it if
-                        // the parentDir is equivalent to the root
+                        // `{.}` addresses the root Turbo namespace even when
+                        // there is no root JavaScript package.
                         if parent_dir_globber.matched(&Path::new(".").into()).is_some() {
                             entry_packages.insert(package, reason);
                         }
@@ -762,11 +770,11 @@ impl<'a, T: GitChangeDetector> FilterResolver<'a, T> {
                     },
                 );
             } else {
-                for name in self.selectable_packages().filter(|name| {
-                    self.pkg_graph
-                        .package_dir(name)
-                        .is_some_and(|path| parent_dir_globber.is_match(path.as_path()))
-                }) {
+                for (name, _) in self
+                    .pkg_graph
+                    .package_scope_directories()
+                    .filter(|(_, path)| parent_dir_globber.is_match(path.as_path()))
+                {
                     entry_packages.insert(
                         name,
                         PackageInclusionReason::InFilteredDirectory {
@@ -912,7 +920,7 @@ mod test {
     use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPathBuf, RelativeUnixPathBuf};
     use turborepo_errors::Spanned;
     use turborepo_repository::{
-        change_mapper::PackageInclusionReason,
+        change_mapper::{AllPackageChangeReason, PackageInclusionReason},
         discovery::PackageDiscovery,
         package_graph::{PackageGraph, PackageName, ROOT_PKG_NAME},
         package_json::PackageJson,
@@ -926,7 +934,7 @@ mod test {
     use super::{FilterResolver, PackageInference};
     use crate::{
         FilterMode,
-        change_detector::GitChangeDetector,
+        change_detector::{GitChangeDetector, all_package_changes},
         filter::ResolutionError,
         target_selector::{GitRange, TargetSelector},
     };
@@ -1683,7 +1691,19 @@ mod test {
         (temp_folder, turbo_root, graph)
     }
 
-    fn make_aggregate_resolver() -> (
+    fn make_aggregate_resolver_with_root(
+        root_package_json: Option<PackageJson>,
+    ) -> (
+        TempDir,
+        FilterResolver<'static, TestChangeDetector<'static>>,
+    ) {
+        make_aggregate_resolver_with_changes(root_package_json, TestChangeDetector::new(&[]))
+    }
+
+    fn make_aggregate_resolver_with_changes(
+        root_package_json: Option<PackageJson>,
+        change_detector: TestChangeDetector<'static>,
+    ) -> (
         TempDir,
         FilterResolver<'static, TestChangeDetector<'static>>,
     ) {
@@ -1699,7 +1719,7 @@ mod test {
             .build()
             .unwrap()
             .block_on(
-                PackageGraph::builder(turbo_root, PackageJson::default())
+                PackageGraph::builder_optional(turbo_root, root_package_json)
                     .with_package_discovery(MockDiscovery)
                     .with_package_jsons(Some(HashMap::new()))
                     .with_toolchain(aggregate)
@@ -1707,13 +1727,16 @@ mod test {
             )
             .unwrap();
         let graph = Box::leak(Box::new(graph));
-        let resolver = FilterResolver::new_with_change_detector(
-            graph,
-            turbo_root,
-            None,
-            TestChangeDetector::new(&[]),
-        );
+        let resolver =
+            FilterResolver::new_with_change_detector(graph, turbo_root, None, change_detector);
         (temp_folder, resolver)
+    }
+
+    fn make_aggregate_resolver() -> (
+        TempDir,
+        FilterResolver<'static, TestChangeDetector<'static>>,
+    ) {
+        make_aggregate_resolver_with_root(Some(PackageJson::default()))
     }
 
     #[test]
@@ -1756,6 +1779,141 @@ mod test {
         );
         assert_eq!(inference.package_name, None);
         assert_eq!(inference.directory_root, AnchoredSystemPathBuf::default());
+    }
+
+    #[test]
+    fn native_root_scope_is_distinct_from_turbo_root_namespace() {
+        let (_tempdir, resolver) = make_aggregate_resolver_with_root(None);
+
+        assert!(!resolver.pkg_graph.has_root_javascript_scope());
+
+        let (all_packages, mode) = resolver.resolve(&None, &[]).unwrap();
+        assert_eq!(mode, FilterMode::AllPackages);
+        assert_eq!(
+            all_packages.into_keys().collect::<HashSet<_>>(),
+            HashSet::from([PackageName::from("cargo-workspace")]),
+            "default scope output contains the aggregate but not a synthetic root package"
+        );
+
+        let by_root_directory = resolver
+            .get_filtered_packages(vec![TargetSelector {
+                parent_dir: Some(AnchoredSystemPathBuf::try_from(".").unwrap()),
+                ..Default::default()
+            }])
+            .unwrap();
+        assert_eq!(
+            by_root_directory.into_keys().collect::<HashSet<_>>(),
+            HashSet::from([PackageName::Root]),
+            "{{.}} selects the root Turbo namespace without creating a root package"
+        );
+
+        let aggregate = resolver
+            .get_filtered_packages(vec![TargetSelector {
+                name_pattern: "cargo-workspace".to_string(),
+                ..Default::default()
+            }])
+            .unwrap();
+        assert_eq!(
+            aggregate.into_keys().collect::<HashSet<_>>(),
+            HashSet::from([PackageName::from("cargo-workspace")]),
+            "aggregate scopes remain selectable without a JavaScript root"
+        );
+
+        let turbo_root_namespace = resolver
+            .get_filtered_packages(vec![TargetSelector {
+                name_pattern: "//".to_string(),
+                ..Default::default()
+            }])
+            .unwrap();
+        assert_eq!(
+            turbo_root_namespace.into_keys().collect::<HashSet<_>>(),
+            HashSet::from([PackageName::Root]),
+            "the root Turbo task namespace remains explicitly selectable"
+        );
+    }
+
+    #[test]
+    fn pure_native_root_filter_modes_follow_resolved_root_identity() {
+        let (_tempdir, resolver) = make_aggregate_resolver_with_root(None);
+        let aggregate = PackageName::from("cargo-workspace");
+
+        let (root_directory, mode) = resolver.resolve(&None, &["{.}".to_string()]).unwrap();
+        assert_eq!(
+            root_directory.into_keys().collect::<HashSet<_>>(),
+            HashSet::from([PackageName::Root])
+        );
+        assert_eq!(mode, FilterMode::ExplicitSelection);
+
+        let (without_root_directory, mode) =
+            resolver.resolve(&None, &["!{.}".to_string()]).unwrap();
+        assert_eq!(
+            without_root_directory.into_keys().collect::<HashSet<_>>(),
+            HashSet::from([aggregate.clone()])
+        );
+        assert_eq!(
+            mode,
+            FilterMode::ExcludeOnly {
+                root_excluded: true
+            },
+            "!{{.}} explicitly excludes the root Turbo namespace"
+        );
+
+        let (root_namespace, mode) = resolver.resolve(&None, &["//".to_string()]).unwrap();
+        assert_eq!(
+            root_namespace.into_keys().collect::<HashSet<_>>(),
+            HashSet::from([PackageName::Root])
+        );
+        assert_eq!(mode, FilterMode::ExplicitSelection);
+
+        let (without_root_namespace, mode) = resolver.resolve(&None, &["!//".to_string()]).unwrap();
+        assert_eq!(
+            without_root_namespace.into_keys().collect::<HashSet<_>>(),
+            HashSet::from([aggregate])
+        );
+        assert_eq!(
+            mode,
+            FilterMode::ExcludeOnly {
+                root_excluded: true
+            },
+            "explicitly excluding // suppresses root task injection"
+        );
+    }
+
+    #[test]
+    fn pure_native_root_git_dependency_selector_matches_root_namespace() {
+        let (_tempdir, resolver) = make_aggregate_resolver_with_changes(
+            None,
+            TestChangeDetector::new(&[("main", None, &["//", "cargo-workspace"])]),
+        );
+
+        let (packages, mode) = resolver
+            .resolve(&None, &["{.}...[main]".to_string()])
+            .unwrap();
+
+        assert_eq!(mode, FilterMode::ExplicitSelection);
+        assert_eq!(
+            packages.into_keys().collect::<HashSet<_>>(),
+            HashSet::from([PackageName::Root]),
+            "root-directory git dependency filters preserve the root Turbo namespace"
+        );
+    }
+
+    #[test]
+    fn all_package_changes_include_pure_native_root_task_namespace() {
+        let (_tempdir, resolver) = make_aggregate_resolver_with_root(None);
+
+        let changed = all_package_changes(
+            resolver.pkg_graph,
+            AllPackageChangeReason::GitRefNotFound {
+                from_ref: None,
+                to_ref: None,
+            },
+        );
+
+        assert_eq!(
+            changed.into_keys().collect::<HashSet<_>>(),
+            HashSet::from([PackageName::Root, PackageName::from("cargo-workspace")])
+        );
     }
 
     /// Test that PackageInference::calculate is deterministic when invoked from

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -161,6 +161,14 @@ namespace remains available independently of whether a root JavaScript package
 scope was contributed; package.json scripts remain a separate temporary
 task-synthesis compatibility input.
 
+Run scope resolution, affected fallback enumeration, and task-level directory
+filters also consume these knowledge-backed views. Aggregate scopes remain
+selectable. The always-available root Turbo task namespace remains distinct
+from root JavaScript package knowledge: explicit `//`, repository-root
+directory syntax `{.}`, root-task injection, and all-packages affected
+fallbacks can select that namespace even in a pure native repository. This
+namespace behavior does not imply that a root package owns the directory.
+
 Repository knowledge accepts at most one physical workspace root for each open
 `ToolchainId`, so a repository cannot combine multiple package managers for one
 language. Repeated observations from one producer of the same kind and


### PR DESCRIPTION
### Description

Part 3 of the package/scope knowledge completion stack.

Move run filtering, affected fallback enumeration, directory matching, package inference, and task entrypoint selection onto knowledge-backed scopes. Root task namespace behavior and aggregate selection remain compatible with existing filters.

### Testing Instructions

- `cargo test -p turborepo-scope`
- `cargo test -p turbo --test filter_run_test --test affected_test --test cargo_workspace_test`