### PR TITLE
refactor: Use package knowledge in repository views

### DIFF
--- a/crates/turborepo-devtools/src/graph.rs
+++ b/crates/turborepo-devtools/src/graph.rs
@@ -34,7 +34,7 @@ pub fn package_graph_to_data(pkg_graph: &PackageGraph) -> PackageGraphData {
         nodes.push(PackageNode {
             id: id.clone(),
             name: display_name,
-            path: path.to_string(),
+            path: path.to_unix().to_string(),
             scripts,
             is_root,
         });

--- a/crates/turborepo-devtools/src/graph.rs
+++ b/crates/turborepo-devtools/src/graph.rs
@@ -17,23 +17,24 @@ pub fn package_graph_to_data(pkg_graph: &PackageGraph) -> PackageGraphData {
     let mut nodes = Vec::new();
     let mut edges = Vec::new();
 
-    // Iterate over all packages
-    for (name, info) in pkg_graph.packages() {
-        let (id, display_name, is_root) = match name {
+    // Iterate over authoritative execution scopes. This preserves aggregate
+    // visualization while omitting the compatibility root in pure Cargo repos.
+    for (name, path) in pkg_graph.package_scope_directories() {
+        let (id, display_name, is_root) = match &name {
             PackageName::Root => (ROOT_PACKAGE_ID.to_string(), "(root)".to_string(), true),
             PackageName::Other(n) => (n.clone(), n.clone(), false),
         };
 
         // Get available scripts from package.json
-        let scripts: Vec<String> = info.package_json.scripts.keys().cloned().collect();
-
-        // Get the package path (directory containing package.json)
-        let path = info.package_path().to_string();
+        let scripts: Vec<String> = pkg_graph
+            .package_json(&name)
+            .map(|manifest| manifest.scripts.keys().cloned().collect())
+            .unwrap_or_default();
 
         nodes.push(PackageNode {
             id: id.clone(),
             name: display_name,
-            path,
+            path: path.to_string(),
             scripts,
             is_root,
         });
@@ -42,7 +43,7 @@ pub fn package_graph_to_data(pkg_graph: &PackageGraph) -> PackageGraphData {
         // Note: All packages (including root) are stored as Workspace nodes in the
         // graph. PackageNode::Root is a separate synthetic node that all
         // workspace packages depend on.
-        let pkg_node = RepoPackageNode::Workspace(name.clone());
+        let pkg_node = RepoPackageNode::Workspace(name);
 
         if let Some(deps) = pkg_graph.immediate_dependencies(&pkg_node) {
             for dep in deps {
@@ -71,10 +72,87 @@ pub fn package_graph_to_data(pkg_graph: &PackageGraph) -> PackageGraphData {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
+    use serde_json::json;
+    use turbopath::AbsoluteSystemPathBuf;
+    use turborepo_repository::{
+        package_graph::PackageGraph, package_json::PackageJson, package_manager::PackageManager,
+    };
+
     use super::*;
+
+    fn temp_root() -> (tempfile::TempDir, AbsoluteSystemPathBuf) {
+        let tempdir = tempfile::tempdir().expect("create temporary repository");
+        let root = AbsoluteSystemPathBuf::try_from(tempdir.path())
+            .expect("temporary repository has an absolute path");
+        (tempdir, root)
+    }
+
+    fn package_json(value: serde_json::Value) -> PackageJson {
+        PackageJson::from_value(value).expect("valid test package.json")
+    }
+
+    async fn javascript_graph() -> (tempfile::TempDir, PackageGraph) {
+        let (tempdir, root) = temp_root();
+        let root_manifest = package_json(json!({
+            "name": "turbo",
+            "scripts": { "build": "turbo build" }
+        }));
+        let package_path = root.join_components(&["packages", "web", "package.json"]);
+        let web_manifest = package_json(json!({
+            "name": "web",
+            "scripts": { "dev": "next dev" }
+        }));
+        let graph = PackageGraph::builder(&root, root_manifest)
+            .with_package_manager(PackageManager::Npm)
+            .with_package_jsons(Some(HashMap::from([(package_path, web_manifest)])))
+            .with_allow_no_package_manager(true)
+            .build()
+            .await
+            .expect("build JavaScript package graph");
+
+        (tempdir, graph)
+    }
 
     #[test]
     fn test_root_package_id() {
         assert_eq!(ROOT_PACKAGE_ID, "__ROOT__");
+    }
+
+    #[tokio::test]
+    async fn uses_knowledge_paths_and_preserves_root_serialization() {
+        let (_tempdir, graph) = javascript_graph().await;
+        let data = package_graph_to_data(&graph);
+
+        let root = data
+            .nodes
+            .iter()
+            .find(|node| node.id == ROOT_PACKAGE_ID)
+            .expect("root JavaScript scope remains visible");
+        assert_eq!(root.name, "(root)");
+        assert_eq!(root.path, "");
+        assert_eq!(root.scripts, ["build"]);
+        assert!(root.is_root);
+
+        let web = data
+            .nodes
+            .iter()
+            .find(|node| node.id == "web")
+            .expect("workspace is visible");
+        assert_eq!(web.path, "packages/web");
+        assert_eq!(web.scripts, ["dev"]);
+        assert!(!web.is_root);
+
+        assert_eq!(
+            serde_json::to_value(web).expect("serialize package node"),
+            json!({
+                "id": "web",
+                "name": "web",
+                "path": "packages/web",
+                "scripts": ["dev"],
+                "isRoot": false
+            })
+        );
     }
 }

--- a/crates/turborepo-lib/src/commands/ls.rs
+++ b/crates/turborepo-lib/src/commands/ls.rs
@@ -152,11 +152,11 @@ async fn query_packages(
         .filter_map(|item| {
             let name = item.get("name")?.as_str()?.to_string();
             let path = item.get("path")?.as_str()?.to_string();
-            let pkg_name = PackageName::from(name.as_str());
-            if pkg_name == PackageName::Root {
+            let package_name = PackageName::from(name.as_str());
+            if package_name == PackageName::Root {
                 return None;
             }
-            if !filtered_pkgs.contains(&pkg_name) {
+            if !filtered_pkgs.contains(&package_name) {
                 return None;
             }
             Some(PackageDetailDisplay { name, path })

--- a/crates/turborepo-lib/src/devtools.rs
+++ b/crates/turborepo-lib/src/devtools.rs
@@ -63,12 +63,15 @@ impl ProperTaskGraphBuilder {
             pkg_graph.package_scope_directories(),
         );
 
-        // Determine if this is a single package repo
-        let is_single = pkg_graph.len() == 1;
+        // Collect authoritative execution scopes, including aggregates. The
+        // compatibility PackageInfo map can contain a synthetic Cargo root.
+        let workspaces: Vec<PackageName> = pkg_graph
+            .package_scope_directories()
+            .map(|(name, _)| name)
+            .collect();
 
-        // Collect all workspaces
-        let workspaces: Vec<PackageName> =
-            pkg_graph.packages().map(|(name, _)| name.clone()).collect();
+        // Determine if this is a single package repo.
+        let is_single = workspaces.len() == 1;
 
         // Collect all root tasks from turbo.json AND root package.json scripts
         // For devtools, we want to show all tasks including root tasks

--- a/crates/turborepo-query/src/lib.rs
+++ b/crates/turborepo-query/src/lib.rs
@@ -752,8 +752,8 @@ impl RepositoryQuery {
             let mut packages = self
                 .run
                 .pkg_dep_graph()
-                .packages()
-                .map(|(name, _)| Package::new(self.run.clone(), name.clone()))
+                .package_scope_directories()
+                .map(|(name, _)| Package::new(self.run.clone(), name))
                 .collect::<Result<Array<_>, _>>()?;
             packages.sort_by(|a, b| a.get_name().cmp(b.get_name()));
             return Ok(packages);
@@ -762,8 +762,8 @@ impl RepositoryQuery {
         let mut packages = self
             .run
             .pkg_dep_graph()
-            .packages()
-            .map(|(name, _)| Package::new(self.run.clone(), name.clone()))
+            .package_scope_directories()
+            .map(|(name, _)| Package::new(self.run.clone(), name))
             .filter(|pkg| pkg.as_ref().is_ok_and(|pkg| filter.check(pkg)))
             .collect::<Result<Array<_>, _>>()?;
         packages.sort_by(|a, b| a.get_name().cmp(b.get_name()));
@@ -773,9 +773,12 @@ impl RepositoryQuery {
 
     async fn external_dependencies(&self) -> Result<Array<ExternalPackage>, Error> {
         let pkg_dep_graph = self.run.pkg_dep_graph();
-        let all_package_names: Vec<_> = pkg_dep_graph.packages().map(|(name, _)| name).collect();
+        let all_package_names: Vec<_> = pkg_dep_graph
+            .package_scope_directories()
+            .map(|(name, _)| name)
+            .collect();
         let mut packages = pkg_dep_graph
-            .transitive_external_dependencies(all_package_names)
+            .transitive_external_dependencies(all_package_names.iter())
             .into_iter()
             .map(|pkg| ExternalPackage::new(self.run.clone(), pkg.clone()))
             .collect::<Array<_>>();

--- a/crates/turborepo-query/src/package.rs
+++ b/crates/turborepo-query/src/package.rs
@@ -40,7 +40,7 @@ impl Package {
         &self.name
     }
 
-    fn from_node(&self, node: &PackageNode) -> Option<Self> {
+    fn package_from_node(&self, node: &PackageNode) -> Option<Self> {
         let PackageNode::Workspace(name) = node else {
             return None;
         };
@@ -57,7 +57,7 @@ impl Package {
     fn collect_nodes<'a>(&self, nodes: impl IntoIterator<Item = &'a PackageNode>) -> Array<Self> {
         nodes
             .into_iter()
-            .filter_map(|node| self.from_node(node))
+            .filter_map(|node| self.package_from_node(node))
             .sorted_by(|a, b| a.name.cmp(&b.name))
             .collect()
     }

--- a/crates/turborepo-query/src/package.rs
+++ b/crates/turborepo-query/src/package.rs
@@ -41,17 +41,15 @@ impl Package {
     }
 
     fn package_from_node(&self, node: &PackageNode) -> Option<Self> {
-        let PackageNode::Workspace(name) = node else {
-            return None;
+        let name = match node {
+            PackageNode::Root => PackageName::Root,
+            PackageNode::Workspace(name) => name.clone(),
         };
-        Self::new(self.run.clone(), name.clone()).ok()
+        Self::new(self.run.clone(), name).ok()
     }
 
     fn is_queryable_node(&self, node: &PackageNode) -> bool {
-        match node {
-            PackageNode::Root => false,
-            PackageNode::Workspace(name) => self.run.pkg_dep_graph().package_view(name).is_some(),
-        }
+        self.package_from_node(node).is_some()
     }
 
     fn collect_nodes<'a>(&self, nodes: impl IntoIterator<Item = &'a PackageNode>) -> Array<Self> {
@@ -180,6 +178,7 @@ impl Package {
             .ok_or_else(|| Error::PackageNotFound(self.name.clone()))?
             .directory()
             .ok_or_else(|| Error::PackageNotFound(self.name.clone()))?
+            .to_unix()
             .to_string())
     }
 

--- a/crates/turborepo-query/src/package.rs
+++ b/crates/turborepo-query/src/package.rs
@@ -26,7 +26,7 @@ impl fmt::Debug for Package {
 impl Package {
     pub fn new(run: Arc<dyn QueryRun>, name: PackageName) -> Result<Self, Error> {
         run.pkg_dep_graph()
-            .package_info(&name)
+            .package_view(&name)
             .ok_or_else(|| Error::PackageNotFound(name.clone()))?;
 
         Ok(Self { run, name })
@@ -38,6 +38,35 @@ impl Package {
 
     pub fn get_name(&self) -> &PackageName {
         &self.name
+    }
+
+    fn from_node(&self, node: &PackageNode) -> Option<Self> {
+        let PackageNode::Workspace(name) = node else {
+            return None;
+        };
+        Self::new(self.run.clone(), name.clone()).ok()
+    }
+
+    fn is_queryable_node(&self, node: &PackageNode) -> bool {
+        match node {
+            PackageNode::Root => false,
+            PackageNode::Workspace(name) => self.run.pkg_dep_graph().package_view(name).is_some(),
+        }
+    }
+
+    fn collect_nodes<'a>(&self, nodes: impl IntoIterator<Item = &'a PackageNode>) -> Array<Self> {
+        nodes
+            .into_iter()
+            .filter_map(|node| self.from_node(node))
+            .sorted_by(|a, b| a.name.cmp(&b.name))
+            .collect()
+    }
+
+    fn count_nodes<'a>(&self, nodes: impl IntoIterator<Item = &'a PackageNode>) -> usize {
+        nodes
+            .into_iter()
+            .filter(|node| self.is_queryable_node(node))
+            .count()
     }
 
     pub fn get_tasks(&self) -> HashMap<String, Spanned<String>> {
@@ -86,46 +115,52 @@ impl Package {
         self.run
             .pkg_dep_graph()
             .immediate_ancestors(&PackageNode::Workspace(self.name.clone()))
-            .map_or(0, |pkgs| pkgs.len())
+            .map_or(0, |packages| self.count_nodes(packages))
     }
 
     pub fn direct_dependencies_count(&self) -> usize {
         self.run
             .pkg_dep_graph()
             .immediate_dependencies(&PackageNode::Workspace(self.name.clone()))
-            .map_or(0, |pkgs| pkgs.len())
+            .map_or(0, |packages| self.count_nodes(packages))
     }
 
     pub fn indirect_dependents_count(&self) -> usize {
         let node: PackageNode = PackageNode::Workspace(self.name.clone());
-        self.run
-            .pkg_dep_graph()
-            .ancestors(&node)
-            .len()
-            .saturating_sub(self.direct_dependents_count())
+        let graph = self.run.pkg_dep_graph();
+        let immediate = graph.immediate_ancestors(&node);
+        self.count_nodes(graph.ancestors(&node).into_iter().filter(|package| {
+            immediate
+                .as_ref()
+                .is_none_or(|nodes| !nodes.contains(*package))
+        }))
     }
 
     pub fn indirect_dependencies_count(&self) -> usize {
         let node: PackageNode = PackageNode::Workspace(self.name.clone());
-        self.run
-            .pkg_dep_graph()
-            .dependencies(&node)
-            .len()
-            .saturating_sub(self.direct_dependencies_count())
+        let graph = self.run.pkg_dep_graph();
+        let immediate = graph.immediate_dependencies(&node);
+        self.count_nodes(graph.dependencies(&node).into_iter().filter(|package| {
+            immediate
+                .as_ref()
+                .is_none_or(|nodes| !nodes.contains(*package))
+        }))
     }
 
     pub fn all_dependents_count(&self) -> usize {
-        self.run
-            .pkg_dep_graph()
-            .ancestors(&PackageNode::Workspace(self.name.clone()))
-            .len()
+        self.count_nodes(
+            self.run
+                .pkg_dep_graph()
+                .ancestors(&PackageNode::Workspace(self.name.clone())),
+        )
     }
 
     pub fn all_dependencies_count(&self) -> usize {
-        self.run
-            .pkg_dep_graph()
-            .dependencies(&PackageNode::Workspace(self.name.clone()))
-            .len()
+        self.count_nodes(
+            self.run
+                .pkg_dep_graph()
+                .dependencies(&PackageNode::Workspace(self.name.clone())),
+        )
     }
 }
 
@@ -141,74 +176,45 @@ impl Package {
         Ok(self
             .run
             .pkg_dep_graph()
-            .package_info(&self.name)
+            .package_view(&self.name)
             .ok_or_else(|| Error::PackageNotFound(self.name.clone()))?
-            .package_path()
+            .directory()
+            .ok_or_else(|| Error::PackageNotFound(self.name.clone()))?
             .to_string())
     }
 
     /// The upstream packages that have this package as a direct dependency
     async fn direct_dependents(&self) -> Result<Array<Package>, Error> {
         let node: PackageNode = PackageNode::Workspace(self.name.clone());
-        Ok(self
-            .run
-            .pkg_dep_graph()
-            .immediate_ancestors(&node)
-            .iter()
-            .flatten()
-            .map(|package| Package {
-                run: self.run.clone(),
-                name: package.as_package_name().clone(),
-            })
-            .sorted_by(|a, b| a.name.cmp(&b.name))
-            .collect())
+        Ok(self.collect_nodes(
+            self.run
+                .pkg_dep_graph()
+                .immediate_ancestors(&node)
+                .into_iter()
+                .flatten(),
+        ))
     }
 
     /// The downstream packages that directly depend on this package
     async fn direct_dependencies(&self) -> Result<Array<Package>, Error> {
         let node: PackageNode = PackageNode::Workspace(self.name.clone());
-        Ok(self
-            .run
-            .pkg_dep_graph()
-            .immediate_dependencies(&node)
-            .iter()
-            .flatten()
-            .map(|package| Package {
-                run: self.run.clone(),
-                name: package.as_package_name().clone(),
-            })
-            .sorted_by(|a, b| a.name.cmp(&b.name))
-            .collect())
+        Ok(self.collect_nodes(
+            self.run
+                .pkg_dep_graph()
+                .immediate_dependencies(&node)
+                .into_iter()
+                .flatten(),
+        ))
     }
 
     async fn all_dependents(&self) -> Result<Array<Package>, Error> {
         let node: PackageNode = PackageNode::Workspace(self.name.clone());
-        Ok(self
-            .run
-            .pkg_dep_graph()
-            .ancestors(&node)
-            .iter()
-            .map(|package| Package {
-                run: self.run.clone(),
-                name: package.as_package_name().clone(),
-            })
-            .sorted_by(|a, b| a.name.cmp(&b.name))
-            .collect())
+        Ok(self.collect_nodes(self.run.pkg_dep_graph().ancestors(&node)))
     }
 
     async fn all_dependencies(&self) -> Result<Array<Package>, Error> {
         let node: PackageNode = PackageNode::Workspace(self.name.clone());
-        Ok(self
-            .run
-            .pkg_dep_graph()
-            .dependencies(&node)
-            .iter()
-            .map(|package| Package {
-                run: self.run.clone(),
-                name: package.as_package_name().clone(),
-            })
-            .sorted_by(|a, b| a.name.cmp(&b.name))
-            .collect())
+        Ok(self.collect_nodes(self.run.pkg_dep_graph().dependencies(&node)))
     }
 
     /// The downstream packages that depend on this package, indirectly
@@ -220,18 +226,13 @@ impl Package {
             .immediate_ancestors(&node)
             .ok_or_else(|| Error::PackageNotFound(self.name.clone()))?;
 
-        Ok(self
-            .run
-            .pkg_dep_graph()
-            .ancestors(&node)
-            .iter()
-            .filter(|package| !immediate_dependents.contains(*package))
-            .map(|package| Package {
-                run: self.run.clone(),
-                name: package.as_package_name().clone(),
-            })
-            .sorted_by(|a, b| a.name.cmp(&b.name))
-            .collect())
+        Ok(self.collect_nodes(
+            self.run
+                .pkg_dep_graph()
+                .ancestors(&node)
+                .into_iter()
+                .filter(|package| !immediate_dependents.contains(*package)),
+        ))
     }
 
     /// The upstream packages that this package depends on, indirectly
@@ -243,18 +244,13 @@ impl Package {
             .immediate_dependencies(&node)
             .ok_or_else(|| Error::PackageNotFound(self.name.clone()))?;
 
-        Ok(self
-            .run
-            .pkg_dep_graph()
-            .dependencies(&node)
-            .iter()
-            .filter(|package| !immediate_dependencies.contains(*package))
-            .map(|package| Package {
-                run: self.run.clone(),
-                name: package.as_package_name().clone(),
-            })
-            .sorted_by(|a, b| a.name.cmp(&b.name))
-            .collect())
+        Ok(self.collect_nodes(
+            self.run
+                .pkg_dep_graph()
+                .dependencies(&node)
+                .into_iter()
+                .filter(|package| !immediate_dependencies.contains(*package)),
+        ))
     }
 
     async fn tasks(&self) -> Array<RepositoryTask> {

--- a/crates/turborepo/tests/command_ls_test.rs
+++ b/crates/turborepo/tests/command_ls_test.rs
@@ -19,6 +19,27 @@ fn test_ls_all_packages() {
 }
 
 #[test]
+fn test_ls_json_preserves_package_paths_and_order() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
+
+    let output = run_turbo(tempdir.path(), &["ls", "--output", "json"]);
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(
+        json["packages"],
+        serde_json::json!({
+            "count": 3,
+            "items": [
+                { "name": "another", "path": "packages/another" },
+                { "name": "my-app", "path": "apps/my-app" },
+                { "name": "util", "path": "packages/util" }
+            ]
+        })
+    );
+}
+
+#[test]
 fn test_ls_with_filter() {
     let tempdir = tempfile::tempdir().unwrap();
     setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();

--- a/crates/turborepo/tests/command_query_test.rs
+++ b/crates/turborepo/tests/command_query_test.rs
@@ -13,7 +13,7 @@ fn test_query_from_file() {
 
     fs::write(
         tempdir.path().join("query.gql"),
-        "query { packages { items { name } } }",
+        "query { packages { items { name path } } }",
     )
     .unwrap();
 
@@ -31,6 +31,17 @@ fn test_query_from_file() {
     assert!(names.contains(&"my-app"));
     assert!(names.contains(&"util"));
     assert!(names.contains(&"another"));
+
+    let paths: Vec<&str> = json["data"]["packages"]["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|item| item["path"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        paths,
+        ["", "packages/another", "apps/my-app", "packages/util"]
+    );
 }
 
 #[test]
@@ -44,4 +55,57 @@ fn test_query_inline() {
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     let version = json["data"]["version"].as_str().unwrap();
     assert!(!version.is_empty(), "version should not be empty");
+}
+
+#[test]
+fn test_pure_cargo_relationships_exclude_structural_root() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::copy_fixture("cargo_pure_workspace", tempdir.path()).unwrap();
+
+    let query = r#"query {
+      app: package(name: "app") {
+        path
+        directDependencies { length items { name path } }
+        allDependencies { length items { name path } }
+        directDependents { length items { name path } }
+        allDependents { length items { name path } }
+      }
+      leaf: package(name: "lib-a") {
+        path
+        directDependencies { length items { name path } }
+        allDependencies { length items { name path } }
+        directDependents { length items { name path } }
+        allDependents { length items { name path } }
+      }
+    }"#;
+    let output = run_turbo(tempdir.path(), &["query", query]);
+    assert!(
+        output.status.success(),
+        "query failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["data"]["app"]["path"], "crates/app");
+    assert_eq!(json["data"]["leaf"]["path"], "crates/lib-a");
+    assert_eq!(json["data"]["leaf"]["directDependencies"]["length"], 0);
+    assert_eq!(json["data"]["leaf"]["allDependencies"]["length"], 0);
+
+    for package in ["app", "leaf"] {
+        for relationship in [
+            "directDependencies",
+            "allDependencies",
+            "directDependents",
+            "allDependents",
+        ] {
+            let relation = &json["data"][package][relationship];
+            let items = relation["items"].as_array().unwrap();
+            assert_eq!(relation["length"].as_u64().unwrap() as usize, items.len());
+            assert!(
+                items
+                    .iter()
+                    .all(|item| { item["name"] != "//" && item["path"].as_str().is_some() })
+            );
+        }
+    }
 }


### PR DESCRIPTION
### Description

Part 4 of the package/scope knowledge completion stack.

Use authoritative scope identity and paths in query, `turbo ls`, and devtools package views. Relationship and script payloads remain unchanged, while structural graph roots are no longer exposed as packages.

### Testing Instructions

- `cargo test -p turborepo-query`
- `cargo test -p turborepo-devtools`
- `cargo test -p turbo --test command_ls_test --test command_query_test`