### PR TITLE
refactor: Use package knowledge in package integrations

### DIFF
--- a/crates/turborepo-boundaries/src/lib.rs
+++ b/crates/turborepo-boundaries/src/lib.rs
@@ -27,14 +27,29 @@ use turbo_trace::{ImportResult, ImportTraceType, ImportType, Tracer, find_import
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 use turborepo_errors::Spanned;
 use turborepo_log::Subsystem;
-use turborepo_repository::package_graph::{PackageGraph, PackageInfo, PackageName, PackageNode};
+use turborepo_repository::{
+    package_graph::{PackageGraph, PackageGraphNodeKind, PackageInfo, PackageName, PackageNode},
+    toolchain::ToolchainId,
+};
 use turborepo_ui::{BOLD_GREEN, BOLD_RED, ColorConfig, color};
 use unrs_resolver::Resolver;
 
 use crate::imports::DependencyLocations;
 
+#[derive(Clone)]
+pub struct PackageScope<'a> {
+    pub name: PackageName,
+    pub directory: &'a turbopath::AnchoredSystemPath,
+    pub kind: PackageGraphNodeKind,
+    pub toolchain: &'a ToolchainId,
+}
+
 pub trait PackageGraphProvider: Send + Sync {
-    fn packages(&self) -> Box<dyn Iterator<Item = (&PackageName, &PackageInfo)> + '_>;
+    /// Authoritative scopes. Implementations must not derive these facts from
+    /// compatibility manifests.
+    fn package_scopes(&self) -> Box<dyn Iterator<Item = PackageScope<'_>> + '_>;
+    /// Phase 2 compatibility payload used only for dependency information.
+    fn package_info(&self, name: &PackageName) -> Option<&PackageInfo>;
     fn immediate_dependencies(&self, node: &PackageNode) -> Option<HashSet<&PackageNode>>;
     fn dependencies(&self, node: &PackageNode) -> Box<dyn Iterator<Item = &PackageNode> + '_>;
     fn ancestors(&self, node: &PackageNode) -> Box<dyn Iterator<Item = &PackageNode> + '_>;
@@ -45,8 +60,20 @@ pub trait PackageGraphProvider: Send + Sync {
 }
 
 impl PackageGraphProvider for PackageGraph {
-    fn packages(&self) -> Box<dyn Iterator<Item = (&PackageName, &PackageInfo)> + '_> {
-        Box::new(self.packages())
+    fn package_scopes(&self) -> Box<dyn Iterator<Item = PackageScope<'_>> + '_> {
+        Box::new(self.node_views().filter_map(|(node, view)| match node {
+            PackageNode::Workspace(name) => Some(PackageScope {
+                name,
+                directory: view.directory()?,
+                kind: view.kind(),
+                toolchain: view.toolchain()?,
+            }),
+            PackageNode::Root => None,
+        }))
+    }
+
+    fn package_info(&self, name: &PackageName) -> Option<&PackageInfo> {
+        PackageGraph::package_info(self, name)
     }
 
     fn immediate_dependencies(&self, node: &PackageNode) -> Option<HashSet<&PackageNode>> {
@@ -207,6 +234,8 @@ pub enum BoundariesDiagnostic {
 
 #[derive(Debug, Error, Diagnostic)]
 pub enum Error {
+    #[error("missing Phase 2 compatibility payload for package `{0}`")]
+    MissingCompatibilityPayload(PackageName),
     #[error("file `{0}` does not have a parent directory")]
     NoParentDir(AbsoluteSystemPathBuf),
     #[error(transparent)]
@@ -478,7 +507,7 @@ impl BoundariesChecker {
     {
         let _span = info_span!("check_boundaries").entered();
         let rules_map = Self::get_processed_rules_map(ctx.root_boundaries_config);
-        let packages: Vec<_> = ctx.pkg_dep_graph.packages().collect();
+        let packages: Vec<_> = ctx.pkg_dep_graph.package_scopes().collect();
         let mut result = BoundariesResult::default();
 
         {
@@ -502,10 +531,20 @@ impl BoundariesChecker {
 
         let packages_to_check: Vec<_> = packages
             .into_iter()
-            .filter(|(name, _)| {
-                ctx.filtered_pkgs.contains(name) && !matches!(name, PackageName::Root)
+            .filter(|scope| {
+                matches!(scope.name, PackageName::Other(_))
+                    && ctx.filtered_pkgs.contains(&scope.name)
+                    && scope.kind == PackageGraphNodeKind::Package
+                    && scope.toolchain == &ToolchainId::JAVASCRIPT
             })
-            .collect();
+            .map(|scope| {
+                let info = ctx
+                    .pkg_dep_graph
+                    .package_info(&scope.name)
+                    .ok_or_else(|| Error::MissingCompatibilityPayload(scope.name.clone()))?;
+                Ok((scope.name, info, scope.directory))
+            })
+            .collect::<Result<_, Error>>()?;
 
         let progress = if show_progress {
             println!("Checking packages...");
@@ -519,11 +558,12 @@ impl BoundariesChecker {
             turborepo_rayon_compat::block_in_place(|| {
                 packages_to_check
                     .par_iter()
-                    .map(|(package_name, package_info)| {
+                    .map(|(package_name, package_info, package_directory)| {
                         let pkg_result = Self::check_package(
                             ctx,
                             package_name,
                             package_info,
+                            package_directory,
                             &rules_map,
                             &global_implicit_dependencies,
                         );
@@ -558,6 +598,7 @@ impl BoundariesChecker {
         ctx: &BoundariesContext<'_, G, T>,
         package_name: &PackageName,
         package_info: &PackageInfo,
+        package_directory: &turbopath::AnchoredSystemPath,
         tag_rules: &Option<ProcessedRulesMap>,
         global_implicit_dependencies: &HashMap<String, Spanned<()>>,
     ) -> Result<BoundariesResult, Error>
@@ -573,6 +614,7 @@ impl BoundariesChecker {
             ctx,
             package_name,
             package_info,
+            package_directory,
             &implicit_dependencies,
             global_implicit_dependencies,
         )?;
@@ -600,6 +642,7 @@ impl BoundariesChecker {
         ctx: &BoundariesContext<'_, G, T>,
         package_name: &PackageName,
         package_info: &PackageInfo,
+        package_directory: &turbopath::AnchoredSystemPath,
         implicit_dependencies: &HashMap<String, Spanned<()>>,
         global_implicit_dependencies: &HashMap<String, Spanned<()>>,
     ) -> Result<BoundariesResult, Error>
@@ -608,7 +651,7 @@ impl BoundariesChecker {
         T: TurboJsonProvider,
     {
         let _span = info_span!("check_package_files", package = %package_name).entered();
-        let package_root = ctx.repo_root.resolve(package_info.package_path());
+        let package_root = ctx.repo_root.resolve(package_directory);
         let internal_dependencies = ctx
             .pkg_dep_graph
             .immediate_dependencies(&PackageNode::Workspace(package_name.to_owned()))
@@ -856,17 +899,67 @@ mod tests {
     // Minimal mock providers for integration tests
     struct MockGraph {
         packages: Vec<(PackageName, PackageInfo)>,
+        aggregates: HashSet<PackageName>,
+        authoritative_directories: HashMap<PackageName, turbopath::AnchoredSystemPathBuf>,
+        missing_payloads: HashSet<PackageName>,
     }
 
     impl MockGraph {
         fn new(packages: Vec<(PackageName, PackageInfo)>) -> Self {
-            Self { packages }
+            Self {
+                packages,
+                aggregates: HashSet::new(),
+                authoritative_directories: HashMap::new(),
+                missing_payloads: HashSet::new(),
+            }
+        }
+
+        fn with_aggregate(mut self, name: PackageName) -> Self {
+            self.aggregates.insert(name);
+            self
+        }
+
+        fn with_directory(mut self, name: PackageName, directory: &str) -> Self {
+            self.authoritative_directories.insert(
+                name,
+                turbopath::AnchoredSystemPathBuf::from_raw(directory).unwrap(),
+            );
+            self
+        }
+
+        fn without_payload(mut self, name: PackageName) -> Self {
+            self.missing_payloads.insert(name);
+            self
         }
     }
 
     impl PackageGraphProvider for MockGraph {
-        fn packages(&self) -> Box<dyn Iterator<Item = (&PackageName, &PackageInfo)> + '_> {
-            Box::new(self.packages.iter().map(|(n, i)| (n, i)))
+        fn package_scopes(&self) -> Box<dyn Iterator<Item = PackageScope<'_>> + '_> {
+            Box::new(self.packages.iter().map(|(name, info)| {
+                PackageScope {
+                    name: name.clone(),
+                    directory: self
+                        .authoritative_directories
+                        .get(name)
+                        .map(|path| path.as_ref())
+                        .unwrap_or_else(|| info.package_path()),
+                    kind: if self.aggregates.contains(name) {
+                        PackageGraphNodeKind::Aggregate
+                    } else {
+                        PackageGraphNodeKind::Package
+                    },
+                    toolchain: &ToolchainId::JAVASCRIPT,
+                }
+            }))
+        }
+
+        fn package_info(&self, name: &PackageName) -> Option<&PackageInfo> {
+            if self.missing_payloads.contains(name) {
+                return None;
+            }
+            self.packages
+                .iter()
+                .find_map(|(candidate, info)| (candidate == name).then_some(info))
         }
 
         fn immediate_dependencies(&self, _: &PackageNode) -> Option<HashSet<&PackageNode>> {
@@ -994,6 +1087,117 @@ mod tests {
             "local imports should not produce diagnostics, got: {:?}",
             result.diagnostics.len()
         );
+    }
+
+    #[test]
+    fn check_boundaries_excludes_aggregate_scopes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = AbsoluteSystemPath::new(tmp.path().to_str().unwrap()).unwrap();
+        let aggregate_name = PackageName::Other("cargo-workspace".into());
+        let graph = MockGraph::new(vec![(
+            aggregate_name.clone(),
+            PackageInfo {
+                package_json_path: turbopath::AnchoredSystemPathBuf::from_raw("Cargo.toml")
+                    .unwrap(),
+                ..Default::default()
+            },
+        )])
+        .with_aggregate(aggregate_name.clone());
+        let filtered = HashSet::from([aggregate_name]);
+        let result = BoundariesChecker::check_boundaries(
+            &BoundariesContext {
+                repo_root,
+                pkg_dep_graph: &graph,
+                turbo_json_provider: &MockTurboJson,
+                root_boundaries_config: None,
+                filtered_pkgs: &filtered,
+            },
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(result.packages_checked, 0);
+        assert_eq!(result.files_checked, 0);
+    }
+
+    #[test]
+    fn authoritative_package_missing_compatibility_payload_fails_closed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = AbsoluteSystemPath::new(tmp.path().to_str().unwrap()).unwrap();
+        let package_name = PackageName::Other("authoritative-web".into());
+        let graph = MockGraph::new(vec![(
+            package_name.clone(),
+            PackageInfo {
+                package_json_path: turbopath::AnchoredSystemPathBuf::from_raw(
+                    "packages/web/package.json",
+                )
+                .unwrap(),
+                ..Default::default()
+            },
+        )])
+        .without_payload(package_name.clone());
+        let filtered = HashSet::from([package_name.clone()]);
+
+        let result = BoundariesChecker::check_boundaries(
+            &BoundariesContext {
+                repo_root,
+                pkg_dep_graph: &graph,
+                turbo_json_provider: &MockTurboJson,
+                root_boundaries_config: None,
+                filtered_pkgs: &filtered,
+            },
+            false,
+        );
+        let Err(error) = result else {
+            panic!("missing compatibility payload must fail closed");
+        };
+
+        assert!(matches!(
+            error,
+            Error::MissingCompatibilityPayload(name) if name == package_name
+        ));
+    }
+
+    #[test]
+    fn check_boundaries_scans_authoritative_package_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = AbsoluteSystemPath::new(tmp.path().to_str().unwrap()).unwrap();
+        let package_name = PackageName::Other("web".into());
+        repo_root
+            .join_components(&["actual", "web"])
+            .create_dir_all()
+            .unwrap();
+        repo_root
+            .join_components(&["actual", "web", "index.ts"])
+            .create_with_contents("export {};\n")
+            .unwrap();
+        let graph = MockGraph::new(vec![(
+            package_name.clone(),
+            PackageInfo {
+                package_json_path: turbopath::AnchoredSystemPathBuf::from_raw(
+                    "stale/web/package.json",
+                )
+                .unwrap(),
+                ..Default::default()
+            },
+        )])
+        .with_directory(package_name.clone(), "actual/web");
+        let filtered = HashSet::from([package_name]);
+
+        let result = BoundariesChecker::check_boundaries(
+            &BoundariesContext {
+                repo_root,
+                pkg_dep_graph: &graph,
+                turbo_json_provider: &MockTurboJson,
+                root_boundaries_config: None,
+                filtered_pkgs: &filtered,
+            },
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(result.packages_checked, 1);
+        assert_eq!(result.files_checked, 1);
     }
 
     #[test]

--- a/crates/turborepo-boundaries/src/tags.rs
+++ b/crates/turborepo-boundaries/src/tags.rs
@@ -420,8 +420,9 @@ where
 #[cfg(test)]
 mod tests {
     use turborepo_repository::{
-        package_graph::{PackageInfo, PackageName, PackageNode},
+        package_graph::{PackageGraphNodeKind, PackageInfo, PackageName, PackageNode},
         package_json::PackageJson,
+        toolchain::ToolchainId,
     };
 
     use super::*;
@@ -472,8 +473,23 @@ mod tests {
     }
 
     impl PackageGraphProvider for MockGraph {
-        fn packages(&self) -> Box<dyn Iterator<Item = (&PackageName, &PackageInfo)> + '_> {
-            Box::new(self.packages.iter().map(|(n, i)| (n, i)))
+        fn package_scopes(&self) -> Box<dyn Iterator<Item = crate::PackageScope<'_>> + '_> {
+            Box::new(
+                self.packages
+                    .iter()
+                    .map(|(name, info)| crate::PackageScope {
+                        name: name.clone(),
+                        directory: info.package_path(),
+                        kind: PackageGraphNodeKind::Package,
+                        toolchain: &ToolchainId::JAVASCRIPT,
+                    }),
+            )
+        }
+
+        fn package_info(&self, name: &PackageName) -> Option<&PackageInfo> {
+            self.packages
+                .iter()
+                .find_map(|(candidate, info)| (candidate == name).then_some(info))
         }
 
         fn immediate_dependencies(&self, _node: &PackageNode) -> Option<HashSet<&PackageNode>> {

--- a/crates/turborepo-lib/src/commands/get_mfe_port.rs
+++ b/crates/turborepo-lib/src/commands/get_mfe_port.rs
@@ -1,11 +1,18 @@
-use std::io;
+use std::{io, io::ErrorKind};
 
 use thiserror::Error;
-use turbopath::AbsoluteSystemPathBuf;
+use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 use turborepo_microfrontends::TurborepoMfeConfig;
-use turborepo_repository::{package_graph::PackageGraphBuilder, package_json::PackageJson};
+use turborepo_repository::{
+    cargo::{CargoToolchain, CARGO_TOML},
+    package_graph::{PackageGraph, PackageGraphNodeKind, PackageName, PackageNode},
+    package_json::PackageJson,
+    toolchain::ToolchainId,
+};
 
-use crate::{commands::CommandBase, microfrontends::MicrofrontendsConfigs};
+use crate::{
+    commands::CommandBase, microfrontends::MicrofrontendsConfigs, run::builder::cargo_enabled,
+};
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -40,30 +47,127 @@ pub async fn run(base: &CommandBase) -> Result<(), Error> {
 
 // Extracted logic for testing
 async fn get_port_for_current_package(base: &CommandBase) -> Result<u16, Error> {
-    // Get the current working directory
     let cwd = AbsoluteSystemPathBuf::cwd()?;
+    get_port_for_current_package_at(base, &cwd).await
+}
 
-    // Read package.json from current directory to get package name
-    let package_json_path = cwd.join_component("package.json");
-    let package_json = PackageJson::load(&package_json_path).map_err(|_| Error::NoPackageJson)?;
-    let package_name = package_json.name.as_deref().ok_or(Error::NoPackageName)?;
+async fn build_package_graph(base: &CommandBase) -> Result<PackageGraph, Error> {
+    let repo_root = &base.repo_root;
+    let root_package_json_path = repo_root.join_component("package.json");
+    let cargo_enabled = cargo_enabled(&base.opts().future_flags);
+    let root_package_json = match PackageJson::load(&root_package_json_path) {
+        Ok(package_json) => Some(package_json),
+        Err(turborepo_repository::package_json::Error::Io(io))
+            if io.kind() == ErrorKind::NotFound
+                && cargo_enabled
+                && repo_root.join_component(CARGO_TOML).exists() =>
+        {
+            None
+        }
+        Err(error) => return Err(error.into()),
+    };
 
-    get_port_for_package(base, package_name).await
+    let mut builder = PackageGraph::builder_optional(repo_root, root_package_json)
+        .with_single_package_mode(base.opts().run_opts.single_package)
+        .with_allow_no_package_manager(base.opts().repo_opts.allow_no_package_manager);
+    if cargo_enabled {
+        builder = builder.with_toolchain(CargoToolchain::new(repo_root.to_owned()));
+    }
+
+    Ok(builder.build().await?)
+}
+
+/// Resolve directory ownership from authoritative repository knowledge. The
+/// deepest package directory wins, so a nested package owns its descendants
+/// instead of inheriting the enclosing package's identity.
+fn package_for_directory(
+    package_graph: &PackageGraph,
+    repo_root: &AbsoluteSystemPath,
+    cwd: &AbsoluteSystemPath,
+) -> Result<String, Error> {
+    let cwd = repo_root.anchor(cwd).map_err(|_| Error::NoPackageJson)?;
+    let owner = package_graph
+        .node_views()
+        .filter_map(|(node, view)| {
+            let directory = view.directory()?;
+            if view.kind() == PackageGraphNodeKind::RootJavaScript && !cwd.as_str().is_empty() {
+                return None;
+            }
+            let component_count = directory.components().count();
+            let is_javascript_package = matches!(
+                view.kind(),
+                PackageGraphNodeKind::Package | PackageGraphNodeKind::RootJavaScript
+            ) && view.toolchain() == Some(&ToolchainId::JAVASCRIPT);
+            cwd.strip_prefix(directory)
+                .map(|_| (component_count, is_javascript_package, node, view))
+        })
+        .max_by_key(|(component_count, is_javascript_package, _, _)| {
+            (*component_count, *is_javascript_package)
+        })
+        .ok_or(Error::NoPackageJson)?;
+
+    match owner {
+        (_, _, PackageNode::Workspace(PackageName::Other(name)), view)
+            if view.kind() == PackageGraphNodeKind::Package
+                && view.toolchain() == Some(&ToolchainId::JAVASCRIPT) =>
+        {
+            Ok(name)
+        }
+        (_, _, PackageNode::Workspace(PackageName::Root), view)
+            if view.kind() == PackageGraphNodeKind::RootJavaScript
+                && view.toolchain() == Some(&ToolchainId::JAVASCRIPT) =>
+        {
+            package_graph
+                .root_javascript_scope_name()
+                .flatten()
+                .map(str::to_owned)
+                .ok_or(Error::NoPackageName)
+        }
+        _ => Err(Error::NoPackageJson),
+    }
+}
+
+fn check_exact_cwd_manifest(
+    repo_root: &AbsoluteSystemPath,
+    cwd: &AbsoluteSystemPath,
+) -> Result<(), Error> {
+    let Ok(relative) = repo_root.anchor(cwd) else {
+        return Err(Error::NoPackageJson);
+    };
+    let manifest = cwd.join_component("package.json");
+    if manifest.exists() || relative.as_str().is_empty() {
+        let package_json = PackageJson::load(&manifest).map_err(|_| Error::NoPackageJson)?;
+        if package_json.name.is_none() {
+            return Err(Error::NoPackageName);
+        }
+    }
+    Ok(())
+}
+
+async fn get_port_for_current_package_at(
+    base: &CommandBase,
+    cwd: &AbsoluteSystemPath,
+) -> Result<u16, Error> {
+    check_exact_cwd_manifest(&base.repo_root, cwd)?;
+    let package_graph = build_package_graph(base).await?;
+    let package_name = package_for_directory(&package_graph, &base.repo_root, cwd)?;
+    get_port_from_graph(base, &package_graph, &package_name)
 }
 
 async fn get_port_for_package(base: &CommandBase, package_name: &str) -> Result<u16, Error> {
-    // Build package graph to find microfrontends config
-    let repo_root = &base.repo_root;
-    let root_package_json_path = repo_root.join_component("package.json");
-    let root_package_json = PackageJson::load(&root_package_json_path)?;
+    let package_graph = build_package_graph(base).await?;
+    get_port_from_graph(base, &package_graph, package_name)
+}
 
-    let package_graph = PackageGraphBuilder::new(repo_root, root_package_json)
-        .with_single_package_mode(false)
-        .build()
-        .await?;
+fn get_port_from_graph(
+    base: &CommandBase,
+    package_graph: &PackageGraph,
+    package_name: &str,
+) -> Result<u16, Error> {
+    let repo_root = &base.repo_root;
 
     // Load microfrontends configuration to find the config file
-    let mfe_configs = MicrofrontendsConfigs::from_disk(repo_root, &package_graph)?
+    let mfe_configs = MicrofrontendsConfigs::from_disk(repo_root, package_graph)?
         .ok_or(Error::NoMicrofrontendsConfig)?;
 
     // Find the config file path
@@ -103,7 +207,7 @@ mod tests {
                 r#"{
                 "name": "root",
                 "packageManager": "pnpm@9.0.0",
-                "workspaces": ["apps/*"]
+                "workspaces": ["apps/*", "apps/*/packages/*"]
             }"#,
             )
             .unwrap();
@@ -111,7 +215,7 @@ mod tests {
         // Create pnpm-workspace.yaml
         repo_root
             .join_component("pnpm-workspace.yaml")
-            .create_with_contents("packages:\n  - 'apps/*'\n")
+            .create_with_contents("packages:\n  - 'apps/*'\n  - 'apps/*/packages/*'\n")
             .unwrap();
 
         // Create turbo.json
@@ -124,11 +228,48 @@ mod tests {
     }
 
     fn create_command_base(repo_root: AbsoluteSystemPathBuf) -> CommandBase {
+        create_command_base_with_cargo(repo_root, false)
+    }
+
+    fn create_command_base_with_cargo(
+        repo_root: AbsoluteSystemPathBuf,
+        cargo_enabled: bool,
+    ) -> CommandBase {
         let args = Args::default();
         let config = TurborepoConfigBuilder::new(&repo_root).build().unwrap();
-        let opts = Opts::new(&repo_root, &args, config).unwrap();
+        let mut opts = Opts::new(&repo_root, &args, config).unwrap();
+        opts.future_flags.experimental_cargo_workspaces = cargo_enabled;
 
         CommandBase::from_opts(opts, repo_root, "test-version", ColorConfig::new(false))
+    }
+
+    fn add_cargo_workspace(repo_root: &AbsoluteSystemPath) -> AbsoluteSystemPathBuf {
+        repo_root
+            .join_component("Cargo.toml")
+            .create_with_contents(
+                "[workspace]\nmembers = [\"rust/member\"]\nresolver = \
+                 \"2\"\n\n[workspace.metadata]\nname = \"cargo-workspace\"\n",
+            )
+            .unwrap();
+        let member = repo_root.join_components(&["rust", "member"]);
+        member.join_component("src").create_dir_all().unwrap();
+        member
+            .join_component("Cargo.toml")
+            .create_with_contents(
+                "[package]\nname = \"cargo-member\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+            )
+            .unwrap();
+        member
+            .join_components(&["src", "lib.rs"])
+            .create_with_contents("")
+            .unwrap();
+        repo_root
+            .join_component("Cargo.lock")
+            .create_with_contents(
+                "version = 4\n\n[[package]]\nname = \"cargo-member\"\nversion = \"0.1.0\"\n",
+            )
+            .unwrap();
+        member
     }
 
     #[tokio::test]
@@ -302,6 +443,192 @@ mod tests {
 
         let port = get_port_for_package(&base, "my-app").await.unwrap();
         assert_eq!(port, 3005);
+    }
+
+    #[tokio::test]
+    async fn test_current_directory_inside_package_uses_directory_owner() {
+        let tmp = TempDir::new().unwrap();
+        let repo_root = setup_test_repo(&tmp);
+        let app_dir = repo_root.join_components(&["apps", "web"]);
+        app_dir.join_component("src").create_dir_all().unwrap();
+        app_dir
+            .join_component("package.json")
+            .create_with_contents(r#"{"name":"web"}"#)
+            .unwrap();
+        app_dir
+            .join_component("microfrontends.json")
+            .create_with_contents(
+                r#"{"version":"1","applications":{"web":{"development":{"local":3010}}}}"#,
+            )
+            .unwrap();
+        let base = create_command_base(repo_root);
+
+        let port = get_port_for_current_package_at(&base, &app_dir.join_component("src"))
+            .await
+            .unwrap();
+
+        assert_eq!(port, 3010);
+    }
+
+    #[tokio::test]
+    async fn test_nested_package_wins_longest_directory_prefix() {
+        let tmp = TempDir::new().unwrap();
+        let repo_root = setup_test_repo(&tmp);
+        let shell_dir = repo_root.join_components(&["apps", "shell"]);
+        let widget_dir = shell_dir.join_components(&["packages", "widget"]);
+        widget_dir.join_component("src").create_dir_all().unwrap();
+        shell_dir
+            .join_component("package.json")
+            .create_with_contents(r#"{"name":"shell"}"#)
+            .unwrap();
+        widget_dir
+            .join_component("package.json")
+            .create_with_contents(r#"{"name":"widget"}"#)
+            .unwrap();
+        shell_dir
+            .join_component("microfrontends.json")
+            .create_with_contents(
+                r#"{"version":"1","applications":{"shell":{"development":{"local":3010}},"widget":{"packageName":"widget","development":{"local":4020},"routing":[{"paths":["/widget"]}]}}}"#,
+            )
+            .unwrap();
+        let base = create_command_base(repo_root);
+
+        let port = get_port_for_current_package_at(&base, &widget_dir.join_component("src"))
+            .await
+            .unwrap();
+
+        assert_eq!(port, 4020);
+    }
+
+    #[tokio::test]
+    async fn test_root_scope_only_owns_exact_repository_root() {
+        let tmp = TempDir::new().unwrap();
+        let repo_root = setup_test_repo(&tmp);
+        repo_root
+            .join_component("microfrontends.json")
+            .create_with_contents(
+                r#"{"version":"1","applications":{"root":{"development":{"local":3007}}}}"#,
+            )
+            .unwrap();
+        let unowned = repo_root.join_component("tools");
+        unowned.create_dir_all().unwrap();
+        let base = create_command_base(repo_root.clone());
+
+        assert_eq!(
+            get_port_for_current_package_at(&base, &repo_root)
+                .await
+                .unwrap(),
+            3007
+        );
+        assert!(matches!(
+            get_port_for_current_package_at(&base, &unowned).await,
+            Err(Error::NoPackageJson)
+        ));
+
+        let outside = TempDir::new().unwrap();
+        let outside = AbsoluteSystemPathBuf::try_from(outside.path().to_path_buf()).unwrap();
+        assert!(matches!(
+            get_port_for_current_package_at(&base, &outside).await,
+            Err(Error::NoPackageJson)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_exact_unnamed_and_malformed_workspace_errors_precede_graph_identity() {
+        for (manifest, expected_unnamed) in [(r#"{}"#, true), ("{", false)] {
+            let tmp = TempDir::new().unwrap();
+            let repo_root = setup_test_repo(&tmp);
+            let app = repo_root.join_components(&["apps", "web"]);
+            app.create_dir_all().unwrap();
+            app.join_component("package.json")
+                .create_with_contents(manifest)
+                .unwrap();
+            let base = create_command_base(repo_root);
+
+            let error = get_port_for_current_package_at(&base, &app)
+                .await
+                .unwrap_err();
+            assert!(if expected_unnamed {
+                matches!(error, Error::NoPackageName)
+            } else {
+                matches!(error, Error::NoPackageJson)
+            });
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cargo_package_is_not_owned_by_javascript_root() {
+        let tmp = TempDir::new().unwrap();
+        let repo_root = setup_test_repo(&tmp);
+        let cargo_member = add_cargo_workspace(&repo_root);
+        let base = create_command_base_with_cargo(repo_root, true);
+
+        assert!(matches!(
+            get_port_for_current_package_at(&base, &cargo_member).await,
+            Err(Error::NoPackageJson)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_colocated_javascript_package_wins_equal_depth_native_scope() {
+        let tmp = TempDir::new().unwrap();
+        let repo_root = setup_test_repo(&tmp);
+        let app = repo_root.join_components(&["apps", "hybrid"]);
+        app.join_component("src").create_dir_all().unwrap();
+        app.join_component("package.json")
+            .create_with_contents(r#"{"name":"hybrid"}"#)
+            .unwrap();
+        app.join_component("microfrontends.json")
+            .create_with_contents(
+                r#"{"version":"1","applications":{"hybrid":{"development":{"local":4555}}}}"#,
+            )
+            .unwrap();
+        app.join_component("Cargo.toml")
+            .create_with_contents(
+                "[package]\nname = \"rust-hybrid\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+            )
+            .unwrap();
+        app.join_components(&["src", "lib.rs"])
+            .create_with_contents("")
+            .unwrap();
+        repo_root
+            .join_component("Cargo.toml")
+            .create_with_contents(
+                "[workspace]\nmembers = [\"apps/hybrid\"]\nresolver = \
+                 \"2\"\n\n[workspace.metadata]\nname = \"cargo-workspace\"\n",
+            )
+            .unwrap();
+        repo_root
+            .join_component("Cargo.lock")
+            .create_with_contents(
+                "version = 4\n\n[[package]]\nname = \"rust-hybrid\"\nversion = \"0.1.0\"\n",
+            )
+            .unwrap();
+        let base = create_command_base_with_cargo(repo_root, true);
+
+        assert_eq!(
+            get_port_for_current_package_at(&base, &app).await.unwrap(),
+            4555
+        );
+    }
+
+    #[tokio::test]
+    async fn test_missing_root_manifest_requires_cargo_feature() {
+        let tmp = TempDir::new().unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        add_cargo_workspace(&repo_root);
+        repo_root
+            .join_component("turbo.json")
+            .create_with_contents("{}")
+            .unwrap();
+
+        let disabled = create_command_base_with_cargo(repo_root.clone(), false);
+        assert!(matches!(
+            build_package_graph(&disabled).await,
+            Err(Error::PackageJson(_))
+        ));
+        let enabled = create_command_base_with_cargo(repo_root, true);
+        assert!(build_package_graph(&enabled).await.is_ok());
     }
 
     #[tokio::test]

--- a/crates/turborepo-lib/src/microfrontends.rs
+++ b/crates/turborepo-lib/src/microfrontends.rs
@@ -2,9 +2,12 @@ use std::collections::{HashMap, HashSet};
 
 use itertools::Itertools;
 use tracing::warn;
-use turbopath::{AbsoluteSystemPath, RelativeUnixPath, RelativeUnixPathBuf};
+use turbopath::{AbsoluteSystemPath, AnchoredSystemPath, RelativeUnixPath, RelativeUnixPathBuf};
 use turborepo_microfrontends::{Error, TurborepoMfeConfig as MfeConfig, MICROFRONTENDS_PACKAGE};
-use turborepo_repository::package_graph::{PackageGraph, PackageInfo, PackageName};
+use turborepo_repository::{
+    package_graph::{PackageGraph, PackageGraphNodeKind, PackageInfo, PackageName},
+    toolchain::ToolchainId,
+};
 use turborepo_task_executor::MfeConfigProvider;
 use turborepo_task_id::{TaskId, TaskName};
 
@@ -43,19 +46,24 @@ impl MicrofrontendsConfigs {
             configs: Vec<(&'a str, Result<Option<MfeConfig>, Error>)>,
         }
 
-        let any_has_mfe_dep = package_graph.packages().any(|(_, info)| {
-            info.package_json
-                .all_dependencies()
-                .any(|(dep, _)| dep.as_str() == MICROFRONTENDS_PACKAGE)
-        });
+        let packages = javascript_packages(package_graph).collect::<Vec<_>>();
+
+        // Dependency tables intentionally remain a Phase 2 PackageJson
+        // compatibility read. Package identity and source roots above are
+        // authoritative repository-knowledge views.
+        let any_has_mfe_dep = packages
+            .iter()
+            .filter_map(|(_, info, _)| *info)
+            .any(has_mfe_dependency);
         tracing::debug!(
             "from_disk - any package has @vercel/microfrontends dep: {}",
             any_has_mfe_dep
         );
 
         type LoadedConfig<'a> = (
-            &'a PackageName,
-            &'a PackageInfo,
+            &'a str,
+            Option<&'a PackageInfo>,
+            &'a AnchoredSystemPath,
             Result<Option<MfeConfig>, Error>,
         );
         // Probing every package directory for a config is two file reads per
@@ -63,17 +71,15 @@ impl MicrofrontendsConfigs {
         // indexed collect), so downstream config processing is unaffected.
         let loaded: Vec<LoadedConfig> = crate::rayon_compat::block_in_place(|| {
             use rayon::prelude::*;
-            package_graph
-                .packages()
-                .collect::<Vec<_>>()
+            packages
                 .into_par_iter()
-                .map(|(name, info)| {
+                .map(|(name, info, directory)| {
                     let config_result = MfeConfig::load_from_dir_with_mfe_dep(
                         repo_root,
-                        info.package_path(),
+                        directory,
                         any_has_mfe_dep,
                     );
-                    (name, info, config_result)
+                    (name, info, directory, config_result)
                 })
                 .collect()
         });
@@ -84,13 +90,10 @@ impl MicrofrontendsConfigs {
                 has_mfe_dep: HashMap::new(),
                 configs: Vec::new(),
             },
-            |mut acc, (name, info, config_result)| {
-                let name_str = name.as_str();
+            |mut acc, (name, info, directory, config_result)| {
+                let name_str = name;
                 acc.names.insert(name_str);
-                let has_dep = info
-                    .package_json
-                    .all_dependencies()
-                    .any(|(dep, _)| dep.as_str() == MICROFRONTENDS_PACKAGE);
+                let has_dep = info.is_some_and(has_mfe_dependency);
                 tracing::debug!(
                     "from_disk - package: {}, has @vercel/microfrontends dep: {}",
                     name_str,
@@ -102,7 +105,7 @@ impl MicrofrontendsConfigs {
                     tracing::debug!(
                         "from_disk - found config in package: {}, path: {:?}",
                         name_str,
-                        info.package_path()
+                        directory
                     );
                 } else if let Err(ref e) = config_result {
                     tracing::debug!(
@@ -349,6 +352,47 @@ impl MicrofrontendsConfigs {
     }
 }
 
+/// The scopes historically probed by microfrontends: the JavaScript root and
+/// real JavaScript workspace packages. Native packages and aggregate execution
+/// scopes are not package directories and must not be interpreted as such.
+fn javascript_packages(
+    package_graph: &PackageGraph,
+) -> impl Iterator<Item = (&str, Option<&PackageInfo>, &turbopath::AnchoredSystemPath)> {
+    package_graph.node_views().filter_map(|(node, view)| {
+        let is_historical_js_scope = matches!(
+            view.kind(),
+            PackageGraphNodeKind::Package | PackageGraphNodeKind::RootJavaScript
+        ) && view.toolchain() == Some(&ToolchainId::JAVASCRIPT);
+        if !is_historical_js_scope {
+            return None;
+        }
+        let name = match node {
+            turborepo_repository::package_graph::PackageNode::Root => return None,
+            turborepo_repository::package_graph::PackageNode::Workspace(PackageName::Root) => "//",
+            turborepo_repository::package_graph::PackageNode::Workspace(PackageName::Other(
+                name,
+            )) => package_graph
+                .real_package_names()
+                .find(|candidate| **candidate == name)?,
+        };
+        let compatibility_name = match name {
+            "//" => PackageName::Root,
+            name => PackageName::Other(name.to_owned()),
+        };
+        Some((
+            name,
+            package_graph.package_info(&compatibility_name),
+            view.directory()?,
+        ))
+    })
+}
+
+fn has_mfe_dependency(info: &PackageInfo) -> bool {
+    info.package_json
+        .all_dependencies()
+        .any(|(dep, _)| dep.as_str() == MICROFRONTENDS_PACKAGE)
+}
+
 impl MfeConfigProvider for MicrofrontendsConfigs {
     fn task_has_mfe_proxy(&self, task_id: &TaskId) -> bool {
         MicrofrontendsConfigs::task_has_mfe_proxy(self, task_id)
@@ -541,9 +585,92 @@ impl ConfigInfo {
 #[cfg(test)]
 mod test {
     use serde_json::json;
+    use tempfile::TempDir;
+    use turbopath::AbsoluteSystemPathBuf;
     use turborepo_microfrontends::MICROFRONTENDS_PACKAGE;
+    use turborepo_repository::{
+        cargo::CargoToolchain, package_graph::PackageGraph, package_json::PackageJson,
+    };
 
     use super::*;
+
+    fn temp_root(tmp: &TempDir) -> AbsoluteSystemPathBuf {
+        AbsoluteSystemPathBuf::try_from(tmp.path().to_path_buf()).unwrap()
+    }
+
+    fn write_mfe_config(root: &AbsoluteSystemPath, package: &str) {
+        root.join_component("microfrontends.json")
+            .create_with_contents(format!(
+                r#"{{"version":"1","applications":{{"{package}":{{"development":{{"local":3000}}}}}}}}"#
+            ))
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn from_disk_probes_the_authoritative_javascript_root() {
+        let tmp = TempDir::new().unwrap();
+        let root = temp_root(&tmp);
+        let root_package_json = PackageJson::from_value(json!({
+            "name": "root-app",
+            "packageManager": "pnpm@9.0.0"
+        }))
+        .unwrap();
+        root.join_component("package.json")
+            .create_with_contents(r#"{"name":"root-app","packageManager":"pnpm@9.0.0"}"#)
+            .unwrap();
+        write_mfe_config(&root, "root-app");
+        let graph = PackageGraph::builder(&root, root_package_json)
+            .with_single_package_mode(true)
+            .build()
+            .await
+            .unwrap();
+
+        let configs = MicrofrontendsConfigs::from_disk(&root, &graph)
+            .unwrap()
+            .expect("root config should be loaded");
+        assert!(configs
+            .config_filename(PackageName::Root.as_str())
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn from_disk_does_not_probe_cargo_aggregate_as_a_package() {
+        let tmp = TempDir::new().unwrap();
+        let root = temp_root(&tmp);
+        root.join_component("Cargo.toml")
+            .create_with_contents(
+                "[workspace]\nmembers = [\"member\"]\n\n[workspace.metadata]\nname = \
+                 \"aggregate\"\n",
+            )
+            .unwrap();
+        root.join_components(&["member", "src"])
+            .create_dir_all()
+            .unwrap();
+        root.join_components(&["member", "Cargo.toml"])
+            .create_with_contents(
+                "[package]\nname = \"member\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+            )
+            .unwrap();
+        root.join_components(&["member", "src", "lib.rs"])
+            .create_with_contents("")
+            .unwrap();
+        root.join_component("Cargo.lock")
+            .create_with_contents(
+                "version = 4\n\n[[package]]\nname = \"member\"\nversion = \"0.1.0\"\n",
+            )
+            .unwrap();
+        write_mfe_config(&root, "aggregate");
+
+        let graph = PackageGraph::builder_optional(&root, None)
+            .with_toolchain(CargoToolchain::new(root.clone()))
+            .build()
+            .await
+            .unwrap();
+
+        assert!(MicrofrontendsConfigs::from_disk(&root, &graph)
+            .unwrap()
+            .is_none());
+    }
 
     struct PackageUpdateTest {
         package_name: &'static str,


### PR DESCRIPTION
### Description

Part 5 of the package/scope knowledge completion stack.

Move boundaries, microfrontend discovery, and `get-mfe-port` package ownership onto authoritative scopes. Nested package lookup uses the deepest directory owner, native/aggregate scopes are handled explicitly, and dependency tables remain later-phase payloads.

### Testing Instructions

- `cargo test -p turborepo-boundaries`
- `cargo test -p turborepo-lib --lib microfrontends::test`
- `cargo test -p turborepo-lib --lib commands::get_mfe_port::tests`