### PR TITLE
refactor: Bind toolchain callbacks to package knowledge

### DIFF
--- a/crates/turborepo-engine/src/builder.rs
+++ b/crates/turborepo-engine/src/builder.rs
@@ -210,12 +210,13 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
 
             // Collect tasks from each workspace and its extends chain
             for workspace in self.workspaces.iter() {
-                let implicit_tasks = if let Some(package) =
-                    self.package_graph.package_info(workspace)
-                    && let Some(toolchain) = self.package_graph.toolchains().get(&package.toolchain)
+                let implicit_tasks = if let Some(context) =
+                    self.package_graph.package_task_context(workspace)
+                    && let Some(toolchain_id) = context.toolchain()
+                    && let Some(toolchain) = self.package_graph.toolchains().get(toolchain_id)
                 {
                     toolchain
-                        .registered_tasks(package)
+                        .registered_tasks(&context)
                         .into_iter()
                         .map(TaskName::from)
                         .collect()

--- a/crates/turborepo-engine/src/builder/definitions.rs
+++ b/crates/turborepo-engine/src/builder/definitions.rs
@@ -101,14 +101,12 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         }
 
         Ok(package_graph
-            .package_info(&PackageName::from(task_id.package()))
-            .and_then(|package| {
-                package_graph
-                    .toolchains()
-                    .get(&package.toolchain)
-                    .map(|toolchain| (package, toolchain))
+            .package_task_context(&PackageName::from(task_id.package()))
+            .and_then(|context| {
+                let toolchain = package_graph.toolchains().get(context.toolchain()?)?;
+                Some((context, toolchain))
             })
-            .is_some_and(|(package, toolchain)| toolchain.registers_task(package, task_id.task())))
+            .is_some_and(|(context, toolchain)| toolchain.registers_task(&context, task_id.task())))
     }
 
     fn has_task_definition_in_run_inner(
@@ -247,23 +245,27 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         };
 
         let path_to_root = self.path_to_root(task_id.as_inner())?;
-        let package_info = self
+        let package_context = self
             .package_graph
-            .package_info(&PackageName::from(task_id.as_inner().package()));
-        let toolchain =
-            package_info.and_then(|info| self.package_graph.toolchains().get(&info.toolchain));
+            .package_task_context(&PackageName::from(task_id.as_inner().package()));
+        let toolchain = package_context
+            .as_ref()
+            .and_then(|context| context.toolchain())
+            .and_then(|toolchain| self.package_graph.toolchains().get(toolchain));
         // Whether the package's toolchain defines a command for this task.
         // Tasks without one are phantom/transit tasks (they exist solely for
         // dependency ordering via `dependsOn: ["^task"]`) and must not hash
         // global input files — they don't execute, and including the files
         // would cause their hash to change and cascade into downstream
         // tasks that depend on them.
-        let defines_task = package_info
+        let defines_task = package_context
+            .as_ref()
             .zip(toolchain)
-            .is_some_and(|(info, toolchain)| toolchain.defines_task(info, task_id.task()));
-        let registered_task = package_info
+            .is_some_and(|(context, toolchain)| toolchain.defines_task(context, task_id.task()));
+        let registered_task = package_context
+            .as_ref()
             .zip(toolchain)
-            .is_some_and(|(info, toolchain)| toolchain.registers_task(info, task_id.task()));
+            .is_some_and(|(context, toolchain)| toolchain.registers_task(context, task_id.task()));
 
         // Most tasks resolve to an identical definition: the same turbo.json
         // chain and task name, differing only by the package's depth (for
@@ -280,8 +282,10 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
                     .get(&task_id.as_inner().as_task_name())
                     .is_some()
             });
-            let javascript =
-                package_info.is_none_or(|info| info.toolchain == ToolchainId::JAVASCRIPT);
+            let javascript = package_context
+                .as_ref()
+                .and_then(|context| context.toolchain())
+                .is_none_or(|toolchain| toolchain == &ToolchainId::JAVASCRIPT);
             (!package_scoped && javascript).then(|| TaskDefMemoKey {
                 chain: turbo_json_chain
                     .iter()
@@ -327,8 +331,15 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         let command_override = resolve_command_override(
             scoped_command,
             unscoped_command,
-            package_info.zip(toolchain),
-            task_id.as_inner().task(),
+            package_context
+                .as_ref()
+                .zip(toolchain)
+                .and_then(|(context, toolchain)| {
+                    Some((
+                        context.toolchain()?,
+                        toolchain.authors_task(context, task_id.as_inner().task()),
+                    ))
+                }),
         );
 
         let mut processed_task_definition = ProcessedTaskDefinition::from_iter(
@@ -340,9 +351,9 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         // Toolchain defaults describe the command the toolchain synthesizes.
         // An override owns its behavior, including the generic cache default.
         if should_apply_toolchain_defaults(command_override.as_ref())
-            && let Some((info, toolchain)) = package_info.zip(toolchain)
+            && let Some((context, toolchain)) = package_context.as_ref().zip(toolchain)
         {
-            let defaults = toolchain.task_defaults(info, task_id.as_inner().task());
+            let defaults = toolchain.task_defaults(context, task_id.as_inner().task());
             if processed_task_definition.cache.is_none() {
                 processed_task_definition.cache = defaults.cache.map(Spanned::new);
             }
@@ -385,9 +396,11 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         // append without forfeiting automatic invalidation; explicit inputs
         // without `$TURBO_DEFAULT$` take full control.
         if inherits_toolchain_task_io(task_def.command.as_ref())
-            && let Some((info, toolchain)) =
-                package_info.zip(toolchain).filter(|(info, toolchain)| {
-                    toolchain.derives_task_io(info, task_id.as_inner().task())
+            && let Some((package_context, toolchain)) = package_context
+                .as_ref()
+                .zip(toolchain)
+                .filter(|(context, toolchain)| {
+                    toolchain.derives_task_io(context, task_id.as_inner().task())
                 })
         {
             let wants_automatic_inputs = !had_explicit_inputs || task_def.inputs.default;
@@ -402,7 +415,7 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
                 )))
                 .into_iter()
                 .filter_map(|dep| match dep {
-                    PackageNode::Workspace(name) => self.package_graph.package_info(name),
+                    PackageNode::Workspace(name) => self.package_graph.package_task_context(name),
                     _ => None,
                 })
                 .collect();
@@ -410,13 +423,13 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
             let empty_environment = turborepo_repository::toolchain::TaskIOEnvironment::default();
             let context = turborepo_repository::toolchain::TaskIOContext {
                 task_args: task_args.args_for_task(task_id.as_inner()),
-                environment: self
-                    .environments
-                    .get(&info.toolchain)
+                environment: package_context
+                    .toolchain()
+                    .and_then(|toolchain| self.environments.get(toolchain))
                     .unwrap_or(&empty_environment),
             };
             if let Some(mut derived) = toolchain.derived_task_io(
-                info,
+                package_context,
                 task_id.as_inner().task(),
                 path_to_root.as_str(),
                 &dependencies,
@@ -457,15 +470,13 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         let turbo_json_chain = self.turbo_json_chain(turbo_json_loader, &package_name)?;
         let registered_task = self
             .package_graph
-            .package_info(&package_name)
-            .and_then(|package| {
-                self.package_graph
-                    .toolchains()
-                    .get(&package.toolchain)
-                    .map(|toolchain| (package, toolchain))
+            .package_task_context(&package_name)
+            .and_then(|context| {
+                let toolchain = self.package_graph.toolchains().get(context.toolchain()?)?;
+                Some((context, toolchain))
             })
-            .is_some_and(|(package, toolchain)| {
-                toolchain.registers_task(package, task_id.as_inner().task())
+            .is_some_and(|(context, toolchain)| {
+                toolchain.registers_task(&context, task_id.as_inner().task())
             });
         Ok(Self::resolve_task_definitions_from_chain(
             turbo_json_chain,
@@ -788,11 +799,7 @@ fn apply_derived_task_io(
 fn resolve_command_override(
     scoped_command: Option<ProcessedCommand>,
     unscoped_command: Option<ProcessedCommand>,
-    package_toolchain: Option<(
-        &turborepo_repository::package_graph::PackageInfo,
-        &dyn turborepo_repository::toolchain::Toolchain,
-    )>,
-    task: &str,
+    package_toolchain: Option<(&turborepo_repository::toolchain::ToolchainId, bool)>,
 ) -> Option<TaskCommandOverride> {
     // Levels 1–2: an explicit per-package command beats everything,
     // including the package's own script — the user targeted this package
@@ -810,7 +817,7 @@ fn resolve_command_override(
     // lean into what the toolchain does natively. Toolchain-synthesized
     // fallbacks (Cargo verb tables) are authored by nobody and sit below
     // the defaults instead.
-    if package_toolchain.is_some_and(|(info, toolchain)| toolchain.authors_task(info, task)) {
+    if package_toolchain.is_some_and(|(_, authors)| authors) {
         return None;
     }
 
@@ -819,11 +826,11 @@ fn resolve_command_override(
     match unscoped_command? {
         ProcessedCommand::Argv(argv) => Some(TaskCommandOverride::Argv(argv.into_inner())),
         ProcessedCommand::PerToolchain(entries) => {
-            let (info, _) = package_toolchain?;
+            let (toolchain, _) = package_toolchain?;
             entries
                 .into_inner()
                 .into_iter()
-                .find(|(toolchain_id, _)| info.toolchain.as_str() == toolchain_id.as_str())
+                .find(|(toolchain_id, _)| toolchain.as_str() == toolchain_id.as_str())
                 .map(|(_, argv)| TaskCommandOverride::Argv(argv))
         }
         // The validator rejects unscoped opt-outs.
@@ -845,34 +852,10 @@ fn inherits_toolchain_task_io(command: Option<&TaskCommandOverride>) -> bool {
 #[cfg(test)]
 mod command_override_tests {
     use turborepo_errors::Spanned;
-    use turborepo_repository::{
-        package_graph::PackageInfo,
-        toolchain::{Toolchain, ToolchainId},
-    };
+    use turborepo_repository::toolchain::ToolchainId;
     use turborepo_types::TaskCommandOverride;
 
     use super::{ProcessedCommand, inherits_toolchain_task_io, resolve_command_override};
-
-    /// A toolchain stub whose only knob is whether the package authors the
-    /// task — the single toolchain property the resolver consults.
-    struct Stub {
-        id: ToolchainId,
-        authors: bool,
-    }
-
-    impl Toolchain for Stub {
-        fn id(&self) -> ToolchainId {
-            self.id.clone()
-        }
-
-        fn discover_packages(&self) -> turborepo_repository::toolchain::DiscoverPackagesFuture<'_> {
-            Box::pin(async { Ok(turborepo_repository::toolchain::DiscoveredPackages::default()) })
-        }
-
-        fn authors_task(&self, _package: &PackageInfo, _task: &str) -> bool {
-            self.authors
-        }
-    }
 
     fn argv(items: &[&str]) -> ProcessedCommand {
         ProcessedCommand::Argv(Spanned::new(items.iter().map(|s| s.to_string()).collect()))
@@ -892,29 +875,11 @@ mod command_override_tests {
         ))
     }
 
-    fn package(toolchain: &ToolchainId) -> PackageInfo {
-        PackageInfo {
-            toolchain: toolchain.clone(),
-            ..Default::default()
-        }
-    }
-
     #[test]
     fn test_precedence_levels() {
-        let rust = Stub {
-            id: ToolchainId::RUST,
-            authors: false,
-        };
-        let js_with_script = Stub {
-            id: ToolchainId::JAVASCRIPT,
-            authors: true,
-        };
-        let js_without_script = Stub {
-            id: ToolchainId::JAVASCRIPT,
-            authors: false,
-        };
-        let rust_pkg = package(&ToolchainId::RUST);
-        let js_pkg = package(&ToolchainId::JAVASCRIPT);
+        let rust = (&ToolchainId::RUST, false);
+        let js_with_script = (&ToolchainId::JAVASCRIPT, true);
+        let js_without_script = (&ToolchainId::JAVASCRIPT, false);
 
         // Levels 1–2: a scoped command beats everything, including an
         // authored script and any unscoped default.
@@ -922,8 +887,7 @@ mod command_override_tests {
             resolve_command_override(
                 Some(argv(&["vitest"])),
                 Some(argv(&["ignored"])),
-                Some((&js_pkg, &js_with_script)),
-                "test",
+                Some(js_with_script),
             ),
             Some(TaskCommandOverride::Argv(vec!["vitest".to_string()])),
         );
@@ -932,8 +896,7 @@ mod command_override_tests {
             resolve_command_override(
                 Some(ProcessedCommand::OptOut(Spanned::new(()))),
                 None,
-                Some((&js_pkg, &js_with_script)),
-                "test",
+                Some(js_with_script),
             ),
             Some(TaskCommandOverride::OptOut),
         );
@@ -941,22 +904,12 @@ mod command_override_tests {
         // Level 3: a package-authored definition shadows the unscoped
         // default…
         assert_eq!(
-            resolve_command_override(
-                None,
-                Some(argv(&["from-default"])),
-                Some((&js_pkg, &js_with_script)),
-                "test",
-            ),
+            resolve_command_override(None, Some(argv(&["from-default"])), Some(js_with_script),),
             None,
         );
         // …but a script-less package takes the default (level 4).
         assert_eq!(
-            resolve_command_override(
-                None,
-                Some(argv(&["from-default"])),
-                Some((&js_pkg, &js_without_script)),
-                "test",
-            ),
+            resolve_command_override(None, Some(argv(&["from-default"])), Some(js_without_script),),
             Some(TaskCommandOverride::Argv(vec!["from-default".to_string()])),
         );
 
@@ -965,7 +918,7 @@ mod command_override_tests {
         // authored by nobody.
         let map = per_toolchain(&[("rust", &["cargo", "nextest", "run"])]);
         assert_eq!(
-            resolve_command_override(None, Some(map.clone()), Some((&rust_pkg, &rust)), "test"),
+            resolve_command_override(None, Some(map.clone()), Some(rust)),
             Some(TaskCommandOverride::Argv(vec![
                 "cargo".to_string(),
                 "nextest".to_string(),
@@ -973,16 +926,13 @@ mod command_override_tests {
             ])),
         );
         assert_eq!(
-            resolve_command_override(None, Some(map), Some((&js_pkg, &js_without_script)), "test"),
+            resolve_command_override(None, Some(map), Some(js_without_script)),
             None,
             "a toolchain without a map key is untouched",
         );
 
         // Level 5: nothing configured → the toolchain resolves as usual.
-        assert_eq!(
-            resolve_command_override(None, None, Some((&rust_pkg, &rust)), "test"),
-            None,
-        );
+        assert_eq!(resolve_command_override(None, None, Some(rust)), None,);
     }
 
     #[test]

--- a/crates/turborepo-engine/src/builder/test.rs
+++ b/crates/turborepo-engine/src/builder/test.rs
@@ -142,6 +142,19 @@ impl Toolchain for AggregateToolchain {
             ))
         })
     }
+
+    fn task_command(
+        &self,
+        _context: &turborepo_repository::package_graph::PackageTaskContext<'_>,
+        _task: &str,
+        _pass_through_args: Option<&[String]>,
+        _override_command: Option<&[String]>,
+    ) -> Result<
+        Option<turborepo_repository::toolchain::TaskCommand>,
+        turborepo_repository::toolchain::Error,
+    > {
+        Ok(None)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -196,6 +209,19 @@ impl Toolchain for StubIOToolchain {
                 vec![WorkspaceRoot::new("stub-io", self.repo_root.clone())],
             ))
         })
+    }
+
+    fn task_command(
+        &self,
+        _context: &turborepo_repository::package_graph::PackageTaskContext<'_>,
+        _task: &str,
+        _pass_through_args: Option<&[String]>,
+        _override_command: Option<&[String]>,
+    ) -> Result<
+        Option<turborepo_repository::toolchain::TaskCommand>,
+        turborepo_repository::toolchain::Error,
+    > {
+        Ok(None)
     }
 
     fn defines_task(

--- a/crates/turborepo-engine/src/builder/test.rs
+++ b/crates/turborepo-engine/src/builder/test.rs
@@ -200,7 +200,7 @@ impl Toolchain for StubIOToolchain {
 
     fn defines_task(
         &self,
-        _package: &turborepo_repository::package_graph::PackageInfo,
+        _package: &turborepo_repository::package_graph::PackageTaskContext<'_>,
         task: &str,
     ) -> bool {
         matches!(task, "build" | "test")
@@ -208,7 +208,7 @@ impl Toolchain for StubIOToolchain {
 
     fn derives_task_io(
         &self,
-        package: &turborepo_repository::package_graph::PackageInfo,
+        package: &turborepo_repository::package_graph::PackageTaskContext<'_>,
         task: &str,
     ) -> bool {
         self.defines_task(package, task)
@@ -220,14 +220,14 @@ impl Toolchain for StubIOToolchain {
 
     fn derived_task_io(
         &self,
-        package: &turborepo_repository::package_graph::PackageInfo,
+        package: &turborepo_repository::package_graph::PackageTaskContext<'_>,
         task: &str,
         _path_to_root: &str,
-        _dependencies: &[&turborepo_repository::package_graph::PackageInfo],
+        _dependencies: &[turborepo_repository::package_graph::PackageTaskContext<'_>],
         _wants_automatic_inputs: bool,
         context: &TaskIOContext<'_>,
     ) -> Option<DerivedTaskIO> {
-        let package_name = package.package_name()?;
+        let package_name = package.package().as_ref();
         self.seen.lock().unwrap().insert(
             format!("{package_name}#{task}"),
             SeenTaskIO {

--- a/crates/turborepo-engine/src/builder/test.rs
+++ b/crates/turborepo-engine/src/builder/test.rs
@@ -155,6 +155,36 @@ impl Toolchain for AggregateToolchain {
     > {
         Ok(None)
     }
+
+    fn task_display_command(
+        &self,
+        _context: &turborepo_repository::package_graph::PackageTaskContext<'_>,
+        _task: &str,
+    ) -> Option<String> {
+        None
+    }
+
+    fn defines_task(
+        &self,
+        _context: &turborepo_repository::package_graph::PackageTaskContext<'_>,
+        _task: &str,
+    ) -> bool {
+        false
+    }
+
+    fn watch_spec(&self) -> turborepo_repository::toolchain::WatchSpec {
+        turborepo_repository::toolchain::WatchSpec::default()
+    }
+
+    fn prune_plan(
+        &self,
+        _kept_packages: &[String],
+    ) -> Result<
+        Option<turborepo_repository::toolchain::PrunePlan>,
+        turborepo_repository::toolchain::Error,
+    > {
+        Ok(None)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -224,12 +254,34 @@ impl Toolchain for StubIOToolchain {
         Ok(None)
     }
 
+    fn task_display_command(
+        &self,
+        _context: &turborepo_repository::package_graph::PackageTaskContext<'_>,
+        _task: &str,
+    ) -> Option<String> {
+        None
+    }
+
     fn defines_task(
         &self,
         _package: &turborepo_repository::package_graph::PackageTaskContext<'_>,
         task: &str,
     ) -> bool {
         matches!(task, "build" | "test")
+    }
+
+    fn watch_spec(&self) -> turborepo_repository::toolchain::WatchSpec {
+        turborepo_repository::toolchain::WatchSpec::default()
+    }
+
+    fn prune_plan(
+        &self,
+        _kept_packages: &[String],
+    ) -> Result<
+        Option<turborepo_repository::toolchain::PrunePlan>,
+        turborepo_repository::toolchain::Error,
+    > {
+        Ok(None)
     }
 
     fn derives_task_io(

--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -80,7 +80,8 @@ pub(crate) fn task_has_command(
         return true;
     }
 
-    let Some(info) = package_graph.package_info(&PackageName::from(task.package())) else {
+    let Some(context) = package_graph.package_task_context(&PackageName::from(task.package()))
+    else {
         return false;
     };
     match engine
@@ -89,10 +90,10 @@ pub(crate) fn task_has_command(
     {
         Some(turborepo_types::TaskCommandOverride::Argv(_)) => true,
         Some(turborepo_types::TaskCommandOverride::OptOut) => false,
-        None => package_graph
-            .toolchains()
-            .get(&info.toolchain)
-            .is_some_and(|toolchain| toolchain.defines_task(info, task.task())),
+        None => context
+            .toolchain()
+            .and_then(|id| package_graph.toolchains().get(id))
+            .is_some_and(|toolchain| toolchain.defines_task(&context, task.task())),
     }
 }
 

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -1582,6 +1582,36 @@ mod task_io_context_tests {
             Ok(None)
         }
 
+        fn task_display_command(
+            &self,
+            _context: &turborepo_repository::package_graph::PackageTaskContext<'_>,
+            _task: &str,
+        ) -> Option<String> {
+            None
+        }
+
+        fn defines_task(
+            &self,
+            _context: &turborepo_repository::package_graph::PackageTaskContext<'_>,
+            _task: &str,
+        ) -> bool {
+            false
+        }
+
+        fn watch_spec(&self) -> turborepo_repository::toolchain::WatchSpec {
+            turborepo_repository::toolchain::WatchSpec::default()
+        }
+
+        fn prune_plan(
+            &self,
+            _kept_packages: &[String],
+        ) -> Result<
+            Option<turborepo_repository::toolchain::PrunePlan>,
+            turborepo_repository::toolchain::Error,
+        > {
+            Ok(None)
+        }
+
         fn task_io_env_vars(&self) -> &[&str] {
             &self.environment
         }

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -1569,6 +1569,19 @@ mod task_io_context_tests {
             Box::pin(async { Ok(DiscoveredPackages::default()) })
         }
 
+        fn task_command(
+            &self,
+            _context: &turborepo_repository::package_graph::PackageTaskContext<'_>,
+            _task: &str,
+            _pass_through_args: Option<&[String]>,
+            _override_command: Option<&[String]>,
+        ) -> Result<
+            Option<turborepo_repository::toolchain::TaskCommand>,
+            turborepo_repository::toolchain::Error,
+        > {
+            Ok(None)
+        }
+
         fn task_io_env_vars(&self) -> &[&str] {
             &self.environment
         }

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -1284,14 +1284,19 @@ impl RunBuilder {
                 continue;
             }
 
-            let has_command = pkg_dep_graph.packages().any(|(_, package)| {
-                pkg_dep_graph
-                    .toolchains()
-                    .get(&package.toolchain)
-                    .is_some_and(|toolchain| toolchain.defines_task(package, task.task()))
-            }) || engine.task_ids().any(|task_id| {
-                task_id.task() == task.task() && task_has_command(engine, pkg_dep_graph, task_id)
-            });
+            let has_command = pkg_dep_graph
+                .packages()
+                .filter_map(|(name, _)| pkg_dep_graph.package_task_context(name))
+                .any(|context| {
+                    context
+                        .toolchain()
+                        .and_then(|id| pkg_dep_graph.toolchains().get(id))
+                        .is_some_and(|toolchain| toolchain.defines_task(&context, task.task()))
+                })
+                || engine.task_ids().any(|task_id| {
+                    task_id.task() == task.task()
+                        && task_has_command(engine, pkg_dep_graph, task_id)
+                });
 
             for package in candidate_packages {
                 let task_id = TaskId::new(package.as_ref(), task.task()).into_owned();

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -526,12 +526,17 @@ impl Run {
                     .or_insert_with(Vec::new)
                     .push(name.to_string())
             }
-            if let Some(toolchain) = self.pkg_dep_graph.toolchains().get(&info.toolchain) {
-                for task_name in toolchain.registered_tasks(info) {
-                    tasks
-                        .entry(task_name)
-                        .or_insert_with(Vec::new)
-                        .push(name.to_string());
+            if let Some(context) = self.pkg_dep_graph.package_task_context(name) {
+                if let Some(toolchain) = context
+                    .toolchain()
+                    .and_then(|id| self.pkg_dep_graph.toolchains().get(id))
+                {
+                    for task_name in toolchain.registered_tasks(&context) {
+                        tasks
+                            .entry(task_name)
+                            .or_insert_with(Vec::new)
+                            .push(name.to_string());
+                    }
                 }
             }
         }

--- a/crates/turborepo-lib/src/task_graph/visitor/exec.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/exec.rs
@@ -64,7 +64,6 @@ impl<'a> ExecContextFactory<'a> {
             })
             .collect();
         let pkg_graph_provider = ToolchainCommandProvider::new(
-            visitor.repo_root,
             &visitor.package_graph,
             visitor.run_opts.task_args(),
             visitor.micro_frontends_configs,

--- a/crates/turborepo-query/src/package.rs
+++ b/crates/turborepo-query/src/package.rs
@@ -85,13 +85,13 @@ impl Package {
         let registered_tasks: HashSet<_> = self
             .run
             .pkg_dep_graph()
-            .package_info(&self.name)
-            .and_then(|package| {
+            .package_task_context(&self.name)
+            .and_then(|context| {
                 self.run
                     .pkg_dep_graph()
                     .toolchains()
-                    .get(&package.toolchain)
-                    .map(|toolchain| toolchain.registered_tasks(package))
+                    .get(context.toolchain()?)
+                    .map(|toolchain| toolchain.registered_tasks(&context))
             })
             .unwrap_or_default()
             .into_iter()

--- a/crates/turborepo-query/src/task.rs
+++ b/crates/turborepo-query/src/task.rs
@@ -41,16 +41,16 @@ impl RepositoryTask {
                 .package
                 .run()
                 .pkg_dep_graph()
-                .package_info(self.package.get_name())
-                .and_then(|package| {
+                .package_task_context(self.package.get_name())
+                .and_then(|context| {
                     self.package
                         .run()
                         .pkg_dep_graph()
                         .toolchains()
-                        .get(&package.toolchain)
-                        .map(|toolchain| (package, toolchain))
+                        .get(context.toolchain()?)
+                        .map(|toolchain| (context, toolchain))
                 })
-                .is_some_and(|(package, toolchain)| toolchain.defines_task(package, &self.name)),
+                .is_some_and(|(context, toolchain)| toolchain.defines_task(&context, &self.name)),
         }
     }
 

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -1003,6 +1003,10 @@ pub struct CargoToolchain {
 enum CargoCommandError {
     #[error("Unable to find cargo binary: {0}")]
     Which(#[from] which::Error),
+    #[error("Cargo task context belongs to repository {actual}, expected {expected}")]
+    ForeignRepository { actual: String, expected: String },
+    #[error("Cargo task context has non-Rust provenance")]
+    WrongToolchain,
 }
 
 impl CargoToolchain {
@@ -1036,6 +1040,31 @@ impl CargoToolchain {
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .clone()
     }
+
+    fn owns_context(&self, context: &crate::package_graph::PackageTaskContext<'_>) -> bool {
+        context.repository_root() == self.repo_root.as_ref()
+            && context.toolchain() == Some(&ToolchainId::RUST)
+    }
+
+    fn validate_context(
+        &self,
+        context: &crate::package_graph::PackageTaskContext<'_>,
+    ) -> Result<(), toolchain::Error> {
+        if context.repository_root() != self.repo_root.as_ref() {
+            return Err(toolchain::Error::Failed(Box::new(
+                CargoCommandError::ForeignRepository {
+                    actual: context.repository_root().to_string(),
+                    expected: self.repo_root.to_string(),
+                },
+            )));
+        }
+        if context.toolchain() != Some(&ToolchainId::RUST) {
+            return Err(toolchain::Error::Failed(Box::new(
+                CargoCommandError::WrongToolchain,
+            )));
+        }
+        Ok(())
+    }
 }
 
 impl Toolchain for CargoToolchain {
@@ -1049,12 +1078,12 @@ impl Toolchain for CargoToolchain {
 
     fn task_command(
         &self,
-        repo_root: &AbsoluteSystemPath,
-        package: &crate::package_graph::PackageInfo,
+        context: &crate::package_graph::PackageTaskContext<'_>,
         task: &str,
         pass_through_args: Option<&[String]>,
         override_command: Option<&[String]>,
     ) -> Result<Option<toolchain::TaskCommand>, toolchain::Error> {
+        self.validate_context(context)?;
         // An override replaces the verb-table resolution and applies to any
         // crate, including tasks outside the built-in verb tables. The serial
         // group survives when the override still invokes cargo: the
@@ -1064,17 +1093,14 @@ impl Toolchain for CargoToolchain {
             let serial_group = (override_command.first().map(String::as_str) == Some("cargo"))
                 .then(|| "cargo".to_string());
             return Ok(toolchain::override_task_command(
-                repo_root,
-                package,
+                context,
                 override_command,
                 pass_through_args,
                 serial_group,
             ));
         }
-        let Some(name) = package.package_name() else {
-            return Ok(None);
-        };
-        let Some(details) = self.package_details(&name) else {
+        let name = context.package().as_ref();
+        let Some(details) = self.package_details(name) else {
             return Ok(None);
         };
         let Some(subcommand) = task_subcommand(details.kind, task) else {
@@ -1087,13 +1113,12 @@ impl Toolchain for CargoToolchain {
             .as_deref()
             .map_err(|err| toolchain::Error::Failed(Box::new(CargoCommandError::Which(*err))))?;
 
-        let scope = match details.kind {
-            // `--package=<name>` as a single token so a hostile crate name
-            // can never be interpreted as a separate flag.
-            CargoPackageKind::Entrypoint | CargoPackageKind::Library => {
-                format!("--package={name}")
-            }
-            CargoPackageKind::Workspace => "--workspace".to_string(),
+        let scope = match context.kind() {
+            // `--package=<name>` as a single token so a hostile crate name can
+            // never be interpreted as a separate flag.
+            crate::package_graph::PackageTaskContextKind::Package => format!("--package={name}"),
+            crate::package_graph::PackageTaskContextKind::Aggregate => "--workspace".to_string(),
+            crate::package_graph::PackageTaskContextKind::Root => return Ok(None),
         };
         let mut args: Vec<std::ffi::OsString> =
             vec![subcommand.into(), scope.into(), "--locked".into()];
@@ -1109,7 +1134,7 @@ impl Toolchain for CargoToolchain {
             args,
             // Scoping flags select the work, so we always run from the
             // workspace root.
-            cwd: repo_root.to_owned(),
+            cwd: self.repo_root.clone(),
             // Concurrent cargo processes serialize on Cargo's
             // build-directory lock anyway (while emitting "Blocking waiting
             // for file lock" noise), so run them one at a time and let each
@@ -1122,22 +1147,24 @@ impl Toolchain for CargoToolchain {
 
     fn task_display_command(
         &self,
-        package: &crate::package_graph::PackageInfo,
+        context: &crate::package_graph::PackageTaskContext<'_>,
         task: &str,
     ) -> Option<String> {
-        let name = package.package_name()?;
-        let details = self.package_details(&name)?;
-        display_command(details.kind, task, &name)
+        self.owns_context(context).then_some(())?;
+        let name = context.package().as_ref();
+        let details = self.package_details(name)?;
+        display_command(details.kind, task, name)
     }
 
     fn task_defaults(
         &self,
-        package: &crate::package_graph::PackageInfo,
+        context: &crate::package_graph::PackageTaskContext<'_>,
         task: &str,
     ) -> toolchain::TaskDefaults {
-        let cache = package
-            .package_name()
-            .and_then(|name| self.package_details(&name))
+        let cache = self
+            .owns_context(context)
+            .then(|| context.package().as_ref())
+            .and_then(|name| self.package_details(name))
             .and_then(|details| {
                 let subcommand = task_subcommand(details.kind, task)?;
                 (subcommand == "run"
@@ -1148,10 +1175,13 @@ impl Toolchain for CargoToolchain {
         toolchain::TaskDefaults { cache }
     }
 
-    fn registered_tasks(&self, package: &crate::package_graph::PackageInfo) -> Vec<String> {
-        package
-            .package_name()
-            .and_then(|name| self.package_details(&name))
+    fn registered_tasks(
+        &self,
+        context: &crate::package_graph::PackageTaskContext<'_>,
+    ) -> Vec<String> {
+        self.owns_context(context)
+            .then(|| context.package().as_ref())
+            .and_then(|name| self.package_details(name))
             .map(|details| {
                 registered_tasks(&details)
                     .into_iter()
@@ -1161,10 +1191,14 @@ impl Toolchain for CargoToolchain {
             .unwrap_or_default()
     }
 
-    fn registers_task(&self, package: &crate::package_graph::PackageInfo, task: &str) -> bool {
-        package
-            .package_name()
-            .and_then(|name| self.package_details(&name))
+    fn registers_task(
+        &self,
+        context: &crate::package_graph::PackageTaskContext<'_>,
+        task: &str,
+    ) -> bool {
+        self.owns_context(context)
+            .then(|| context.package().as_ref())
+            .and_then(|name| self.package_details(name))
             .is_some_and(|details| registered_tasks(&details).contains(&task))
     }
 
@@ -1241,15 +1275,23 @@ impl Toolchain for CargoToolchain {
         vars
     }
 
-    fn defines_task(&self, package: &crate::package_graph::PackageInfo, task: &str) -> bool {
-        package
-            .package_name()
-            .and_then(|name| self.package_details(&name))
+    fn defines_task(
+        &self,
+        context: &crate::package_graph::PackageTaskContext<'_>,
+        task: &str,
+    ) -> bool {
+        self.owns_context(context)
+            .then(|| context.package().as_ref())
+            .and_then(|name| self.package_details(name))
             .and_then(|details| task_subcommand(details.kind, task))
             .is_some()
     }
 
-    fn derives_task_io(&self, package: &crate::package_graph::PackageInfo, task: &str) -> bool {
+    fn derives_task_io(
+        &self,
+        package: &crate::package_graph::PackageTaskContext<'_>,
+        task: &str,
+    ) -> bool {
         // Mirrors the early returns of `derived_task_io`: a known crate
         // with a Cargo subcommand for this task.
         self.defines_task(package, task)
@@ -1461,15 +1503,16 @@ impl Toolchain for CargoToolchain {
 
     fn derived_task_io(
         &self,
-        package: &crate::package_graph::PackageInfo,
+        package: &crate::package_graph::PackageTaskContext<'_>,
         task: &str,
         path_to_root: &str,
-        dependencies: &[&crate::package_graph::PackageInfo],
+        dependencies: &[crate::package_graph::PackageTaskContext<'_>],
         wants_automatic_inputs: bool,
         context: &toolchain::TaskIOContext<'_>,
     ) -> Option<toolchain::DerivedTaskIO> {
-        let name = package.package_name()?;
-        let details = self.package_details(&name)?;
+        self.owns_context(package).then_some(())?;
+        let name = package.package().as_ref();
+        let details = self.package_details(name)?;
         let subcommand = task_subcommand(details.kind, task)?;
 
         // The workspace lockfile/manifest, Cargo config, and pinned
@@ -1499,14 +1542,13 @@ impl Toolchain for CargoToolchain {
         let dependency_globs = || {
             let mut globs: Vec<String> = dependencies
                 .iter()
-                .filter(|dep| dep.toolchain == ToolchainId::RUST)
+                .filter(|dep| dep.toolchain() == Some(&ToolchainId::RUST))
                 .filter(|dep| {
-                    dep.package_name()
-                        .and_then(|dep_name| self.package_details(&dep_name))
+                    self.package_details(dep.package().as_ref())
                         .is_some_and(|details| details.kind != CargoPackageKind::Workspace)
                 })
                 .flat_map(|dep| {
-                    crate_source_globs(path_to_root, dep.package_path().to_unix().as_str())
+                    crate_source_globs(path_to_root, dep.directory().to_unix().as_str())
                 })
                 .collect();
             for dependency in &details.compilation_dependencies {
@@ -1546,8 +1588,7 @@ impl Toolchain for CargoToolchain {
                                 let effective_target =
                                     layout.target.as_deref().unwrap_or(&workspace.host_target);
                                 let platform = target_platform(effective_target)?;
-                                let package_directory =
-                                    self.repo_root.resolve(package.package_path());
+                                let package_directory = self.repo_root.resolve(package.directory());
                                 let target_directory =
                                     AnchoredSystemPathBuf::relative_path_between(
                                         &package_directory,
@@ -3752,10 +3793,21 @@ release: 1.96.0-nightly\n",
         }
     }
 
+    #[rustfmt::skip]
+    fn task_context<'a>(root: &'a AbsoluteSystemPath, name: &str, directory: &'a str, package: Option<&'a crate::package_graph::PackageInfo>) -> crate::package_graph::PackageTaskContext<'a> {
+        let kind = if directory.is_empty() {
+            crate::package_graph::PackageTaskContextKind::Aggregate
+        } else {
+            crate::package_graph::PackageTaskContextKind::Package
+        };
+        crate::package_graph::PackageTaskContext::new_for_test(name.into(), root, turbopath::AnchoredSystemPath::new(directory).unwrap(), package, kind, Some(&ToolchainId::RUST))
+    }
+
     fn os_args(args: &[&str]) -> Vec<std::ffi::OsString> {
         args.iter().map(std::ffi::OsString::from).collect()
     }
 
+    #[rustfmt::skip]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_cargo_task_commands() {
         let (_tmp, root) = tempdir_root();
@@ -3765,14 +3817,20 @@ release: 1.96.0-nightly\n",
         // Discovery records the per-package details command resolution uses.
         toolchain.discover_packages().await.unwrap();
 
-        let app = package_info("app", "crates/app/Cargo.toml");
-        let lib_a = package_info("lib-a", "crates/lib-a/Cargo.toml");
-        let workspace = package_info("fixture-ws", "Cargo.toml");
+        let mut stale_package = package_info("stale-name", "stale/Cargo.toml");
+        stale_package.toolchain = ToolchainId::JAVASCRIPT;
+        let app_context = task_context(&root, "app", "crates/app", Some(&stale_package));
+        let lib_a_context = task_context(&root, "lib-a", "crates/lib-a", None);
+        let workspace_context = task_context(&root, "fixture-ws", "", Some(&stale_package));
+
+        let foreign_root = root.join_component("foreign");
+        let foreign_context = task_context(&foreign_root, "app", "crates/app", None);
+        assert!(toolchain.task_command(&foreign_context, "build", None, None).unwrap_err().to_string().contains("belongs to repository"));
 
         // Entrypoint build: scoped to the crate, serialized on the cargo
         // group, run from the workspace root.
         let cmd = toolchain
-            .task_command(&root, &app, "build", None, None)
+            .task_command(&app_context, "build", None, None)
             .unwrap()
             .expect("entrypoint build resolves");
         assert_eq!(cmd.args, os_args(&["build", "--package=app", "--locked"]));
@@ -3782,7 +3840,7 @@ release: 1.96.0-nightly\n",
         // `run` is exempt from the serial group and forwards pass-through
         // args to the binary after `--`.
         let cmd = toolchain
-            .task_command(&root, &app, "dev", Some(&["--port".to_string()]), None)
+            .task_command(&app_context, "dev", Some(&["--port".to_string()]), None)
             .unwrap()
             .expect("entrypoint dev resolves to cargo run");
         assert_eq!(
@@ -3794,7 +3852,12 @@ release: 1.96.0-nightly\n",
         // Other subcommands attach pass-through args as cargo flags, no
         // separator.
         let cmd = toolchain
-            .task_command(&root, &app, "build", Some(&["--release".to_string()]), None)
+            .task_command(
+                &app_context,
+                "build",
+                Some(&["--release".to_string()]),
+                None,
+            )
             .unwrap()
             .expect("entrypoint build resolves");
         assert_eq!(
@@ -3804,24 +3867,24 @@ release: 1.96.0-nightly\n",
 
         // A filtered library build resolves directly to that package.
         let cmd = toolchain
-            .task_command(&root, &lib_a, "build", None, None)
+            .task_command(&lib_a_context, "build", None, None)
             .unwrap()
             .expect("library build resolves");
         assert_eq!(cmd.args, os_args(&["build", "--package=lib-a", "--locked"]));
         let cmd = toolchain
-            .task_command(&root, &lib_a, "test", None, None)
+            .task_command(&lib_a_context, "test", None, None)
             .unwrap()
             .expect("library test resolves");
         assert_eq!(cmd.args, os_args(&["test", "--package=lib-a", "--locked"]));
         let cmd = toolchain
-            .task_command(&root, &app, "check", None, None)
+            .task_command(&app_context, "check", None, None)
             .unwrap()
             .expect("entrypoint check resolves");
         assert_eq!(cmd.args, os_args(&["check", "--package=app", "--locked"]));
 
         // The workspace package runs verification verbs at workspace scope.
         let cmd = toolchain
-            .task_command(&root, &workspace, "lint", None, None)
+            .task_command(&workspace_context, "lint", None, None)
             .unwrap()
             .expect("workspace lint resolves to clippy");
         assert_eq!(cmd.args, os_args(&["clippy", "--workspace", "--locked"]));
@@ -3831,8 +3894,7 @@ release: 1.96.0-nightly\n",
         // `--`; e.g. `turbo test -- --nocapture` reaches the test harness.
         let cmd = toolchain
             .task_command(
-                &root,
-                &workspace,
+                &workspace_context,
                 "test",
                 Some(&["--nocapture".to_string()]),
                 None,
@@ -3845,38 +3907,29 @@ release: 1.96.0-nightly\n",
         );
         assert!(
             toolchain
-                .task_command(&root, &workspace, "build", None, None)
+                .task_command(&workspace_context, "build", None, None)
                 .unwrap()
                 .is_none(),
             "workspace-wide build would duplicate entrypoint builds"
         );
 
         // Display strings derive from the same tables.
-        assert_eq!(
-            toolchain.task_display_command(&app, "build").as_deref(),
-            Some("cargo build --package=app --locked")
-        );
+        assert_eq!(toolchain.task_display_command(&app_context, "build").as_deref(), Some("cargo build --package=app --locked"));
+        assert_eq!(toolchain.task_display_command(&workspace_context, "test").as_deref(), Some("cargo test --workspace --locked"));
+        assert_eq!(toolchain.task_display_command(&lib_a_context, "test").as_deref(), Some("cargo test --package=lib-a --locked"));
         assert_eq!(
             toolchain
-                .task_display_command(&workspace, "test")
+                .task_display_command(&lib_a_context, "build")
                 .as_deref(),
-            Some("cargo test --workspace --locked")
-        );
-        assert_eq!(
-            toolchain.task_display_command(&lib_a, "test").as_deref(),
-            Some("cargo test --package=lib-a --locked")
-        );
-        assert_eq!(
-            toolchain.task_display_command(&lib_a, "build").as_deref(),
             Some("cargo build --package=lib-a --locked")
         );
 
-        assert_eq!(toolchain.task_defaults(&app, "run").cache, Some(false));
-        assert_eq!(toolchain.task_defaults(&app, "dev").cache, Some(false));
-        assert_eq!(toolchain.task_defaults(&app, "build").cache, None);
-        assert_eq!(toolchain.task_defaults(&workspace, "test").cache, None);
-        assert_eq!(toolchain.task_defaults(&lib_a, "test").cache, None);
-        assert_eq!(toolchain.task_defaults(&lib_a, "build").cache, Some(false));
+        assert_eq!(toolchain.task_defaults(&app_context, "run").cache, Some(false));
+        assert_eq!(toolchain.task_defaults(&app_context, "dev").cache, Some(false));
+        assert_eq!(toolchain.task_defaults(&app_context, "build").cache, None);
+        assert_eq!(toolchain.task_defaults(&workspace_context, "test").cache, None);
+        assert_eq!(toolchain.task_defaults(&lib_a_context, "test").cache, None);
+        assert_eq!(toolchain.task_defaults(&lib_a_context, "build").cache, Some(false));
 
         assert_eq!(
             toolchain.select_task_entrypoints(
@@ -3952,8 +4005,9 @@ release: 1.96.0-nightly\n",
         let toolchain = CargoToolchain::new(root.clone());
         toolchain.discover_packages().await.unwrap();
 
-        let lib_a = package_info("lib-a", "crates/lib-a/Cargo.toml");
-        let workspace = package_info("fixture-ws", "Cargo.toml");
+        let stale_package = package_info("stale-name", "stale/Cargo.toml");
+        let lib_a_context = task_context(&root, "lib-a", "crates/lib-a", Some(&stale_package));
+        let workspace_context = task_context(&root, "fixture-ws", "", Some(&stale_package));
 
         // An override applies to any crate and any task. cwd is the package's
         // directory, and an argv still invoking cargo keeps the serial group
@@ -3961,7 +4015,7 @@ release: 1.96.0-nightly\n",
         // exists because of cargo's build-directory lock).
         let override_argv = vec!["cargo".to_string(), "fuzz".to_string(), "run".to_string()];
         let cmd = toolchain
-            .task_command(&root, &lib_a, "fuzz", None, Some(&override_argv))
+            .task_command(&lib_a_context, "fuzz", None, Some(&override_argv))
             .unwrap()
             .expect("override defines the task for a library crate");
         assert_eq!(cmd.program, std::ffi::OsString::from("cargo"));
@@ -3974,8 +4028,7 @@ release: 1.96.0-nightly\n",
         let override_argv = vec!["./scripts/test.sh".to_string()];
         let cmd = toolchain
             .task_command(
-                &root,
-                &workspace,
+                &workspace_context,
                 "test",
                 Some(&["--fast".to_string()]),
                 Some(&override_argv),
@@ -4000,6 +4053,9 @@ release: 1.96.0-nightly\n",
         let app = package_info("app", "crates/app/Cargo.toml");
         let lib_a = package_info("lib-a", "crates/lib-a/Cargo.toml");
         let workspace = package_info("fixture-ws", "Cargo.toml");
+        let app_ctx = task_context(&root, "app", "crates/app", Some(&app));
+        let lib_ctx = task_context(&root, "lib-a", "crates/lib-a", Some(&lib_a));
+        let workspace_ctx = task_context(&root, "fixture-ws", "", Some(&workspace));
         let environment = toolchain::TaskIOEnvironment::default();
         let context = toolchain::TaskIOContext {
             task_args: None,
@@ -4007,18 +4063,18 @@ release: 1.96.0-nightly\n",
         };
 
         // defines_task mirrors the verb tables.
-        assert!(toolchain.defines_task(&app, "build"));
-        assert!(toolchain.defines_task(&app, "test"));
-        assert!(toolchain.defines_task(&lib_a, "test"));
-        assert!(toolchain.defines_task(&lib_a, "build"));
-        assert!(toolchain.defines_task(&workspace, "test"));
+        assert!(toolchain.defines_task(&app_ctx, "build"));
+        assert!(toolchain.defines_task(&app_ctx, "test"));
+        assert!(toolchain.defines_task(&lib_ctx, "test"));
+        assert!(toolchain.defines_task(&lib_ctx, "build"));
+        assert!(toolchain.defines_task(&workspace_ctx, "test"));
 
         // Entrypoint build with automatic inputs: workspace files + the
         // dependency crate closure as inputs (own sources via default
         // hashing), deliverables as outputs.
-        let deps = [&lib_a];
+        let deps = [lib_ctx.clone()];
         let io = toolchain
-            .derived_task_io(&app, "build", "../..", &deps, true, &context)
+            .derived_task_io(&app_ctx, "build", "../..", &deps, true, &context)
             .expect("entrypoint build derives IO");
         assert!(
             !io.input_globs
@@ -4073,14 +4129,21 @@ release: 1.96.0-nightly\n",
             environment: &environment,
         };
         let unsupported = toolchain
-            .derived_task_io(&app, "build", "../..", &deps, true, &unsupported_context)
+            .derived_task_io(
+                &app_ctx,
+                "build",
+                "../..",
+                &deps,
+                true,
+                &unsupported_context,
+            )
             .expect("entrypoint build derives IO");
         assert_eq!(unsupported.outputs, toolchain::DerivedOutputs::Unavailable);
 
         // Explicit inputs without $TURBO_DEFAULT$: workspace files still
         // apply, but no closure globs and no default-hashing override.
         let io = toolchain
-            .derived_task_io(&app, "build", "../..", &deps, false, &context)
+            .derived_task_io(&app_ctx, "build", "../..", &deps, false, &context)
             .expect("entrypoint build derives IO");
         assert!(io.input_globs.contains(&"../../Cargo.toml".to_string()));
         assert!(!io.input_globs.iter().any(|glob| glob.contains("lib-a")));
@@ -4088,15 +4151,15 @@ release: 1.96.0-nightly\n",
 
         // Non-build entrypoint verbs cache no deliverables.
         let io = toolchain
-            .derived_task_io(&app, "dev", "../..", &deps, true, &context)
+            .derived_task_io(&app_ctx, "dev", "../..", &deps, true, &context)
             .expect("entrypoint dev derives IO");
         assert_eq!(io.outputs, toolchain::DerivedOutputs::Resolved(Vec::new()));
 
         // The workspace package hashes crate directories instead of the
         // repo root's default file set.
-        let deps = [&app, &lib_a];
+        let deps = [app_ctx.clone(), lib_ctx.clone()];
         let io = toolchain
-            .derived_task_io(&workspace, "test", "", &deps, true, &context)
+            .derived_task_io(&workspace_ctx, "test", "", &deps, true, &context)
             .expect("workspace test derives IO");
         assert_eq!(io.package_default_inputs, Some(false));
         assert!(io.input_globs.contains(&"crates/app/**".to_string()));
@@ -4107,7 +4170,7 @@ release: 1.96.0-nightly\n",
         // Library verification hashes dev dependencies even when their cycle
         // prevents them from appearing in the package graph.
         let io = toolchain
-            .derived_task_io(&lib_a, "test", "../..", &[], true, &context)
+            .derived_task_io(&lib_ctx, "test", "../..", &[], true, &context)
             .expect("library test derives IO");
         assert_eq!(io.package_default_inputs, Some(true));
         assert!(
@@ -4121,7 +4184,7 @@ release: 1.96.0-nightly\n",
         // Library build artifacts are Cargo-internal and cannot be restored as
         // stable Turborepo outputs, so implicit caching fails closed.
         let io = toolchain
-            .derived_task_io(&lib_a, "build", "../..", &[], true, &context)
+            .derived_task_io(&lib_ctx, "build", "../..", &[], true, &context)
             .expect("library build derives IO");
         assert_eq!(io.package_default_inputs, Some(true));
         assert_eq!(io.outputs, toolchain::DerivedOutputs::Unavailable);

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -1331,6 +1331,16 @@ mod test {
         fn discover_packages(&self) -> DiscoverPackagesFuture<'_> {
             Box::pin(async move { Ok(DiscoveredPackages::new(Vec::new(), self.roots.clone())) })
         }
+
+        fn task_command(
+            &self,
+            _context: &crate::package_graph::PackageTaskContext<'_>,
+            _task: &str,
+            _pass_through_args: Option<&[String]>,
+            _override_command: Option<&[String]>,
+        ) -> Result<Option<crate::toolchain::TaskCommand>, crate::toolchain::Error> {
+            Ok(None)
+        }
     }
 
     struct PackageWithoutRootToolchain {
@@ -1354,6 +1364,16 @@ mod test {
                     Vec::new(),
                 ))
             })
+        }
+
+        fn task_command(
+            &self,
+            _context: &crate::package_graph::PackageTaskContext<'_>,
+            _task: &str,
+            _pass_through_args: Option<&[String]>,
+            _override_command: Option<&[String]>,
+        ) -> Result<Option<crate::toolchain::TaskCommand>, crate::toolchain::Error> {
+            Ok(None)
         }
     }
 

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -1341,6 +1341,33 @@ mod test {
         ) -> Result<Option<crate::toolchain::TaskCommand>, crate::toolchain::Error> {
             Ok(None)
         }
+
+        fn task_display_command(
+            &self,
+            _context: &crate::package_graph::PackageTaskContext<'_>,
+            _task: &str,
+        ) -> Option<String> {
+            None
+        }
+
+        fn defines_task(
+            &self,
+            _context: &crate::package_graph::PackageTaskContext<'_>,
+            _task: &str,
+        ) -> bool {
+            false
+        }
+
+        fn watch_spec(&self) -> crate::toolchain::WatchSpec {
+            crate::toolchain::WatchSpec::default()
+        }
+
+        fn prune_plan(
+            &self,
+            _kept_packages: &[String],
+        ) -> Result<Option<crate::toolchain::PrunePlan>, crate::toolchain::Error> {
+            Ok(None)
+        }
     }
 
     struct PackageWithoutRootToolchain {
@@ -1373,6 +1400,33 @@ mod test {
             _pass_through_args: Option<&[String]>,
             _override_command: Option<&[String]>,
         ) -> Result<Option<crate::toolchain::TaskCommand>, crate::toolchain::Error> {
+            Ok(None)
+        }
+
+        fn task_display_command(
+            &self,
+            _context: &crate::package_graph::PackageTaskContext<'_>,
+            _task: &str,
+        ) -> Option<String> {
+            None
+        }
+
+        fn defines_task(
+            &self,
+            _context: &crate::package_graph::PackageTaskContext<'_>,
+            _task: &str,
+        ) -> bool {
+            false
+        }
+
+        fn watch_spec(&self) -> crate::toolchain::WatchSpec {
+            crate::toolchain::WatchSpec::default()
+        }
+
+        fn prune_plan(
+            &self,
+            _kept_packages: &[String],
+        ) -> Result<Option<crate::toolchain::PrunePlan>, crate::toolchain::Error> {
             Ok(None)
         }
     }

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -223,6 +223,7 @@ pub struct PackageTaskContext<'a> {
     directory: &'a AnchoredSystemPath,
     package_info: Option<&'a PackageInfo>,
     kind: PackageTaskContextKind,
+    toolchain: Option<&'a crate::toolchain::ToolchainId>,
     requires_compatibility_payload: bool,
 }
 
@@ -234,6 +235,12 @@ pub enum PackageTaskContextKind {
 }
 
 impl<'a> PackageTaskContext<'a> {
+    #[cfg(test)]
+    #[rustfmt::skip]
+    pub(crate) fn new_for_test(package: PackageName, repository_root: &'a AbsoluteSystemPath, directory: &'a AnchoredSystemPath, package_info: Option<&'a PackageInfo>, kind: PackageTaskContextKind, toolchain: Option<&'a crate::toolchain::ToolchainId>) -> Self {
+        Self { package, repository_root, directory, package_info, kind, toolchain, requires_compatibility_payload: package_info.is_some() }
+    }
+
     pub fn package(&self) -> &PackageName {
         &self.package
     }
@@ -252,6 +259,10 @@ impl<'a> PackageTaskContext<'a> {
 
     pub fn kind(&self) -> PackageTaskContextKind {
         self.kind
+    }
+
+    pub fn toolchain(&self) -> Option<&'a crate::toolchain::ToolchainId> {
+        self.toolchain
     }
 
     pub fn requires_compatibility_payload(&self) -> bool {
@@ -551,11 +562,14 @@ impl PackageGraph {
     /// required to construct a context. The root identity denotes Turbo's root
     /// task namespace and is always anchored at the repository directory.
     pub fn package_task_context(&self, package: &PackageName) -> Option<PackageTaskContext<'_>> {
-        let (package, directory, kind, requires_compatibility_payload) = match package {
+        let (package, directory, kind, toolchain, requires_compatibility_payload) = match package {
             PackageName::Root => (
                 PackageName::Root,
                 self.knowledge.repository_directory(),
                 PackageTaskContextKind::Root,
+                self.knowledge
+                    .root_javascript_scope()
+                    .map(|scope| scope.toolchain()),
                 self.knowledge.root_javascript_scope().is_some(),
             ),
             PackageName::Other(name) => {
@@ -568,6 +582,7 @@ impl PackageGraph {
                     PackageName::Other(scope.identity().to_owned()),
                     scope.directory(),
                     kind,
+                    Some(scope.toolchain()),
                     true,
                 )
             }
@@ -580,6 +595,7 @@ impl PackageGraph {
             directory,
             package_info,
             kind,
+            toolchain,
             requires_compatibility_payload,
         })
     }
@@ -2442,6 +2458,7 @@ version = "0.1.0"
             pkg_graph.repository_knowledge().repository_directory()
         );
         assert_eq!(root_context.kind(), PackageTaskContextKind::Root);
+        assert_eq!(root_context.toolchain(), None);
         assert!(std::ptr::eq(
             root_context.package_info().unwrap(),
             pkg_graph.package_info(&PackageName::Root).unwrap()
@@ -2499,6 +2516,43 @@ version = "0.1.0"
         assert_eq!(lib_a.toolchain, crate::toolchain::ToolchainId::RUST);
         let workspace_pkg = pkg_graph.package_info(&PackageName::from("acme")).unwrap();
         assert_eq!(workspace_pkg.toolchain, crate::toolchain::ToolchainId::RUST);
+
+        // Compatibility identity, path, and provenance may be stale without
+        // changing command resolution. The graph-created context remains
+        // bound to repository knowledge and Cargo receives those facts.
+        let app_name = PackageName::from("app");
+        {
+            let stale = pkg_graph.packages.get_mut(&app_name).unwrap();
+            stale.package_json.name = Some(Spanned::new("stale-app".to_string()));
+            stale.package_json_path = AnchoredSystemPathBuf::from_raw("stale/Cargo.toml").unwrap();
+            stale.toolchain = crate::toolchain::ToolchainId::JAVASCRIPT;
+        }
+        let app_context = pkg_graph.package_task_context(&app_name).unwrap();
+        assert_eq!(app_context.package(), &app_name);
+        assert_eq!(
+            app_context.directory(),
+            AnchoredSystemPath::new("rust/app").unwrap()
+        );
+        assert_eq!(
+            app_context.toolchain(),
+            Some(&crate::toolchain::ToolchainId::RUST)
+        );
+        let command = pkg_graph
+            .toolchains()
+            .get(app_context.toolchain().unwrap())
+            .unwrap()
+            .task_command(&app_context, "build", None, None)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            command.args,
+            vec![
+                std::ffi::OsString::from("build"),
+                std::ffi::OsString::from("--package=app"),
+                std::ffi::OsString::from("--locked"),
+            ]
+        );
+        assert_eq!(command.cwd, root);
 
         // Crate path dependencies still become graph edges without a package
         // manager: the `workspace:*` protocol resolves internally regardless.

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -354,10 +354,7 @@ pub trait Toolchain: Send + Sync {
         &self,
         context: &crate::package_graph::PackageTaskContext<'_>,
         task: &str,
-    ) -> Option<String> {
-        let _ = (context, task);
-        None
-    }
+    ) -> Option<String>;
 
     /// Whether the package itself *authors* a definition for `task` — a
     /// package.json script, written by the package's owner. Distinct from
@@ -406,10 +403,7 @@ pub trait Toolchain: Send + Sync {
         &self,
         context: &crate::package_graph::PackageTaskContext<'_>,
         task: &str,
-    ) -> bool {
-        let _ = (context, task);
-        false
-    }
+    ) -> bool;
 
     /// Defaults this toolchain supplies for `task` when turbo.json does not
     /// configure the corresponding field. Explicit user configuration always
@@ -503,18 +497,13 @@ pub trait Toolchain: Send + Sync {
     /// How filesystem events relate to this toolchain in watch mode:
     /// workspace-definition files whose change requires rediscovery, and
     /// build-byproduct directories whose events must be ignored.
-    fn watch_spec(&self) -> WatchSpec {
-        WatchSpec::default()
-    }
+    fn watch_spec(&self) -> WatchSpec;
 
     /// What `turbo prune` must carry for this toolchain so the pruned
     /// repository is self-contained, given the names of this toolchain's
     /// packages already selected for the pruned output. `None` means the
     /// toolchain contributes nothing beyond the packages themselves.
-    fn prune_plan(&self, kept_packages: &[String]) -> Result<Option<PrunePlan>, Error> {
-        let _ = kept_packages;
-        Ok(None)
-    }
+    fn prune_plan(&self, kept_packages: &[String]) -> Result<Option<PrunePlan>, Error>;
 
     /// Called after the pruned output is fully written, with its root
     /// directory. Toolchains may polish their own files in place (e.g.
@@ -1411,6 +1400,30 @@ mod tests {
                 _pass_through_args: Option<&[String]>,
                 _override_command: Option<&[String]>,
             ) -> Result<Option<TaskCommand>, Error> {
+                Ok(None)
+            }
+
+            fn task_display_command(
+                &self,
+                _context: &crate::package_graph::PackageTaskContext<'_>,
+                _task: &str,
+            ) -> Option<String> {
+                None
+            }
+
+            fn defines_task(
+                &self,
+                _context: &crate::package_graph::PackageTaskContext<'_>,
+                _task: &str,
+            ) -> bool {
+                false
+            }
+
+            fn watch_spec(&self) -> WatchSpec {
+                WatchSpec::default()
+            }
+
+            fn prune_plan(&self, _kept_packages: &[String]) -> Result<Option<PrunePlan>, Error> {
                 Ok(None)
             }
         }

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -345,10 +345,7 @@ pub trait Toolchain: Send + Sync {
         task: &str,
         pass_through_args: Option<&[String]>,
         override_command: Option<&[String]>,
-    ) -> Result<Option<TaskCommand>, Error> {
-        let _ = (context, task, pass_through_args, override_command);
-        Ok(None)
-    }
+    ) -> Result<Option<TaskCommand>, Error>;
 
     /// A one-line description of what `task` runs for `package`, for
     /// dry-run output and run summaries. Derived from the same tables as
@@ -1405,6 +1402,16 @@ mod tests {
             }
             fn discover_packages(&self) -> DiscoverPackagesFuture<'_> {
                 Box::pin(async { Ok(DiscoveredPackages::default()) })
+            }
+
+            fn task_command(
+                &self,
+                _context: &crate::package_graph::PackageTaskContext<'_>,
+                _task: &str,
+                _pass_through_args: Option<&[String]>,
+                _override_command: Option<&[String]>,
+            ) -> Result<Option<TaskCommand>, Error> {
+                Ok(None)
             }
         }
 

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -296,8 +296,7 @@ pub struct TaskCommand {
 /// package's own, uniformly across toolchains; the caller supplies its
 /// toolchain-specific serial group.
 pub fn override_task_command(
-    repo_root: &AbsoluteSystemPath,
-    package: &crate::package_graph::PackageInfo,
+    context: &crate::package_graph::PackageTaskContext<'_>,
     override_command: &[String],
     pass_through_args: Option<&[String]>,
     serial_group: Option<String>,
@@ -310,7 +309,7 @@ pub fn override_task_command(
     Some(TaskCommand {
         program: OsString::from(program),
         args,
-        cwd: repo_root.resolve(package.package_path()),
+        cwd: context.repository_root().resolve(context.directory()),
         serial_group,
     })
 }
@@ -342,19 +341,12 @@ pub trait Toolchain: Send + Sync {
     /// cannot know an arbitrary command's separator convention.
     fn task_command(
         &self,
-        repo_root: &AbsoluteSystemPath,
-        package: &crate::package_graph::PackageInfo,
+        context: &crate::package_graph::PackageTaskContext<'_>,
         task: &str,
         pass_through_args: Option<&[String]>,
         override_command: Option<&[String]>,
     ) -> Result<Option<TaskCommand>, Error> {
-        let _ = (
-            repo_root,
-            package,
-            task,
-            pass_through_args,
-            override_command,
-        );
+        let _ = (context, task, pass_through_args, override_command);
         Ok(None)
     }
 
@@ -363,10 +355,10 @@ pub trait Toolchain: Send + Sync {
     /// [`Toolchain::task_command`] so display cannot drift from execution.
     fn task_display_command(
         &self,
-        package: &crate::package_graph::PackageInfo,
+        context: &crate::package_graph::PackageTaskContext<'_>,
         task: &str,
     ) -> Option<String> {
-        let _ = (package, task);
+        let _ = (context, task);
         None
     }
 
@@ -377,22 +369,33 @@ pub trait Toolchain: Send + Sync {
     ///
     /// Authored definitions shadow unscoped `command` defaults from the
     /// root turbo.json; synthesized ones sit below them.
-    fn authors_task(&self, package: &crate::package_graph::PackageInfo, task: &str) -> bool {
-        let _ = (package, task);
+    fn authors_task(
+        &self,
+        context: &crate::package_graph::PackageTaskContext<'_>,
+        task: &str,
+    ) -> bool {
+        let _ = (context, task);
         false
     }
 
     /// Task names this toolchain makes available without an explicit
     /// turbo.json definition. These act as lowest-precedence empty task
     /// definitions; normal task configuration still overrides them.
-    fn registered_tasks(&self, package: &crate::package_graph::PackageInfo) -> Vec<String> {
-        let _ = package;
+    fn registered_tasks(
+        &self,
+        context: &crate::package_graph::PackageTaskContext<'_>,
+    ) -> Vec<String> {
+        let _ = context;
         Vec::new()
     }
 
     /// Whether [`Toolchain::registered_tasks`] contains `task`.
-    fn registers_task(&self, package: &crate::package_graph::PackageInfo, task: &str) -> bool {
-        self.registered_tasks(package)
+    fn registers_task(
+        &self,
+        context: &crate::package_graph::PackageTaskContext<'_>,
+        task: &str,
+    ) -> bool {
+        self.registered_tasks(context)
             .iter()
             .any(|registered| registered == task)
     }
@@ -402,8 +405,12 @@ pub trait Toolchain: Send + Sync {
     /// solely for dependency ordering via `dependsOn: ["^task"]`): they do
     /// not execute, so hashing concerns like global input files must not
     /// apply to them.
-    fn defines_task(&self, package: &crate::package_graph::PackageInfo, task: &str) -> bool {
-        let _ = (package, task);
+    fn defines_task(
+        &self,
+        context: &crate::package_graph::PackageTaskContext<'_>,
+        task: &str,
+    ) -> bool {
+        let _ = (context, task);
         false
     }
 
@@ -412,10 +419,10 @@ pub trait Toolchain: Send + Sync {
     /// wins.
     fn task_defaults(
         &self,
-        package: &crate::package_graph::PackageInfo,
+        context: &crate::package_graph::PackageTaskContext<'_>,
         task: &str,
     ) -> TaskDefaults {
-        let _ = (package, task);
+        let _ = (context, task);
         TaskDefaults::default()
     }
 
@@ -445,10 +452,10 @@ pub trait Toolchain: Send + Sync {
     /// whole story.
     fn derived_task_io(
         &self,
-        package: &crate::package_graph::PackageInfo,
+        package: &crate::package_graph::PackageTaskContext<'_>,
         task: &str,
         path_to_root: &str,
-        dependencies: &[&crate::package_graph::PackageInfo],
+        dependencies: &[crate::package_graph::PackageTaskContext<'_>],
         wants_automatic_inputs: bool,
         context: &TaskIOContext<'_>,
     ) -> Option<DerivedTaskIO> {
@@ -467,7 +474,11 @@ pub trait Toolchain: Send + Sync {
     /// package/task. Callers use this to skip assembling the (expensive)
     /// dependency-closure argument when the answer is knowably `None` —
     /// notably engine construction, which resolves a definition per task.
-    fn derives_task_io(&self, package: &crate::package_graph::PackageInfo, task: &str) -> bool {
+    fn derives_task_io(
+        &self,
+        package: &crate::package_graph::PackageTaskContext<'_>,
+        task: &str,
+    ) -> bool {
         let _ = (package, task);
         false
     }
@@ -899,8 +910,7 @@ impl<P: PackageDiscovery + Send + Sync> Toolchain for JavaScriptToolchain<P> {
 
     fn task_command(
         &self,
-        repo_root: &AbsoluteSystemPath,
-        package: &crate::package_graph::PackageInfo,
+        context: &crate::package_graph::PackageTaskContext<'_>,
         task: &str,
         pass_through_args: Option<&[String]>,
         override_command: Option<&[String]>,
@@ -910,14 +920,16 @@ impl<P: PackageDiscovery + Send + Sync> Toolchain for JavaScriptToolchain<P> {
         // bypasses `<pm> run`, so `node_modules/.bin` is not added to PATH.
         if let Some(override_command) = override_command {
             return Ok(override_task_command(
-                repo_root,
-                package,
+                context,
                 override_command,
                 pass_through_args,
                 None,
             ));
         }
         // No script (or an empty one) means the task is a no-op.
+        let Some(package) = context.package_info() else {
+            return Ok(None);
+        };
         if package
             .package_json
             .scripts
@@ -951,45 +963,56 @@ impl<P: PackageDiscovery + Send + Sync> Toolchain for JavaScriptToolchain<P> {
         Ok(Some(TaskCommand {
             program,
             args,
-            cwd: repo_root.resolve(package.package_path()),
+            cwd: context.repository_root().resolve(context.directory()),
             serial_group: None,
         }))
     }
 
     fn task_display_command(
         &self,
-        package: &crate::package_graph::PackageInfo,
+        context: &crate::package_graph::PackageTaskContext<'_>,
         task: &str,
     ) -> Option<String> {
         // Summaries show the script text itself, matching historical
         // behavior.
-        package
+        context
+            .package_info()?
             .package_json
             .scripts
             .get(task)
             .map(|script| script.as_inner().clone())
     }
 
-    fn defines_task(&self, package: &crate::package_graph::PackageInfo, task: &str) -> bool {
-        package
-            .package_json
-            .scripts
-            .get(task)
-            .is_some_and(|script| !script.is_empty())
+    fn defines_task(
+        &self,
+        context: &crate::package_graph::PackageTaskContext<'_>,
+        task: &str,
+    ) -> bool {
+        context.package_info().is_some_and(|package| {
+            package
+                .package_json
+                .scripts
+                .get(task)
+                .is_some_and(|script| !script.is_empty())
+        })
     }
 
     /// package.json scripts are authored by the package: they shadow
     /// unscoped `command` defaults.
-    fn authors_task(&self, package: &crate::package_graph::PackageInfo, task: &str) -> bool {
-        self.defines_task(package, task)
+    fn authors_task(
+        &self,
+        context: &crate::package_graph::PackageTaskContext<'_>,
+        task: &str,
+    ) -> bool {
+        self.defines_task(context, task)
     }
 
     fn derived_task_io(
         &self,
-        _package: &crate::package_graph::PackageInfo,
+        _package: &crate::package_graph::PackageTaskContext<'_>,
         _task: &str,
         _path_to_root: &str,
-        _dependencies: &[&crate::package_graph::PackageInfo],
+        _dependencies: &[crate::package_graph::PackageTaskContext<'_>],
         _wants_automatic_inputs: bool,
         _context: &TaskIOContext<'_>,
     ) -> Option<DerivedTaskIO> {
@@ -1086,6 +1109,34 @@ mod tests {
         assert_eq!(custom.to_string(), "gleam");
         let dynamic = ToolchainId::new(String::from("python-uv"));
         assert_eq!(dynamic.as_str(), "python-uv");
+    }
+
+    #[test]
+    fn pure_native_root_override_uses_repository_context() {
+        let root =
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+        let directory = turbopath::AnchoredSystemPath::new("").unwrap();
+        let context = crate::package_graph::PackageTaskContext::new_for_test(
+            crate::package_graph::PackageName::Root,
+            &root,
+            directory,
+            None,
+            crate::package_graph::PackageTaskContextKind::Root,
+            None,
+        );
+        let argv = ["./scripts/release".to_string(), "check".to_string()];
+        let pass_through = ["--locked".to_string()];
+
+        let command = override_task_command(&context, &argv, Some(&pass_through), None)
+            .expect("non-empty root override resolves");
+
+        assert_eq!(command.program, OsString::from("./scripts/release"));
+        assert_eq!(
+            command.args,
+            vec![OsString::from("check"), OsString::from("--locked")]
+        );
+        assert_eq!(command.cwd, root);
+        assert_eq!(command.serial_group, None);
     }
 
     #[test]
@@ -1211,19 +1262,29 @@ mod tests {
 
         let package = crate::package_graph::PackageInfo {
             package_json: PackageJson::from_value(serde_json::json!({
-                "name": "web",
+                "name": "stale-web",
                 "scripts": { "build": "next build", "empty": "" }
             }))
             .unwrap(),
-            package_json_path: turbopath::AnchoredSystemPathBuf::from_raw(
-                ["apps", "web", "package.json"].join(std::path::MAIN_SEPARATOR_STR),
-            )
-            .unwrap(),
+            // Identity/path/toolchain are deliberately stale compatibility
+            // fields. Command framing must come from `context`.
+            package_json_path: turbopath::AnchoredSystemPathBuf::from_raw("stale/package.json")
+                .unwrap(),
+            toolchain: ToolchainId::RUST,
             ..Default::default()
         };
+        let package_directory = turbopath::AnchoredSystemPath::new("apps/web").unwrap();
+        let context = crate::package_graph::PackageTaskContext::new_for_test(
+            "web".into(),
+            repo_root,
+            package_directory,
+            Some(&package),
+            crate::package_graph::PackageTaskContextKind::Package,
+            Some(&ToolchainId::JAVASCRIPT),
+        );
 
         let command = toolchain
-            .task_command(repo_root, &package, "build", None, None)
+            .task_command(&context, "build", None, None)
             .unwrap()
             .expect("script exists, command resolves");
         // The program is the resolved npm binary (or node.exe on Windows);
@@ -1245,23 +1306,23 @@ mod tests {
         // Missing and empty scripts are no-ops.
         assert!(
             toolchain
-                .task_command(repo_root, &package, "lint", None, None)
+                .task_command(&context, "lint", None, None)
                 .unwrap()
                 .is_none()
         );
         assert!(
             toolchain
-                .task_command(repo_root, &package, "empty", None, None)
+                .task_command(&context, "empty", None, None)
                 .unwrap()
                 .is_none()
         );
 
         // Display shows the script text itself.
         assert_eq!(
-            toolchain.task_display_command(&package, "build").as_deref(),
+            toolchain.task_display_command(&context, "build").as_deref(),
             Some("next build")
         );
-        assert_eq!(toolchain.task_display_command(&package, "lint"), None);
+        assert_eq!(toolchain.task_display_command(&context, "lint"), None);
 
         // A `command` override replaces the whole package-manager
         // indirection: argv[0] is the program, nothing is prepended, cwd is
@@ -1270,8 +1331,7 @@ mod tests {
         let override_argv = vec!["vitest".to_string(), "run".to_string()];
         let cmd = toolchain
             .task_command(
-                repo_root,
-                &package,
+                &context,
                 "lint",
                 Some(&["--bail".to_string()]),
                 Some(&override_argv),
@@ -1283,7 +1343,7 @@ mod tests {
             cmd.args,
             vec![OsString::from("run"), OsString::from("--bail")]
         );
-        assert_eq!(cmd.cwd, repo_root.resolve(package.package_path()));
+        assert_eq!(cmd.cwd, repo_root.resolve(package_directory));
         assert_eq!(cmd.serial_group, None);
     }
 

--- a/crates/turborepo-run-summary/src/task_factory.rs
+++ b/crates/turborepo-run-summary/src/task_factory.rs
@@ -111,10 +111,10 @@ where
             Some(turborepo_types::TaskCommandOverride::OptOut) => "<OPT OUT>".to_string(),
             None => self
                 .package_graph
-                .toolchains()
-                .get(&workspace_info.toolchain)
-                .and_then(|toolchain| {
-                    toolchain.task_display_command(workspace_info, task_id.task())
+                .package_task_context(&task_id.package().into())
+                .and_then(|context| {
+                    let toolchain = self.package_graph.toolchains().get(context.toolchain()?)?;
+                    toolchain.task_display_command(&context, task_id.task())
                 })
                 .unwrap_or_else(|| "<NONEXISTENT>".to_string()),
         };

--- a/crates/turborepo-scope/src/filter.rs
+++ b/crates/turborepo-scope/src/filter.rs
@@ -1016,6 +1016,36 @@ mod test {
         > {
             Ok(None)
         }
+
+        fn task_display_command(
+            &self,
+            _context: &turborepo_repository::package_graph::PackageTaskContext<'_>,
+            _task: &str,
+        ) -> Option<String> {
+            None
+        }
+
+        fn defines_task(
+            &self,
+            _context: &turborepo_repository::package_graph::PackageTaskContext<'_>,
+            _task: &str,
+        ) -> bool {
+            false
+        }
+
+        fn watch_spec(&self) -> turborepo_repository::toolchain::WatchSpec {
+            turborepo_repository::toolchain::WatchSpec::default()
+        }
+
+        fn prune_plan(
+            &self,
+            _kept_packages: &[String],
+        ) -> Result<
+            Option<turborepo_repository::toolchain::PrunePlan>,
+            turborepo_repository::toolchain::Error,
+        > {
+            Ok(None)
+        }
     }
 
     /// Make a project resolver with the provided dependencies. Extras is for

--- a/crates/turborepo-scope/src/filter.rs
+++ b/crates/turborepo-scope/src/filter.rs
@@ -1003,6 +1003,19 @@ mod test {
                 ))
             })
         }
+
+        fn task_command(
+            &self,
+            _context: &turborepo_repository::package_graph::PackageTaskContext<'_>,
+            _task: &str,
+            _pass_through_args: Option<&[String]>,
+            _override_command: Option<&[String]>,
+        ) -> Result<
+            Option<turborepo_repository::toolchain::TaskCommand>,
+            turborepo_repository::toolchain::Error,
+        > {
+            Ok(None)
+        }
     }
 
     /// Make a project resolver with the provided dependencies. Extras is for

--- a/crates/turborepo-task-executor/src/command.rs
+++ b/crates/turborepo-task-executor/src/command.rs
@@ -10,7 +10,7 @@ use turbopath::{AbsoluteSystemPath, PathError, RelativeUnixPath};
 use turborepo_env::EnvironmentVariableMap;
 use turborepo_process::Command;
 use turborepo_repository::{
-    package_graph::{PackageGraph, PackageInfo, PackageName},
+    package_graph::{PackageGraph, PackageInfo, PackageName, PackageTaskContext},
     package_manager::PackageManager,
     toolchain::CompileCacheEndpoint,
 };
@@ -163,7 +163,6 @@ impl PackageInfoProvider for PackageGraph {
 /// microfrontends proxy decorations.
 #[derive(Debug)]
 pub struct ToolchainCommandProvider<'a, M = crate::NoMfeConfig> {
-    repo_root: &'a AbsoluteSystemPath,
     package_graph: &'a PackageGraph,
     task_args: TaskArgs<'a>,
     mfe_configs: Option<&'a M>,
@@ -179,7 +178,6 @@ pub struct ToolchainCommandProvider<'a, M = crate::NoMfeConfig> {
 
 impl<'a, M: MfeConfigProvider> ToolchainCommandProvider<'a, M> {
     pub fn new(
-        repo_root: &'a AbsoluteSystemPath,
         package_graph: &'a PackageGraph,
         task_args: TaskArgs<'a>,
         mfe_configs: Option<&'a M>,
@@ -187,7 +185,6 @@ impl<'a, M: MfeConfigProvider> ToolchainCommandProvider<'a, M> {
         command_overrides: HashMap<TaskId<'static>, TaskCommandOverride>,
     ) -> Self {
         Self {
-            repo_root,
             package_graph,
             task_args,
             mfe_configs,
@@ -196,9 +193,12 @@ impl<'a, M: MfeConfigProvider> ToolchainCommandProvider<'a, M> {
         }
     }
 
-    fn package_info(&self, task_id: &TaskId) -> Result<&PackageInfo, CommandProviderError> {
+    fn package_context(
+        &self,
+        task_id: &TaskId,
+    ) -> Result<PackageTaskContext<'_>, CommandProviderError> {
         self.package_graph
-            .package_info(&PackageName::from(task_id.package()))
+            .package_task_context(&PackageName::from(task_id.package()))
             .ok_or_else(|| CommandProviderError::MissingPackage {
                 package_name: task_id.package().into(),
                 task_id: task_id.clone().into_owned(),
@@ -218,15 +218,7 @@ impl<'a, M: MfeConfigProvider, E: From<CommandProviderError>> CommandProvider<E>
         task_id: &TaskId,
         environment: &EnvironmentVariableMap,
     ) -> Result<Option<Command>, E> {
-        let workspace_info = self.package_info(task_id)?;
-        let toolchain = self
-            .package_graph
-            .toolchains()
-            .get(&workspace_info.toolchain)
-            .ok_or_else(|| CommandProviderError::MissingToolchain {
-                toolchain: workspace_info.toolchain.clone(),
-                package_name: task_id.package().into(),
-            })?;
+        let package_context = self.package_context(task_id)?;
 
         // A resolved `command` override is authoritative in both
         // directions: an opt-out is an explicit no-op (same outcome as a
@@ -239,10 +231,39 @@ impl<'a, M: MfeConfigProvider, E: From<CommandProviderError>> CommandProvider<E>
             None => None,
         };
 
+        // A pure-native repository still has Turbo's root task namespace, but
+        // no root language toolchain. Explicit root command overrides are
+        // generic argv and execute directly at the knowledge-backed repo root.
+        let Some(toolchain_id) = package_context.toolchain() else {
+            let Some(override_command) = override_command else {
+                return Ok(None);
+            };
+            let Some(spec) = turborepo_repository::toolchain::override_task_command(
+                &package_context,
+                override_command,
+                self.task_args.args_for_task(task_id),
+                None,
+            ) else {
+                return Ok(None);
+            };
+            let mut cmd = Command::new(spec.program);
+            cmd.args(spec.args).current_dir(spec.cwd);
+            apply_environment(&mut cmd, environment);
+            cmd.open_stdin();
+            return Ok(Some(cmd));
+        };
+        let toolchain = self
+            .package_graph
+            .toolchains()
+            .get(toolchain_id)
+            .ok_or_else(|| CommandProviderError::MissingToolchain {
+                toolchain: toolchain_id.clone(),
+                package_name: package_context.package().clone(),
+            })?;
+
         let spec = toolchain
             .task_command(
-                self.repo_root,
-                workspace_info,
+                &package_context,
                 task_id.task(),
                 self.task_args.args_for_task(task_id),
                 override_command,


### PR DESCRIPTION
### Description

Part 8 of the package/scope knowledge completion stack.

Bind every toolchain task callback to graph-created package contexts. JavaScript and Cargo command framing, task availability, defaults, display commands, and derived I/O no longer recover identity, paths, or provenance from compatibility manifests.

### Testing Instructions

- `cargo test -p turborepo-repository -p turborepo-engine -p turborepo-task-executor`
- `cargo test -p turbo --test cargo_workspace_test`