### PR TITLE
refactor: Use package knowledge for microfrontend commands

### DIFF
--- a/crates/turborepo-lib/src/task_graph/visitor/command.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/command.rs
@@ -11,24 +11,22 @@ pub type ToolchainCommandProvider<'a> =
 
 // Re-export MicroFrontendProxyProvider from turborepo-task-executor with our
 // MicrofrontendsConfigs type
-pub type MicroFrontendProxyProvider<'a, T> =
-    turborepo_task_executor::MicroFrontendProxyProvider<'a, T, MicrofrontendsConfigs>;
+pub type MicroFrontendProxyProvider<'a> =
+    turborepo_task_executor::MicroFrontendProxyProvider<'a, MicrofrontendsConfigs>;
 
 #[cfg(test)]
 mod test {
     use std::ffi::OsStr;
 
     use insta::assert_snapshot;
-    use turbopath::{AbsoluteSystemPath, AnchoredSystemPath};
+    use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPath};
     use turborepo_env::EnvironmentVariableMap;
     use turborepo_microfrontends::{TurborepoMfeConfig as Config, MICROFRONTENDS_PACKAGE};
     use turborepo_process::Command;
     use turborepo_repository::{
-        package_graph::{PackageInfo, PackageName},
-        package_json::PackageJson,
-        package_manager::PackageManager,
+        package_graph::PackageGraph, package_json::PackageJson, package_manager::PackageManager,
     };
-    use turborepo_task_executor::{CommandProvider, PackageInfoProvider};
+    use turborepo_task_executor::CommandProvider;
     use turborepo_task_id::TaskId;
 
     use super::*;
@@ -120,30 +118,10 @@ mod test {
         assert!(cmd.is_none(), "expected no cmd, got {cmd:?}");
     }
 
-    #[test]
-    fn test_mfe_application_passed() {
-        let repo_root = AbsoluteSystemPath::new(if cfg!(windows) {
-            "C:\\repo-root"
-        } else {
-            "/tmp/repo-root"
-        })
-        .unwrap();
-        struct MockPackageInfo(PackageInfo);
-        impl PackageInfoProvider for MockPackageInfo {
-            fn package_manager(&self) -> Option<&PackageManager> {
-                Some(&PackageManager::Npm)
-            }
-
-            fn package_info(&self, name: &PackageName) -> Option<&PackageInfo> {
-                match name {
-                    PackageName::Root => unimplemented!(),
-                    PackageName::Other(name) => match name.as_str() {
-                        "web" | "docs" => Some(&self.0),
-                        _ => None,
-                    },
-                }
-            }
-        }
+    #[tokio::test]
+    async fn test_mfe_application_passed() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(tempdir.path()).unwrap();
         let mut config = Config::from_str(
             r#"
         {
@@ -170,24 +148,28 @@ mod test {
         .unwrap()
         .unwrap();
 
-        let mock_package_info = MockPackageInfo(PackageInfo {
-            package_json: PackageJson {
-                dependencies: Some(
-                    vec![(MICROFRONTENDS_PACKAGE.to_owned(), "1.0.0".to_owned())]
-                        .into_iter()
-                        .collect(),
-                ),
-                ..Default::default()
-            },
-            package_json_path: AnchoredSystemPath::new("package.json").unwrap().to_owned(),
-            unresolved_external_dependencies: None,
-            transitive_dependencies: None,
+        let package_json = PackageJson {
+            name: Some(turborepo_errors::Spanned::new("web".to_owned())),
+            dependencies: Some(
+                vec![(MICROFRONTENDS_PACKAGE.to_owned(), "1.0.0".to_owned())]
+                    .into_iter()
+                    .collect(),
+            ),
             ..Default::default()
-        });
+        };
+        let package_graph = PackageGraph::builder(&repo_root, PackageJson::default())
+            .with_package_manager(PackageManager::Npm)
+            .with_package_jsons(Some(std::collections::HashMap::from([(
+                repo_root.join_components(&["web", "package.json"]),
+                package_json,
+            )])))
+            .with_allow_no_package_manager(true)
+            .build()
+            .await
+            .unwrap();
         let mut factory = CommandFactory::new();
         factory.add_provider(MicroFrontendProxyProvider::new(
-            repo_root,
-            &mock_package_info,
+            &package_graph,
             [TaskId::new("docs", "dev"), TaskId::new("web", "proxy")].iter(),
             &microfrontends_configs,
         ));

--- a/crates/turborepo-lib/src/task_graph/visitor/exec.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/exec.rs
@@ -73,7 +73,6 @@ impl<'a> ExecContextFactory<'a> {
         let mut command_factory = CommandFactory::new();
         if let Some(micro_frontends_configs) = visitor.micro_frontends_configs {
             command_factory.add_provider(MicroFrontendProxyProvider::new(
-                visitor.repo_root,
                 visitor.package_graph.as_ref(),
                 engine.task_ids(),
                 micro_frontends_configs,

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -620,6 +620,19 @@ impl PackageGraph {
         true
     }
 
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn set_package_json_name_for_test(
+        &mut self,
+        package: &PackageName,
+        name: Option<String>,
+    ) -> bool {
+        let Some(package_info) = self.packages.get_mut(package) else {
+            return false;
+        };
+        package_info.package_json.name = name.map(turborepo_errors::Spanned::new);
+        true
+    }
+
     /// Iterates the structural graph sentinel followed by every authoritative
     /// execution scope. The root JavaScript scope is omitted when no root
     /// `package.json` exists.

--- a/crates/turborepo-task-executor/Cargo.toml
+++ b/crates/turborepo-task-executor/Cargo.toml
@@ -71,4 +71,6 @@ convert_case = "0.6.0"
 
 [dev-dependencies]
 tempfile = { workspace = true }
-turborepo-repository = { path = "../turborepo-repository", features = ["test-util"] }
+turborepo-repository = { path = "../turborepo-repository", features = [
+  "test-util",
+] }

--- a/crates/turborepo-task-executor/Cargo.toml
+++ b/crates/turborepo-task-executor/Cargo.toml
@@ -71,3 +71,4 @@ convert_case = "0.6.0"
 
 [dev-dependencies]
 tempfile = { workspace = true }
+turborepo-repository = { path = "../turborepo-repository", features = ["test-util"] }

--- a/crates/turborepo-task-executor/src/command.rs
+++ b/crates/turborepo-task-executor/src/command.rs
@@ -6,12 +6,11 @@
 use std::collections::{HashMap, HashSet};
 
 use tracing::debug;
-use turbopath::{AbsoluteSystemPath, PathError, RelativeUnixPath};
+use turbopath::{PathError, RelativeUnixPath};
 use turborepo_env::EnvironmentVariableMap;
 use turborepo_process::Command;
 use turborepo_repository::{
-    package_graph::{PackageGraph, PackageInfo, PackageName, PackageTaskContext},
-    package_manager::PackageManager,
+    package_graph::{PackageGraph, PackageName, PackageTaskContext},
     toolchain::CompileCacheEndpoint,
 };
 use turborepo_task_id::TaskId;
@@ -114,6 +113,22 @@ pub enum CommandProviderError {
         package_name: PackageName,
         task_id: TaskId<'static>,
     },
+    #[error("Missing compatibility payload for package {package_name}.")]
+    MissingPackagePayload { package_name: PackageName },
+    #[error("Package {package_name} is not a JavaScript package execution scope.")]
+    InvalidMfePackageContext { package_name: PackageName },
+    #[error("Package directory {directory} is outside repository root {repository_root}.")]
+    PackageDirectoryOutsideRepository {
+        repository_root: String,
+        directory: String,
+    },
+    #[error(
+        "Package payload identity {actual:?} does not match authoritative identity {expected}."
+    )]
+    PackagePayloadIdentityMismatch {
+        expected: PackageName,
+        actual: Option<String>,
+    },
     #[error("Missing microfrontends config path for package {package_name}.")]
     MissingMfeConfigPath { package_name: PackageName },
     #[error("Invalid microfrontends config path {path} for package {package_name}.")]
@@ -122,6 +137,16 @@ pub enum CommandProviderError {
         path: String,
         #[source]
         source: PathError,
+    },
+    #[error("Unsafe microfrontends config path {path} for package {package_name}.")]
+    UnsafeMfeConfigPath {
+        package_name: PackageName,
+        path: String,
+    },
+    #[error("Microfrontends config path {path} is outside repository root {repository_root}.")]
+    MfeConfigOutsideRepository {
+        repository_root: String,
+        path: String,
     },
     #[error("Microfrontends require a package manager")]
     MissingPackageManager,
@@ -134,23 +159,6 @@ pub enum CommandProviderError {
     },
     #[error(transparent)]
     Toolchain(#[from] turborepo_repository::toolchain::Error),
-}
-
-/// A trait for fetching package information required to execute commands
-pub trait PackageInfoProvider {
-    fn package_manager(&self) -> Option<&PackageManager>;
-
-    fn package_info(&self, name: &PackageName) -> Option<&PackageInfo>;
-}
-
-impl PackageInfoProvider for PackageGraph {
-    fn package_manager(&self) -> Option<&PackageManager> {
-        PackageGraph::package_manager(self)
-    }
-
-    fn package_info(&self, name: &PackageName) -> Option<&PackageInfo> {
-        PackageGraph::package_info(self, name)
-    }
 }
 
 /// Command provider that resolves commands through the package's toolchain.
@@ -336,30 +344,26 @@ impl<'a, M: MfeConfigProvider, E: From<CommandProviderError>> CommandProvider<E>
 /// This provider handles the `proxy` task for microfrontends configurations,
 /// creating commands to start the proxy server.
 #[derive(Debug)]
-pub struct MicroFrontendProxyProvider<'a, T, M> {
-    repo_root: &'a AbsoluteSystemPath,
-    package_graph: &'a T,
+pub struct MicroFrontendProxyProvider<'a, M> {
+    package_graph: &'a PackageGraph,
     tasks_in_graph: HashSet<TaskId<'a>>,
     mfe_configs: &'a M,
 }
 
-impl<'a, T: PackageInfoProvider, M: MfeConfigProvider> MicroFrontendProxyProvider<'a, T, M> {
+impl<'a, M: MfeConfigProvider> MicroFrontendProxyProvider<'a, M> {
     /// Creates a new `MicroFrontendProxyProvider`.
     ///
     /// # Arguments
-    /// * `repo_root` - The root of the repository
     /// * `package_graph` - The package graph provider
     /// * `tasks_in_graph` - Iterator of tasks that are part of the current
     ///   execution graph
     /// * `micro_frontends_configs` - The microfrontends configuration
     pub fn new<'b>(
-        repo_root: &'a AbsoluteSystemPath,
-        package_graph: &'a T,
+        package_graph: &'a PackageGraph,
         tasks_in_graph: impl Iterator<Item = &'b TaskId<'static>>,
         micro_frontends_configs: &'a M,
     ) -> Self {
         Self {
-            repo_root,
             package_graph,
             tasks_in_graph: tasks_in_graph.cloned().collect(),
             mfe_configs: micro_frontends_configs,
@@ -370,23 +374,64 @@ impl<'a, T: PackageInfoProvider, M: MfeConfigProvider> MicroFrontendProxyProvide
         (task_id.task() == "proxy").then(|| self.mfe_configs.dev_tasks(task_id.package()))?
     }
 
-    fn package_info(&self, task_id: &TaskId) -> Result<&PackageInfo, CommandProviderError> {
+    fn package_context(
+        &self,
+        task_id: &TaskId,
+    ) -> Result<PackageTaskContext<'_>, CommandProviderError> {
         self.package_graph
-            .package_info(&PackageName::from(task_id.package()))
+            .package_task_context(&PackageName::from(task_id.package()))
             .ok_or_else(|| CommandProviderError::MissingPackage {
                 package_name: task_id.package().into(),
                 task_id: task_id.clone().into_owned(),
             })
     }
 
-    fn has_custom_proxy(&self, task_id: &TaskId) -> Result<bool, CommandProviderError> {
-        let package_info = self.package_info(task_id)?;
-        Ok(package_info.package_json.scripts.contains_key("proxy"))
+    fn validated_package_context(
+        &self,
+        task_id: &TaskId,
+    ) -> Result<PackageTaskContext<'_>, CommandProviderError> {
+        let context = self.package_context(task_id)?;
+        Self::validate_package_context(context)
+    }
+
+    fn validate_package_context(
+        context: PackageTaskContext<'_>,
+    ) -> Result<PackageTaskContext<'_>, CommandProviderError> {
+        let Some(package_info) = context.package_info() else {
+            return Err(CommandProviderError::MissingPackagePayload {
+                package_name: context.package().clone(),
+            });
+        };
+        let package_directory = context.repository_root().resolve(context.directory());
+        if !context.repository_root().contains(&package_directory) {
+            return Err(CommandProviderError::PackageDirectoryOutsideRepository {
+                repository_root: context.repository_root().to_string(),
+                directory: package_directory.to_string(),
+            });
+        }
+        if context.toolchain() != Some(&turborepo_repository::toolchain::ToolchainId::JAVASCRIPT)
+            || context.kind()
+                == turborepo_repository::package_graph::PackageTaskContextKind::Aggregate
+        {
+            return Err(CommandProviderError::InvalidMfePackageContext {
+                package_name: context.package().clone(),
+            });
+        }
+        let actual = package_info.package_name();
+        if context.kind() == turborepo_repository::package_graph::PackageTaskContextKind::Package
+            && actual.as_deref() != Some(context.package().as_ref())
+        {
+            return Err(CommandProviderError::PackagePayloadIdentityMismatch {
+                expected: context.package().clone(),
+                actual,
+            });
+        }
+        Ok(context)
     }
 }
 
-impl<'a, T: PackageInfoProvider + Send + Sync, M: MfeConfigProvider, E: From<CommandProviderError>>
-    CommandProvider<E> for MicroFrontendProxyProvider<'a, T, M>
+impl<'a, M: MfeConfigProvider, E: From<CommandProviderError>> CommandProvider<E>
+    for MicroFrontendProxyProvider<'a, M>
 {
     fn command(
         &self,
@@ -412,8 +457,13 @@ impl<'a, T: PackageInfoProvider + Send + Sync, M: MfeConfigProvider, E: From<Com
             task_id
         );
 
-        let has_custom_proxy = self.has_custom_proxy(task_id)?;
-        let package_info = self.package_info(task_id)?;
+        let package_context = self.validated_package_context(task_id)?;
+        let package_info = package_context.package_info().ok_or_else(|| {
+            CommandProviderError::MissingPackagePayload {
+                package_name: package_context.package().clone(),
+            }
+        })?;
+        let has_custom_proxy = package_info.package_json.scripts.contains_key("proxy");
 
         // Check if package depends on @vercel/microfrontends
         const MICROFRONTENDS_PACKAGE: &str = "@vercel/microfrontends";
@@ -435,21 +485,48 @@ impl<'a, T: PackageInfoProvider + Send + Sync, M: MfeConfigProvider, E: From<Com
                     .then_some(app_name.as_str())
             })
             .collect();
-        let package_dir = self.repo_root.resolve(package_info.package_path());
+        let package_dir = package_context
+            .repository_root()
+            .resolve(package_context.directory());
         let mfe_config_filename = self
             .mfe_configs
-            .config_filename(task_id.package())
+            .config_filename(package_context.package().as_ref())
             .ok_or_else(|| CommandProviderError::MissingMfeConfigPath {
-                package_name: task_id.to_workspace_name(),
+                package_name: package_context.package().clone(),
             })?;
+        let unsafe_path = mfe_config_filename.starts_with('/')
+            || mfe_config_filename.contains('\\')
+            || mfe_config_filename
+                .split('/')
+                .any(|component| component == "..")
+            || mfe_config_filename
+                .split('/')
+                .next()
+                .is_some_and(|component| component.contains(':'));
+        if unsafe_path {
+            return Err(CommandProviderError::UnsafeMfeConfigPath {
+                package_name: package_context.package().clone(),
+                path: mfe_config_filename,
+            }
+            .into());
+        }
         let mfe_config_path = RelativeUnixPath::new(&mfe_config_filename).map_err(|source| {
             CommandProviderError::InvalidMfeConfigPath {
-                package_name: task_id.to_workspace_name(),
+                package_name: package_context.package().clone(),
                 path: mfe_config_filename.clone(),
                 source,
             }
         })?;
-        let mfe_path = self.repo_root.join_unix_path(mfe_config_path);
+        let mfe_path = package_context
+            .repository_root()
+            .join_unix_path(mfe_config_path);
+        if !package_context.repository_root().contains(&mfe_path) {
+            return Err(CommandProviderError::MfeConfigOutsideRepository {
+                repository_root: package_context.repository_root().to_string(),
+                path: mfe_path.to_string(),
+            }
+            .into());
+        }
 
         let cmd = if has_custom_proxy {
             debug!("MicroFrontendProxyProvider::command - using custom proxy script");
@@ -518,27 +595,12 @@ mod tests {
     use tempfile::TempDir;
     use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
     use turborepo_errors::Spanned;
-    use turborepo_repository::package_json::PackageJson;
+    use turborepo_repository::{package_json::PackageJson, package_manager::PackageManager};
+    use turborepo_task_id::TaskName;
 
     use super::*;
 
-    struct MockPackageInfoProvider {
-        package_info: PackageInfo,
-        package_manager: PackageManager,
-    }
-
-    impl PackageInfoProvider for MockPackageInfoProvider {
-        fn package_manager(&self) -> Option<&PackageManager> {
-            Some(&self.package_manager)
-        }
-
-        fn package_info(&self, name: &PackageName) -> Option<&PackageInfo> {
-            matches!(name, PackageName::Other(package) if package == "web")
-                .then_some(&self.package_info)
-        }
-    }
-
-    struct MockMfeConfig;
+    struct MockMfeConfig(&'static str);
 
     impl MfeConfigProvider for MockMfeConfig {
         fn task_has_mfe_proxy(&self, _task_id: &TaskId) -> bool {
@@ -562,12 +624,12 @@ mod tests {
         }
 
         fn dev_tasks(&self, package_name: &str) -> Option<Vec<(TaskId<'static>, String)>> {
-            (package_name == "web")
+            matches!(package_name, "web" | "//")
                 .then(|| vec![(TaskId::new("docs", "dev"), "docs-app".to_owned())])
         }
 
         fn config_filename(&self, package_name: &str) -> Option<String> {
-            (package_name == "web").then(|| "web/microfrontends.json".to_owned())
+            matches!(package_name, "web" | "//").then(|| self.0.to_owned())
         }
     }
 
@@ -586,7 +648,7 @@ mod tests {
         let tempdir = tempfile::tempdir().unwrap();
         let repo_root =
             AbsoluteSystemPathBuf::new(tempdir.path().to_string_lossy().to_string()).unwrap();
-        let package_dir = tempdir.path().join("web");
+        let package_dir = tempdir.path().join("apps/site/web");
         fs::create_dir_all(&package_dir).unwrap();
 
         (tempdir, repo_root, package_dir)
@@ -608,37 +670,69 @@ mod tests {
         ]))
     }
 
-    fn package_info(package_json: PackageJson) -> PackageInfo {
-        PackageInfo {
-            package_json,
-            package_json_path: AnchoredSystemPathBuf::from_raw("web/package.json").unwrap(),
-            unresolved_external_dependencies: None,
-            transitive_dependencies: None,
-            ..Default::default()
-        }
+    async fn package_graph(
+        repo_root: &AbsoluteSystemPathBuf,
+        package_dir: &Path,
+        package_json: PackageJson,
+    ) -> PackageGraph {
+        let mut package_json = package_json;
+        package_json.name = Some(Spanned::new("web".to_owned()));
+        let package_path = AbsoluteSystemPathBuf::try_from(package_dir)
+            .unwrap()
+            .join_component("package.json");
+        let mut graph = PackageGraph::builder(repo_root, PackageJson::default())
+            .with_package_manager(PackageManager::Npm)
+            .with_package_jsons(Some(HashMap::from([(package_path, package_json)])))
+            .with_allow_no_package_manager(true)
+            .build()
+            .await
+            .unwrap();
+        assert!(graph.set_package_json_path_for_test(
+            &PackageName::from("web"),
+            AnchoredSystemPathBuf::from_raw("stale/package.json").unwrap()
+        ));
+        graph
+    }
+
+    async fn root_package_graph(
+        repo_root: &AbsoluteSystemPathBuf,
+        root_json: PackageJson,
+    ) -> PackageGraph {
+        PackageGraph::builder(repo_root, root_json)
+            .with_package_manager(PackageManager::Npm)
+            .with_package_jsons(Some(HashMap::new()))
+            .with_allow_no_package_manager(true)
+            .build()
+            .await
+            .unwrap()
     }
 
     fn proxy_command(
-        repo_root: &AbsoluteSystemPathBuf,
-        package_info_provider: &MockPackageInfoProvider,
+        package_graph: &PackageGraph,
         environment: &EnvironmentVariableMap,
     ) -> Command {
-        let mfe_config = MockMfeConfig;
-        let tasks = [TaskId::new("docs", "dev"), TaskId::new("web", "proxy")];
-        let provider = MicroFrontendProxyProvider::new(
-            repo_root,
-            package_info_provider,
-            tasks.iter(),
-            &mfe_config,
-        );
+        let mfe_config = MockMfeConfig("configs/microfrontends.json");
+        proxy_command_result(package_graph, environment, &mfe_config, "web")
+            .unwrap()
+            .unwrap()
+    }
 
-        CommandProvider::<CommandProviderError>::command(
-            &provider,
-            &TaskId::new("web", "proxy"),
-            environment,
-        )
-        .unwrap()
-        .unwrap()
+    fn proxy_command_result(
+        package_graph: &PackageGraph,
+        environment: &EnvironmentVariableMap,
+        mfe_config: &MockMfeConfig,
+        package: &str,
+    ) -> Result<Option<Command>, CommandProviderError> {
+        let tasks = [TaskId::new("docs", "dev"), TaskId::new("web", "proxy")];
+        let provider = MicroFrontendProxyProvider::new(package_graph, tasks.iter(), mfe_config);
+
+        let task_id = if package == "//" {
+            TaskId::from_graph(&PackageName::Root, &TaskName::from("proxy"))
+        } else {
+            TaskId::new(package, "proxy").into_owned()
+        };
+        assert_eq!(task_id.package(), package);
+        CommandProvider::<CommandProviderError>::command(&provider, &task_id, environment)
     }
 
     async fn command_stdout(cmd: Command) -> String {
@@ -802,17 +896,30 @@ mod tests {
         let (_tempdir, repo_root, package_dir) = create_test_repo();
         let inherited_env = inherited_env_name();
         write_custom_proxy_package(&package_dir, inherited_env);
-        let package_info_provider = MockPackageInfoProvider {
-            package_info: package_info(PackageJson {
+        let package_graph = package_graph(
+            &repo_root,
+            &package_dir,
+            PackageJson {
                 scripts: BTreeMap::from([(
                     "proxy".to_owned(),
                     Spanned::new("node print-env.js".to_owned()),
                 )]),
                 ..Default::default()
-            }),
-            package_manager: PackageManager::Npm,
-        };
-        let cmd = proxy_command(&repo_root, &package_info_provider, &filtered_environment());
+            },
+        )
+        .await;
+        let cmd = proxy_command(&package_graph, &filtered_environment());
+        assert!(
+            cmd.label()
+                .starts_with(&format!("({})", package_dir.display()))
+                && (cmd.program().to_string_lossy().contains("npm")
+                    || cmd.program().to_string_lossy().contains("node"))
+        );
+        let config_path = repo_root.join_components(&["configs", "microfrontends.json"]);
+        assert!(cmd.label().ends_with(&format!(
+            " run proxy -- {} --names docs-app",
+            config_path.as_str()
+        )));
         let stdout = command_stdout(cmd).await;
 
         assert_filtered_environment(&stdout, inherited_env);
@@ -823,19 +930,177 @@ mod tests {
         let (_tempdir, repo_root, package_dir) = create_test_repo();
         let inherited_env = inherited_env_name();
         write_microfrontends_binary(&package_dir, inherited_env);
-        let package_info_provider = MockPackageInfoProvider {
-            package_info: package_info(PackageJson {
+        let package_graph = package_graph(
+            &repo_root,
+            &package_dir,
+            PackageJson {
                 dependencies: Some(BTreeMap::from([(
                     "@vercel/microfrontends".to_owned(),
                     "1.0.0".to_owned(),
                 )])),
                 ..Default::default()
-            }),
-            package_manager: PackageManager::Npm,
-        };
-        let cmd = proxy_command(&repo_root, &package_info_provider, &filtered_environment());
+            },
+        )
+        .await;
+        let cmd = proxy_command(&package_graph, &filtered_environment());
+        assert_eq!(
+            cmd.program(),
+            package_dir
+                .join("node_modules")
+                .join(".bin")
+                .join(if cfg!(windows) {
+                    "microfrontends.cmd"
+                } else {
+                    "microfrontends"
+                })
+                .as_os_str()
+        );
+        assert!(
+            cmd.label()
+                .starts_with(&format!("({})", package_dir.display()))
+        );
+        let config_path = repo_root.join_components(&["configs", "microfrontends.json"]);
+        assert!(
+            cmd.label()
+                .ends_with(&format!(" proxy {} --names docs-app", config_path.as_str()))
+        );
         let stdout = command_stdout(cmd).await;
 
         assert_filtered_environment(&stdout, inherited_env);
+    }
+
+    #[tokio::test]
+    async fn test_microfrontend_proxy_requires_compatibility_payload() {
+        let (_tempdir, repo_root, package_dir) = create_test_repo();
+        let mut graph = package_graph(&repo_root, &package_dir, PackageJson::default()).await;
+        graph.remove_package_info_for_test(&PackageName::from("web"));
+        let mfe_config = MockMfeConfig("configs/microfrontends.json");
+        let tasks = [TaskId::new("docs", "dev"), TaskId::new("web", "proxy")];
+        let command_provider = MicroFrontendProxyProvider::new(&graph, tasks.iter(), &mfe_config);
+
+        let error = CommandProvider::<CommandProviderError>::command(
+            &command_provider,
+            &TaskId::new("web", "proxy"),
+            &EnvironmentVariableMap::default(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            CommandProviderError::MissingPackagePayload { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_microfrontend_proxy_rejects_invalid_contexts_and_config_paths() {
+        let (_tempdir, repo_root, package_dir) = create_test_repo();
+        let environment = EnvironmentVariableMap::default();
+        let config = MockMfeConfig("configs/microfrontends.json");
+        let mut graph = package_graph(&repo_root, &package_dir, PackageJson::default()).await;
+
+        assert!(
+            graph.set_package_json_name_for_test(
+                &PackageName::from("web"),
+                Some("other".to_owned())
+            )
+        );
+        assert!(matches!(
+            proxy_command_result(&graph, &environment, &config, "web"),
+            Err(CommandProviderError::PackagePayloadIdentityMismatch { .. })
+        ));
+        assert!(
+            graph.set_package_json_name_for_test(&PackageName::from("web"), Some("web".to_owned()))
+        );
+        for path in [
+            "../config.json",
+            "C:/config.json",
+            r"configs\microfrontends.json",
+        ] {
+            let config = MockMfeConfig(path);
+            assert!(matches!(
+                proxy_command_result(&graph, &environment, &config, "web"),
+                Err(CommandProviderError::UnsafeMfeConfigPath { .. })
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_root_javascript_proxy_uses_repository_root() {
+        let (_tempdir, repo_root, _package_dir) = create_test_repo();
+        let environment = EnvironmentVariableMap::default();
+        let config = MockMfeConfig("configs/microfrontends.json");
+        let pure_root = PackageGraph::builder_optional(&repo_root, None)
+            .build()
+            .await
+            .unwrap();
+        let error = MicroFrontendProxyProvider::<MockMfeConfig>::validate_package_context(
+            pure_root.package_task_context(&PackageName::Root).unwrap(),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            CommandProviderError::InvalidMfePackageContext { .. }
+        ));
+        let custom_graph = root_package_graph(
+            &repo_root,
+            PackageJson {
+                name: Some(Spanned::new("root-name".to_owned())),
+                scripts: BTreeMap::from([("proxy".to_owned(), Spanned::new("proxy".to_owned()))]),
+                ..Default::default()
+            },
+        )
+        .await;
+        assert!(
+            custom_graph
+                .package_task_context(&PackageName::Root)
+                .unwrap()
+                .package_info()
+                .unwrap()
+                .package_json
+                .scripts
+                .contains_key("proxy")
+        );
+        let custom = proxy_command_result(&custom_graph, &environment, &config, "//")
+            .unwrap()
+            .unwrap();
+        assert!(
+            custom
+                .label()
+                .starts_with(&format!("({}", custom_graph.repo_root().as_str())),
+            "unexpected root command: {}",
+            custom.label()
+        );
+        assert!(custom.label().contains(" run proxy "));
+
+        let binary_graph = root_package_graph(
+            &repo_root,
+            PackageJson {
+                dependencies: Some(BTreeMap::from([(
+                    "@vercel/microfrontends".to_owned(),
+                    "1.0.0".to_owned(),
+                )])),
+                ..Default::default()
+            },
+        )
+        .await;
+        let binary = proxy_command_result(&binary_graph, &environment, &config, "//")
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            binary.program(),
+            binary_graph
+                .repo_root()
+                .join_components(&[
+                    "node_modules",
+                    ".bin",
+                    if cfg!(windows) {
+                        "microfrontends.cmd"
+                    } else {
+                        "microfrontends"
+                    },
+                ])
+                .as_std_path()
+                .as_os_str()
+        );
     }
 }

--- a/crates/turborepo-task-executor/src/command.rs
+++ b/crates/turborepo-task-executor/src/command.rs
@@ -648,7 +648,7 @@ mod tests {
         let tempdir = tempfile::tempdir().unwrap();
         let repo_root =
             AbsoluteSystemPathBuf::new(tempdir.path().to_string_lossy().to_string()).unwrap();
-        let package_dir = tempdir.path().join("apps/site/web");
+        let package_dir = tempdir.path().join("apps").join("site").join("web");
         fs::create_dir_all(&package_dir).unwrap();
 
         (tempdir, repo_root, package_dir)

--- a/crates/turborepo-task-executor/src/lib.rs
+++ b/crates/turborepo-task-executor/src/lib.rs
@@ -26,7 +26,7 @@ mod visitor;
 
 pub use command::{
     CommandFactory, CommandProvider, CommandProviderError, MicroFrontendProxyProvider,
-    PackageInfoProvider, ToolchainCommandProvider,
+    ToolchainCommandProvider,
 };
 pub use exec::{
     DryRunExecutor, ExecOutcome, HashTrackerProvider, InternalError, SuccessOutcome,


### PR DESCRIPTION
### Description

Part 9 of the package/scope knowledge completion stack.

Resolve microfrontend proxy cwd, local binary paths, package identity, and repository-relative config paths directly from `PackageGraph`. Unsafe config paths and ineligible native scopes fail explicitly; root JavaScript proxies remain supported.

### Testing Instructions

- `cargo test -p turborepo-task-executor`
- `cargo test -p turborepo-lib --lib task_graph::visitor::command::test`
- `cargo test -p turborepo-lib --lib microfrontends::test`