### PR TITLE
refactor: Use package knowledge for run summaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9091,6 +9091,7 @@ dependencies = [
  "serde_json",
  "svix-ksuid",
  "tabwriter",
+ "tempfile",
  "test-case",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -741,14 +741,21 @@ impl RunBuilder {
             (self.opts.repo_opts.allow_no_turbo_json || micro_frontend_configs.is_some())
             {
                 let package_scripts = pkg_dep_graph
-                    .packages()
-                    .map(|(package, info)| {
-                        (
-                            package.clone(),
-                            info.package_json.scripts.keys().cloned().collect(),
-                        )
+                    .package_task_contexts()
+                    .map(|context| {
+                        let package = context.package().clone();
+                        let info = context.package_info();
+                        if context.requires_compatibility_payload() && info.is_none() {
+                            return Err(Error::MissingPackagePayload(package));
+                        }
+                        Ok((
+                            package,
+                            info.into_iter()
+                                .flat_map(|info| info.package_json.scripts.keys().cloned())
+                                .collect(),
+                        ))
                     })
-                    .collect();
+                    .collect::<Result<_, Error>>()?;
                 UnifiedTurboJsonLoader::workspace_no_turbo_json(
                     reader,
                     pkg_dep_graph.package_scope_directories(),
@@ -1284,19 +1291,14 @@ impl RunBuilder {
                 continue;
             }
 
-            let has_command = pkg_dep_graph
-                .packages()
-                .filter_map(|(name, _)| pkg_dep_graph.package_task_context(name))
-                .any(|context| {
-                    context
-                        .toolchain()
-                        .and_then(|id| pkg_dep_graph.toolchains().get(id))
-                        .is_some_and(|toolchain| toolchain.defines_task(&context, task.task()))
-                })
-                || engine.task_ids().any(|task_id| {
-                    task_id.task() == task.task()
-                        && task_has_command(engine, pkg_dep_graph, task_id)
-                });
+            let has_command = pkg_dep_graph.package_task_contexts().any(|context| {
+                context
+                    .toolchain()
+                    .and_then(|id| pkg_dep_graph.toolchains().get(id))
+                    .is_some_and(|toolchain| toolchain.defines_task(&context, task.task()))
+            }) || engine.task_ids().any(|task_id| {
+                task_id.task() == task.task() && task_has_command(engine, pkg_dep_graph, task_id)
+            });
 
             for package in candidate_packages {
                 let task_id = TaskId::new(package.as_ref(), task.task()).into_owned();

--- a/crates/turborepo-lib/src/run/error.rs
+++ b/crates/turborepo-lib/src/run/error.rs
@@ -2,7 +2,7 @@ use miette::Diagnostic;
 use thiserror::Error;
 use turborepo_daemon::{DaemonConnectorError, DaemonError};
 use turborepo_engine::GraphVisualizerError;
-use turborepo_repository::package_graph;
+use turborepo_repository::{package_graph, package_graph::PackageName};
 use turborepo_scope::filter::ResolutionError;
 use turborepo_task_hash::{global_hash, Error as TaskHashError};
 use turborepo_ui::tui;
@@ -69,6 +69,8 @@ pub enum Error {
     Join(#[from] tokio::task::JoinError),
     #[error("Missing root workspace")]
     MissingRootWorkspace,
+    #[error("Missing compatibility package payload for {0}")]
+    MissingPackagePayload(PackageName),
     #[error("File hash task did not complete")]
     FileHashTaskIncomplete,
     #[error("Internal dependency hash task did not complete")]

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -516,27 +516,33 @@ impl Run {
     // Used to print a list of potential tasks to run. Obeys the `--filter` flag
     pub fn get_potential_tasks(&self) -> Result<BTreeMap<String, Vec<String>>, Error> {
         let mut tasks = BTreeMap::new();
-        for (name, info) in self.pkg_dep_graph.packages() {
+        for context in self.pkg_dep_graph.package_task_contexts() {
+            let name = context.package();
             if !self.filtered_pkgs.contains(name) {
                 continue;
             }
-            for task_name in info.package_json.scripts.keys() {
+            let package_info = context.package_info();
+            if context.requires_compatibility_payload() && package_info.is_none() {
+                return Err(Error::MissingPackagePayload(name.clone()));
+            }
+            for task_name in package_info
+                .into_iter()
+                .flat_map(|info| info.package_json.scripts.keys())
+            {
                 tasks
                     .entry(task_name.clone())
                     .or_insert_with(Vec::new)
                     .push(name.to_string())
             }
-            if let Some(context) = self.pkg_dep_graph.package_task_context(name) {
-                if let Some(toolchain) = context
-                    .toolchain()
-                    .and_then(|id| self.pkg_dep_graph.toolchains().get(id))
-                {
-                    for task_name in toolchain.registered_tasks(&context) {
-                        tasks
-                            .entry(task_name)
-                            .or_insert_with(Vec::new)
-                            .push(name.to_string());
-                    }
+            if let Some(toolchain) = context
+                .toolchain()
+                .and_then(|id| self.pkg_dep_graph.toolchains().get(id))
+            {
+                for task_name in toolchain.registered_tasks(&context) {
+                    tasks
+                        .entry(task_name)
+                        .or_insert_with(Vec::new)
+                        .push(name.to_string());
                 }
             }
         }
@@ -1219,8 +1225,9 @@ impl Run {
                     s.spawn(|_| {
                         let _span =
                             tracing::info_span!("compute_external_deps_hashes_task").entered();
-                        external_deps_hashes =
-                            Some(compute_external_deps_hashes(self.pkg_dep_graph.packages()));
+                        external_deps_hashes = Some(compute_external_deps_hashes(
+                            self.pkg_dep_graph.package_task_contexts(),
+                        ));
                     });
                 }
             });
@@ -1235,6 +1242,7 @@ impl Run {
             internal_deps_result.ok_or(Error::InternalDepsTaskIncomplete)??;
         let global_file_inputs =
             global_file_result.ok_or(Error::GlobalFileHashTaskIncomplete)??;
+        let external_deps_hashes = external_deps_hashes.transpose()?;
 
         let root_external_dependencies_hash = is_monorepo.then(|| {
             root_workspace
@@ -1317,7 +1325,7 @@ impl Run {
             external_deps_hashes,
             compile_cache_endpoint,
         )
-        .await;
+        .await?;
 
         if self.opts.run_opts.dry_run.is_some() {
             visitor.dry_run();

--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -231,7 +231,7 @@ impl<'a> Visitor<'a> {
         micro_frontends_configs: Option<&'a MicrofrontendsConfigs>,
         external_deps_hashes: Option<HashMap<String, String>>,
         compile_cache_endpoint: Option<CompileCacheEndpoint>,
-    ) -> Self {
+    ) -> Result<Self, Error> {
         let (task_hasher, color_cache, grouping_layer) = {
             let _span = tracing::info_span!("visitor_new").entered();
             let mut task_hasher = TaskHasher::new(
@@ -250,8 +250,9 @@ impl<'a> Visitor<'a> {
             match external_deps_hashes {
                 Some(cache) => task_hasher.set_external_deps_hash_cache(cache),
                 None => crate::rayon_compat::block_in_place(|| {
-                    task_hasher.precompute_external_deps_hashes(package_graph.packages());
-                }),
+                    task_hasher
+                        .precompute_external_deps_hashes(package_graph.package_task_contexts())
+                })?,
             }
 
             let color_cache = ColorSelector::default();
@@ -278,7 +279,7 @@ impl<'a> Visitor<'a> {
             }
         }
 
-        Self {
+        Ok(Self {
             color_cache,
             dry: false,
             global_env_mode: run_opts.env_mode,
@@ -299,7 +300,7 @@ impl<'a> Visitor<'a> {
             warnings: Default::default(),
             micro_frontends_configs,
             compile_cache_endpoint,
-        }
+        })
     }
 
     /// Pre-compute task hashes and execution environments for all tasks in

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -600,6 +600,25 @@ impl PackageGraph {
         })
     }
 
+    /// Iterates every authoritative Turbo task namespace.
+    ///
+    /// The root namespace is always first and present exactly once, including
+    /// in repositories without a root JavaScript scope. All other identities
+    /// follow authoritative repository observation order; compatibility
+    /// payload entries cannot add or remove namespaces from this iterator.
+    pub fn package_task_contexts(&self) -> impl Iterator<Item = PackageTaskContext<'_>> + '_ {
+        std::iter::once(PackageName::Root)
+            .chain(
+                self.knowledge
+                    .scopes()
+                    .map(|scope| PackageName::Other(scope.identity().to_owned())),
+            )
+            .map(|package| match self.package_task_context(&package) {
+                Some(context) => context,
+                None => unreachable!("authoritative package name must resolve to a task context"),
+            })
+    }
+
     /// Test hook for exercising knowledge-backed consumers without a
     /// compatibility projection.
     #[cfg(any(test, feature = "test-util"))]
@@ -630,6 +649,19 @@ impl PackageGraph {
             return false;
         };
         package_info.package_json.name = name.map(turborepo_errors::Spanned::new);
+        true
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn set_compatibility_toolchain_for_test(
+        &mut self,
+        package: &PackageName,
+        toolchain: crate::toolchain::ToolchainId,
+    ) -> bool {
+        let Some(package_info) = self.packages.get_mut(package) else {
+            return false;
+        };
+        package_info.toolchain = toolchain;
         true
     }
 
@@ -2581,6 +2613,51 @@ version = "0.1.0"
             pkg_graph
                 .remove_package_info_for_test(&PackageName::Root)
                 .is_some()
+        );
+        assert!(pkg_graph.remove_package_info_for_test(&app_name).is_some());
+        let contexts = pkg_graph.package_task_contexts().collect::<Vec<_>>();
+        assert_eq!(
+            contexts.first().map(|context| context.package()),
+            Some(&PackageName::Root)
+        );
+        assert_eq!(
+            contexts
+                .iter()
+                .filter(|context| context.package() == &PackageName::Root)
+                .count(),
+            1
+        );
+        assert!(contexts.iter().any(|context| {
+            context.package() == &app_name && context.kind() == PackageTaskContextKind::Package
+        }));
+        assert!(contexts.iter().any(|context| {
+            context.package() == &PackageName::from("acme")
+                && context.kind() == PackageTaskContextKind::Aggregate
+        }));
+        for enumerated in &contexts {
+            let point = pkg_graph
+                .package_task_context(enumerated.package())
+                .expect("enumerated authoritative name must support point lookup");
+            assert_eq!(enumerated.package(), point.package());
+            assert_eq!(enumerated.repository_root(), point.repository_root());
+            assert_eq!(enumerated.directory(), point.directory());
+            assert_eq!(enumerated.kind(), point.kind());
+            assert_eq!(enumerated.toolchain(), point.toolchain());
+            assert_eq!(
+                enumerated.requires_compatibility_payload(),
+                point.requires_compatibility_payload()
+            );
+            assert_eq!(
+                enumerated.package_info().map(std::ptr::from_ref),
+                point.package_info().map(std::ptr::from_ref)
+            );
+        }
+        assert!(
+            contexts
+                .iter()
+                .find(|context| context.package() == &app_name)
+                .is_some_and(|context| context.package_info().is_none()),
+            "removing compatibility payload must not remove the package namespace"
         );
         let root_without_payload = pkg_graph
             .package_task_context(&PackageName::Root)

--- a/crates/turborepo-run-summary/Cargo.toml
+++ b/crates/turborepo-run-summary/Cargo.toml
@@ -34,7 +34,9 @@ url = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
+tempfile = { workspace = true }
 test-case = { workspace = true }
+turborepo-repository = { workspace = true, features = ["test-util"] }
 
 [lints]
 workspace = true

--- a/crates/turborepo-run-summary/src/task_factory.rs
+++ b/crates/turborepo-run-summary/src/task_factory.rs
@@ -300,7 +300,7 @@ pub fn get_external_deps_hash(
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, sync::Arc};
+    use std::{collections::HashMap, path::Path, sync::Arc};
 
     use serde_json::json;
     use tempfile::tempdir;
@@ -448,10 +448,15 @@ mod tests {
 
         let summary = factory.task_summary(task_id, None).unwrap();
         assert_eq!(summary.shared.command, "echo build");
-        assert_eq!(summary.shared.directory.as_deref(), Some("packages/app"));
+        let app_directory = Path::new("packages").join("app");
         assert_eq!(
-            summary.shared.log_file.as_deref(),
-            Some("packages/app/.turbo/turbo-build.log")
+            summary.shared.directory.as_deref().map(Path::new),
+            Some(app_directory.as_path())
+        );
+        let app_log = app_directory.join(".turbo").join("turbo-build.log");
+        assert_eq!(
+            summary.shared.log_file.as_deref().map(Path::new),
+            Some(app_log.as_path())
         );
         assert_eq!(
             summary.shared.hash_of_external_dependencies,

--- a/crates/turborepo-run-summary/src/task_factory.rs
+++ b/crates/turborepo-run-summary/src/task_factory.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use turbopath::AnchoredSystemPath;
 use turborepo_env::EnvironmentVariableMap;
 use turborepo_lockfiles::Package;
-use turborepo_repository::package_graph::{PackageGraph, PackageInfo, PackageName};
+use turborepo_repository::package_graph::{PackageGraph, PackageName, PackageTaskContext};
 use turborepo_task_id::TaskId;
 use turborepo_types::{
     EngineInfo, EnvMode, HashTrackerInfo, LOG_DIR, RunOptsInfo, TaskDefinition, task_log_filename,
@@ -31,6 +31,8 @@ pub struct TaskSummaryFactory<'a, E, H, R> {
 pub enum Error {
     #[error("No workspace found for {0}")]
     MissingWorkspace(String),
+    #[error("No compatibility package payload found for {0}")]
+    MissingPackagePayload(PackageName),
     #[error("No task definition found for {0}")]
     MissingTask(TaskId<'static>),
     #[error("No task hash found for {0}")]
@@ -76,8 +78,8 @@ where
         task_id: TaskId<'static>,
         execution: Option<TaskExecutionSummary>,
     ) -> Result<TaskSummary, Error> {
-        let workspace_info = self.workspace_info(&task_id)?;
-        let shared = self.shared(&task_id, execution, workspace_info, |dep_task_id| {
+        let package_context = self.package_context(&task_id)?;
+        let shared = self.shared(&task_id, execution, &package_context, |dep_task_id| {
             Some(dep_task_id.clone())
         })?;
         let package = task_id.package().to_string();
@@ -95,7 +97,7 @@ where
         &self,
         task_id: &TaskId<'static>,
         execution: Option<TaskExecutionSummary>,
-        workspace_info: &PackageInfo,
+        package_context: &PackageTaskContext<'_>,
         display_task: impl Fn(&TaskId<'static>) -> Option<T> + Copy,
     ) -> Result<SharedTaskSummary<T>, Error> {
         let task_definition = self.task_definition(task_id)?;
@@ -106,18 +108,12 @@ where
         // the display string (JavaScript: the script text; Cargo: the cargo
         // invocation), derived from the same tables as execution so display
         // cannot drift from what runs.
-        let command = match &task_definition.command {
-            Some(turborepo_types::TaskCommandOverride::Argv(argv)) => argv.join(" "),
-            Some(turborepo_types::TaskCommandOverride::OptOut) => "<OPT OUT>".to_string(),
-            None => self
-                .package_graph
-                .package_task_context(&task_id.package().into())
-                .and_then(|context| {
-                    let toolchain = self.package_graph.toolchains().get(context.toolchain()?)?;
-                    toolchain.task_display_command(&context, task_id.task())
-                })
-                .unwrap_or_else(|| "<NONEXISTENT>".to_string()),
-        };
+        let command = summary_command(
+            self.package_graph,
+            package_context,
+            task_definition,
+            task_id.task(),
+        );
 
         let expanded_outputs = self
             .hash_tracker
@@ -155,9 +151,14 @@ where
         let (dependencies, dependents) = self.dependencies_and_dependents(task_id, display_task);
 
         let log_file = if task_definition.cache {
-            let path = workspace_info.package_path().to_owned();
             let relative_log_file = workspace_relative_log_file(task_id.task())?;
-            Some(path.join(&relative_log_file).to_string())
+            Some(
+                package_context
+                    .directory()
+                    .to_owned()
+                    .join(&relative_log_file)
+                    .to_string(),
+            )
         } else {
             None
         };
@@ -175,14 +176,23 @@ where
         // The hash is precomputed where the closure is computed; the
         // per-run cache and the recompute below only apply to graphs built
         // without a closure hasher. All three produce identical output.
-        let hash_of_external_dependencies = workspace_info
-            .external_deps_hash
-            .clone()
+        let package_info = package_context.package_info();
+        if package_context.requires_compatibility_payload() && package_info.is_none() {
+            return Err(Error::MissingPackagePayload(
+                package_context.package().clone(),
+            ));
+        }
+        let hash_of_external_dependencies = package_info
+            .and_then(|info| info.external_deps_hash.clone())
             .or_else(|| {
                 self.external_deps_hashes
                     .and_then(|hashes| hashes.get(task_id.package()).cloned())
             })
-            .unwrap_or_else(|| get_external_deps_hash(&workspace_info.transitive_dependencies));
+            .unwrap_or_else(|| {
+                package_info
+                    .map(|info| get_external_deps_hash(&info.transitive_dependencies))
+                    .unwrap_or_default()
+            });
 
         Ok(SharedTaskSummary {
             hash,
@@ -201,7 +211,7 @@ where
                 false => Some(task_definition.outputs.exclusions.clone()),
             },
             log_file,
-            directory: Some(workspace_info.package_path().to_string()),
+            directory: Some(package_context.directory().to_string()),
             resolved_task_definition: task_definition.clone().into(),
             expanded_outputs,
             framework,
@@ -218,10 +228,10 @@ where
         })
     }
 
-    fn workspace_info(&self, task_id: &TaskId) -> Result<&PackageInfo, Error> {
+    fn package_context(&self, task_id: &TaskId) -> Result<PackageTaskContext<'_>, Error> {
         let workspace_name = PackageName::from(task_id.package());
         self.package_graph
-            .package_info(&workspace_name)
+            .package_task_context(&workspace_name)
             .ok_or_else(|| Error::MissingWorkspace(workspace_name.to_string()))
     }
 
@@ -243,6 +253,23 @@ where
         let dependencies = collect_nodes(self.engine.dependencies(task_id));
         let dependents = collect_nodes(self.engine.dependents(task_id));
         (dependencies, dependents)
+    }
+}
+
+fn summary_command(
+    package_graph: &PackageGraph,
+    package_context: &PackageTaskContext<'_>,
+    task_definition: &TaskDefinition,
+    task: &str,
+) -> String {
+    match &task_definition.command {
+        Some(turborepo_types::TaskCommandOverride::Argv(argv)) => argv.join(" "),
+        Some(turborepo_types::TaskCommandOverride::OptOut) => "<OPT OUT>".to_string(),
+        None => package_context
+            .toolchain()
+            .and_then(|id| package_graph.toolchains().get(id))
+            .and_then(|toolchain| toolchain.task_display_command(package_context, task))
+            .unwrap_or_else(|| "<NONEXISTENT>".to_string()),
     }
 }
 
@@ -269,4 +296,193 @@ pub fn get_external_deps_hash(
     let transitive_deps: Vec<&Package> = transitive_dependencies.iter().map(|pkg| &**pkg).collect();
 
     LockFilePackagesRef(transitive_deps).hash()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, sync::Arc};
+
+    use serde_json::json;
+    use tempfile::tempdir;
+    use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
+    use turborepo_repository::{
+        package_graph::PackageName, package_json::PackageJson, toolchain::ToolchainId,
+    };
+    use turborepo_types::{
+        DryRunMode, HashTrackerCacheHitMetadata, HashTrackerDetailedMap, HashTrackerInfo,
+        RunOptsInfo,
+    };
+
+    use super::*;
+
+    struct TestEngine {
+        definitions: HashMap<TaskId<'static>, TaskDefinition>,
+        edges: Vec<TaskId<'static>>,
+    }
+
+    impl EngineInfo for TestEngine {
+        type TaskIter<'a> = std::slice::Iter<'a, TaskId<'static>>;
+
+        fn task_definition(&self, task_id: &TaskId<'static>) -> Option<&TaskDefinition> {
+            self.definitions.get(task_id)
+        }
+
+        fn dependencies(&self, _task_id: &TaskId<'static>) -> Option<Self::TaskIter<'_>> {
+            Some(self.edges.iter())
+        }
+
+        fn dependents(&self, _task_id: &TaskId<'static>) -> Option<Self::TaskIter<'_>> {
+            Some(self.edges.iter())
+        }
+    }
+
+    struct TestHashes;
+
+    impl HashTrackerInfo for TestHashes {
+        fn hash(&self, _task_id: &TaskId) -> Option<Arc<str>> {
+            Some(Arc::from("hash"))
+        }
+
+        fn env_vars(&self, _task_id: &TaskId) -> Option<HashTrackerDetailedMap> {
+            Some(HashTrackerDetailedMap::default())
+        }
+
+        fn cache_status(&self, _task_id: &TaskId) -> Option<HashTrackerCacheHitMetadata> {
+            None
+        }
+
+        fn expanded_outputs(&self, _task_id: &TaskId) -> Option<Vec<AnchoredSystemPathBuf>> {
+            None
+        }
+
+        fn framework(&self, _task_id: &TaskId) -> Option<String> {
+            None
+        }
+
+        fn expanded_inputs(
+            &self,
+            _task_id: &TaskId,
+        ) -> Option<Vec<(turbopath::RelativeUnixPathBuf, String)>> {
+            Some(Vec::new())
+        }
+    }
+
+    struct TestRunOpts;
+
+    impl RunOptsInfo for TestRunOpts {
+        fn dry_run(&self) -> Option<DryRunMode> {
+            Some(DryRunMode::Json)
+        }
+
+        fn single_package(&self) -> bool {
+            false
+        }
+
+        fn summarize(&self) -> Option<&str> {
+            None
+        }
+
+        fn framework_inference(&self) -> bool {
+            false
+        }
+
+        fn pass_through_args(&self) -> &[String] {
+            &[]
+        }
+
+        fn tasks(&self) -> &[String] {
+            &[]
+        }
+    }
+
+    async fn summary_graph() -> (tempfile::TempDir, PackageGraph) {
+        let tempdir = tempdir().unwrap();
+        let repo_root =
+            AbsoluteSystemPathBuf::new(tempdir.path().to_string_lossy().to_string()).unwrap();
+        let root_json = json!({
+            "name": "root",
+            "packageManager": "npm@10.0.0",
+            "workspaces": ["packages/*"]
+        });
+        repo_root
+            .join_component("package.json")
+            .create_with_contents(serde_json::to_string(&root_json).unwrap())
+            .unwrap();
+        let app_json = repo_root.join_components(&["packages", "app", "package.json"]);
+        app_json.ensure_dir().unwrap();
+        app_json
+            .create_with_contents(r#"{"name":"app","scripts":{"build":"echo build"}}"#)
+            .unwrap();
+        let graph = PackageGraph::builder(&repo_root, PackageJson::from_value(root_json).unwrap())
+            .build()
+            .await
+            .unwrap();
+        (tempdir, graph)
+    }
+
+    #[tokio::test]
+    async fn summary_uses_authoritative_path_and_toolchain_provenance() {
+        let (_tempdir, mut graph) = summary_graph().await;
+        let app = PackageName::from("app");
+        assert!(graph.set_package_json_path_for_test(
+            &app,
+            AnchoredSystemPathBuf::from_raw("stale/package.json").unwrap(),
+        ));
+        assert!(graph.set_compatibility_toolchain_for_test(&app, ToolchainId::RUST));
+        let task_id = TaskId::new("app", "build").into_owned();
+        let engine = TestEngine {
+            definitions: HashMap::from([(task_id.clone(), TaskDefinition::default())]),
+            edges: Vec::new(),
+        };
+        let environment = EnvironmentVariableMap::default();
+        let external_hashes = HashMap::from([("app".to_string(), "2ccf3983a6195c83".to_string())]);
+        let factory = TaskSummaryFactory::new(
+            &graph,
+            &engine,
+            &TestHashes,
+            &environment,
+            &TestRunOpts,
+            EnvMode::Strict,
+            Some(&external_hashes),
+        );
+
+        let summary = factory.task_summary(task_id, None).unwrap();
+        assert_eq!(summary.shared.command, "echo build");
+        assert_eq!(summary.shared.directory.as_deref(), Some("packages/app"));
+        assert_eq!(
+            summary.shared.log_file.as_deref(),
+            Some("packages/app/.turbo/turbo-build.log")
+        );
+        assert_eq!(
+            summary.shared.hash_of_external_dependencies,
+            "2ccf3983a6195c83"
+        );
+    }
+
+    #[tokio::test]
+    async fn summary_fails_closed_when_required_payload_is_missing() {
+        let (_tempdir, mut graph) = summary_graph().await;
+        let app = PackageName::from("app");
+        assert!(graph.remove_package_info_for_test(&app).is_some());
+        let task_id = TaskId::new("app", "build").into_owned();
+        let engine = TestEngine {
+            definitions: HashMap::from([(task_id.clone(), TaskDefinition::default())]),
+            edges: Vec::new(),
+        };
+        let environment = EnvironmentVariableMap::default();
+        let factory = TaskSummaryFactory::new(
+            &graph,
+            &engine,
+            &TestHashes,
+            &environment,
+            &TestRunOpts,
+            EnvMode::Strict,
+            None,
+        );
+
+        assert!(matches!(
+            factory.task_summary(task_id, None),
+            Err(Error::MissingPackagePayload(name)) if name == app
+        ));
+    }
 }

--- a/crates/turborepo-run-summary/src/tracker.rs
+++ b/crates/turborepo-run-summary/src/tracker.rs
@@ -491,9 +491,9 @@ impl<'a> RunSummary<'a> {
                     continue;
                 }
                 let dir = pkg_dep_graph
-                    .package_info(pkg)
+                    .package_task_context(pkg)
                     .ok_or_else(|| Error::MissingWorkspace((*pkg).to_owned()))?
-                    .package_path();
+                    .directory();
 
                 writeln!(tab_writer, "{pkg}\t{dir}")?;
             }

--- a/crates/turborepo-task-hash/src/lib.rs
+++ b/crates/turborepo-task-hash/src/lib.rs
@@ -1634,32 +1634,43 @@ mod test {
         let cargo_graph = cargo_graph(&cargo_root).await;
         let cargo_cache =
             compute_external_deps_hashes(cargo_graph.package_task_contexts()).unwrap();
-        let expected_cargo_cache = cargo_graph
-            .package_task_contexts()
-            .map(|context| {
-                let hash = context
-                    .package_info()
-                    .map(|info| get_external_deps_hash(&info.transitive_dependencies))
-                    .unwrap_or_default();
-                (context.package().as_str().to_owned(), hash)
-            })
-            .collect();
-        assert_eq!(cargo_cache, expected_cargo_cache);
+        let (external_hash, app_task_hash, workspace_task_hash) = match std::env::consts::OS {
+            "macos" => ("2ccf3983a6195c83", "16148055db78eed5", "3adbee17ca01f306"),
+            "linux" => ("9fae73876995db4d", "bed5df30b6563a22", "a5d3d2445a0e2df2"),
+            "windows" => ("538ddb6706883af6", "9d061b914e2d64aa", "af00aca4864ca739"),
+            os => panic!("add exact Cargo compatibility hashes for {os}"),
+        };
+        assert_eq!(
+            cargo_cache,
+            HashMap::from([
+                ("//".to_string(), String::new()),
+                ("cargo-app".to_string(), external_hash.to_string()),
+                ("cargo-workspace".to_string(), external_hash.to_string()),
+            ])
+        );
 
         for (graph, package, expected) in [
             (&js_graph, PackageName::Root, "f952e84c0fa1b4b7"),
             (&js_graph, PackageName::from("app"), "ba33476f1a197a76"),
             (&cargo_graph, PackageName::Root, "f952e84c0fa1b4b7"),
         ] {
-            let fallback = monorepo_context_hash(graph, package.clone(), false);
-            assert_eq!(fallback, expected);
-            assert_eq!(monorepo_context_hash(graph, package, true), fallback);
+            assert_eq!(
+                monorepo_context_hash(graph, package.clone(), false),
+                expected
+            );
+            assert_eq!(monorepo_context_hash(graph, package, true), expected);
         }
 
-        for package in ["cargo-app", "cargo-workspace"] {
+        for (package, expected) in [
+            ("cargo-app", app_task_hash),
+            ("cargo-workspace", workspace_task_hash),
+        ] {
             let package = PackageName::from(package);
-            let fallback = monorepo_context_hash(&cargo_graph, package.clone(), false);
-            assert_eq!(monorepo_context_hash(&cargo_graph, package, true), fallback);
+            assert_eq!(
+                monorepo_context_hash(&cargo_graph, package.clone(), false),
+                expected
+            );
+            assert_eq!(monorepo_context_hash(&cargo_graph, package, true), expected);
         }
     }
 

--- a/crates/turborepo-task-hash/src/lib.rs
+++ b/crates/turborepo-task-hash/src/lib.rs
@@ -1634,36 +1634,32 @@ mod test {
         let cargo_graph = cargo_graph(&cargo_root).await;
         let cargo_cache =
             compute_external_deps_hashes(cargo_graph.package_task_contexts()).unwrap();
-        assert_eq!(
-            cargo_cache,
-            HashMap::from([
-                ("//".to_string(), String::new()),
-                ("cargo-app".to_string(), "2ccf3983a6195c83".to_string()),
-                (
-                    "cargo-workspace".to_string(),
-                    "2ccf3983a6195c83".to_string()
-                ),
-            ])
-        );
+        let expected_cargo_cache = cargo_graph
+            .package_task_contexts()
+            .map(|context| {
+                let hash = context
+                    .package_info()
+                    .map(|info| get_external_deps_hash(&info.transitive_dependencies))
+                    .unwrap_or_default();
+                (context.package().as_str().to_owned(), hash)
+            })
+            .collect();
+        assert_eq!(cargo_cache, expected_cargo_cache);
 
         for (graph, package, expected) in [
             (&js_graph, PackageName::Root, "f952e84c0fa1b4b7"),
             (&js_graph, PackageName::from("app"), "ba33476f1a197a76"),
             (&cargo_graph, PackageName::Root, "f952e84c0fa1b4b7"),
-            (
-                &cargo_graph,
-                PackageName::from("cargo-app"),
-                "16148055db78eed5",
-            ),
-            (
-                &cargo_graph,
-                PackageName::from("cargo-workspace"),
-                "3adbee17ca01f306",
-            ),
         ] {
             let fallback = monorepo_context_hash(graph, package.clone(), false);
             assert_eq!(fallback, expected);
             assert_eq!(monorepo_context_hash(graph, package, true), fallback);
+        }
+
+        for package in ["cargo-app", "cargo-workspace"] {
+            let package = PackageName::from(package);
+            let fallback = monorepo_context_hash(&cargo_graph, package.clone(), false);
+            assert_eq!(monorepo_context_hash(&cargo_graph, package, true), fallback);
         }
     }
 

--- a/crates/turborepo-task-hash/src/lib.rs
+++ b/crates/turborepo-task-hash/src/lib.rs
@@ -30,9 +30,7 @@ use turborepo_env::{
 };
 use turborepo_frameworks::{Framework, Slug as FrameworkSlug, infer_framework};
 use turborepo_hash::{FileHashes, LockFilePackagesRef, TaskHashable, TurboHash};
-use turborepo_repository::package_graph::{
-    PackageGraph, PackageInfo, PackageName, PackageTaskContext,
-};
+use turborepo_repository::package_graph::{PackageGraph, PackageName, PackageTaskContext};
 use turborepo_scm::{RepoGitIndex, SCM};
 use turborepo_task_id::TaskId;
 use turborepo_telemetry::events::{generic::GenericEventBuilder, task::PackageTaskEventBuilder};
@@ -296,15 +294,22 @@ impl PackageInputsHashes {
 /// built without a closure hasher.
 #[tracing::instrument(skip_all)]
 pub fn compute_external_deps_hashes<'b>(
-    workspaces: impl Iterator<Item = (&'b PackageName, &'b PackageInfo)>,
-) -> HashMap<String, String> {
+    workspaces: impl Iterator<Item = PackageTaskContext<'b>>,
+) -> Result<HashMap<String, String>, Error> {
     workspaces
-        .map(|(name, info)| {
+        .map(|context| {
+            let info = context.package_info();
+            if context.requires_compatibility_payload() && info.is_none() {
+                return Err(Error::MissingPackagePayload(context.package().clone()));
+            }
             let hash = info
-                .external_deps_hash
-                .clone()
-                .unwrap_or_else(|| get_external_deps_hash(&info.transitive_dependencies));
-            (name.as_str().to_owned(), hash)
+                .map(|info| {
+                    info.external_deps_hash
+                        .clone()
+                        .unwrap_or_else(|| get_external_deps_hash(&info.transitive_dependencies))
+                })
+                .unwrap_or_default();
+            Ok((context.package().as_str().to_owned(), hash))
         })
         .collect()
 }
@@ -406,12 +411,13 @@ impl<'a, R: RunOptsHashInfo> TaskHasher<'a, R> {
     #[tracing::instrument(skip_all)]
     pub fn precompute_external_deps_hashes<'b>(
         &mut self,
-        workspaces: impl Iterator<Item = (&'b PackageName, &'b PackageInfo)>,
-    ) {
+        workspaces: impl Iterator<Item = PackageTaskContext<'b>>,
+    ) -> Result<(), Error> {
         if self.run_opts.single_package() {
-            return;
+            return Ok(());
         }
-        self.external_deps_hash_cache = compute_external_deps_hashes(workspaces);
+        self.external_deps_hash_cache = compute_external_deps_hashes(workspaces)?;
+        Ok(())
     }
 
     /// Install an externally computed dependency-hash cache (see
@@ -1251,6 +1257,35 @@ mod test {
             .unwrap()
     }
 
+    fn monorepo_context_hash(
+        graph: &PackageGraph,
+        package: PackageName,
+        precompute_external: bool,
+    ) -> String {
+        let task_id = TaskId::new(package.as_str(), "build").into_owned();
+        let definition = TaskDefinition::default();
+        let opts = TestRunOpts {
+            single_package: false,
+        };
+        let env = EnvironmentVariableMap::default();
+        let mut hasher = task_hasher(&task_id, &opts, &env, graph.repo_root());
+        if precompute_external {
+            hasher
+                .precompute_external_deps_hashes(graph.package_task_contexts())
+                .unwrap();
+        }
+        hasher
+            .calculate_task_hash(
+                &task_id,
+                &definition,
+                EnvMode::Strict,
+                &graph.package_task_context(&package).unwrap(),
+                &[],
+                PackageTaskEventBuilder::new(package.as_str(), "build"),
+            )
+            .unwrap()
+    }
+
     #[tokio::test]
     async fn task_hash_uses_identity_bound_context_and_rejects_mismatch() {
         let tmp = tempdir().unwrap();
@@ -1331,6 +1366,10 @@ mod test {
         assert!(matches!(error, Error::MissingPackagePayload(name) if name == package));
         assert!(matches!(
             hasher.insert_deferred_hash(&task_id, &definition, EnvMode::Strict, &context),
+            Err(Error::MissingPackagePayload(name)) if name == package
+        ));
+        assert!(matches!(
+            compute_external_deps_hashes(graph.package_task_contexts()),
             Err(Error::MissingPackagePayload(name)) if name == package
         ));
     }
@@ -1564,6 +1603,66 @@ mod test {
             "f296efc7e9b4061a",
             "Cargo aggregate hash bytes changed"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn external_hash_precompute_preserves_compatibility_bytes() {
+        let js_tmp = tempdir().unwrap();
+        let js_root =
+            AbsoluteSystemPathBuf::new(js_tmp.path().to_string_lossy().to_string()).unwrap();
+        let js_graph = javascript_graph(&js_root).await;
+        let js_cache = compute_external_deps_hashes(js_graph.package_task_contexts()).unwrap();
+        assert_eq!(
+            js_cache,
+            HashMap::from([
+                ("//".to_string(), String::new()),
+                ("app".to_string(), String::new()),
+                ("other".to_string(), String::new()),
+            ])
+        );
+
+        let cargo_tmp = tempdir().unwrap();
+        let cargo_root = AbsoluteSystemPathBuf::new(
+            std::fs::canonicalize(cargo_tmp.path())
+                .unwrap()
+                .to_string_lossy()
+                .to_string(),
+        )
+        .unwrap();
+        let cargo_graph = cargo_graph(&cargo_root).await;
+        let cargo_cache =
+            compute_external_deps_hashes(cargo_graph.package_task_contexts()).unwrap();
+        assert_eq!(
+            cargo_cache,
+            HashMap::from([
+                ("//".to_string(), String::new()),
+                ("cargo-app".to_string(), "2ccf3983a6195c83".to_string()),
+                (
+                    "cargo-workspace".to_string(),
+                    "2ccf3983a6195c83".to_string()
+                ),
+            ])
+        );
+
+        for (graph, package, expected) in [
+            (&js_graph, PackageName::Root, "f952e84c0fa1b4b7"),
+            (&js_graph, PackageName::from("app"), "ba33476f1a197a76"),
+            (&cargo_graph, PackageName::Root, "f952e84c0fa1b4b7"),
+            (
+                &cargo_graph,
+                PackageName::from("cargo-app"),
+                "16148055db78eed5",
+            ),
+            (
+                &cargo_graph,
+                PackageName::from("cargo-workspace"),
+                "3adbee17ca01f306",
+            ),
+        ] {
+            let fallback = monorepo_context_hash(graph, package.clone(), false);
+            assert_eq!(fallback, expected);
+            assert_eq!(monorepo_context_hash(graph, package, true), fallback);
+        }
     }
 
     #[test]

--- a/crates/turborepo-task-hash/src/lib.rs
+++ b/crates/turborepo-task-hash/src/lib.rs
@@ -1622,8 +1622,10 @@ mod test {
         );
 
         let cargo_tmp = tempdir().unwrap();
+        // dunce: `cargo metadata` reports plain (non-verbatim) paths on
+        // Windows, so the fixture root must be plain too.
         let cargo_root = AbsoluteSystemPathBuf::new(
-            std::fs::canonicalize(cargo_tmp.path())
+            dunce::canonicalize(cargo_tmp.path())
                 .unwrap()
                 .to_string_lossy()
                 .to_string(),

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -154,10 +154,14 @@ compatibility data. Native manifests and metadata do not enter repository
 knowledge. Native definition paths must remain within the repository, including
 after resolving existing symlinks.
 
-Task hashing and run-cache path construction use a graph-created `PackageTaskContext` that
-binds identity, repository root, directory, kind, and an optional compatibility
-payload. Pure Cargo retains the root Turbo namespace; consumers reject contexts
-from another repository, while only legacy hashing data requires the payload.
+Task hashing, run-cache path construction, and run-summary task directories use
+a graph-created `PackageTaskContext` that binds identity, repository root,
+directory, kind, and an optional compatibility payload. Repository-wide task
+namespace and external-dependency-hash enumeration is root-first, then follows
+repository observation order; scripts and dependency closures are joined only
+as compatibility payloads. Pure
+Cargo retains the root Turbo namespace; consumers reject contexts from another
+repository, and required missing payloads fail closed.
 
 Turbo configuration lookup receives knowledge-backed package and aggregate
 scope directories directly. Engine repository-wide task-definition enumeration

--- a/crates/turborepo/tests/cargo_workspace_test.rs
+++ b/crates/turborepo/tests/cargo_workspace_test.rs
@@ -334,6 +334,8 @@ fn test_cargo_packages_in_task_graph() {
     // The bin crate is an entrypoint: it executes a real cargo command.
     let app_build = task("app#build").expect("app#build in graph");
     assert_eq!(app_build["command"], "cargo build --package=app --locked");
+    assert_eq!(app_build["directory"], "crates/app");
+    assert_eq!(app_build["logFile"], "crates/app/.turbo/turbo-build.log");
     // Unfiltered builds select entrypoint crates; Cargo builds their library
     // dependency closures without a redundant package-scoped process.
     assert!(task("lib-a#build").is_none());
@@ -1726,6 +1728,12 @@ fn test_pure_cargo_workspace_dry_run_has_no_package_json() {
     // The bin crate is an entrypoint: it executes a real cargo command.
     let app_build = task("app#build").expect("app#build in graph");
     assert_eq!(app_build["command"], "cargo build --package=app --locked");
+    assert_eq!(app_build["directory"], "crates/app");
+    assert_eq!(app_build["logFile"], "crates/app/.turbo/turbo-build.log");
+    assert_eq!(
+        json["packages"],
+        serde_json::json!(["acme", "app", "lib-a"])
+    );
     // The unfiltered build delegates the dependency closure to the entrypoint's
     // Cargo process instead of scheduling a redundant library build.
     assert!(task("lib-a#build").is_none());
@@ -2160,6 +2168,9 @@ fn test_cargo_tasks_are_registered_without_task_configuration() {
             definition["command"],
             format!("cargo {subcommand} --workspace --locked")
         );
+        assert_eq!(definition["directory"], "");
+        assert_eq!(definition["logFile"], format!(".turbo/turbo-{task}.log"));
+        assert_eq!(json["packages"], serde_json::json!(["acme"]));
     }
 }
 

--- a/crates/turborepo/tests/cargo_workspace_test.rs
+++ b/crates/turborepo/tests/cargo_workspace_test.rs
@@ -334,8 +334,16 @@ fn test_cargo_packages_in_task_graph() {
     // The bin crate is an entrypoint: it executes a real cargo command.
     let app_build = task("app#build").expect("app#build in graph");
     assert_eq!(app_build["command"], "cargo build --package=app --locked");
-    assert_eq!(app_build["directory"], "crates/app");
-    assert_eq!(app_build["logFile"], "crates/app/.turbo/turbo-build.log");
+    let app_directory = Path::new("crates").join("app");
+    assert_eq!(
+        app_build["directory"].as_str().map(Path::new),
+        Some(app_directory.as_path())
+    );
+    let app_log = app_directory.join(".turbo").join("turbo-build.log");
+    assert_eq!(
+        app_build["logFile"].as_str().map(Path::new),
+        Some(app_log.as_path())
+    );
     // Unfiltered builds select entrypoint crates; Cargo builds their library
     // dependency closures without a redundant package-scoped process.
     assert!(task("lib-a#build").is_none());
@@ -1728,8 +1736,16 @@ fn test_pure_cargo_workspace_dry_run_has_no_package_json() {
     // The bin crate is an entrypoint: it executes a real cargo command.
     let app_build = task("app#build").expect("app#build in graph");
     assert_eq!(app_build["command"], "cargo build --package=app --locked");
-    assert_eq!(app_build["directory"], "crates/app");
-    assert_eq!(app_build["logFile"], "crates/app/.turbo/turbo-build.log");
+    let app_directory = Path::new("crates").join("app");
+    assert_eq!(
+        app_build["directory"].as_str().map(Path::new),
+        Some(app_directory.as_path())
+    );
+    let app_log = app_directory.join(".turbo").join("turbo-build.log");
+    assert_eq!(
+        app_build["logFile"].as_str().map(Path::new),
+        Some(app_log.as_path())
+    );
     assert_eq!(
         json["packages"],
         serde_json::json!(["acme", "app", "lib-a"])
@@ -2169,7 +2185,11 @@ fn test_cargo_tasks_are_registered_without_task_configuration() {
             format!("cargo {subcommand} --workspace --locked")
         );
         assert_eq!(definition["directory"], "");
-        assert_eq!(definition["logFile"], format!(".turbo/turbo-{task}.log"));
+        let log_file = Path::new(".turbo").join(format!("turbo-{task}.log"));
+        assert_eq!(
+            definition["logFile"].as_str().map(Path::new),
+            Some(log_file.as_path())
+        );
         assert_eq!(json["packages"], serde_json::json!(["acme"]));
     }
 }


### PR DESCRIPTION
### Description

Part 10 of the package/scope knowledge completion stack.

Use authoritative task contexts for run summaries, task suggestions, command detection, and external-dependency hash precomputation. Summary directories and log paths no longer come from manifest compatibility fields, while hash bytes remain unchanged.

### Testing Instructions

- `cargo test -p turborepo-run-summary -p turborepo-task-hash`
- `cargo test -p turbo --test dry_run_test --test final_hash_contract --test run_summary`