### PR TITLE
refactor: Use consistent repository construction

### DIFF
--- a/crates/turborepo-devtools/src/lib.rs
+++ b/crates/turborepo-devtools/src/lib.rs
@@ -15,6 +15,8 @@ pub use server::{DevtoolsServer, ServerError};
 pub use types::*;
 pub use watcher::{DevtoolsWatcher, WatchError, WatchEvent};
 
+pub use crate::graph::package_graph_to_data;
+
 /// Default port for the devtools WebSocket server
 pub const DEFAULT_PORT: u16 = 9876;
 

--- a/crates/turborepo-devtools/src/server.rs
+++ b/crates/turborepo-devtools/src/server.rs
@@ -28,11 +28,9 @@ use tokio::{
 };
 use tracing::{debug, error, info, warn};
 use turbopath::AbsoluteSystemPathBuf;
-use turborepo_repository::{package_graph::PackageGraphBuilder, package_json::PackageJson};
 
 use crate::{
-    graph::package_graph_to_data,
-    types::{GraphState, ServerMessage, TaskGraphBuilder},
+    types::{GraphState, RepositoryGraphBuilder, ServerMessage},
     watcher::{DevtoolsWatcher, WatchEvent},
 };
 
@@ -78,15 +76,16 @@ struct AppState {
 }
 
 /// The devtools WebSocket server
-pub struct DevtoolsServer<T: TaskGraphBuilder> {
+pub struct DevtoolsServer<T: RepositoryGraphBuilder> {
     repo_root: AbsoluteSystemPathBuf,
     port: u16,
     task_graph_builder: T,
+    watcher_paths: Vec<AbsoluteSystemPathBuf>,
     auth_token: String,
     allowed_origin: String,
 }
 
-impl<T: TaskGraphBuilder + 'static> DevtoolsServer<T> {
+impl<T: RepositoryGraphBuilder + 'static> DevtoolsServer<T> {
     /// Creates a new devtools server with a task graph builder.
     ///
     /// The task graph builder should use the same logic as `turbo run`
@@ -98,10 +97,28 @@ impl<T: TaskGraphBuilder + 'static> DevtoolsServer<T> {
         task_graph_builder: T,
         allowed_origin: impl Into<String>,
     ) -> Self {
+        Self::new_with_paths(
+            repo_root,
+            port,
+            task_graph_builder,
+            allowed_origin,
+            Vec::new(),
+        )
+    }
+
+    /// Creates a server that watches additional exact configuration paths.
+    pub fn new_with_paths(
+        repo_root: AbsoluteSystemPathBuf,
+        port: u16,
+        task_graph_builder: T,
+        allowed_origin: impl Into<String>,
+        watcher_paths: Vec<AbsoluteSystemPathBuf>,
+    ) -> Self {
         Self {
             repo_root,
             port,
             task_graph_builder,
+            watcher_paths,
             auth_token: generate_auth_token(),
             allowed_origin: allowed_origin.into(),
         }
@@ -125,7 +142,7 @@ impl<T: TaskGraphBuilder + 'static> DevtoolsServer<T> {
         let (update_tx, _) = broadcast::channel::<()>(16);
 
         // Start file watcher
-        let watcher = DevtoolsWatcher::new(self.repo_root.clone())?;
+        let watcher = DevtoolsWatcher::new_with_paths(self.repo_root.clone(), self.watcher_paths)?;
         let mut watch_rx = watcher.subscribe();
 
         // Spawn task to handle file changes and rebuild graph
@@ -326,35 +343,16 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
 /// Build the current graph state from the repository
 async fn build_graph_state(
     repo_root: &AbsoluteSystemPathBuf,
-    task_graph_builder: &dyn TaskGraphBuilder,
+    task_graph_builder: &dyn RepositoryGraphBuilder,
 ) -> Result<GraphState, ServerError> {
-    // Load root package.json
-    let root_package_json_path = repo_root.join_component("package.json");
-    let root_package_json = PackageJson::load(&root_package_json_path)
-        .map_err(|e| ServerError::PackageJson(e.to_string()))?;
-
-    // Build package graph using local discovery (no daemon)
-    // We use allow_no_package_manager to be more permissive about package manager
-    // detection
-    let pkg_graph = PackageGraphBuilder::new(repo_root, root_package_json)
-        .with_allow_no_package_manager(true)
-        .build()
-        .await
-        .map_err(|e| ServerError::PackageGraph(e.to_string()))?;
-
-    // Convert package graph to serializable format
-    let package_graph = package_graph_to_data(&pkg_graph);
-
-    // Build task graph using the provided builder (which uses proper turbo run
-    // logic)
-    let task_graph = task_graph_builder
-        .build_task_graph()
+    let graphs = task_graph_builder
+        .build_graphs()
         .await
         .map_err(|e| ServerError::TaskGraph(e.to_string()))?;
 
     Ok(GraphState {
-        package_graph,
-        task_graph,
+        package_graph: graphs.package_graph,
+        task_graph: graphs.task_graph,
         repo_root: repo_root.to_string(),
         turbo_version: env!("CARGO_PKG_VERSION").to_string(),
     })

--- a/crates/turborepo-devtools/src/types.rs
+++ b/crates/turborepo-devtools/src/types.rs
@@ -44,6 +44,15 @@ pub struct GraphState {
     pub turbo_version: String,
 }
 
+/// Package and task graphs produced from one repository generation.
+#[derive(Debug, Clone)]
+pub struct GraphData {
+    /// Serializable package graph from the generation.
+    pub package_graph: PackageGraphData,
+    /// Serializable task graph derived from that same generation.
+    pub task_graph: TaskGraphData,
+}
+
 /// Package dependency graph in a serializable format
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -111,21 +120,20 @@ pub enum TaskGraphError {
     BuildError(String),
 }
 
-/// Trait for building task graphs.
+/// Builds both protocol graphs from one repository generation.
 ///
-/// This trait allows the core turbo library to provide its own implementation
-/// of task graph building, ensuring consistency with the actual `turbo run`
-/// task graph logic.
+/// This is an intentional pre-1.0 API evolution from the former task-only
+/// builder: package and task views must never come from different generations.
 ///
-/// The devtools server will call this trait to build task graphs when files
-/// change, rather than using its own simplified logic.
-pub trait TaskGraphBuilder: Send + Sync {
-    /// Build the task graph for the given repository.
+/// The devtools server calls this trait when files change rather than running
+/// independent package discovery.
+pub trait RepositoryGraphBuilder: Send + Sync {
+    /// Build both graphs for the repository.
     ///
     /// This should use the same logic as `turbo run` to build the task graph,
     /// including proper resolution of `dependsOn`, topological dependencies,
     /// and task inheritance from turbo.json files.
-    fn build_task_graph(
+    fn build_graphs(
         &self,
-    ) -> Pin<Box<dyn Future<Output = Result<TaskGraphData, TaskGraphError>> + Send + '_>>;
+    ) -> Pin<Box<dyn Future<Output = Result<GraphData, TaskGraphError>> + Send + '_>>;
 }

--- a/crates/turborepo-devtools/src/watcher.rs
+++ b/crates/turborepo-devtools/src/watcher.rs
@@ -3,13 +3,18 @@
 //! Watches the repository for changes to relevant files (package.json,
 //! turbo.json, etc.) and emits events when changes are detected.
 
-use std::{path::Path, time::Duration};
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
 
 use thiserror::Error;
 use tokio::sync::{broadcast, oneshot};
 use tracing::{debug, trace, warn};
 use turbopath::AbsoluteSystemPathBuf;
-use turborepo_filewatch::{FileSystemWatcher, WatchScope, WatchSource};
+use turborepo_filewatch::{FileSystemWatcher, WatchInterest, WatchScope, WatchSource};
 
 /// Errors that can occur during file watching
 #[derive(Debug, Error)]
@@ -38,6 +43,8 @@ const RELEVANT_FILES: &[&str] = &[
     "yarn.lock",
     "pnpm-lock.yaml",
     "bun.lockb",
+    "Cargo.toml",
+    "Cargo.lock",
 ];
 
 /// Directories to ignore entirely
@@ -54,8 +61,18 @@ pub struct DevtoolsWatcher {
 impl DevtoolsWatcher {
     /// Creates a new devtools watcher for the given repository root.
     pub fn new(repo_root: AbsoluteSystemPathBuf) -> Result<Self, WatchError> {
+        Self::new_with_paths(repo_root, Vec::new())
+    }
+
+    /// Creates a watcher with exact paths that bypass filename and ignored
+    /// directory filtering.
+    pub fn new_with_paths(
+        repo_root: AbsoluteSystemPathBuf,
+        exact_paths: Vec<AbsoluteSystemPathBuf>,
+    ) -> Result<Self, WatchError> {
         // Create file system watcher
         let file_watcher = FileSystemWatcher::new_with_default_cookie_dir(&repo_root)?;
+        let exact_paths = exact_watch_paths(&repo_root, exact_paths);
 
         // Set up channels
         let (exit_tx, exit_rx) = oneshot::channel();
@@ -65,6 +82,7 @@ impl DevtoolsWatcher {
         tokio::spawn(watch_loop(
             repo_root,
             file_watcher.source(),
+            exact_paths,
             event_tx,
             exit_rx,
         ));
@@ -80,6 +98,23 @@ impl DevtoolsWatcher {
     pub fn subscribe(&self) -> broadcast::Receiver<WatchEvent> {
         self.event_rx.resubscribe()
     }
+}
+
+fn exact_watch_paths(
+    repo_root: &AbsoluteSystemPathBuf,
+    paths: Vec<AbsoluteSystemPathBuf>,
+) -> HashSet<PathBuf> {
+    let mut paths: HashSet<PathBuf> = paths
+        .into_iter()
+        .map(|path| path.as_std_path().to_owned())
+        .collect();
+    paths.insert(
+        repo_root
+            .join_components(&[".turbo", "config.json"])
+            .as_std_path()
+            .to_owned(),
+    );
+    paths
 }
 
 /// Check if a path is in an ignored directory
@@ -100,14 +135,23 @@ fn is_relevant_file(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
+fn should_watch_path(path: &Path, exact_paths: &HashSet<PathBuf>) -> bool {
+    exact_paths.contains(path) || (!is_in_ignored_dir(path) && is_relevant_file(path))
+}
+
 /// Main watch loop that processes file events
 async fn watch_loop(
     _repo_root: AbsoluteSystemPathBuf,
     file_events: WatchSource,
+    exact_paths: HashSet<PathBuf>,
     event_tx: broadcast::Sender<WatchEvent>,
     exit_rx: oneshot::Receiver<()>,
 ) {
-    let scope = WatchScope::predicate(|path| !is_in_ignored_dir(path) && is_relevant_file(path));
+    let physical_interest = WatchInterest::new();
+    physical_interest.replace(exact_paths.iter().cloned());
+    let exact_paths = Arc::new(exact_paths);
+    let scope = WatchScope::predicate(move |path| should_watch_path(path, &exact_paths))
+        .with_physical_interest(physical_interest);
     let Ok(mut file_events) = file_events.subscribe(scope).await else {
         warn!("File watching not available");
         return;
@@ -177,6 +221,8 @@ mod tests {
         assert!(is_relevant_file(Path::new("turbo.json")));
         assert!(is_relevant_file(Path::new("turbo.jsonc")));
         assert!(is_relevant_file(Path::new("pnpm-workspace.yaml")));
+        assert!(is_relevant_file(Path::new("crates/app/Cargo.toml")));
+        assert!(is_relevant_file(Path::new("Cargo.lock")));
         assert!(!is_relevant_file(Path::new("index.ts")));
         assert!(!is_relevant_file(Path::new("README.md")));
     }
@@ -192,5 +238,26 @@ mod tests {
             "/repo/packages/app/package.json"
         )));
         assert!(!is_in_ignored_dir(Path::new("turbo.json")));
+    }
+
+    #[test]
+    fn exact_config_paths_bypass_normal_ignore_and_filename_rules() {
+        let repo_root = AbsoluteSystemPathBuf::new("/repo".to_owned()).expect("absolute root");
+        let custom = repo_root.join_components(&[".turbo", "custom.config"]);
+        let arbitrary = repo_root.join_components(&["config", "devtools.conf"]);
+        let local_config = PathBuf::from("/repo/.turbo/config.json");
+        let exact_paths = exact_watch_paths(&repo_root, vec![custom.clone(), arbitrary.clone()]);
+
+        assert!(should_watch_path(custom.as_std_path(), &exact_paths));
+        assert!(should_watch_path(arbitrary.as_std_path(), &exact_paths));
+        assert!(should_watch_path(&local_config, &exact_paths));
+        assert!(!should_watch_path(
+            Path::new("/repo/.turbo/unrelated.json"),
+            &exact_paths
+        ));
+        assert!(!should_watch_path(
+            Path::new("/repo/.turbo/turbo.json"),
+            &exact_paths
+        ));
     }
 }

--- a/crates/turborepo-devtools/src/watcher.rs
+++ b/crates/turborepo-devtools/src/watcher.rs
@@ -242,22 +242,20 @@ mod tests {
 
     #[test]
     fn exact_config_paths_bypass_normal_ignore_and_filename_rules() {
-        let repo_root = AbsoluteSystemPathBuf::new("/repo".to_owned()).expect("absolute root");
+        let tempdir = tempfile::tempdir().expect("create temporary repository");
+        let repo_root = AbsoluteSystemPathBuf::new(tempdir.path().to_string_lossy().to_string())
+            .expect("absolute root");
         let custom = repo_root.join_components(&[".turbo", "custom.config"]);
         let arbitrary = repo_root.join_components(&["config", "devtools.conf"]);
-        let local_config = PathBuf::from("/repo/.turbo/config.json");
+        let local_config = repo_root.join_components(&[".turbo", "config.json"]);
+        let unrelated = repo_root.join_components(&[".turbo", "unrelated.json"]);
+        let turbo_json = repo_root.join_components(&[".turbo", "turbo.json"]);
         let exact_paths = exact_watch_paths(&repo_root, vec![custom.clone(), arbitrary.clone()]);
 
         assert!(should_watch_path(custom.as_std_path(), &exact_paths));
         assert!(should_watch_path(arbitrary.as_std_path(), &exact_paths));
-        assert!(should_watch_path(&local_config, &exact_paths));
-        assert!(!should_watch_path(
-            Path::new("/repo/.turbo/unrelated.json"),
-            &exact_paths
-        ));
-        assert!(!should_watch_path(
-            Path::new("/repo/.turbo/turbo.json"),
-            &exact_paths
-        ));
+        assert!(should_watch_path(local_config.as_std_path(), &exact_paths));
+        assert!(!should_watch_path(unrelated.as_std_path(), &exact_paths));
+        assert!(!should_watch_path(turbo_json.as_std_path(), &exact_paths));
     }
 }

--- a/crates/turborepo-lib/src/cli/args.rs
+++ b/crates/turborepo-lib/src/cli/args.rs
@@ -108,6 +108,10 @@ pub struct Args {
     // DO NOT MAKE THIS VISIBLE
     // Instead use the getter method execution_args()
     pub(super) execution_args: Option<ExecutionArgs>,
+    /// The legacy flag is stripped before clap parsing. Non-run commands use
+    /// this field because they have no command-local `ExecutionArgs`.
+    #[clap(skip)]
+    pub(crate) single_package: bool,
     #[clap(subcommand)]
     pub command: Option<Command>,
 }
@@ -390,10 +394,11 @@ impl Args {
         let (is_single_package, single_package_free) = Self::remove_single_package(os_args);
         let mut args = Args::try_parse_from(single_package_free)?;
         // --single-package is stripped before clap parsing, so we need to
-        // propagate it back. The value can appear in two places in the struct.
-        // We defensively attempt to set both.
+        // propagate it back. Preserve clap's optional global execution args;
+        // creating them here conflicts with explicit run/watch arguments.
+        args.single_package = is_single_package;
         if let Some(ref mut execution_args) = args.execution_args {
-            execution_args.single_package = is_single_package
+            execution_args.single_package = is_single_package;
         }
 
         if let Some(

--- a/crates/turborepo-lib/src/cli/error.rs
+++ b/crates/turborepo-lib/src/cli/error.rs
@@ -69,6 +69,8 @@ pub enum Error {
     #[error(transparent)]
     SerdeJson(#[from] serde_json::Error),
     #[error(transparent)]
+    TurboJson(#[from] turborepo_turbo_json::Error),
+    #[error(transparent)]
     #[diagnostic(transparent)]
     Watch(#[from] watch::Error),
     #[error("Devtools error: {0}")]

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -428,7 +428,7 @@ async fn run_main(
             let event = CommandEventBuilder::new("devtools").with_parent(&root_telemetry);
             event.track_call();
 
-            crate::commands::devtools::run(repo_root, *port, *no_open).await?;
+            crate::commands::devtools::run(repo_root, cli_args.clone(), *port, *no_open).await?;
             Ok(0)
         }
         Command::Docs {

--- a/crates/turborepo-lib/src/cli/test.rs
+++ b/crates/turborepo-lib/src/cli/test.rs
@@ -1821,6 +1821,7 @@ fn test_set_single_package() {
             None
         })
         .unwrap_or(false));
+    assert!(explicit_run.execution_args.is_none());
 
     let watch = Args::parse(
         ["turbo", "watch", "--single-package", "build"]
@@ -1838,6 +1839,7 @@ fn test_set_single_package() {
             None
         })
         .unwrap_or(false));
+    assert!(watch.execution_args.is_none());
 }
 
 #[test_case::test_case(&["turbo", "watch", "build", "--no-daemon"]; "after watch")]

--- a/crates/turborepo-lib/src/commands/config.rs
+++ b/crates/turborepo-lib/src/commands/config.rs
@@ -1,10 +1,13 @@
 use camino::Utf8Path;
 use serde::Serialize;
 use turbopath::AbsoluteSystemPathBuf;
-use turborepo_repository::{package_graph::PackageGraph, package_json::PackageJson};
+use turborepo_repository::{cargo::CargoToolchain, package_graph::PackageGraph};
 use turborepo_types::{EnvMode, UIMode};
 
-use crate::{cli, commands::CommandBase, Args};
+use crate::{
+    cli, config::resolve_configuration_from_args, run::builder::load_root_package_json,
+    turbo_json::RawTurboJson, Args,
+};
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -32,12 +35,20 @@ struct ConfigOutput<'a> {
 }
 
 pub async fn run(repo_root: AbsoluteSystemPathBuf, args: Args) -> Result<(), cli::Error> {
-    let config = CommandBase::load_config(&repo_root, &args)?;
-    let root_package_json = PackageJson::load(&repo_root.join_component("package.json"))?;
+    let config = resolve_configuration_from_args(&repo_root, &args)?;
+    let root_turbo_json_path = config.root_turbo_json_path(&repo_root)?;
+    let future_flags = RawTurboJson::read(&repo_root, &root_turbo_json_path, true)?
+        .and_then(|raw| raw.future_flags.map(|flags| flags.into_inner()))
+        .unwrap_or_default();
+    let cargo_enabled = future_flags.experimental_cargo_workspaces;
+    let root_package_json = load_root_package_json(&repo_root, cargo_enabled)?;
 
-    let package_graph = PackageGraph::builder(&repo_root, root_package_json)
-        .build()
-        .await?;
+    let mut builder = PackageGraph::builder_optional(&repo_root, root_package_json)
+        .with_allow_no_package_manager(config.allow_no_package_manager());
+    if cargo_enabled {
+        builder = builder.with_toolchain(CargoToolchain::new(repo_root.clone()));
+    }
+    let package_graph = builder.build().await?;
 
     let package_manager = package_graph.package_manager().map(|pm| pm.name());
 

--- a/crates/turborepo-lib/src/commands/devtools.rs
+++ b/crates/turborepo-lib/src/commands/devtools.rs
@@ -6,7 +6,7 @@
 use turbopath::AbsoluteSystemPathBuf;
 use turborepo_devtools::{find_available_port, DevtoolsServer};
 
-use crate::{cli, devtools::ProperTaskGraphBuilder};
+use crate::{cli, config::resolve_configuration_from_args, devtools::ProperTaskGraphBuilder, Args};
 
 // In production, use the hosted devtools UI
 // For local development, set TURBO_DEVTOOLS_LOCAL=1 to use localhost:3000
@@ -24,6 +24,7 @@ const DEVTOOLS_ORIGIN: &str = if cfg!(debug_assertions) {
 /// Run the devtools server.
 pub async fn run(
     repo_root: AbsoluteSystemPathBuf,
+    args: Args,
     port: u16,
     no_open: bool,
 ) -> Result<(), cli::Error> {
@@ -32,10 +33,20 @@ pub async fn run(
 
     // Create the task graph builder that uses EngineBuilder
     // This ensures the devtools shows the same task graph as `turbo run`
-    let task_graph_builder = ProperTaskGraphBuilder::new(repo_root.clone());
+    // Only snapshot an explicit path. Default turbo.json/turbo.jsonc selection
+    // remains refreshable through the normal filename watches.
+    let config = resolve_configuration_from_args(&repo_root, &args)?;
+    let watcher_paths = config.root_turbo_json_path.into_iter().collect();
+    let task_graph_builder = ProperTaskGraphBuilder::new(repo_root.clone(), args);
 
     // Create server with the task graph builder
-    let server = DevtoolsServer::new(repo_root, port, task_graph_builder, DEVTOOLS_ORIGIN);
+    let server = DevtoolsServer::new_with_paths(
+        repo_root,
+        port,
+        task_graph_builder,
+        DEVTOOLS_ORIGIN,
+        watcher_paths,
+    );
 
     let url = format!(
         "{}?port={}#token={}",

--- a/crates/turborepo-lib/src/devtools.rs
+++ b/crates/turborepo-lib/src/devtools.rs
@@ -7,17 +7,23 @@ use std::{future::Future, pin::Pin};
 
 use tracing::debug;
 use turbopath::AbsoluteSystemPathBuf;
-use turborepo_devtools::{GraphEdge, TaskGraphBuilder, TaskGraphData, TaskGraphError, TaskNode};
+use turborepo_devtools::{
+    package_graph_to_data, GraphData, GraphEdge, RepositoryGraphBuilder, TaskGraphData,
+    TaskGraphError, TaskNode,
+};
 use turborepo_repository::{
+    cargo::CargoToolchain,
     package_graph::{PackageGraph, PackageGraphBuilder, PackageName},
-    package_json::PackageJson,
 };
 use turborepo_task_id::TaskName;
 
 use crate::{
-    config::resolve_turbo_config_path,
+    commands::CommandBase,
     engine::{EngineBuilder, TaskNode as EngineTaskNode},
+    opts::Opts,
+    run::builder::{cargo_enabled, load_root_package_json},
     turbo_json::{TurboJsonReader, UnifiedTurboJsonLoader},
+    Args,
 };
 
 /// Task graph builder that uses the proper `EngineBuilder` logic.
@@ -27,22 +33,46 @@ use crate::{
 /// executes.
 pub struct ProperTaskGraphBuilder {
     repo_root: AbsoluteSystemPathBuf,
+    args: Args,
 }
 
 impl ProperTaskGraphBuilder {
     /// Create a new proper task graph builder
-    pub fn new(repo_root: AbsoluteSystemPathBuf) -> Self {
-        Self { repo_root }
+    pub fn new(repo_root: AbsoluteSystemPathBuf, args: Args) -> Self {
+        Self { repo_root, args }
+    }
+
+    fn resolve_opts(&self) -> Result<Opts, TaskGraphError> {
+        let config = CommandBase::load_config(&self.repo_root, &self.args)
+            .map_err(|error| TaskGraphError::BuildError(error.to_string()))?;
+        let root_turbo_json_path = config
+            .root_turbo_json_path(&self.repo_root)
+            .map_err(|error| TaskGraphError::BuildError(error.to_string()))?;
+        if self.repo_root.anchor(&root_turbo_json_path).is_err() {
+            return Err(TaskGraphError::BuildError(format!(
+                "Devtools root Turbo config must be inside the repository: {} is outside {}",
+                root_turbo_json_path, self.repo_root
+            )));
+        }
+        Opts::new(&self.repo_root, &self.args, config)
+            .map_err(|error| TaskGraphError::BuildError(error.to_string()))
     }
 
     /// Build the package graph for the repository
-    async fn build_package_graph(&self) -> Result<PackageGraph, TaskGraphError> {
-        let root_package_json_path = self.repo_root.join_component("package.json");
-        let root_package_json = PackageJson::load(&root_package_json_path)
-            .map_err(|e| TaskGraphError::BuildError(format!("Failed to load package.json: {e}")))?;
+    async fn build_package_graph(&self, opts: &Opts) -> Result<PackageGraph, TaskGraphError> {
+        let root_package_json =
+            load_root_package_json(&self.repo_root, cargo_enabled(&opts.future_flags)).map_err(
+                |e| TaskGraphError::BuildError(format!("Failed to load package.json: {e}")),
+            )?;
 
-        PackageGraphBuilder::new(&self.repo_root, root_package_json)
-            .with_allow_no_package_manager(true)
+        let mut builder = PackageGraphBuilder::new_optional(&self.repo_root, root_package_json)
+            .with_single_package_mode(opts.run_opts.single_package)
+            .with_allow_no_package_manager(opts.repo_opts.allow_no_package_manager);
+        if cargo_enabled(&opts.future_flags) {
+            builder = builder.with_toolchain(CargoToolchain::new(self.repo_root.clone()));
+        }
+
+        builder
             .build()
             .await
             .map_err(|e| TaskGraphError::BuildError(format!("Failed to build package graph: {e}")))
@@ -52,16 +82,26 @@ impl ProperTaskGraphBuilder {
     fn build_engine_task_graph(
         &self,
         pkg_graph: &PackageGraph,
+        opts: &Opts,
     ) -> Result<TaskGraphData, TaskGraphError> {
         // Create turbo json loader
-        let root_turbo_json_path = resolve_turbo_config_path(&self.repo_root)
-            .map_err(|e| TaskGraphError::BuildError(format!("{e}")))?;
-        let reader = TurboJsonReader::new(self.repo_root.clone());
-        let loader = UnifiedTurboJsonLoader::workspace(
-            reader,
-            root_turbo_json_path.clone(),
-            pkg_graph.package_scope_directories(),
-        );
+        let reader =
+            TurboJsonReader::new(self.repo_root.clone()).with_future_flags(opts.future_flags);
+        let loader = match (
+            opts.run_opts.single_package,
+            pkg_graph.package_json(&PackageName::Root).cloned(),
+        ) {
+            (true, Some(root_package_json)) => UnifiedTurboJsonLoader::single_package(
+                reader,
+                opts.repo_opts.root_turbo_json_path.clone(),
+                root_package_json,
+            ),
+            _ => UnifiedTurboJsonLoader::workspace(
+                reader,
+                opts.repo_opts.root_turbo_json_path.clone(),
+                pkg_graph.package_scope_directories(),
+            ),
+        };
 
         // Collect authoritative execution scopes, including aggregates. The
         // compatibility PackageInfo map can contain a synthetic Cargo root.
@@ -69,9 +109,6 @@ impl ProperTaskGraphBuilder {
             .package_scope_directories()
             .map(|(name, _)| name)
             .collect();
-
-        // Determine if this is a single package repo.
-        let is_single = workspaces.len() == 1;
 
         // Collect all root tasks from turbo.json AND root package.json scripts
         // For devtools, we want to show all tasks including root tasks
@@ -99,13 +136,18 @@ impl ProperTaskGraphBuilder {
 
         // Build engine with all tasks
         // We use `add_all_tasks` to get the complete task graph for visualization
-        let engine = EngineBuilder::new(&self.repo_root, pkg_graph, &loader, is_single)
-            .with_workspaces(workspaces)
-            .with_root_tasks(root_tasks)
-            .add_all_tasks()
-            .do_not_validate_engine() // Don't validate for devtools visualization
-            .build()
-            .map_err(|e| TaskGraphError::BuildError(format!("Failed to build task graph: {e}")))?;
+        let engine = EngineBuilder::new(
+            &self.repo_root,
+            pkg_graph,
+            &loader,
+            opts.run_opts.single_package,
+        )
+        .with_workspaces(workspaces)
+        .with_root_tasks(root_tasks)
+        .add_all_tasks()
+        .do_not_validate_engine() // Don't validate for devtools visualization
+        .build()
+        .map_err(|e| TaskGraphError::BuildError(format!("Failed to build task graph: {e}")))?;
 
         // Convert engine to TaskGraphData
         let mut nodes = Vec::new();
@@ -164,21 +206,304 @@ impl ProperTaskGraphBuilder {
 
         Ok(TaskGraphData { nodes, edges })
     }
+
+    async fn build_graph_data(&self) -> Result<GraphData, TaskGraphError> {
+        let opts = self.resolve_opts()?;
+        let pkg_graph = self.build_package_graph(&opts).await?;
+        let package_graph = package_graph_to_data(&pkg_graph);
+        let task_graph = self.build_engine_task_graph(&pkg_graph, &opts)?;
+        Ok(GraphData {
+            package_graph,
+            task_graph,
+        })
+    }
 }
 
-impl TaskGraphBuilder for ProperTaskGraphBuilder {
-    fn build_task_graph(
+impl RepositoryGraphBuilder for ProperTaskGraphBuilder {
+    fn build_graphs(
         &self,
-    ) -> Pin<Box<dyn Future<Output = Result<TaskGraphData, TaskGraphError>> + Send + '_>> {
-        Box::pin(async move {
-            let pkg_graph = self.build_package_graph().await?;
-            self.build_engine_task_graph(&pkg_graph)
-        })
+    ) -> Pin<Box<dyn Future<Output = Result<GraphData, TaskGraphError>> + Send + '_>> {
+        Box::pin(self.build_graph_data())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    // Tests would go here - we can verify that the ProperTaskGraphBuilder
-    // produces the same results as a real turbo run would
+    use std::{collections::HashSet, ffi::OsString};
+
+    use turbopath::AbsoluteSystemPathBuf;
+    use turborepo_devtools::RepositoryGraphBuilder;
+
+    use super::ProperTaskGraphBuilder;
+    use crate::Args;
+
+    fn setup_cargo(root: &AbsoluteSystemPathBuf) {
+        root.join_components(&["crates", "rust-app", "src"])
+            .create_dir_all()
+            .expect("create crate source directory");
+        root.join_component("Cargo.toml")
+            .create_with_contents(
+                "[workspace]\nmembers = [\"crates/*\"]\nresolver = \
+                 \"2\"\n\n[workspace.metadata]\nname = \"acme\"\n",
+            )
+            .expect("write workspace manifest");
+        root.join_components(&["crates", "rust-app", "Cargo.toml"])
+            .create_with_contents(
+                "[package]\nname = \"rust-app\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+            )
+            .expect("write crate manifest");
+        root.join_components(&["crates", "rust-app", "src", "main.rs"])
+            .create_with_contents("fn main() {}\n")
+            .expect("write crate source");
+        root.join_component("Cargo.lock")
+            .create_with_contents(
+                "version = 4\n\n[[package]]\nname = \"rust-app\"\nversion = \"0.1.0\"\n",
+            )
+            .expect("write Cargo lockfile");
+    }
+
+    fn builder(root: &AbsoluteSystemPathBuf) -> ProperTaskGraphBuilder {
+        let args = Args::parse(
+            ["turbo", "devtools", "--no-open"]
+                .into_iter()
+                .map(OsString::from)
+                .collect(),
+        )
+        .expect("parse devtools arguments");
+        ProperTaskGraphBuilder::new(root.clone(), args)
+    }
+
+    fn builder_with_config(
+        root: &AbsoluteSystemPathBuf,
+        config: &AbsoluteSystemPathBuf,
+    ) -> ProperTaskGraphBuilder {
+        let args = Args::parse(vec![
+            OsString::from("turbo"),
+            OsString::from(format!("--root-turbo-json={config}")),
+            OsString::from("devtools"),
+            OsString::from("--no-open"),
+        ])
+        .expect("parse devtools arguments");
+        ProperTaskGraphBuilder::new(root.clone(), args)
+    }
+
+    fn setup_javascript(root: &AbsoluteSystemPathBuf) {
+        root.join_components(&["packages", "web"])
+            .create_dir_all()
+            .expect("create JavaScript workspace");
+        root.join_component("package.json")
+            .create_with_contents(
+                r#"{"name":"root","packageManager":"npm@10.5.0","workspaces":["packages/*"],"scripts":{"lint":"eslint ."}}"#,
+            )
+            .expect("write root package.json");
+        root.join_components(&["packages", "web", "package.json"])
+            .create_with_contents(r#"{"name":"web","scripts":{"build":"next build"}}"#)
+            .expect("write workspace package.json");
+        root.join_component("package-lock.json")
+            .create_with_contents(
+                r#"{"name":"root","lockfileVersion":3,"packages":{"":{"name":"root","workspaces":["packages/*"]},"packages/web":{"name":"web"}}}"#,
+            )
+            .expect("write npm lockfile");
+    }
+
+    fn package_names(graphs: &turborepo_devtools::GraphData) -> HashSet<&str> {
+        graphs
+            .package_graph
+            .nodes
+            .iter()
+            .map(|node| node.name.as_str())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn pure_cargo_uses_the_same_generation_for_package_and_task_scopes() {
+        let tempdir = tempfile::tempdir().expect("create temporary repository");
+        let root = AbsoluteSystemPathBuf::try_from(tempdir.path()).expect("absolute repository");
+        setup_cargo(&root);
+        root.join_component("turbo.json")
+            .create_with_contents(
+                r#"{"futureFlags":{"experimentalCargoWorkspaces":true},"tasks":{"build":{}}}"#,
+            )
+            .expect("write turbo.json");
+
+        let graphs = builder(&root)
+            .build_graphs()
+            .await
+            .expect("build devtools graphs");
+        let packages = package_names(&graphs);
+
+        assert_eq!(packages, HashSet::from(["acme", "rust-app"]));
+        assert!(graphs.task_graph.nodes.iter().any(|node| {
+            node.package == "rust-app" && node.task == "build" && node.script.is_empty()
+        }));
+        assert!(graphs
+            .task_graph
+            .nodes
+            .iter()
+            .filter(|node| node.package != "//")
+            .all(|node| packages.contains(node.package.as_str())));
+    }
+
+    #[tokio::test]
+    async fn malformed_javascript_root_is_not_hidden_by_cargo_support() {
+        let tempdir = tempfile::tempdir().expect("create temporary repository");
+        let root = AbsoluteSystemPathBuf::try_from(tempdir.path()).expect("absolute repository");
+        setup_cargo(&root);
+        root.join_component("package.json")
+            .create_with_contents("{")
+            .expect("write malformed package.json");
+
+        let error = builder(&root)
+            .build_graphs()
+            .await
+            .expect_err("malformed package.json must fail");
+        assert!(error.to_string().contains("package.json"));
+    }
+
+    #[tokio::test]
+    async fn mixed_repository_preserves_javascript_scripts_and_native_scopes() {
+        let tempdir = tempfile::tempdir().expect("create temporary repository");
+        let root = AbsoluteSystemPathBuf::try_from(tempdir.path()).expect("absolute repository");
+        setup_cargo(&root);
+        setup_javascript(&root);
+        root.join_component("turbo.json")
+            .create_with_contents(
+                r#"{"futureFlags":{"experimentalCargoWorkspaces":true},"tasks":{"build":{},"lint":{}}}"#,
+            )
+            .expect("write turbo.json");
+
+        let graphs = builder(&root)
+            .build_graphs()
+            .await
+            .expect("build devtools graphs");
+        let packages = package_names(&graphs);
+
+        assert!(packages.is_superset(&HashSet::from(["(root)", "web", "acme", "rust-app"])));
+        assert!(graphs.task_graph.nodes.iter().any(|node| {
+            node.package == "web" && node.task == "build" && node.script == "next build"
+        }));
+        assert!(graphs.task_graph.nodes.iter().any(|node| {
+            node.package == "//" && node.task == "lint" && node.script == "eslint ."
+        }));
+    }
+
+    #[tokio::test]
+    async fn refresh_reloads_cargo_future_flag() {
+        let tempdir = tempfile::tempdir().expect("create temporary repository");
+        let root = AbsoluteSystemPathBuf::try_from(tempdir.path()).expect("absolute repository");
+        setup_cargo(&root);
+        setup_javascript(&root);
+        root.join_component("turbo.json")
+            .create_with_contents(r#"{"tasks":{"build":{}}}"#)
+            .expect("write turbo.json");
+        let builder = builder(&root);
+
+        let before = builder.build_graphs().await.expect("build JS graph");
+        assert!(!package_names(&before).contains("rust-app"));
+
+        root.join_component("turbo.json")
+            .create_with_contents(
+                r#"{"futureFlags":{"experimentalCargoWorkspaces":true},"tasks":{"build":{}}}"#,
+            )
+            .expect("enable Cargo support");
+        let after = builder.build_graphs().await.expect("build mixed graph");
+        assert!(package_names(&after).contains("rust-app"));
+    }
+
+    #[tokio::test]
+    async fn refresh_reselects_default_turbo_config_file() {
+        let tempdir = tempfile::tempdir().expect("create temporary repository");
+        let root = AbsoluteSystemPathBuf::try_from(tempdir.path()).expect("absolute repository");
+        setup_javascript(&root);
+        root.join_component("turbo.json")
+            .create_with_contents(r#"{"tasks":{"build":{},"lint":{}}}"#)
+            .expect("write turbo.json");
+        let builder = builder(&root);
+
+        builder.build_graphs().await.expect("build from turbo.json");
+        assert!(builder
+            .resolve_opts()
+            .expect("resolve turbo.json")
+            .repo_opts
+            .root_turbo_json_path
+            .ends_with("turbo.json"));
+
+        root.join_component("turbo.json")
+            .remove()
+            .expect("remove turbo.json");
+        root.join_component("turbo.jsonc")
+            .create_with_contents("// refreshed\n{\"tasks\":{\"build\":{},\"lint\":{}}}")
+            .expect("write turbo.jsonc");
+
+        builder
+            .build_graphs()
+            .await
+            .expect("build from turbo.jsonc");
+        assert!(builder
+            .resolve_opts()
+            .expect("resolve turbo.jsonc")
+            .repo_opts
+            .root_turbo_json_path
+            .ends_with("turbo.jsonc"));
+    }
+
+    #[tokio::test]
+    async fn refresh_keeps_explicit_turbo_config_selection() {
+        let tempdir = tempfile::tempdir().expect("create temporary repository");
+        let root = AbsoluteSystemPathBuf::try_from(tempdir.path()).expect("absolute repository");
+        setup_javascript(&root);
+        let custom_config = root.join_component("custom.json");
+        custom_config
+            .create_with_contents(r#"{"tasks":{"build":{},"lint":{}}}"#)
+            .expect("write custom config");
+        root.join_component("turbo.json")
+            .create_with_contents(r#"{"tasks":{}}"#)
+            .expect("write default config");
+        let builder = builder_with_config(&root, &custom_config);
+
+        builder
+            .build_graphs()
+            .await
+            .expect("build from custom config");
+        root.join_component("turbo.json")
+            .remove()
+            .expect("remove default config");
+        root.join_component("turbo.jsonc")
+            .create_with_contents("{")
+            .expect("write malformed default config");
+
+        builder
+            .build_graphs()
+            .await
+            .expect("refresh still uses custom config");
+        assert_eq!(
+            builder
+                .resolve_opts()
+                .expect("resolve custom config")
+                .repo_opts
+                .root_turbo_json_path,
+            custom_config
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_explicit_turbo_config_outside_repository() {
+        let tempdir = tempfile::tempdir().expect("create temporary repository");
+        let root = AbsoluteSystemPathBuf::try_from(tempdir.path()).expect("absolute repository");
+        setup_javascript(&root);
+        let external_dir = tempfile::tempdir().expect("create external config directory");
+        let external_config = AbsoluteSystemPathBuf::try_from(external_dir.path())
+            .expect("absolute external directory")
+            .join_component("turbo.json");
+        external_config
+            .create_with_contents(r#"{"tasks":{"build":{}}}"#)
+            .expect("write external config");
+
+        let error = builder_with_config(&root, &external_config)
+            .build_graphs()
+            .await
+            .expect_err("external config must be rejected");
+        assert!(error.to_string().contains("must be inside the repository"));
+        assert!(error.to_string().contains(external_config.as_str()));
+    }
 }

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -157,6 +157,10 @@ impl Opts {
             team_slug: team_slug.map(|s| s.to_string()),
         });
 
+        let default_execution_args = Box::new(ExecutionArgs {
+            single_package: args.single_package,
+            ..Default::default()
+        });
         let (execution_args, run_args) = match &args.command {
             Some(Command::Run {
                 run_args,
@@ -194,7 +198,7 @@ impl Opts {
 
                 (&Box::new(execution_args), &Box::default())
             }
-            _ => (&Box::default(), &Box::default()),
+            _ => (&default_execution_args, &Box::default()),
         };
 
         // Resolve cache directory once to avoid duplicate git process spawning.
@@ -780,6 +784,23 @@ mod test {
         continue_on_error: ContinueMode,
         dry_run: Option<DryRunMode>,
         affected: Option<(String, String)>,
+    }
+
+    #[test]
+    fn devtools_preserves_global_single_package_option() {
+        let tempdir = TempDir::new().expect("create temporary repository");
+        let repo_root = AbsoluteSystemPathBuf::try_from(tempdir.path()).expect("absolute path");
+        let args = Args::parse(
+            ["turbo", "--single-package", "devtools", "--no-open"]
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+        )
+        .expect("parse devtools arguments");
+        let opts = Opts::new(&repo_root, &args, ConfigurationOptions::default())
+            .expect("resolve devtools options");
+
+        assert!(opts.run_opts.single_package);
     }
 
     #[test_case(TestCaseOpts{

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -511,25 +511,12 @@ impl RunBuilder {
                 })
             })
         };
-        let package_json_path = self.repo_root.join_component("package.json");
         // A pure Cargo workspace (experimentalCargoWorkspaces, no root
         // package.json) has no JavaScript root manifest. A *missing* file is
         // only tolerated in that mode; a malformed one always fails, and a
         // missing one without Cargo support keeps the original hard error.
-        let root_package_json = match PackageJson::load(&package_json_path) {
-            Ok(package_json) => Some(package_json),
-            Err(package_json::Error::Io(io))
-                if io.kind() == ErrorKind::NotFound
-                    && cargo_enabled(&self.opts.future_flags)
-                    && self
-                        .repo_root
-                        .join_component(turborepo_repository::cargo::CARGO_TOML)
-                        .exists() =>
-            {
-                None
-            }
-            Err(e) => return Err(e.into()),
-        };
+        let root_package_json =
+            load_root_package_json(&self.repo_root, cargo_enabled(&self.opts.future_flags))?;
         let run_telemetry = GenericEventBuilder::new().with_parent(&telemetry);
         let repo_telemetry =
             RepoEventBuilder::new(&self.repo_root.to_string()).with_parent(&telemetry);
@@ -1522,6 +1509,25 @@ impl RunBuilder {
 /// invoker sees the same package graph.
 pub(crate) fn cargo_enabled(future_flags: &turborepo_turbo_json::FutureFlags) -> bool {
     future_flags.experimental_cargo_workspaces
+}
+
+pub(crate) fn load_root_package_json(
+    repo_root: &AbsoluteSystemPath,
+    cargo_enabled: bool,
+) -> Result<Option<PackageJson>, package_json::Error> {
+    match PackageJson::load(&repo_root.join_component("package.json")) {
+        Ok(package_json) => Ok(Some(package_json)),
+        Err(package_json::Error::Io(io))
+            if io.kind() == ErrorKind::NotFound
+                && cargo_enabled
+                && repo_root
+                    .join_component(turborepo_repository::cargo::CARGO_TOML)
+                    .exists() =>
+        {
+            Ok(None)
+        }
+        Err(error) => Err(error),
+    }
 }
 
 fn origins_match(url1: &str, url2: &str) -> bool {

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -163,6 +163,16 @@ as compatibility payloads. Pure
 Cargo retains the root Turbo namespace; consumers reject contexts from another
 repository, and required missing payloads fail closed.
 
+Repository-facing commands use the same optional-root construction policy as
+`turbo run`: a missing root `package.json` is accepted only when Cargo support
+is enabled and a root `Cargo.toml` exists, while malformed manifests always
+fail. Devtools creates one package-graph generation per initial load or refresh
+and derives both its package and task protocol graphs from that generation; the
+server never performs independent package discovery. Each refresh also
+re-resolves configuration, default config-file selection, and future flags.
+Its watcher gives explicit custom config and repository-local config paths
+physical coverage even when normal ignored-directory filtering would omit them.
+
 Turbo configuration lookup receives knowledge-backed package and aggregate
 scope directories directly. Engine repository-wide task-definition enumeration
 and non-root missing-scope validation use the same views. The root Turbo task

--- a/crates/turborepo/tests/config_test.rs
+++ b/crates/turborepo/tests/config_test.rs
@@ -4,6 +4,32 @@ mod common;
 
 use common::{run_turbo, run_turbo_with_env, setup};
 
+fn setup_cargo_workspace(root: &std::path::Path) {
+    std::fs::create_dir_all(root.join("crates/app/src")).unwrap();
+    std::fs::write(
+        root.join("Cargo.toml"),
+        "[workspace]\nmembers = [\"crates/*\"]\nresolver = \"2\"\n\n[workspace.metadata]\nname = \
+         \"acme\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("crates/app/Cargo.toml"),
+        "[package]\nname = \"cargo-app\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .unwrap();
+    std::fs::write(root.join("crates/app/src/main.rs"), "fn main() {}\n").unwrap();
+    std::fs::write(
+        root.join("Cargo.lock"),
+        "version = 4\n\n[[package]]\nname = \"cargo-app\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("turbo.json"),
+        r#"{"futureFlags":{"experimentalCargoWorkspaces":true},"tasks":{"build":{}}}"#,
+    )
+    .unwrap();
+}
+
 fn config_json(output: &std::process::Output) -> serde_json::Value {
     serde_json::from_slice(&output.stdout).expect("expected valid JSON from turbo config")
 }
@@ -26,6 +52,76 @@ fn test_config_defaults() {
     assert_eq!(cfg["envMode"], "strict");
     assert!(cfg["daemon"].is_null());
     assert!(cfg["concurrency"].is_null());
+    assert_eq!(cfg["packageManager"], "npm");
+}
+
+#[test]
+fn config_supports_pure_cargo_without_changing_protocol_shape() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_cargo_workspace(tempdir.path());
+
+    let output = run_turbo(tempdir.path(), &["config"]);
+    assert!(output.status.success(), "{output:?}");
+    assert!(config_json(&output).get("packageManager").is_none());
+}
+
+#[test]
+fn config_preserves_javascript_package_manager_output() {
+    let tempdir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tempdir.path().join("package.json"),
+        r#"{"name":"root","packageManager":"npm@10.5.0"}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        tempdir.path().join("package-lock.json"),
+        r#"{"name":"root","lockfileVersion":3,"packages":{"":{"name":"root"}}}"#,
+    )
+    .unwrap();
+    std::fs::write(tempdir.path().join("turbo.json"), r#"{"tasks":{}}"#).unwrap();
+
+    let output = run_turbo(tempdir.path(), &["config"]);
+    assert!(output.status.success(), "{output:?}");
+    assert_eq!(config_json(&output)["packageManager"], "npm");
+}
+
+#[test]
+fn config_introspects_invalid_run_concurrency_without_validating_it() {
+    let tempdir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tempdir.path().join("package.json"),
+        r#"{"name":"root","packageManager":"npm@10.5.0"}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        tempdir.path().join("package-lock.json"),
+        r#"{"name":"root","lockfileVersion":3,"packages":{"":{"name":"root"}}}"#,
+    )
+    .unwrap();
+    std::fs::write(tempdir.path().join("turbo.json"), r#"{"tasks":{}}"#).unwrap();
+
+    let output = run_turbo(tempdir.path(), &["--concurrency=invalid", "config"]);
+    assert!(output.status.success(), "{output:?}");
+    assert_eq!(config_json(&output)["concurrency"], "invalid");
+}
+
+#[test]
+fn config_rejects_missing_root_manifest_without_cargo() {
+    let tempdir = tempfile::tempdir().unwrap();
+    std::fs::write(tempdir.path().join("turbo.json"), r#"{"tasks":{}}"#).unwrap();
+
+    let output = run_turbo(tempdir.path(), &["config"]);
+    assert!(!output.status.success());
+}
+
+#[test]
+fn config_rejects_malformed_root_manifest_with_cargo_enabled() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_cargo_workspace(tempdir.path());
+    std::fs::write(tempdir.path().join("package.json"), "{").unwrap();
+
+    let output = run_turbo(tempdir.path(), &["config"]);
+    assert!(!output.status.success());
 }
 
 #[test]


### PR DESCRIPTION
### Description

Part 14 of the package/scope knowledge completion stack.

Apply optional-root/Cargo construction consistently to `turbo config` and devtools. Devtools now derives package and task protocol graphs from one repository generation per refresh and watches all active construction inputs; config preserves its narrow introspection behavior.

### Testing Instructions

- `cargo test -p turborepo-devtools`
- `cargo test -p turborepo-lib --lib cli::test --lib devtools::tests`
- `cargo test -p turbo --test config_test`

<sub>CLOSES TURBO-5777</sub>