### PR TITLE
refactor: Delete legacy package and scope authority

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8900,6 +8900,7 @@ dependencies = [
  "tokio",
  "tracing",
  "turbopath",
+ "turborepo-errors",
  "turborepo-lockfiles",
  "turborepo-repository",
  "turborepo-scm",

--- a/crates/turborepo-boundaries/src/lib.rs
+++ b/crates/turborepo-boundaries/src/lib.rs
@@ -906,10 +906,23 @@ mod tests {
 
     impl MockGraph {
         fn new(packages: Vec<(PackageName, PackageInfo)>) -> Self {
+            let authoritative_directories = packages
+                .iter()
+                .map(|(name, _)| {
+                    (
+                        name.clone(),
+                        turbopath::AnchoredSystemPathBuf::from_raw(format!(
+                            "packages/{}",
+                            name.as_str()
+                        ))
+                        .unwrap(),
+                    )
+                })
+                .collect();
             Self {
                 packages,
                 aggregates: HashSet::new(),
-                authoritative_directories: HashMap::new(),
+                authoritative_directories,
                 missing_payloads: HashSet::new(),
             }
         }
@@ -935,14 +948,14 @@ mod tests {
 
     impl PackageGraphProvider for MockGraph {
         fn package_scopes(&self) -> Box<dyn Iterator<Item = PackageScope<'_>> + '_> {
-            Box::new(self.packages.iter().map(|(name, info)| {
+            Box::new(self.packages.iter().map(|(name, _)| {
                 PackageScope {
                     name: name.clone(),
                     directory: self
                         .authoritative_directories
                         .get(name)
                         .map(|path| path.as_ref())
-                        .unwrap_or_else(|| info.package_path()),
+                        .expect("mock package must have an authoritative directory"),
                     kind: if self.aggregates.contains(name) {
                         PackageGraphNodeKind::Aggregate
                     } else {
@@ -1038,10 +1051,6 @@ mod tests {
                 PackageName::Other("pkg-a".into()),
                 PackageInfo {
                     package_json: Default::default(),
-                    package_json_path: turbopath::AnchoredSystemPathBuf::from_raw(
-                        "packages/pkg-a/package.json",
-                    )
-                    .unwrap(),
                     unresolved_external_dependencies: None,
                     transitive_dependencies: None,
                     ..Default::default()
@@ -1051,10 +1060,6 @@ mod tests {
                 PackageName::Other("pkg-b".into()),
                 PackageInfo {
                     package_json: Default::default(),
-                    package_json_path: turbopath::AnchoredSystemPathBuf::from_raw(
-                        "packages/pkg-b/package.json",
-                    )
-                    .unwrap(),
                     unresolved_external_dependencies: None,
                     transitive_dependencies: None,
                     ..Default::default()
@@ -1097,8 +1102,6 @@ mod tests {
         let graph = MockGraph::new(vec![(
             aggregate_name.clone(),
             PackageInfo {
-                package_json_path: turbopath::AnchoredSystemPathBuf::from_raw("Cargo.toml")
-                    .unwrap(),
                 ..Default::default()
             },
         )])
@@ -1128,10 +1131,6 @@ mod tests {
         let graph = MockGraph::new(vec![(
             package_name.clone(),
             PackageInfo {
-                package_json_path: turbopath::AnchoredSystemPathBuf::from_raw(
-                    "packages/web/package.json",
-                )
-                .unwrap(),
                 ..Default::default()
             },
         )])
@@ -1174,10 +1173,6 @@ mod tests {
         let graph = MockGraph::new(vec![(
             package_name.clone(),
             PackageInfo {
-                package_json_path: turbopath::AnchoredSystemPathBuf::from_raw(
-                    "stale/web/package.json",
-                )
-                .unwrap(),
                 ..Default::default()
             },
         )])

--- a/crates/turborepo-boundaries/src/tags.rs
+++ b/crates/turborepo-boundaries/src/tags.rs
@@ -430,7 +430,7 @@ mod tests {
 
     // Minimal mock graph that tracks packages, dependencies, and ancestors.
     struct MockGraph {
-        packages: Vec<(PackageName, PackageInfo)>,
+        packages: Vec<(PackageName, turbopath::AnchoredSystemPathBuf, PackageInfo)>,
         deps: HashMap<PackageNode, Vec<PackageNode>>,
         ancestors: HashMap<PackageNode, Vec<PackageNode>>,
     }
@@ -448,12 +448,9 @@ mod tests {
             let pkg_name = PackageName::Other(name.into());
             self.packages.push((
                 pkg_name,
+                turbopath::AnchoredSystemPathBuf::from_raw(format!("packages/{name}")).unwrap(),
                 PackageInfo {
                     package_json: PackageJson::default(),
-                    package_json_path: turbopath::AnchoredSystemPathBuf::from_raw(format!(
-                        "packages/{name}/package.json"
-                    ))
-                    .unwrap(),
                     unresolved_external_dependencies: None,
                     transitive_dependencies: None,
                     ..Default::default()
@@ -477,9 +474,9 @@ mod tests {
             Box::new(
                 self.packages
                     .iter()
-                    .map(|(name, info)| crate::PackageScope {
+                    .map(|(name, directory, _)| crate::PackageScope {
                         name: name.clone(),
-                        directory: info.package_path(),
+                        directory,
                         kind: PackageGraphNodeKind::Package,
                         toolchain: &ToolchainId::JAVASCRIPT,
                     }),
@@ -489,7 +486,7 @@ mod tests {
         fn package_info(&self, name: &PackageName) -> Option<&PackageInfo> {
             self.packages
                 .iter()
-                .find_map(|(candidate, info)| (candidate == name).then_some(info))
+                .find_map(|(candidate, _, info)| (candidate == name).then_some(info))
         }
 
         fn immediate_dependencies(&self, _node: &PackageNode) -> Option<HashSet<&PackageNode>> {

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -1475,7 +1475,7 @@ mod tests {
     };
 
     use serde_json::json;
-    use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
+    use turbopath::AbsoluteSystemPathBuf;
     use turborepo_errors::Spanned;
     use turborepo_repository::{
         discovery::{DiscoveryResponse, PackageDiscovery},
@@ -1773,7 +1773,7 @@ mod tests {
             .unwrap();
 
         let web = PackageName::from("web");
-        let mut package_graph = PackageGraph::builder(
+        let package_graph = PackageGraph::builder(
             &root,
             PackageJson::from_value(json!({
                 "name": "repo",
@@ -1789,12 +1789,6 @@ mod tests {
         .build()
         .await
         .unwrap();
-        assert!(package_graph.set_package_json_path_for_test(
-            &web,
-            AnchoredSystemPathBuf::from_raw("stale/Cargo.toml").unwrap()
-        ));
-        assert!(package_graph.set_compatibility_toolchain_for_test(&web, ToolchainId::RUST));
-
         let out_directory = root.join_component("out");
         let full_directory = out_directory.join_component("full");
         let json_directory = out_directory.join_component("json");

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -1145,10 +1145,16 @@ impl Run {
         };
         let repo_index = repo_index_arc.as_ref().as_ref();
 
-        let root_workspace = self
+        let root_context = self
             .pkg_dep_graph
-            .package_info(&PackageName::Root)
+            .package_task_context(&PackageName::Root)
             .ok_or(Error::MissingRootWorkspace)?;
+        let empty_root_workspace = turborepo_repository::package_graph::PackageInfo::default();
+        let root_workspace = match root_context.package_info() {
+            Some(payload) => payload,
+            None if !root_context.requires_compatibility_payload() => &empty_root_workspace,
+            None => return Err(Error::MissingPackagePayload(PackageName::Root)),
+        };
 
         let is_monorepo = !self.opts.run_opts.single_package;
 

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -3778,17 +3778,12 @@ release: 1.96.0-nightly\n",
         assert_eq!(roots.len(), 1);
     }
 
-    fn package_info(name: &str, manifest_rel: &str) -> crate::package_graph::PackageInfo {
+    fn package_info(name: &str) -> crate::package_graph::PackageInfo {
         crate::package_graph::PackageInfo {
             package_json: PackageJson {
                 name: Some(Spanned::new(name.to_string())),
                 ..Default::default()
             },
-            package_json_path: turbopath::AnchoredSystemPathBuf::from_raw(
-                manifest_rel.replace('/', std::path::MAIN_SEPARATOR_STR),
-            )
-            .unwrap(),
-            toolchain: ToolchainId::RUST,
             ..Default::default()
         }
     }
@@ -3817,8 +3812,7 @@ release: 1.96.0-nightly\n",
         // Discovery records the per-package details command resolution uses.
         toolchain.discover_packages().await.unwrap();
 
-        let mut stale_package = package_info("stale-name", "stale/Cargo.toml");
-        stale_package.toolchain = ToolchainId::JAVASCRIPT;
+        let stale_package = package_info("stale-name");
         let app_context = task_context(&root, "app", "crates/app", Some(&stale_package));
         let lib_a_context = task_context(&root, "lib-a", "crates/lib-a", None);
         let workspace_context = task_context(&root, "fixture-ws", "", Some(&stale_package));
@@ -4005,7 +3999,7 @@ release: 1.96.0-nightly\n",
         let toolchain = CargoToolchain::new(root.clone());
         toolchain.discover_packages().await.unwrap();
 
-        let stale_package = package_info("stale-name", "stale/Cargo.toml");
+        let stale_package = package_info("stale-name");
         let lib_a_context = task_context(&root, "lib-a", "crates/lib-a", Some(&stale_package));
         let workspace_context = task_context(&root, "fixture-ws", "", Some(&stale_package));
 
@@ -4050,9 +4044,9 @@ release: 1.96.0-nightly\n",
         let toolchain = CargoToolchain::new(root.clone());
         toolchain.discover_packages().await.unwrap();
 
-        let app = package_info("app", "crates/app/Cargo.toml");
-        let lib_a = package_info("lib-a", "crates/lib-a/Cargo.toml");
-        let workspace = package_info("fixture-ws", "Cargo.toml");
+        let app = package_info("app");
+        let lib_a = package_info("lib-a");
+        let workspace = package_info("fixture-ws");
         let app_ctx = task_context(&root, "app", "crates/app", Some(&app));
         let lib_ctx = task_context(&root, "lib-a", "crates/lib-a", Some(&lib_a));
         let workspace_ctx = task_context(&root, "fixture-ws", "", Some(&workspace));

--- a/crates/turborepo-repository/src/change_mapper/mod.rs
+++ b/crates/turborepo-repository/src/change_mapper/mod.rs
@@ -352,6 +352,8 @@ pub enum ChangeMapError {
     Yarnrc(#[from] yarnrc::Error),
     #[error("No lockfile")]
     NoLockfile,
+    #[error("Missing compatibility payload for package {0}")]
+    MissingPackagePayload(PackageName),
     #[error("Lockfile error: {0}")]
     Lockfile(turborepo_lockfiles::Error),
 }
@@ -360,6 +362,7 @@ impl From<ChangedPackagesError> for ChangeMapError {
     fn from(value: ChangedPackagesError) -> Self {
         match value {
             ChangedPackagesError::NoLockfile => Self::NoLockfile,
+            ChangedPackagesError::MissingPackagePayload(name) => Self::MissingPackagePayload(name),
             ChangedPackagesError::Lockfile(e) => Self::Lockfile(e),
         }
     }

--- a/crates/turborepo-repository/src/change_mapper/package.rs
+++ b/crates/turborepo-repository/src/change_mapper/package.rs
@@ -282,17 +282,13 @@ mod tests {
             }
         }
 
-        let mut graph = PackageGraphBuilder::new(root, PackageJson::default())
+        let graph = PackageGraphBuilder::new(root, PackageJson::default())
             .with_package_discovery(NestedDiscovery {
                 parent_manifest,
                 child_manifest,
             })
             .build()
             .await?;
-        assert!(graph.set_package_json_path_for_test(
-            &crate::package_graph::PackageName::from("child"),
-            AnchoredSystemPathBuf::from_raw("stale/package.json")?,
-        ));
         let file = AnchoredSystemPathBuf::from_raw(
             ["packages", "parent", "child", "src", "index.ts"].join(std::path::MAIN_SEPARATOR_STR),
         )?;

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -78,10 +78,10 @@ pub enum Error {
         path: AbsoluteSystemPathBuf,
         repository_root: AbsoluteSystemPathBuf,
     },
-    #[error("missing compatibility projection for discovered scope {name}")]
-    MissingCompatibilityProjection { name: String },
-    #[error("compatibility projection {name} has no authoritative discovered scope")]
-    UnexpectedCompatibilityProjection { name: String },
+    #[error("missing compatibility payload for discovered scope {name}")]
+    MissingCompatibilityPayload { name: String },
+    #[error("compatibility payload {name} has no authoritative discovered scope")]
+    UnexpectedCompatibilityPayload { name: String },
     #[error("repository package knowledge was not constructed")]
     MissingRepositoryKnowledge,
     #[error(transparent)]
@@ -388,7 +388,7 @@ struct BuildState<'a, S, T> {
 }
 
 struct PackageGraphAssembler {
-    workspaces: HashMap<PackageName, PackageInfo>,
+    package_payloads: HashMap<PackageName, PackageInfo>,
     workspace_graph: Graph<PackageNode, DependencyKind>,
     root_node_index: NodeIndex,
     root_workspace_index: NodeIndex,
@@ -396,7 +396,7 @@ struct PackageGraphAssembler {
 }
 
 struct PackageGraphAssembly {
-    workspaces: HashMap<PackageName, PackageInfo>,
+    package_payloads: HashMap<PackageName, PackageInfo>,
     workspace_graph: Graph<PackageNode, DependencyKind>,
     root_node_index: NodeIndex,
     root_workspace_index: NodeIndex,
@@ -404,9 +404,11 @@ struct PackageGraphAssembly {
 }
 
 impl PackageGraphAssembler {
-    fn new(root_package_info: PackageInfo) -> Self {
-        let mut workspaces = HashMap::new();
-        workspaces.insert(PackageName::Root, root_package_info);
+    fn new(root_package_info: Option<PackageInfo>) -> Self {
+        let mut package_payloads = HashMap::new();
+        if let Some(root_package_info) = root_package_info {
+            package_payloads.insert(PackageName::Root, root_package_info);
+        }
 
         let mut workspace_graph = Graph::new();
         let root_node_index = workspace_graph.add_node(PackageNode::Root);
@@ -423,7 +425,7 @@ impl PackageGraphAssembler {
         node_lookup.insert(root_workspace, root_workspace_index);
 
         Self {
-            workspaces,
+            package_payloads,
             workspace_graph,
             root_node_index,
             root_workspace_index,
@@ -432,30 +434,17 @@ impl PackageGraphAssembler {
     }
 
     fn reserve(&mut self, additional: usize) {
-        self.workspaces.reserve(additional);
+        self.package_payloads.reserve(additional);
         self.node_lookup.reserve(additional);
     }
 
-    fn add_package(&mut self, name: PackageName, info: PackageInfo) -> Result<(), Error> {
-        match self.workspaces.entry(name) {
-            std::collections::hash_map::Entry::Vacant(vacant) => {
-                let name = vacant.key().clone();
-                vacant.insert(info);
-                let node = PackageNode::Workspace(name);
-                let idx = self.workspace_graph.add_node(node.clone());
-                self.node_lookup.insert(node, idx);
-                Ok(())
-            }
-            std::collections::hash_map::Entry::Occupied(occupied) => {
-                let existing_path = occupied.get().package_json_path.to_string();
-                let name = occupied.key().to_string();
-                Err(Error::DuplicateWorkspace {
-                    name,
-                    path: info.package_json_path.to_string(),
-                    existing_path,
-                })
-            }
+    fn add_scope(&mut self, name: PackageName, info: Option<PackageInfo>) {
+        if let Some(info) = info {
+            self.package_payloads.insert(name.clone(), info);
         }
+        let node = PackageNode::Workspace(name);
+        let idx = self.workspace_graph.add_node(node.clone());
+        self.node_lookup.insert(node, idx);
     }
 
     fn add_knowledge(
@@ -468,35 +457,35 @@ impl PackageGraphAssembler {
 
         for package in knowledge.packages() {
             let name = package.identity();
-            let mut info = compatibility.remove(name).ok_or_else(|| {
-                Error::MissingCompatibilityProjection {
-                    name: name.to_string(),
-                }
-            })?;
-            info.package_json_path = package.definition_path().to_owned();
-            info.toolchain = package.toolchain().clone();
-            self.add_package(PackageName::Other(name.to_string()), info)?;
+            self.add_scope(
+                PackageName::Other(name.to_string()),
+                Some(compatibility.remove(name).ok_or_else(|| {
+                    Error::MissingCompatibilityPayload {
+                        name: name.to_string(),
+                    }
+                })?),
+            );
         }
         for aggregate in knowledge.aggregate_scopes() {
             let name = aggregate.identity();
-            let mut info = compatibility.remove(name).ok_or_else(|| {
-                Error::MissingCompatibilityProjection {
-                    name: name.to_string(),
-                }
-            })?;
-            info.package_json_path = aggregate.definition_path().to_owned();
-            info.toolchain = aggregate.toolchain().clone();
-            self.add_package(PackageName::Other(name.to_string()), info)?;
+            self.add_scope(
+                PackageName::Other(name.to_string()),
+                Some(compatibility.remove(name).ok_or_else(|| {
+                    Error::MissingCompatibilityPayload {
+                        name: name.to_string(),
+                    }
+                })?),
+            );
         }
         if let Some(name) = compatibility.keys().next() {
-            return Err(Error::UnexpectedCompatibilityProjection { name: name.clone() });
+            return Err(Error::UnexpectedCompatibilityPayload { name: name.clone() });
         }
         Ok(())
     }
 
     fn finish(self) -> PackageGraphAssembly {
         PackageGraphAssembly {
-            workspaces: self.workspaces,
+            package_payloads: self.package_payloads,
             workspace_graph: self.workspace_graph,
             root_node_index: self.root_node_index,
             root_workspace_index: self.root_workspace_index,
@@ -542,14 +531,10 @@ where
         // registered nor queried for a package manager. The graph is built
         // entirely from the extra toolchains (Cargo).
         let no_javascript = root_package_json.is_none();
-        let root_package_info = PackageInfo {
-            // The root node always needs a descriptor; a pure Cargo workspace
-            // has none, so it gets an empty one. The graph's public
-            // `root_package_json()` still reports `None` (see below).
-            package_json: root_package_json.clone().unwrap_or_default(),
-            package_json_path: AnchoredSystemPathBuf::from_raw("package.json")?,
+        let root_package_info = root_package_json.clone().map(|package_json| PackageInfo {
+            package_json,
             ..Default::default()
-        };
+        });
         let assembler = PackageGraphAssembler::new(root_package_info);
 
         // The discovery strategy is shared (via the JavaScript toolchain)
@@ -607,8 +592,6 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             manifest_path,
             external_dependencies,
         } = package.into_parts();
-        let relative_json_path =
-            AnchoredSystemPathBuf::relative_path_between(self.repo_root, &manifest_path);
         // Toolchain-resolved external identities (e.g. Cargo's per-crate
         // lockfile closures), in the sorted representation the JS lockfile
         // phase produces. That phase later fills this for JavaScript
@@ -622,8 +605,6 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
         });
         let entry = PackageInfo {
             package_json: json,
-            package_json_path: relative_json_path,
-            toolchain: toolchain.clone(),
             transitive_dependencies,
             ..Default::default()
         };
@@ -788,7 +769,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             }
         };
         let PackageGraphAssembly {
-            workspaces,
+            package_payloads,
             workspace_graph,
             root_node_index,
             root_workspace_index,
@@ -817,7 +798,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             root_workspace_index,
             node_lookup,
             root_package_json,
-            packages: workspaces,
+            package_payloads,
             lockfile: lockfile.map(Arc::from),
             package_manager,
             knowledge,
@@ -855,15 +836,18 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
         let split_deps = {
             use rayon::prelude::*;
             self.assembler
-                .workspaces
+                .package_payloads
                 .par_iter()
                 .map(|(name, entry)| {
+                    let Some(definition_path) = scope_definition_path(knowledge, name) else {
+                        unreachable!("validated payload must have authoritative scope knowledge")
+                    };
                     (
                         name.clone(),
                         Dependencies::new(
                             self.repo_root,
-                            &entry.package_json_path,
-                            &self.assembler.workspaces,
+                            definition_path,
+                            &self.assembler.package_payloads,
                             link_workspace_packages,
                             entry.package_json.dependencies_with_kind(),
                             &path_index,
@@ -876,7 +860,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
         for (name, deps) in split_deps {
             let entry = self
                 .assembler
-                .workspaces
+                .package_payloads
                 .get_mut(&name)
                 .expect("workspace present in ");
             let Dependencies { internal, external } = deps;
@@ -921,15 +905,11 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
         match self.lockfile.take() {
             Some(lockfile) => Ok(lockfile),
             None => {
-                let lockfile = package_manager.read_lockfile(
-                    self.repo_root,
-                    self.assembler
-                        .workspaces
-                        .get(&PackageName::Root)
-                        .as_ref()
-                        .map(|e| &e.package_json)
-                        .expect("root workspace should have json"),
-                )?;
+                let root_package_json = self
+                    .root_package_json
+                    .as_ref()
+                    .expect("JavaScript package manager requires a root package.json");
+                let lockfile = package_manager.read_lockfile(self.repo_root, root_package_json)?;
                 Ok(lockfile)
             }
         }
@@ -1035,6 +1015,18 @@ fn scope_directory_and_toolchain<'a>(
     }
 }
 
+fn scope_definition_path<'a>(
+    knowledge: &'a RepositoryKnowledge,
+    name: &PackageName,
+) -> Option<&'a AnchoredSystemPath> {
+    match name {
+        PackageName::Root => knowledge
+            .root_javascript_scope()
+            .map(|scope| scope.definition_path()),
+        PackageName::Other(name) => knowledge.scope(name).map(|scope| scope.definition_path()),
+    }
+}
+
 impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
     fn all_external_dependencies(
         &self,
@@ -1044,7 +1036,7 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             .as_deref()
             .ok_or(Error::MissingRepositoryKnowledge)?;
         self.assembler
-            .workspaces
+            .package_payloads
             .iter()
             // Only JavaScript packages participate in the JS lockfile's
             // external-dependency closures. This map is keyed by directory,
@@ -1096,7 +1088,7 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             .knowledge
             .as_deref()
             .ok_or(Error::MissingRepositoryKnowledge)?;
-        for (name, entry) in &mut self.assembler.workspaces {
+        for (name, entry) in &mut self.assembler.package_payloads {
             // Mirror of the filter in all_external_dependencies: a non-JS
             // package sharing a directory with a JS package must not steal
             // its closure.
@@ -1196,7 +1188,7 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             Error::MissingRepositoryKnowledge,
         )))?;
         let PackageGraphAssembly {
-            workspaces,
+            package_payloads,
             workspace_graph,
             root_node_index,
             root_workspace_index,
@@ -1208,7 +1200,7 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             root_workspace_index,
             node_lookup,
             root_package_json,
-            packages: workspaces,
+            package_payloads,
             package_manager,
             lockfile: arc_lockfile,
             knowledge,
@@ -1228,7 +1220,7 @@ struct Dependencies {
 impl Dependencies {
     pub fn new<'a, I: IntoIterator<Item = (&'a String, &'a String, DependencyKind)>>(
         repo_root: &AbsoluteSystemPath,
-        workspace_json_path: &AnchoredSystemPathBuf,
+        workspace_json_path: &AnchoredSystemPath,
         workspaces: &HashMap<PackageName, PackageInfo>,
         link_workspace_packages: bool,
         dependencies: I,
@@ -1544,26 +1536,16 @@ mod test {
             assert_eq!(app_view.toolchain(), Some(&ToolchainId::JAVASCRIPT));
             assert_eq!(graph.node_views().count(), 4);
 
-            for package in knowledge.packages() {
-                let graph_name = PackageName::from(package.identity());
-                assert_eq!(graph.package_dir(&graph_name), Some(package.directory()));
-                assert_eq!(
-                    graph
-                        .package_info(&graph_name)
-                        .expect("knowledge package is assembled into the graph")
-                        .package_json_path(),
-                    package.definition_path()
-                );
-            }
-
             let mut packages = graph
-                .packages()
-                .map(|(name, info)| {
+                .package_task_contexts()
+                .map(|context| {
+                    let definition = graph
+                        .package_definition_path(context.package())
+                        .map(|path| path.to_unix().to_string());
                     (
-                        name.as_str().to_string(),
-                        info.package_path().to_unix().to_string(),
-                        info.package_json_path().to_unix().to_string(),
-                        info.package_name(),
+                        context.package().as_str().to_string(),
+                        context.directory().to_unix().to_string(),
+                        definition,
                     )
                 })
                 .collect::<Vec<_>>();
@@ -1575,20 +1557,17 @@ mod test {
                     (
                         "//".to_string(),
                         "".to_string(),
-                        "package.json".to_string(),
-                        root_name.map(str::to_string),
+                        Some("package.json".to_string()),
                     ),
                     (
                         "@scope/nested".to_string(),
                         "packages/group/nested".to_string(),
-                        "packages/group/nested/package.json".to_string(),
-                        Some("@scope/nested".to_string()),
+                        Some("packages/group/nested/package.json".to_string()),
                     ),
                     (
                         "app".to_string(),
                         "apps/app".to_string(),
-                        "apps/app/package.json".to_string(),
-                        Some("app".to_string()),
+                        Some("apps/app/package.json".to_string()),
                     ),
                 ]
             );
@@ -1623,9 +1602,9 @@ mod test {
         );
         assert_eq!(retained_generation.packages().count(), 0);
 
-        let packages = graph.packages().collect::<Vec<_>>();
-        assert_eq!(packages.len(), 1);
-        assert_eq!(packages[0].0, &PackageName::Root);
+        let contexts = graph.package_task_contexts().collect::<Vec<_>>();
+        assert_eq!(contexts.len(), 1);
+        assert_eq!(contexts[0].package(), &PackageName::Root);
         assert_eq!(
             graph
                 .package_dir(&PackageName::Root)
@@ -1635,12 +1614,8 @@ mod test {
             ""
         );
         assert_eq!(
-            packages[0].1.package_json_path().to_unix().to_string(),
-            "package.json"
-        );
-        assert_eq!(
-            packages[0].1.package_name().as_deref(),
-            Some("user-facing-root-name")
+            graph.package_definition_path(&PackageName::Root),
+            Some(AnchoredSystemPath::new("package.json").unwrap())
         );
     }
 

--- a/crates/turborepo-repository/src/package_graph/dep_splitter.rs
+++ b/crates/turborepo-repository/src/package_graph/dep_splitter.rs
@@ -18,17 +18,6 @@ use crate::{knowledge::RepositoryKnowledge, package_manager::pnpm::PnpmCatalogs}
 pub struct WorkspacePathIndex<'a>(HashMap<&'a AnchoredSystemPath, PackageName>);
 
 impl<'a> WorkspacePathIndex<'a> {
-    #[cfg(test)]
-    pub fn new(workspaces: &'a HashMap<PackageName, PackageInfo>) -> Self {
-        Self(
-            workspaces
-                .iter()
-                .filter(|(_, info)| info.toolchain == crate::toolchain::ToolchainId::JAVASCRIPT)
-                .map(|(name, info)| (info.package_path(), name.clone()))
-                .collect(),
-        )
-    }
-
     /// Builds the production index from authoritative package/scope paths and
     /// provenance rather than compatibility `PackageInfo` fields.
     pub(crate) fn from_knowledge(knowledge: &'a RepositoryKnowledge) -> Self {
@@ -307,6 +296,29 @@ mod test {
     use super::*;
     use crate::package_json::PackageJson;
 
+    fn path_index() -> WorkspacePathIndex<'static> {
+        let foo = if cfg!(windows) {
+            r"packages\@scope\foo"
+        } else {
+            "packages/@scope/foo"
+        };
+        let baz = if cfg!(windows) {
+            r"packages\baz"
+        } else {
+            "packages/baz"
+        };
+        WorkspacePathIndex(HashMap::from([
+            (
+                AnchoredSystemPath::new(foo).unwrap(),
+                PackageName::from("@scope/foo"),
+            ),
+            (
+                AnchoredSystemPath::new(baz).unwrap(),
+                PackageName::from("baz"),
+            ),
+        ]))
+    }
+
     #[test_case("1.2.3", None, "1.2.3", Some("@scope/foo"), true ; "handles exact match")]
     #[test_case("1.2.3", None, "^1.0.0", Some("@scope/foo"), true ; "handles semver range satisfied")]
     #[test_case("2.3.4", None, "^1.0.0", None, true ; "handles semver range not satisfied")]
@@ -359,11 +371,6 @@ mod test {
                         version: Some(package_version.to_string()),
                         ..Default::default()
                     },
-                    package_json_path: AnchoredSystemPathBuf::from_raw(
-                        ["packages", "@scope", "foo", "package.json"]
-                            .join(std::path::MAIN_SEPARATOR_STR),
-                    )
-                    .unwrap(),
                     unresolved_external_dependencies: None,
                     transitive_dependencies: None,
                     ..Default::default()
@@ -376,10 +383,6 @@ mod test {
                         version: Some("1.0.0".to_string()),
                         ..Default::default()
                     },
-                    package_json_path: AnchoredSystemPathBuf::from_raw(
-                        ["packages", "bar", "package.json"].join(std::path::MAIN_SEPARATOR_STR),
-                    )
-                    .unwrap(),
                     unresolved_external_dependencies: None,
                     transitive_dependencies: None,
                     ..Default::default()
@@ -392,10 +395,6 @@ mod test {
                         version: Some("1.0.0".to_string()),
                         ..Default::default()
                     },
-                    package_json_path: AnchoredSystemPathBuf::from_raw(
-                        ["packages", "baz", "package.json"].join(std::path::MAIN_SEPARATOR_STR),
-                    )
-                    .unwrap(),
                     unresolved_external_dependencies: None,
                     transitive_dependencies: None,
                     ..Default::default()
@@ -408,10 +407,6 @@ mod test {
                         version: Some("6.0.3".to_string()),
                         ..Default::default()
                     },
-                    package_json_path: AnchoredSystemPathBuf::from_raw(
-                        ["packages", "buffer", "package.json"].join(std::path::MAIN_SEPARATOR_STR),
-                    )
-                    .unwrap(),
                     unresolved_external_dependencies: None,
                     transitive_dependencies: None,
                     ..Default::default()
@@ -420,7 +415,7 @@ mod test {
             map
         };
 
-        let path_index = WorkspacePathIndex::new(&workspaces);
+        let path_index = path_index();
         let splitter = DependencySplitter {
             repo_root: &root,
             workspace_dir: &pkg_dir,
@@ -500,10 +495,6 @@ mod test {
                         version: Some("1.0.0".to_string()),
                         ..Default::default()
                     },
-                    package_json_path: AnchoredSystemPathBuf::from_raw(
-                        ["packages", "pkg-b", "package.json"].join(std::path::MAIN_SEPARATOR_STR),
-                    )
-                    .unwrap(),
                     unresolved_external_dependencies: None,
                     transitive_dependencies: None,
                     ..Default::default()
@@ -512,7 +503,7 @@ mod test {
             map
         };
         let catalogs = make_catalogs(&[("pkg-b", "workspace:*")], &[]);
-        let path_index = WorkspacePathIndex::new(&workspaces);
+        let path_index = path_index();
         let splitter = DependencySplitter {
             repo_root: &root,
             workspace_dir: &pkg_dir,
@@ -545,10 +536,6 @@ mod test {
                         version: Some("1.0.0".to_string()),
                         ..Default::default()
                     },
-                    package_json_path: AnchoredSystemPathBuf::from_raw(
-                        ["packages", "pkg-b", "package.json"].join(std::path::MAIN_SEPARATOR_STR),
-                    )
-                    .unwrap(),
                     unresolved_external_dependencies: None,
                     transitive_dependencies: None,
                     ..Default::default()
@@ -557,7 +544,7 @@ mod test {
             map
         };
         let catalogs = make_catalogs(&[], &[("internal", &[("pkg-b", "workspace:*")])]);
-        let path_index = WorkspacePathIndex::new(&workspaces);
+        let path_index = path_index();
         let splitter = DependencySplitter {
             repo_root: &root,
             workspace_dir: &pkg_dir,
@@ -590,10 +577,6 @@ mod test {
                         version: Some("1.2.3".to_string()),
                         ..Default::default()
                     },
-                    package_json_path: AnchoredSystemPathBuf::from_raw(
-                        ["packages", "pkg-b", "package.json"].join(std::path::MAIN_SEPARATOR_STR),
-                    )
-                    .unwrap(),
                     unresolved_external_dependencies: None,
                     transitive_dependencies: None,
                     ..Default::default()
@@ -603,7 +586,7 @@ mod test {
         };
         // catalog resolves to a semver range that matches the workspace package version
         let catalogs = make_catalogs(&[("pkg-b", "^1.0.0")], &[]);
-        let path_index = WorkspacePathIndex::new(&workspaces);
+        let path_index = path_index();
         let splitter = DependencySplitter {
             repo_root: &root,
             workspace_dir: &pkg_dir,
@@ -630,7 +613,7 @@ mod test {
         let workspaces = HashMap::new();
         // "react" is not a workspace package
         let catalogs = make_catalogs(&[("react", "^18.2.0")], &[]);
-        let path_index = WorkspacePathIndex::new(&workspaces);
+        let path_index = path_index();
         let splitter = DependencySplitter {
             repo_root: &root,
             workspace_dir: &pkg_dir,
@@ -660,10 +643,6 @@ mod test {
                         version: Some("1.0.0".to_string()),
                         ..Default::default()
                     },
-                    package_json_path: AnchoredSystemPathBuf::from_raw(
-                        ["packages", "pkg-b", "package.json"].join(std::path::MAIN_SEPARATOR_STR),
-                    )
-                    .unwrap(),
                     unresolved_external_dependencies: None,
                     transitive_dependencies: None,
                     ..Default::default()
@@ -671,7 +650,7 @@ mod test {
             );
             map
         };
-        let path_index = WorkspacePathIndex::new(&workspaces);
+        let path_index = path_index();
         // No catalogs - catalog: specifier can't be resolved, treated as external
         let splitter = DependencySplitter {
             repo_root: &root,
@@ -702,10 +681,6 @@ mod test {
                         version: Some("1.0.0".to_string()),
                         ..Default::default()
                     },
-                    package_json_path: AnchoredSystemPathBuf::from_raw(
-                        ["packages", "pkg-b", "package.json"].join(std::path::MAIN_SEPARATOR_STR),
-                    )
-                    .unwrap(),
                     unresolved_external_dependencies: None,
                     transitive_dependencies: None,
                     ..Default::default()
@@ -715,7 +690,7 @@ mod test {
         };
         // "catalog:default" should resolve to the default catalog
         let catalogs = make_catalogs(&[("pkg-b", "workspace:*")], &[]);
-        let path_index = WorkspacePathIndex::new(&workspaces);
+        let path_index = path_index();
         let splitter = DependencySplitter {
             repo_root: &root,
             workspace_dir: &pkg_dir,

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -47,7 +47,7 @@ pub struct PackageGraph {
     root_workspace_index: NodeIndex,
     #[allow(dead_code)]
     node_lookup: HashMap<PackageNode, petgraph::graph::NodeIndex>,
-    packages: HashMap<PackageName, PackageInfo>,
+    package_payloads: HashMap<PackageName, PackageInfo>,
     root_package_json: Option<PackageJson>,
     package_manager: Option<PackageManager>,
     lockfile: Option<Arc<dyn Lockfile>>,
@@ -98,9 +98,9 @@ impl WorkspacePackage {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct PackageInfo {
     /// A temporary compatibility descriptor for relationships and tasks.
+    /// Its native `name` may be retained for later payload semantics, but must
+    /// never be used as package identity or to derive paths or provenance.
     pub package_json: PackageJson,
-    /// Path to the package's native manifest, anchored to the repo root.
-    pub package_json_path: AnchoredSystemPathBuf,
     pub unresolved_external_dependencies: Option<BTreeMap<PackageKey, PackageVersion>>, /* name -> version */
     /// The workspace's external dependency closure, sorted by `Package`'s
     /// `(key, version)` ordering. Members are `Arc`-shared across workspaces.
@@ -111,31 +111,6 @@ pub struct PackageInfo {
     /// resolved closures, e.g. Cargo's), consumers compute the hash from
     /// the sorted closure on demand.
     pub external_deps_hash: Option<String>,
-    /// The toolchain that discovered this package. Defaults to JavaScript.
-    pub toolchain: crate::toolchain::ToolchainId,
-}
-
-impl PackageInfo {
-    pub fn package_name(&self) -> Option<String> {
-        self.package_json
-            .name
-            .as_ref()
-            .map(|name| name.as_inner().clone())
-    }
-
-    pub fn package_json_path(&self) -> &AnchoredSystemPath {
-        &self.package_json_path
-    }
-
-    /// Get the path to this package.
-    ///
-    /// note: This is infallible because `package_json_path` is guaranteed to
-    /// have       at least one segment
-    pub fn package_path(&self) -> &AnchoredSystemPath {
-        self.package_json_path
-            .parent()
-            .expect("at least one segment")
-    }
 }
 
 type PackageKey = String;
@@ -237,7 +212,8 @@ impl<'a> PackageTaskContext<'a> {
     #[cfg(test)]
     #[rustfmt::skip]
     pub(crate) fn new_for_test(package: PackageName, repository_root: &'a AbsoluteSystemPath, directory: &'a AnchoredSystemPath, package_info: Option<&'a PackageInfo>, kind: PackageTaskContextKind, toolchain: Option<&'a crate::toolchain::ToolchainId>) -> Self {
-        Self { package, repository_root, directory, package_info, kind, toolchain, requires_compatibility_payload: package_info.is_some() }
+        let requires_compatibility_payload = package != PackageName::Root || toolchain == Some(&crate::toolchain::ToolchainId::JAVASCRIPT);
+        Self { package, repository_root, directory, package_info, kind, toolchain, requires_compatibility_payload }
     }
 
     pub fn package(&self) -> &PackageName {
@@ -469,11 +445,11 @@ impl PackageGraph {
     /// Returns the number of packages in the repo
     /// *including* the root package.
     pub fn len(&self) -> usize {
-        self.packages.len()
+        self.package_task_contexts().count()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.packages.is_empty()
+        false
     }
 
     pub fn package_manager(&self) -> Option<&PackageManager> {
@@ -603,7 +579,7 @@ impl PackageGraph {
                 )
             }
         };
-        let package_info = self.packages.get(&package);
+        let package_info = self.package_payloads.get(&package);
 
         Some(PackageTaskContext {
             package,
@@ -639,45 +615,19 @@ impl PackageGraph {
     /// compatibility projection.
     #[cfg(any(test, feature = "test-util"))]
     pub fn remove_package_info_for_test(&mut self, package: &PackageName) -> Option<PackageInfo> {
-        self.packages.remove(package)
+        self.package_payloads.remove(package)
     }
 
     #[cfg(any(test, feature = "test-util"))]
-    pub fn set_package_json_path_for_test(
+    pub fn set_compatibility_manifest_name_for_test(
         &mut self,
         package: &PackageName,
-        package_json_path: AnchoredSystemPathBuf,
+        compatibility_manifest_name: Option<String>,
     ) -> bool {
-        let Some(package_info) = self.packages.get_mut(package) else {
+        let Some(payload) = self.package_payloads.get_mut(package) else {
             return false;
         };
-        package_info.package_json_path = package_json_path;
-        true
-    }
-
-    #[cfg(any(test, feature = "test-util"))]
-    pub fn set_package_json_name_for_test(
-        &mut self,
-        package: &PackageName,
-        name: Option<String>,
-    ) -> bool {
-        let Some(package_info) = self.packages.get_mut(package) else {
-            return false;
-        };
-        package_info.package_json.name = name.map(turborepo_errors::Spanned::new);
-        true
-    }
-
-    #[cfg(any(test, feature = "test-util"))]
-    pub fn set_compatibility_toolchain_for_test(
-        &mut self,
-        package: &PackageName,
-        toolchain: crate::toolchain::ToolchainId,
-    ) -> bool {
-        let Some(package_info) = self.packages.get_mut(package) else {
-            return false;
-        };
-        package_info.toolchain = toolchain;
+        payload.package_json.name = compatibility_manifest_name.map(turborepo_errors::Spanned::new);
         true
     }
 
@@ -783,7 +733,7 @@ impl PackageGraph {
                 mut hashes,
             })) => {
                 let knowledge = &self.knowledge;
-                for (name, info) in &mut self.packages {
+                for (name, info) in &mut self.package_payloads {
                     // Mirror of the filter in the inline path
                     // (`populate_transitive_dependencies`): a non-JS package
                     // sharing a directory with a JS package must not steal
@@ -817,7 +767,7 @@ impl PackageGraph {
     }
 
     pub fn package_json(&self, package: &PackageName) -> Option<&PackageJson> {
-        let entry = self.packages.get(package)?;
+        let entry = self.package_payloads.get(package)?;
         Some(&entry.package_json)
     }
 
@@ -832,7 +782,7 @@ impl PackageGraph {
     }
 
     pub fn package_info(&self, package: &PackageName) -> Option<&PackageInfo> {
-        self.packages.get(package)
+        self.package_payloads.get(package)
     }
 
     fn package_dir_for_node(&self, node: &PackageNode) -> Option<&AnchoredSystemPath> {
@@ -863,10 +813,6 @@ impl PackageGraph {
             .edges_connecting(*from_index, *to_index)
             .next()
             .map(|edge| *edge.weight())
-    }
-
-    pub fn packages(&self) -> impl Iterator<Item = (&PackageName, &PackageInfo)> {
-        self.packages.iter()
     }
 
     pub fn root_package_json(&self) -> Option<&PackageJson> {
@@ -1111,7 +1057,7 @@ impl PackageGraph {
     ) -> HashSet<&turborepo_lockfiles::Package> {
         packages
             .into_iter()
-            .filter_map(|package| self.packages.get(package))
+            .filter_map(|package| self.package_payloads.get(package))
             .filter_map(|entry| entry.transitive_dependencies.as_ref())
             .flatten()
             .map(|pkg| &**pkg)
@@ -1127,13 +1073,21 @@ impl PackageGraph {
     ) -> Result<Vec<ExternalDependencyChange>, ChangedPackagesError> {
         let current = self.lockfile().ok_or(ChangedPackagesError::NoLockfile)?;
 
+        for context in self.package_task_contexts() {
+            if context.requires_compatibility_payload() && context.package_info().is_none() {
+                return Err(ChangedPackagesError::MissingPackagePayload(
+                    context.package().clone(),
+                ));
+            }
+        }
+
         let external_deps = self
-            .packages()
-            .filter_map(|(name, info)| {
+            .package_task_contexts()
+            .filter_map(|context| {
+                let info = context.package_info()?;
                 let dep = info.unresolved_external_dependencies.as_ref()?;
-                let directory = self.package_dir(name)?;
                 Some((
-                    directory.to_unix().to_string(),
+                    context.directory().to_unix().to_string(),
                     dep.iter()
                         .map(|(name, version)| (name.to_owned(), version.to_owned()))
                         .collect(),
@@ -1154,10 +1108,11 @@ impl PackageGraph {
         let changed = if global_change {
             None
         } else {
-            self.packages
-                .iter()
-                .filter_map(|(name, info)| {
-                    let package_dir = self.package_dir(name)?;
+            self.package_task_contexts()
+                .filter_map(|context| {
+                    let info = context.package_info()?;
+                    let name = context.package().clone();
+                    let package_dir = context.directory();
                     let previous_closure = closures.get(package_dir.to_unix().as_str());
                     // Both closures are sorted by (key, version), so `Vec`
                     // equality is set equality here.
@@ -1213,19 +1168,17 @@ impl PackageGraph {
         };
 
         Ok(changed.unwrap_or_else(|| {
-            self.packages
-                .keys()
-                .filter_map(|name| {
-                    let path = self.package_dir(name)?.to_owned();
+            self.package_task_contexts()
+                .map(|context| {
                     let package = WorkspacePackage {
-                        name: name.clone(),
-                        path,
+                        name: context.package().clone(),
+                        path: context.directory().to_owned(),
                     };
-                    Some(ExternalDependencyChange {
+                    ExternalDependencyChange {
                         package,
                         added: Vec::new(),
                         removed: Vec::new(),
-                    })
+                    }
                 })
                 .collect()
         }))
@@ -1251,10 +1204,17 @@ impl PackageGraph {
         // TODO: provide size hint from Lockfile trait
         let mut map: HashMap<turborepo_lockfiles::Package, HashSet<PackageNode>> = HashMap::new();
         // First find which packages directly depend on each external package
-        for (pkg, info) in self.packages.iter() {
+        for context in self.package_task_contexts() {
+            let Some(info) = context.package_info() else {
+                debug_assert!(
+                    !context.requires_compatibility_payload(),
+                    "builder invariant: required package context has no payload"
+                );
+                continue;
+            };
             for dep in info.transitive_dependencies.iter().flatten() {
                 let rdeps = map.entry((**dep).clone()).or_default();
-                rdeps.insert(PackageNode::Workspace(pkg.clone()));
+                rdeps.insert(PackageNode::Workspace(context.package().clone()));
             }
         }
         // Now trace through all ancestors of the direct dependants
@@ -1288,7 +1248,7 @@ impl PackageGraph {
         &self,
         package: &PackageName,
     ) -> Option<&BTreeMap<PackageKey, PackageVersion>> {
-        let entry = self.packages.get(package)?;
+        let entry = self.package_payloads.get(package)?;
         entry.unresolved_external_dependencies.as_ref()
     }
 }
@@ -1297,6 +1257,8 @@ impl PackageGraph {
 pub enum ChangedPackagesError {
     #[error("No lockfile")]
     NoLockfile,
+    #[error("Missing compatibility payload for package {0}")]
+    MissingPackagePayload(PackageName),
     #[error("Lockfile error")]
     Lockfile(#[from] turborepo_lockfiles::Error),
 }
@@ -1499,7 +1461,7 @@ mod test {
                 .unwrap();
 
             apply_patch(tempdir.path(), lockfile, dep_patch);
-            let dep_graph = build_lockfile_aware_graph(&root, package_manager.clone());
+            let mut dep_graph = build_lockfile_aware_graph(&root, package_manager.clone());
             let mut dep_changed = dep_graph
                 .changed_packages_from_lockfile(previous.as_ref())
                 .unwrap();
@@ -1513,6 +1475,12 @@ mod test {
                 vec![PackageName::from("b")],
                 "{pm_name}: dependency lockfile change should only affect b"
             );
+            let missing = PackageName::from("b");
+            assert!(dep_graph.remove_package_info_for_test(&missing).is_some());
+            assert!(matches!(
+                dep_graph.changed_packages_from_lockfile(previous.as_ref()),
+                Err(ChangedPackagesError::MissingPackagePayload(name)) if name == missing
+            ));
 
             let previous_dep = package_manager
                 .read_lockfile(&root, &root_package_json)
@@ -1614,7 +1582,7 @@ mod test {
             .collect::<HashSet<_>>()
         );
         let b_external = pkg_graph
-            .packages
+            .package_payloads
             .get(&PackageName::from("b"))
             .unwrap()
             .unresolved_external_dependencies
@@ -1745,14 +1713,14 @@ mod test {
         let bar = PackageName::from("bar");
 
         let foo_deps = pkg_graph
-            .packages
+            .package_payloads
             .get(&foo)
             .unwrap()
             .transitive_dependencies
             .as_ref()
             .unwrap();
         let bar_deps = pkg_graph
-            .packages
+            .package_payloads
             .get(&bar)
             .unwrap()
             .transitive_dependencies
@@ -1843,7 +1811,7 @@ mod test {
         // Before the join, closures are absent.
         assert!(
             deferred
-                .packages
+                .package_payloads
                 .values()
                 .all(|info| info.transitive_dependencies.is_none()),
             "deferred graph must not have closures before ensure"
@@ -1853,8 +1821,8 @@ mod test {
         // Idempotent.
         deferred.ensure_transitive_closures();
 
-        for (name, info) in inline.packages.iter() {
-            let deferred_info = deferred.packages.get(name).unwrap();
+        for (name, info) in &inline.package_payloads {
+            let deferred_info = deferred.package_payloads.get(name).unwrap();
             assert_eq!(
                 info.transitive_dependencies, deferred_info.transitive_dependencies,
                 "closures must match for {name}"
@@ -2347,7 +2315,7 @@ version = "0.1.0"
         // was decided by HashMap iteration order, roughly a coin flip per
         // process/build.
         for _ in 0..8 {
-            let pkg_graph = PackageGraph::builder(
+            let mut pkg_graph = PackageGraph::builder(
                 &root,
                 PackageJson::from_value(json!({ "name": "root", "dependencies": { "a": "1" } }))
                     .unwrap(),
@@ -2368,16 +2336,39 @@ version = "0.1.0"
             .unwrap();
 
             assert!(pkg_graph.validate().is_ok());
+            assert!(pkg_graph.package_task_contexts().all(|context| {
+                context.requires_compatibility_payload() && context.package_info().is_some()
+            }));
 
-            // All packages present, tagged with their toolchain.
-            let app = pkg_graph.package_info(&PackageName::from("app")).unwrap();
-            assert_eq!(app.toolchain, crate::toolchain::ToolchainId::RUST);
-            let js_pkg = pkg_graph
-                .package_info(&PackageName::from("js-pkg"))
-                .unwrap();
-            assert_eq!(js_pkg.toolchain, crate::toolchain::ToolchainId::JAVASCRIPT);
+            let app_name = PackageName::from("app");
+            assert!(pkg_graph.set_compatibility_manifest_name_for_test(
+                &app_name,
+                Some("stale-payload-name".into())
+            ));
+            assert_eq!(
+                pkg_graph.package_task_context(&app_name).unwrap().package(),
+                &app_name
+            );
+            assert!(
+                pkg_graph
+                    .package_task_context(&PackageName::from("stale-payload-name"))
+                    .is_none()
+            );
+
+            // All packages are present with knowledge-backed provenance.
+            assert_eq!(
+                pkg_graph.package_toolchain(&PackageName::from("app")),
+                Some(&crate::toolchain::ToolchainId::RUST)
+            );
+            assert_eq!(
+                pkg_graph.package_toolchain(&PackageName::from("js-pkg")),
+                Some(&crate::toolchain::ToolchainId::JAVASCRIPT)
+            );
             let workspace_pkg = pkg_graph.package_info(&PackageName::from("acme")).unwrap();
-            assert_eq!(workspace_pkg.toolchain, crate::toolchain::ToolchainId::RUST);
+            assert_eq!(
+                pkg_graph.package_toolchain(&PackageName::from("acme")),
+                Some(&crate::toolchain::ToolchainId::RUST)
+            );
 
             let knowledge = pkg_graph.repository_knowledge();
             let cargo_app = knowledge.scope("app").expect("Cargo crate is a package");
@@ -2520,10 +2511,8 @@ version = "0.1.0"
         );
         assert_eq!(root_context.kind(), PackageTaskContextKind::Root);
         assert_eq!(root_context.toolchain(), None);
-        assert!(std::ptr::eq(
-            root_context.package_info().unwrap(),
-            pkg_graph.package_info(&PackageName::Root).unwrap()
-        ));
+        assert!(root_context.package_info().is_none());
+        assert!(pkg_graph.package_info(&PackageName::Root).is_none());
         assert_eq!(pkg_graph.package_definition_path(&PackageName::Root), None);
         assert_eq!(pkg_graph.package_toolchain(&PackageName::Root), None);
         assert!(
@@ -2571,23 +2560,22 @@ version = "0.1.0"
         );
 
         // The Cargo crates and synthetic workspace package populate the graph.
-        let app = pkg_graph.package_info(&PackageName::from("app")).unwrap();
-        assert_eq!(app.toolchain, crate::toolchain::ToolchainId::RUST);
-        let lib_a = pkg_graph.package_info(&PackageName::from("lib-a")).unwrap();
-        assert_eq!(lib_a.toolchain, crate::toolchain::ToolchainId::RUST);
-        let workspace_pkg = pkg_graph.package_info(&PackageName::from("acme")).unwrap();
-        assert_eq!(workspace_pkg.toolchain, crate::toolchain::ToolchainId::RUST);
+        assert_eq!(
+            pkg_graph.package_toolchain(&PackageName::from("app")),
+            Some(&crate::toolchain::ToolchainId::RUST)
+        );
+        assert_eq!(
+            pkg_graph.package_toolchain(&PackageName::from("lib-a")),
+            Some(&crate::toolchain::ToolchainId::RUST)
+        );
+        assert_eq!(
+            pkg_graph.package_toolchain(&PackageName::from("acme")),
+            Some(&crate::toolchain::ToolchainId::RUST)
+        );
 
-        // Compatibility identity, path, and provenance may be stale without
-        // changing command resolution. The graph-created context remains
-        // bound to repository knowledge and Cargo receives those facts.
+        // Command resolution receives identity, path, and provenance from the
+        // graph-created context.
         let app_name = PackageName::from("app");
-        {
-            let stale = pkg_graph.packages.get_mut(&app_name).unwrap();
-            stale.package_json.name = Some(Spanned::new("stale-app".to_string()));
-            stale.package_json_path = AnchoredSystemPathBuf::from_raw("stale/Cargo.toml").unwrap();
-            stale.toolchain = crate::toolchain::ToolchainId::JAVASCRIPT;
-        }
         let app_context = pkg_graph.package_task_context(&app_name).unwrap();
         assert_eq!(app_context.package(), &app_name);
         assert_eq!(
@@ -2628,7 +2616,7 @@ version = "0.1.0"
         assert!(
             pkg_graph
                 .remove_package_info_for_test(&PackageName::Root)
-                .is_some()
+                .is_none()
         );
         assert!(pkg_graph.remove_package_info_for_test(&app_name).is_some());
         let contexts = pkg_graph.package_task_contexts().collect::<Vec<_>>();

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -1252,11 +1252,6 @@ mod tests {
                 "scripts": { "build": "next build", "empty": "" }
             }))
             .unwrap(),
-            // Identity/path/toolchain are deliberately stale compatibility
-            // fields. Command framing must come from `context`.
-            package_json_path: turbopath::AnchoredSystemPathBuf::from_raw("stale/package.json")
-                .unwrap(),
-            toolchain: ToolchainId::RUST,
             ..Default::default()
         };
         let package_directory = turbopath::AnchoredSystemPath::new("apps/web").unwrap();

--- a/crates/turborepo-run-cache/src/lib.rs
+++ b/crates/turborepo-run-cache/src/lib.rs
@@ -1077,15 +1077,11 @@ mod test {
     }
 
     #[tokio::test]
-    async fn task_cache_uses_context_and_ignores_stale_or_missing_payload() {
+    async fn task_cache_uses_context_and_ignores_missing_payload() {
         let tmp = tempdir().unwrap();
         let repo_root =
             AbsoluteSystemPathBuf::new(tmp.path().to_string_lossy().to_string()).unwrap();
         let mut graph = javascript_graph(&repo_root, "packages").await;
-        assert!(graph.set_package_json_path_for_test(
-            &PackageName::from("app"),
-            AnchoredSystemPathBuf::from_raw(format!("stale{MAIN_SEPARATOR}package.json")).unwrap(),
-        ));
         let cache = run_cache(&repo_root);
         let definition = TaskDefinition {
             incremental: Some(vec![IncrementalPartition {

--- a/crates/turborepo-run-summary/src/task_factory.rs
+++ b/crates/turborepo-run-summary/src/task_factory.rs
@@ -422,13 +422,12 @@ mod tests {
 
     #[tokio::test]
     async fn summary_uses_authoritative_path_and_toolchain_provenance() {
-        let (_tempdir, mut graph) = summary_graph().await;
+        let (_tempdir, graph) = summary_graph().await;
         let app = PackageName::from("app");
-        assert!(graph.set_package_json_path_for_test(
-            &app,
-            AnchoredSystemPathBuf::from_raw("stale/package.json").unwrap(),
-        ));
-        assert!(graph.set_compatibility_toolchain_for_test(&app, ToolchainId::RUST));
+        assert_eq!(
+            graph.package_task_context(&app).unwrap().toolchain(),
+            Some(&ToolchainId::JAVASCRIPT)
+        );
         let task_id = TaskId::new("app", "build").into_owned();
         let engine = TestEngine {
             definitions: HashMap::from([(task_id.clone(), TaskDefinition::default())]),

--- a/crates/turborepo-task-executor/src/command.rs
+++ b/crates/turborepo-task-executor/src/command.rs
@@ -122,13 +122,6 @@ pub enum CommandProviderError {
         repository_root: String,
         directory: String,
     },
-    #[error(
-        "Package payload identity {actual:?} does not match authoritative identity {expected}."
-    )]
-    PackagePayloadIdentityMismatch {
-        expected: PackageName,
-        actual: Option<String>,
-    },
     #[error("Missing microfrontends config path for package {package_name}.")]
     MissingMfeConfigPath { package_name: PackageName },
     #[error("Invalid microfrontends config path {path} for package {package_name}.")]
@@ -397,11 +390,6 @@ impl<'a, M: MfeConfigProvider> MicroFrontendProxyProvider<'a, M> {
     fn validate_package_context(
         context: PackageTaskContext<'_>,
     ) -> Result<PackageTaskContext<'_>, CommandProviderError> {
-        let Some(package_info) = context.package_info() else {
-            return Err(CommandProviderError::MissingPackagePayload {
-                package_name: context.package().clone(),
-            });
-        };
         let package_directory = context.repository_root().resolve(context.directory());
         if !context.repository_root().contains(&package_directory) {
             return Err(CommandProviderError::PackageDirectoryOutsideRepository {
@@ -417,13 +405,9 @@ impl<'a, M: MfeConfigProvider> MicroFrontendProxyProvider<'a, M> {
                 package_name: context.package().clone(),
             });
         }
-        let actual = package_info.package_name();
-        if context.kind() == turborepo_repository::package_graph::PackageTaskContextKind::Package
-            && actual.as_deref() != Some(context.package().as_ref())
-        {
-            return Err(CommandProviderError::PackagePayloadIdentityMismatch {
-                expected: context.package().clone(),
-                actual,
+        if context.package_info().is_none() {
+            return Err(CommandProviderError::MissingPackagePayload {
+                package_name: context.package().clone(),
             });
         }
         Ok(context)
@@ -593,7 +577,7 @@ mod tests {
     };
 
     use tempfile::TempDir;
-    use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
+    use turbopath::AbsoluteSystemPathBuf;
     use turborepo_errors::Spanned;
     use turborepo_repository::{package_json::PackageJson, package_manager::PackageManager};
     use turborepo_task_id::TaskName;
@@ -680,18 +664,13 @@ mod tests {
         let package_path = AbsoluteSystemPathBuf::try_from(package_dir)
             .unwrap()
             .join_component("package.json");
-        let mut graph = PackageGraph::builder(repo_root, PackageJson::default())
+        PackageGraph::builder(repo_root, PackageJson::default())
             .with_package_manager(PackageManager::Npm)
             .with_package_jsons(Some(HashMap::from([(package_path, package_json)])))
             .with_allow_no_package_manager(true)
             .build()
             .await
-            .unwrap();
-        assert!(graph.set_package_json_path_for_test(
-            &PackageName::from("web"),
-            AnchoredSystemPathBuf::from_raw("stale/package.json").unwrap()
-        ));
-        graph
+            .unwrap()
     }
 
     async fn root_package_graph(
@@ -995,22 +974,7 @@ mod tests {
     async fn test_microfrontend_proxy_rejects_invalid_contexts_and_config_paths() {
         let (_tempdir, repo_root, package_dir) = create_test_repo();
         let environment = EnvironmentVariableMap::default();
-        let config = MockMfeConfig("configs/microfrontends.json");
-        let mut graph = package_graph(&repo_root, &package_dir, PackageJson::default()).await;
-
-        assert!(
-            graph.set_package_json_name_for_test(
-                &PackageName::from("web"),
-                Some("other".to_owned())
-            )
-        );
-        assert!(matches!(
-            proxy_command_result(&graph, &environment, &config, "web"),
-            Err(CommandProviderError::PackagePayloadIdentityMismatch { .. })
-        ));
-        assert!(
-            graph.set_package_json_name_for_test(&PackageName::from("web"), Some("web".to_owned()))
-        );
+        let graph = package_graph(&repo_root, &package_dir, PackageJson::default()).await;
         for path in [
             "../config.json",
             "C:/config.json",

--- a/crates/turborepo-task-hash/src/lib.rs
+++ b/crates/turborepo-task-hash/src/lib.rs
@@ -1509,13 +1509,8 @@ mod test {
                 .to_string(),
         )
         .unwrap();
-        let mut graph = cargo_graph(&repo_root).await;
-        let with_payload = context_hash(&graph, PackageName::Root, false);
-        assert!(
-            graph
-                .remove_package_info_for_test(&PackageName::Root)
-                .is_some()
-        );
+        let graph = cargo_graph(&repo_root).await;
+        let baseline = context_hash(&graph, PackageName::Root, false);
         assert!(
             !graph
                 .package_task_context(&PackageName::Root)
@@ -1551,7 +1546,7 @@ mod test {
                 &graph.package_task_context(&PackageName::Root).unwrap(),
             )
             .unwrap();
-        assert_eq!(context_hash(&graph, PackageName::Root, false), with_payload);
+        assert_eq!(context_hash(&graph, PackageName::Root, false), baseline);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -144,23 +144,32 @@ Represents the workspace structure and package dependencies:
 - Validates that all non-root packages have a `name` field
   (`PackageGraph::validate()`)
 
-`RepositoryKnowledge` is the crate-private authority for package identity and
-paths during node assembly, and the resulting `PackageGraph` retains that exact
-immutable generation. Consumers migrate incrementally through narrow
-knowledge-backed graph queries and may temporarily use `PackageInfo`
-compatibility projections. Their identity, path, scope kind, and provenance are
-knowledge-backed; relationship and task payloads remain associated native
-compatibility data. Native manifests and metadata do not enter repository
-knowledge. Native definition paths must remain within the repository, including
-after resolving existing symlinks.
+`RepositoryKnowledge` is the crate-private authority for package identity,
+paths, scope kind, and provenance during node assembly, and the resulting
+`PackageGraph` retains that exact immutable generation. Phase 1 of the payload
+deletion is complete: `PackageInfo` carries no identity, definition path,
+directory, or toolchain provenance; the graph exposes no payload-map identity
+enumeration. Consumers enumerate and resolve authoritative contexts/views, then
+look up an optional payload only for the remaining relationship and task data.
+The retained native `PackageJson.name` is non-authoritative payload data: no
+consumer may derive package identity, path, or provenance from it.
+Native manifests and metadata do not enter repository knowledge. Native
+definition paths must remain within the repository, including after resolving
+existing symlinks.
+
+The remaining payload deletion phases are explicit:
+
+- **Phase 2:** Move script, dependency, and version reads behind task/relationship queries.
+- **Phase 3:** Move unresolved dependency and lockfile-closure/hash state behind lockfile and hashing queries.
+- **Phase 4:** Delete `PackageInfo`, its payload map, and optional-payload compatibility plumbing once all fail-closed consumers use those queries.
 
 Task hashing, run-cache path construction, and run-summary task directories use
 a graph-created `PackageTaskContext` that binds identity, repository root,
 directory, kind, and an optional compatibility payload. Repository-wide task
 namespace and external-dependency-hash enumeration is root-first, then follows
 repository observation order; scripts and dependency closures are joined only
-as compatibility payloads. Pure
-Cargo retains the root Turbo namespace; consumers reject contexts from another
+as compatibility payloads. Pure Cargo retains the root Turbo namespace without
+synthesizing an empty root payload; consumers reject contexts from another
 repository, and required missing payloads fail closed.
 
 Repository-facing commands use the same optional-root construction policy as

--- a/packages/turbo-repository/rust/Cargo.toml
+++ b/packages/turbo-repository/rust/Cargo.toml
@@ -24,6 +24,7 @@ tracing = "0.1.37"
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
+turborepo-errors = { workspace = true }
 
 [build-dependencies]
 napi-build = "2.0.1"

--- a/packages/turbo-repository/rust/src/internal.rs
+++ b/packages/turbo-repository/rust/src/internal.rs
@@ -3,9 +3,10 @@ use thiserror::Error;
 use turbopath::{AbsoluteSystemPathBuf, PathError};
 use turborepo_repository::{
     inference::{self, RepoMode as WorkspaceType, RepoState as WorkspaceState},
-    package_graph::PackageGraphBuilder,
+    package_graph::{PackageGraph, PackageGraphBuilder},
     package_json::PackageJson,
     package_manager,
+    toolchain::ToolchainId,
 };
 
 use crate::{Package, PackageManager, Workspace};
@@ -29,15 +30,6 @@ pub(crate) enum Error {
         error: String,
         path: AbsoluteSystemPathBuf,
     },
-    #[error("Failed to discover packages from root {workspace_root}: {error}")]
-    PackageJsons {
-        error: package_manager::Error,
-        workspace_root: AbsoluteSystemPathBuf,
-    },
-    #[error("Failed to join package discovery task: {0}")]
-    PackageDiscoveryJoin(#[from] tokio::task::JoinError),
-    #[error("Package directory {0} has no parent")]
-    MissingParent(AbsoluteSystemPathBuf),
     #[error("Package graph error: {0}")]
     PackageGraph(#[from] turborepo_repository::package_graph::Error),
     #[error("package.json error: {0}")]
@@ -108,7 +100,6 @@ impl Workspace {
 
         Ok(Self {
             absolute_path: workspace_state.root.to_string(),
-            workspace_state,
             is_multi_package,
             package_manager: PackageManager {
                 name: package_manager_name.to_string(),
@@ -118,57 +109,73 @@ impl Workspace {
     }
 
     pub(crate) async fn packages_internal(&self) -> Result<Vec<Package>, Error> {
-        // Note: awkward error handling because we memoize the error from package
-        // manager discovery. That probably isn't the best design. We should
-        // address it when we decide how we want to handle possibly finding a
-        // repo root but not finding a package manager.
-        let package_manager = self
-            .workspace_state
-            .package_manager
-            .as_ref()
-            .map_err(|error| Error::PackageManager {
-                error: error.to_string(),
-                path: self.workspace_state.root.clone(),
-            })?;
+        packages_from_graph(&self.graph)
+    }
+}
 
-        let package_manager = package_manager.clone();
-        let workspace_root = self.workspace_state.root.clone();
+fn packages_from_graph(graph: &PackageGraph) -> Result<Vec<Package>, Error> {
+    let mut packages = graph
+        .package_task_contexts()
+        .filter(|context| {
+            graph.is_real_package(context.package())
+                && context.toolchain() == Some(&ToolchainId::JAVASCRIPT)
+        })
+        .map(|context| {
+            let path = graph.repo_root().resolve(context.directory());
+            Package::new(
+                context.package().as_str().to_owned(),
+                graph.repo_root(),
+                &path,
+            )
+            .map_err(Error::from)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    packages.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    Ok(packages)
+}
 
-        let package_json_paths =
-            tokio::task::spawn(async move { package_manager.get_package_jsons(&workspace_root) })
-                .await
-                .map_err(Error::PackageDiscoveryJoin)?
-                .map_err(|error| Error::PackageJsons {
-                    error,
-                    workspace_root: self.workspace_state.root.clone(),
-                })?;
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
 
-        let packages = package_json_paths
-            .filter_map(|path| {
-                // Return an error if we fail to load the package.json
-                let pkg_json = match PackageJson::load(&path) {
-                    Ok(pkg) => pkg,
-                    Err(err) => return Some(Err(err.into())),
-                };
+    use turborepo_errors::Spanned;
 
-                // Skip packages that don't have names
-                let name = pkg_json.name?;
+    use super::*;
 
-                // Get the package path and turn it into a package
-                // Error if we fail to get the package path (parent to
-                // package_json_path)
-                path.parent()
-                    .map(|package_path| {
-                        Ok(Package::new(
-                            name.into_inner(),
-                            &self.workspace_state.root,
-                            package_path,
-                        )?)
-                    })
-                    .or_else(|| Some(Err(Error::MissingParent(path.to_owned()))))
-            })
-            .collect::<Result<Vec<Package>, Error>>()?;
+    #[tokio::test]
+    async fn package_listing_uses_retained_graph_generation() {
+        let root = AbsoluteSystemPathBuf::new(std::env::temp_dir().to_string_lossy()).unwrap();
+        let package_jsons = HashMap::from([
+            (
+                root.join_components(&["z", "package.json"]),
+                PackageJson {
+                    name: Some(Spanned::new("z".into())),
+                    ..Default::default()
+                },
+            ),
+            (
+                root.join_components(&["a", "package.json"]),
+                PackageJson {
+                    name: Some(Spanned::new("a".into())),
+                    ..Default::default()
+                },
+            ),
+        ]);
+        let graph = PackageGraphBuilder::new(&root, PackageJson::default())
+            .with_package_manager(package_manager::PackageManager::Npm)
+            .with_package_jsons(Some(package_jsons))
+            .with_allow_no_package_manager(true)
+            .build()
+            .await
+            .unwrap();
 
-        Ok(packages)
+        let packages = packages_from_graph(&graph).unwrap();
+        assert_eq!(
+            packages
+                .iter()
+                .map(|package| package.name.as_str())
+                .collect::<Vec<_>>(),
+            ["a", "z"]
+        );
     }
 }

--- a/packages/turbo-repository/rust/src/lib.rs
+++ b/packages/turbo-repository/rust/src/lib.rs
@@ -12,7 +12,6 @@ use turborepo_repository::{
         ChangeMapper, DefaultPackageChangeMapper, DefaultPackageChangeMapperWithLockfile,
         LockfileContents, PackageChangeMapper, PackageChanges,
     },
-    inference::RepoState as WorkspaceState,
     package_graph::{PackageGraph, PackageName, PackageNode, ROOT_PKG_NAME, WorkspacePackage},
 };
 use turborepo_scm::SCM;
@@ -53,7 +52,6 @@ pub struct PackageManager {
 
 #[napi]
 pub struct Workspace {
-    workspace_state: WorkspaceState,
     /// The absolute path to the workspace root.
     #[napi(readonly)]
     pub absolute_path: String,
@@ -95,12 +93,9 @@ impl Package {
 
         pkgs.iter()
             .filter_map(|node| {
-                let info = graph.package_info(node.as_package_name())?;
-                // If we don't get a package name back, we'll just skip it.
-                let name = info.package_name()?;
-                let anchored_package_path = info.package_path();
-                let package_path = workspace_path.resolve(anchored_package_path);
-                Package::new(name, workspace_path, &package_path).ok()
+                let context = graph.package_task_context(node.as_package_name())?;
+                let package_path = workspace_path.resolve(context.directory());
+                Package::new(context.package().to_string(), workspace_path, &package_path).ok()
             })
             .collect()
     }
@@ -119,12 +114,9 @@ impl Package {
         pkgs.iter()
             .filter(|node| !matches!(node, PackageNode::Root))
             .filter_map(|node| {
-                let info = graph.package_info(node.as_package_name())?;
-                // If we don't get a package name back, we'll just skip it.
-                let name = info.package_name()?;
-                let anchored_package_path = info.package_path();
-                let package_path = workspace_path.resolve(anchored_package_path);
-                Package::new(name, workspace_path, &package_path).ok()
+                let context = graph.package_task_context(node.as_package_name())?;
+                let package_path = workspace_path.resolve(context.directory());
+                Package::new(context.package().to_string(), workspace_path, &package_path).ok()
             })
             .collect()
     }
@@ -199,8 +191,15 @@ impl Workspace {
         let mut seen = HashSet::new();
         let mut result: Vec<String> = self
             .graph
-            .packages()
-            .filter_map(|(_name, info)| info.transitive_dependencies.as_ref())
+            .package_task_contexts()
+            .filter_map(|context| {
+                let info = context.package_info();
+                debug_assert!(
+                    info.is_some() || !context.requires_compatibility_payload(),
+                    "builder invariant: required package context has no payload"
+                );
+                info.and_then(|info| info.transitive_dependencies.as_ref())
+            })
             .flatten()
             .filter(|pkg| seen.insert(&pkg.key))
             .filter_map(|pkg| lockfile.human_name(pkg).map(|name| format!("npm/{name}")))
@@ -299,10 +298,10 @@ impl Workspace {
         let packages = match package_changes {
             PackageChanges::All(_) => self
                 .graph
-                .packages()
-                .map(|(name, info)| WorkspacePackage {
-                    name: name.to_owned(),
-                    path: info.package_path().to_owned(),
+                .package_task_contexts()
+                .map(|context| WorkspacePackage {
+                    name: context.package().clone(),
+                    path: context.directory().to_owned(),
                 })
                 .collect::<Vec<WorkspacePackage>>(),
             PackageChanges::Some(packages) => packages.into_keys().collect(),


### PR DESCRIPTION
### Description

Final part of the package/scope knowledge completion stack.

Delete package identity, definition path, directory, and toolchain provenance from `PackageInfo`; remove payload-map package enumeration; stop synthesizing a pure-Cargo root payload; and migrate the NAPI wrapper to the retained graph generation. Compatibility payloads now contain only relationship, resolution, and task data for later phases.

### Testing Instructions

- `cargo check --workspace --all-targets`
- `cargo test -p turborepo-repository -p turborepo-engine -p turborepo-lib -p turborepo-scope -p turborepo-query`
- `cargo test -p turbo`
- `cargo lint`
- `pnpm run format`
- `pnpm run check:toml`

<sub>CLOSES TURBO-5777</sub>