### PR TITLE
fix: Scroll TUI task list with mouse wheel

### DIFF
--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -63,6 +63,7 @@ pub struct App<W> {
     tasks_by_status: TasksByStatus,
     section_focus: LayoutSections,
     task_list_scroll: TableState,
+    task_list_scroll_detached: bool,
     selected_task_index: usize,
     is_task_selection_pinned: bool,
     showing_help_popup: bool,
@@ -141,6 +142,7 @@ impl<W> App<W> {
             selected_task_index,
             tasks_by_status,
             task_list_scroll: TableState::default().with_selected(selected_task_index),
+            task_list_scroll_detached: false,
             showing_help_popup: false,
             is_task_selection_pinned: preferences.active_task().is_some(),
             preferences,
@@ -312,6 +314,7 @@ impl<W> App<W> {
         } else {
             self.selected_task_index = (self.selected_task_index + 1) % num_rows;
             self.task_list_scroll.select(Some(self.selected_task_index));
+            self.task_list_scroll_detached = false;
         }
 
         self.cancel_selection_drag_if_task_changed();
@@ -334,6 +337,7 @@ impl<W> App<W> {
                 .checked_sub(1)
                 .unwrap_or(num_rows - 1);
             self.task_list_scroll.select(Some(self.selected_task_index));
+            self.task_list_scroll_detached = false;
         }
 
         self.cancel_selection_drag_if_task_changed();
@@ -342,30 +346,21 @@ impl<W> App<W> {
     }
 
     fn scroll_task_list(&mut self, direction: Direction) -> Result<(), Error> {
-        if matches!(self.section_focus, LayoutSections::Search { .. }) {
-            return self.search_scroll(direction);
-        }
-        if matches!(self.section_focus, LayoutSections::SearchLocked { .. }) {
-            match direction {
-                Direction::Down => self.next(),
-                Direction::Up => self.previous(),
-            }
-            return Ok(());
-        }
-
-        let last_index = self.tasks_by_status.count_all().saturating_sub(1);
-        let index = match direction {
-            Direction::Down => self.selected_task_index.saturating_add(1).min(last_index),
-            Direction::Up => self.selected_task_index.saturating_sub(1),
+        let visible_rows = usize::from(self.size.task_list_visible_task_rows());
+        let max_offset = self
+            .tasks_by_status
+            .count_all()
+            .saturating_sub(visible_rows);
+        let offset = match direction {
+            Direction::Down => self
+                .task_list_scroll
+                .offset()
+                .saturating_add(1)
+                .min(max_offset),
+            Direction::Up => self.task_list_scroll.offset().saturating_sub(1),
         };
-        if index != self.selected_task_index {
-            self.selected_task_index = index;
-            self.task_list_scroll.select(Some(index));
-            self.cancel_selection_drag_if_task_changed();
-        }
-
-        self.is_task_selection_pinned = true;
-        self.persist_active_task().ok();
+        *self.task_list_scroll.offset_mut() = offset;
+        self.task_list_scroll_detached = true;
         Ok(())
     }
 
@@ -1027,6 +1022,7 @@ impl<W> App<W> {
         }
         self.selected_task_index = index;
         self.task_list_scroll.select(Some(index));
+        self.task_list_scroll_detached = false;
         self.is_task_selection_pinned = true;
         self.persist_active_task().ok();
     }
@@ -1075,6 +1071,7 @@ impl<W> App<W> {
         };
         self.selected_task_index = new_index_to_highlight;
         self.task_list_scroll.select(Some(new_index_to_highlight));
+        self.task_list_scroll_detached = false;
         self.cancel_selection_drag_if_task_changed();
 
         Ok(())
@@ -1084,6 +1081,7 @@ impl<W> App<W> {
     pub fn reset_scroll(&mut self) {
         self.is_task_selection_pinned = false;
         self.task_list_scroll.select(Some(0));
+        self.task_list_scroll_detached = false;
         self.selected_task_index = 0;
         self.cancel_selection_drag_if_task_changed();
     }
@@ -1924,7 +1922,19 @@ fn view<W>(app: &mut App<W>, f: &mut Frame) {
     let [table, pane] = horizontal.areas(f.area());
 
     let table_to_render = TaskTable::new(&app.tasks_by_status, &app.section_focus);
-    f.render_stateful_widget(&table_to_render, table, &mut app.task_list_scroll);
+    if app.task_list_scroll_detached {
+        let offset = app.task_list_scroll.offset();
+        let visible_rows = usize::from(app.size.task_list_visible_task_rows());
+        let selected = app
+            .task_list_scroll
+            .selected()
+            .filter(|selected| (offset..offset.saturating_add(visible_rows)).contains(selected));
+        let mut render_state = app.task_list_scroll.with_selected(selected);
+        f.render_stateful_widget(&table_to_render, table, &mut render_state);
+        *app.task_list_scroll.offset_mut() = render_state.offset();
+    } else {
+        f.render_stateful_widget(&table_to_render, table, &mut app.task_list_scroll);
+    }
 
     if let Ok(active_task) = app.active_task() {
         let active_task = active_task.to_string();
@@ -3466,7 +3476,7 @@ mod test {
     }
 
     #[test]
-    fn test_mouse_wheel_over_task_list_moves_selection_without_wrapping() -> Result<(), Error> {
+    fn test_mouse_wheel_over_task_list_scrolls_viewport_without_selecting() -> Result<(), Error> {
         use crossterm::event::{KeyModifiers, MouseEvent, MouseEventKind};
 
         let repo_root_tmp = tempdir()?;
@@ -3486,24 +3496,28 @@ mod test {
             modifiers: KeyModifiers::empty(),
         };
 
-        app.handle_mouse(scroll(MouseEventKind::ScrollUp))?;
-        assert_eq!(app.active_task()?, "task-0");
-        assert_eq!(app.preferences.active_task(), Some("task-0"));
-
         for _ in 0..12 {
             app.handle_mouse(scroll(MouseEventKind::ScrollDown))?;
         }
-        assert_eq!(app.active_task()?, "task-9");
-        assert_eq!(app.task_list_scroll.selected(), Some(9));
+        assert_eq!(app.active_task()?, "task-0");
+        assert_eq!(app.task_list_scroll.selected(), Some(0));
+        assert_eq!(app.task_list_scroll.offset(), 7);
+        assert!(!app.is_task_selection_pinned);
+        assert_eq!(app.preferences.active_task(), None);
 
         app.handle_mouse(scroll(MouseEventKind::ScrollUp))?;
-        assert_eq!(app.active_task()?, "task-8");
-        assert_eq!(app.preferences.active_task(), Some("task-8"));
+        assert_eq!(app.active_task()?, "task-0");
+        assert_eq!(app.task_list_scroll.offset(), 6);
 
         let mut pane_scroll = scroll(MouseEventKind::ScrollDown);
         pane_scroll.column = app.size.task_list_width();
         app.handle_mouse(pane_scroll)?;
-        assert_eq!(app.active_task()?, "task-8");
+        assert_eq!(app.active_task()?, "task-0");
+        assert_eq!(app.task_list_scroll.offset(), 6);
+
+        app.next();
+        assert_eq!(app.active_task()?, "task-1");
+        assert!(!app.task_list_scroll_detached);
         Ok(())
     }
 

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -70,7 +70,8 @@ pub struct App<W> {
     done: bool,
     preferences: PreferenceLoader,
     scrollback_len: u64,
-    scroll_momentum: ScrollMomentum,
+    log_scroll_momentum: ScrollMomentum,
+    task_list_scroll_momentum: ScrollMomentum,
     log_events: Vec<turborepo_log::LogEvent>,
     showing_log_panel: bool,
     /// While set, the pane footer shows "Copied to clipboard". Cleared once
@@ -147,7 +148,8 @@ impl<W> App<W> {
             is_task_selection_pinned: preferences.active_task().is_some(),
             preferences,
             scrollback_len,
-            scroll_momentum: ScrollMomentum::new(),
+            log_scroll_momentum: ScrollMomentum::new(),
+            task_list_scroll_momentum: ScrollMomentum::new(),
             log_events: Vec::new(),
             showing_log_panel: false,
             clipboard_notice_expiry: None,
@@ -314,7 +316,7 @@ impl<W> App<W> {
         } else {
             self.selected_task_index = (self.selected_task_index + 1) % num_rows;
             self.task_list_scroll.select(Some(self.selected_task_index));
-            self.task_list_scroll_detached = false;
+            self.reattach_task_list_scroll();
         }
 
         self.cancel_selection_drag_if_task_changed();
@@ -337,7 +339,7 @@ impl<W> App<W> {
                 .checked_sub(1)
                 .unwrap_or(num_rows - 1);
             self.task_list_scroll.select(Some(self.selected_task_index));
-            self.task_list_scroll_detached = false;
+            self.reattach_task_list_scroll();
         }
 
         self.cancel_selection_drag_if_task_changed();
@@ -346,6 +348,7 @@ impl<W> App<W> {
     }
 
     fn scroll_task_list(&mut self, direction: Direction) -> Result<(), Error> {
+        let lines = self.task_list_scroll_momentum.on_scroll_event(direction);
         let visible_rows = usize::from(self.size.task_list_visible_task_rows());
         let max_offset = self
             .tasks_by_status
@@ -355,13 +358,18 @@ impl<W> App<W> {
             Direction::Down => self
                 .task_list_scroll
                 .offset()
-                .saturating_add(1)
+                .saturating_add(lines)
                 .min(max_offset),
-            Direction::Up => self.task_list_scroll.offset().saturating_sub(1),
+            Direction::Up => self.task_list_scroll.offset().saturating_sub(lines),
         };
         *self.task_list_scroll.offset_mut() = offset;
         self.task_list_scroll_detached = true;
         Ok(())
+    }
+
+    fn reattach_task_list_scroll(&mut self) {
+        self.task_list_scroll_detached = false;
+        self.task_list_scroll_momentum.reset();
     }
 
     #[tracing::instrument(skip_all)]
@@ -371,9 +379,9 @@ impl<W> App<W> {
         use_momentum: bool,
     ) -> Result<(), Error> {
         let lines = if use_momentum {
-            self.scroll_momentum.on_scroll_event(direction)
+            self.log_scroll_momentum.on_scroll_event(direction)
         } else {
-            self.scroll_momentum.reset();
+            self.log_scroll_momentum.reset();
             1
         };
 
@@ -1022,7 +1030,7 @@ impl<W> App<W> {
         }
         self.selected_task_index = index;
         self.task_list_scroll.select(Some(index));
-        self.task_list_scroll_detached = false;
+        self.reattach_task_list_scroll();
         self.is_task_selection_pinned = true;
         self.persist_active_task().ok();
     }
@@ -1071,7 +1079,7 @@ impl<W> App<W> {
         };
         self.selected_task_index = new_index_to_highlight;
         self.task_list_scroll.select(Some(new_index_to_highlight));
-        self.task_list_scroll_detached = false;
+        self.reattach_task_list_scroll();
         self.cancel_selection_drag_if_task_changed();
 
         Ok(())
@@ -1081,7 +1089,7 @@ impl<W> App<W> {
     pub fn reset_scroll(&mut self) {
         self.is_task_selection_pinned = false;
         self.task_list_scroll.select(Some(0));
-        self.task_list_scroll_detached = false;
+        self.reattach_task_list_scroll();
         self.selected_task_index = 0;
         self.cancel_selection_drag_if_task_changed();
     }
@@ -1803,32 +1811,32 @@ fn update(
         }
         Event::ScrollUp => {
             app.is_task_selection_pinned = true;
-            app.scroll_momentum.reset();
+            app.log_scroll_momentum.reset();
             app.scroll_terminal_output(Direction::Up, false)?
         }
         Event::ScrollDown => {
             app.is_task_selection_pinned = true;
-            app.scroll_momentum.reset();
+            app.log_scroll_momentum.reset();
             app.scroll_terminal_output(Direction::Down, false)?;
         }
         Event::PageUp => {
             app.is_task_selection_pinned = true;
-            app.scroll_momentum.reset();
+            app.log_scroll_momentum.reset();
             app.scroll_terminal_output_by_page(Direction::Up)?;
         }
         Event::PageDown => {
             app.is_task_selection_pinned = true;
-            app.scroll_momentum.reset();
+            app.log_scroll_momentum.reset();
             app.scroll_terminal_output_by_page(Direction::Down)?;
         }
         Event::JumpToLogsTop => {
             app.is_task_selection_pinned = true;
-            app.scroll_momentum.reset();
+            app.log_scroll_momentum.reset();
             app.jump_to_logs_top()?;
         }
         Event::JumpToLogsBottom => {
             app.is_task_selection_pinned = true;
-            app.scroll_momentum.reset();
+            app.log_scroll_momentum.reset();
             app.jump_to_logs_bottom()?;
         }
         Event::ClearLogs => {
@@ -3501,19 +3509,21 @@ mod test {
         }
         assert_eq!(app.active_task()?, "task-0");
         assert_eq!(app.task_list_scroll.selected(), Some(0));
-        assert_eq!(app.task_list_scroll.offset(), 7);
+        let scrolled_offset = app.task_list_scroll.offset();
+        assert!((1..=7).contains(&scrolled_offset));
         assert!(!app.is_task_selection_pinned);
         assert_eq!(app.preferences.active_task(), None);
 
+        std::thread::sleep(Duration::from_millis(60));
         app.handle_mouse(scroll(MouseEventKind::ScrollUp))?;
         assert_eq!(app.active_task()?, "task-0");
-        assert_eq!(app.task_list_scroll.offset(), 6);
+        assert_eq!(app.task_list_scroll.offset(), scrolled_offset - 1);
 
         let mut pane_scroll = scroll(MouseEventKind::ScrollDown);
         pane_scroll.column = app.size.task_list_width();
         app.handle_mouse(pane_scroll)?;
         assert_eq!(app.active_task()?, "task-0");
-        assert_eq!(app.task_list_scroll.offset(), 6);
+        assert_eq!(app.task_list_scroll.offset(), scrolled_offset - 1);
 
         app.next();
         assert_eq!(app.active_task()?, "task-1");

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -341,6 +341,34 @@ impl<W> App<W> {
         self.persist_active_task().ok();
     }
 
+    fn scroll_task_list(&mut self, direction: Direction) -> Result<(), Error> {
+        if matches!(self.section_focus, LayoutSections::Search { .. }) {
+            return self.search_scroll(direction);
+        }
+        if matches!(self.section_focus, LayoutSections::SearchLocked { .. }) {
+            match direction {
+                Direction::Down => self.next(),
+                Direction::Up => self.previous(),
+            }
+            return Ok(());
+        }
+
+        let last_index = self.tasks_by_status.count_all().saturating_sub(1);
+        let index = match direction {
+            Direction::Down => self.selected_task_index.saturating_add(1).min(last_index),
+            Direction::Up => self.selected_task_index.saturating_sub(1),
+        };
+        if index != self.selected_task_index {
+            self.selected_task_index = index;
+            self.task_list_scroll.select(Some(index));
+            self.cancel_selection_drag_if_task_changed();
+        }
+
+        self.is_task_selection_pinned = true;
+        self.persist_active_task().ok();
+        Ok(())
+    }
+
     #[tracing::instrument(skip_all)]
     pub fn scroll_terminal_output(
         &mut self,
@@ -811,6 +839,27 @@ impl<W> App<W> {
         mut event: crossterm::event::MouseEvent,
         now: Instant,
     ) -> Result<(), Error> {
+        let has_sidebar = self.preferences.is_task_list_visible();
+        let table_width = if has_sidebar {
+            self.size.task_list_width()
+        } else {
+            0
+        };
+        let scroll_direction = match event.kind {
+            crossterm::event::MouseEventKind::ScrollDown => Some(Direction::Down),
+            crossterm::event::MouseEventKind::ScrollUp => Some(Direction::Up),
+            _ => None,
+        };
+        if let Some(direction) = scroll_direction {
+            if event.column < table_width {
+                self.scroll_task_list(direction)?;
+            } else {
+                self.is_task_selection_pinned = true;
+                self.scroll_terminal_output(direction, true)?;
+            }
+            return Ok(());
+        }
+
         let is_selection_down = matches!(
             event.kind,
             crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left)
@@ -886,13 +935,6 @@ impl<W> App<W> {
             }
         }
 
-        // Only offset by table width if the sidebar is visible
-        let has_sidebar = self.preferences.is_task_list_visible();
-        let table_width = if has_sidebar {
-            self.size.task_list_width()
-        } else {
-            0
-        };
         let pane_left_padding = self.size.pane_left_padding_with_sidebar(has_sidebar);
         let pane_rows = self.size.pane_rows();
         debug!("original mouse event: {event:?}, table_width: {table_width}");
@@ -1770,10 +1812,6 @@ fn update(
             app.is_task_selection_pinned = true;
             app.scroll_momentum.reset();
             app.scroll_terminal_output(Direction::Down, false)?;
-        }
-        Event::ScrollWithMomentum(direction) => {
-            app.is_task_selection_pinned = true;
-            app.scroll_terminal_output(direction, true)?;
         }
         Event::PageUp => {
             app.is_task_selection_pinned = true;
@@ -3424,6 +3462,48 @@ mod test {
         app.handle_mouse(click(5))?;
         assert_eq!(app.active_task()?, "task-4");
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_mouse_wheel_over_task_list_moves_selection_without_wrapping() -> Result<(), Error> {
+        use crossterm::event::{KeyModifiers, MouseEvent, MouseEventKind};
+
+        let repo_root_tmp = tempdir()?;
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root_tmp.path())
+            .expect("Failed to create AbsoluteSystemPathBuf");
+        let mut app: App<()> = App::new_for_test(
+            6,
+            100,
+            (0..10).map(|i| format!("task-{i}")).collect(),
+            PreferenceLoader::new(&repo_root),
+            2048,
+        );
+        let scroll = |kind| MouseEvent {
+            kind,
+            column: 0,
+            row: 2,
+            modifiers: KeyModifiers::empty(),
+        };
+
+        app.handle_mouse(scroll(MouseEventKind::ScrollUp))?;
+        assert_eq!(app.active_task()?, "task-0");
+        assert_eq!(app.preferences.active_task(), Some("task-0"));
+
+        for _ in 0..12 {
+            app.handle_mouse(scroll(MouseEventKind::ScrollDown))?;
+        }
+        assert_eq!(app.active_task()?, "task-9");
+        assert_eq!(app.task_list_scroll.selected(), Some(9));
+
+        app.handle_mouse(scroll(MouseEventKind::ScrollUp))?;
+        assert_eq!(app.active_task()?, "task-8");
+        assert_eq!(app.preferences.active_task(), Some("task-8"));
+
+        let mut pane_scroll = scroll(MouseEventKind::ScrollDown);
+        pane_scroll.column = app.size.task_list_width();
+        app.handle_mouse(pane_scroll)?;
+        assert_eq!(app.active_task()?, "task-8");
         Ok(())
     }
 

--- a/crates/turborepo-ui/src/tui/event.rs
+++ b/crates/turborepo-ui/src/tui/event.rs
@@ -36,7 +36,6 @@ pub enum Event {
     Down,
     ScrollUp,
     ScrollDown,
-    ScrollWithMomentum(Direction),
     PageUp,
     PageDown,
     JumpToLogsTop,

--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -41,12 +41,8 @@ impl InputOptions<'_> {
         match event {
             crossterm::event::Event::Key(k) => translate_key_event(self, k),
             crossterm::event::Event::Mouse(m) => match m.kind {
-                crossterm::event::MouseEventKind::ScrollDown => {
-                    Some(Event::ScrollWithMomentum(Direction::Down))
-                }
-                crossterm::event::MouseEventKind::ScrollUp => {
-                    Some(Event::ScrollWithMomentum(Direction::Up))
-                }
+                crossterm::event::MouseEventKind::ScrollDown
+                | crossterm::event::MouseEventKind::ScrollUp => Some(Event::Mouse(m)),
                 crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left)
                 | crossterm::event::MouseEventKind::Drag(crossterm::event::MouseButton::Left)
                 | crossterm::event::MouseEventKind::Up(crossterm::event::MouseButton::Left) => {
@@ -508,6 +504,21 @@ mod test {
         assert!(matches!(
             in_find().handle_crossterm_event(crossterm::event::Event::Mouse(event)),
             Some(Event::Mouse(_))
+        ));
+    }
+
+    #[test]
+    fn forwards_mouse_scroll_with_coordinates() {
+        let event = crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::ScrollDown,
+            column: 7,
+            row: 3,
+            modifiers: KeyModifiers::empty(),
+        };
+
+        assert!(matches!(
+            in_list().handle_crossterm_event(crossterm::event::Event::Mouse(event)),
+            Some(Event::Mouse(actual)) if actual == event
         ));
     }
 

--- a/crates/turborepo/tests/tui_test.rs
+++ b/crates/turborepo/tests/tui_test.rs
@@ -362,7 +362,6 @@ fn streams_logs_and_restores_the_terminal_on_shutdown() -> Result<()> {
 }
 
 #[test]
-#[ignore = "known bug: mouse-wheel input over the sidebar does not scroll the task list"]
 fn scrolls_the_task_list_with_the_mouse_wheel_over_the_sidebar() -> Result<()> {
     let mut context = launch_tui_with(
         "list",
@@ -382,13 +381,13 @@ fn scrolls_the_task_list_with_the_mouse_wheel_over_the_sidebar() -> Result<()> {
     let before_text = before.frame.text();
     let before_tasks = visible_sidebar_tasks(&before_text);
 
-    context
-        .session
-        .send(b"\x1b[<65;5;5M\x1b[<65;5;5M\x1b[<65;5;5M\x1b[<65;5;5M\x1b[<65;5;5M")?;
-    thread::sleep(Duration::from_millis(500));
-
-    let after = capture(&mut context.session)?;
-    assert_ne!(visible_sidebar_tasks(&after.frame.text()), before_tasks);
+    context.session.send(&b"\x1b[<65;5;5M".repeat(20))?;
+    wait_for_screen(
+        &mut context.session,
+        "mouse-wheel input did not scroll the task list",
+        Duration::from_secs(2),
+        |text, _| visible_sidebar_tasks(text) != before_tasks,
+    )?;
     Ok(())
 }
 

--- a/crates/turborepo/tests/tui_test.rs
+++ b/crates/turborepo/tests/tui_test.rs
@@ -188,6 +188,15 @@ fn visible_sidebar_tasks(text: &str) -> Vec<&str> {
         .collect()
 }
 
+fn visible_pane_task(text: &str) -> Option<&str> {
+    text.lines().find_map(|line| {
+        line.split_once('│')?
+            .1
+            .split_once(" >")
+            .map(|(task, _)| task.trim())
+    })
+}
+
 fn cells_for_text<'a>(frame: &'a Frame, text: &str) -> Result<Vec<&'a Cell>> {
     let characters = text.chars().collect::<Vec<_>>();
     for y in 0..frame.rows {
@@ -380,14 +389,21 @@ fn scrolls_the_task_list_with_the_mouse_wheel_over_the_sidebar() -> Result<()> {
     let before = capture(&mut context.session)?;
     let before_text = before.frame.text();
     let before_tasks = visible_sidebar_tasks(&before_text);
+    let before_active_task = visible_pane_task(&before_text)
+        .context("visible frame did not include the active task title")?
+        .to_owned();
 
     context.session.send(&b"\x1b[<65;5;5M".repeat(20))?;
-    wait_for_screen(
+    let after = wait_for_screen(
         &mut context.session,
         "mouse-wheel input did not scroll the task list",
         Duration::from_secs(2),
         |text, _| visible_sidebar_tasks(text) != before_tasks,
     )?;
+    assert_eq!(
+        visible_pane_task(&after.frame.text()),
+        Some(before_active_task.as_str())
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- Preserve mouse-wheel coordinates through TUI input translation
- Scroll only the task-list viewport when the pointer is over the sidebar
- Keep the active task and output pane unchanged while browsing the list
- Reuse the same acceleration, throttling, and decay algorithm as log scrolling
- Keep independent momentum state for the task list and log pane
- Reattach the viewport to selection on keyboard navigation or row clicks

## Testing

- `cargo test --package turborepo-ui --features tui` (130 passed)
- `cargo test --package turbo --test tui_test scrolls_the_task_list_with_the_mouse_wheel_over_the_sidebar`
- `cargo fmt --all -- --check`
- `pnpm format`
- `pnpm lint`