### PR TITLE
feat(codemod): add truncateMiddle helper function to codemod logger utils

### DIFF
--- a/packages/turbo-codemod/src/utils/logger.ts
+++ b/packages/turbo-codemod/src/utils/logger.ts
@@ -51,3 +51,12 @@ export class Logger {
     );
   }
 }
+
+export function truncateMiddle(str: string, maxLength: number): string {
+  if (typeof str !== "string" || str.length <= maxLength || maxLength <= 3) {
+    return str;
+  }
+  const charsToShow = Math.ceil((maxLength - 3) / 2);
+  const backChars = Math.floor((maxLength - 3) / 2);
+  return `${str.slice(0, charsToShow)}...${str.slice(str.length - backChars)}`;
+}


### PR DESCRIPTION
## Description
Adds a type-safe \	runcateMiddle(str, maxLength)\ string formatting helper function to \packages/turbo-codemod/src/utils/logger.ts\ for cleanly formatting long transformer names, pipeline keys, and file paths in codemod output.

## Features
- Middle string truncation with \...\ ellipsis.
- Preserves head and tail context for readability in codemod output.