### PR TITLE
chore: Upgrade brace-expansion

### DIFF
--- a/packages/turbo-codemod/package.json
+++ b/packages/turbo-codemod/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^7.10.1",
-    "brace-expansion": "1.1.16",
+    "brace-expansion": "5.0.8",
     "commander": "9.5.0",
     "diff": "5.2.2",
     "find-up": "4.1.0",

--- a/packages/turbo-gen/package.json
+++ b/packages/turbo-gen/package.json
@@ -40,7 +40,7 @@
     "@types/fs-extra": "9.0.13",
     "@types/node": "18.17.4",
     "@types/validate-npm-package-name": "4.0.0",
-    "brace-expansion": "5.0.7",
+    "brace-expansion": "5.0.8",
     "commander": "10.0.0",
     "fs-extra": "10.1.0",
     "handlebars": "4.7.9",

--- a/packages/turbo-vsc/package.json
+++ b/packages/turbo-vsc/package.json
@@ -42,7 +42,7 @@
     "check-types": "tsc -p ./ --noEmit"
   },
   "dependencies": {
-    "brace-expansion": "2.1.2",
+    "brace-expansion": "5.0.8",
     "vscode-languageclient": "9.0.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -401,8 +401,8 @@ importers:
         specifier: ^7.10.1
         version: 7.10.1(@types/node@18.17.4)
       brace-expansion:
-        specifier: 1.1.16
-        version: 1.1.16
+        specifier: 5.0.8
+        version: 5.0.8
       commander:
         specifier: 9.5.0
         version: 9.5.0
@@ -529,8 +529,8 @@ importers:
         specifier: 4.0.0
         version: 4.0.0
       brace-expansion:
-        specifier: 5.0.7
-        version: 5.0.7
+        specifier: 5.0.8
+        version: 5.0.8
       commander:
         specifier: 10.0.0
         version: 10.0.0
@@ -864,8 +864,8 @@ importers:
   packages/turbo-vsc:
     dependencies:
       brace-expansion:
-        specifier: 2.1.2
-        version: 2.1.2
+        specifier: 5.0.8
+        version: 5.0.8
       vscode-languageclient:
         specifier: 9.0.1
         version: 9.0.1
@@ -5623,9 +5623,9 @@ packages:
   brace-expansion@2.1.2:
     resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -14715,7 +14715,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -17897,7 +17897,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.4:
     dependencies:
@@ -17913,7 +17913,7 @@ snapshots:
 
   minimatch@9.0.7:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## Summary

- upgrade the reported brace-expansion dependencies to 5.0.8
- address CVE-2026-14257 in turbo-codemod, turbo-gen, and turbo-vsc
- update the pnpm lockfile

Linear: VULN-13535, VULN-13534, VULN-13533

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --filter @turbo/workspaces build`
- `pnpm --filter @turbo/codemod test --runInBand`
- `pnpm --filter @turbo/gen build:embed`
- `pnpm --filter @turbo/gen test --runInBand`
- `pnpm --filter turbo-vsc test`
- package type checks for turbo-codemod, turbo-gen, and turbo-vsc
- pre-push format and TOML checks