### PR TITLE
fix: Make releases resumable

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -11,7 +11,7 @@
 # 7. Publish the VS Code extension from the release tag
 # 8. Alias versioned docs (e.g., v2-5-4.turborepo.dev)
 # 9. Create a release branch and open a PR, even if VS Code publishing fails
-# 10. On failure, cleanup the staging branch and release tag automatically
+# 10. On failure before npm publishing starts, cleanup the staging branch
 #
 # Canary releases run on an hourly schedule.
 # Manual releases are triggered via workflow_dispatch.
@@ -530,6 +530,8 @@ jobs:
     # TODO: Add rust-smoke-test back to needs and if-condition when re-enabled.
     needs: [stage, build-rust, js-smoke-test]
     if: ${{ always() && needs.stage.result == 'success' && needs.build-rust.result == 'success' && needs.js-smoke-test.result == 'success' }}
+    outputs:
+      publish-started: ${{ steps.publish-state.outputs.started }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -568,6 +570,11 @@ jobs:
 
       - name: Build release tool
         run: turbo run build --filter=@turbo/releaser
+
+      - name: Mark publishing started
+        if: ${{ !inputs.dry_run }}
+        id: publish-state
+        run: echo "started=true" >> "$GITHUB_OUTPUT"
 
       - name: Perform Release
         run: |
@@ -624,6 +631,20 @@ jobs:
           VERSION: ${{ needs.stage.outputs.version }}
           PREVIOUS_TAG: ${{ needs.stage.outputs.previous-tag }}
         run: |
+          EXPECTED_SHA=$(git rev-parse HEAD)
+          for ATTEMPT in {1..24}; do
+            REMOTE_SHA=$(gh api "repos/${{ github.repository }}/git/ref/tags/v${VERSION}" --jq '.object.sha' 2>/dev/null || true)
+            if [ "$REMOTE_SHA" = "$EXPECTED_SHA" ]; then
+              echo "Tag v${VERSION} is visible through the GitHub API."
+              break
+            fi
+            if [ "$ATTEMPT" -eq 24 ]; then
+              echo "::error::Tag v${VERSION} did not resolve to ${EXPECTED_SHA} through the GitHub API after 2 minutes. Last observed SHA: ${REMOTE_SHA:-missing}."
+              exit 1
+            fi
+            sleep 5
+          done
+
           PRERELEASE_FLAG=""
           if [[ "$VERSION" == *"-canary."* ]]; then
             PRERELEASE_FLAG=("--prerelease")
@@ -636,11 +657,15 @@ jobs:
             NOTES_START_TAG_FLAG=("--notes-start-tag" "$PREVIOUS_TAG")
           fi
 
-          gh release create "v${VERSION}" \
-            --title "Turborepo v${VERSION}" \
-            --generate-notes \
-            "${NOTES_START_TAG_FLAG[@]}" \
-            "${PRERELEASE_FLAG[@]}"
+          if gh release view "v${VERSION}" >/dev/null 2>&1; then
+            echo "GitHub release v${VERSION} already exists. Skipping."
+          else
+            gh release create "v${VERSION}" \
+              --title "Turborepo v${VERSION}" \
+              --generate-notes \
+              "${NOTES_START_TAG_FLAG[@]}" \
+              "${PRERELEASE_FLAG[@]}"
+          fi
 
   publish-vscode-extension:
     name: "Publish VS Code Extension"
@@ -892,6 +917,7 @@ jobs:
       ${{
         always()
         && needs.stage.result == 'success'
+        && needs.npm-publish.outputs.publish-started != 'true'
         && (
           needs.build-rust.result == 'failure'
           || needs.js-smoke-test.result == 'failure'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ docs: Update installation instructions
 
 - The `LSP` workflow packages `packages/turbo-vsc` VSIX artifacts for release. Stable and canary Turborepo versions are mapped to Marketplace-safe `major.minor.patch` versions before packaging.
 - Canary VS Code extension packages use `--pre-release`.
-- Non-dry-run releases publish the VS Code extension through the `LSP` workflow using `publish=true`, `dry_run=false`, and a `VSCE_PAT` secret on the protected `vscode-marketplace` environment. This publish path must not block release PR creation or cleanup published npm release state.
+- Non-dry-run releases publish the VS Code extension through the `LSP` workflow using `publish=true`, `dry_run=false`, and a `VSCE_PAT` secret on the protected `vscode-marketplace` environment. This publish path must not block release PR creation. Once npm publishing starts, preserve the staging branch and release tag so partial releases can be resumed safely.
+- npm publishing is resumable per package: existing versions are skipped only when registry integrity and the requested dist-tag match the local release and provenance is present, and `turbo` publishes last after the native and supporting packages.
 - The `Release` workflow signs and notarizes macOS `turbo` binaries during `build-rust` using static GitHub secrets and `apple-codesign`/`rcodesign`.
 - The `Release` and `LSP` workflows install Zig during `build-rust` because `turbo` and `turborepo-lsp` link `libghostty-vt` through `libghostty-vt-sys`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -612,11 +612,21 @@ This is because the Rust binary is never published to crates.io; it's only publi
 
 This section covers common failure scenarios and how to recover from them.
 
+#### Release Failed During or After npm Publish
+
+The workflow preserves the staging branch and any release tag once npm publishing starts. If publishing or a downstream job fails, re-run the failed jobs. The releaser checks each package version against the public npm registry: missing packages are published, while existing packages are skipped only when tarball integrity and the requested dist-tag match and a provenance attestation is present. Packages with different contents stop the release because npm versions are immutable. The primary `turbo` package is published last so it does not expose an incomplete release through the main package entry point.
+
+After `npm publish` reports an error, the releaser polls npm before retrying. If the registry accepted the package despite the CLI error, matching integrity confirms the publish and the release continues.
+
+The GitHub release step waits for the pushed tag to become visible through the GitHub API before creating the release. If that wait times out, verify that the tag points to the staging commit before re-running the failed jobs.
+
 #### Canary Release Failed Mid-Publish
 
 If a canary release fails after some packages were published but before others:
 
-1. **Identify what was published**:
+1. **Re-run the failed jobs**: The preserved staging branch and registry integrity checks allow the publisher to skip packages that completed and resume with missing packages.
+
+2. **If recovery reports different contents, identify what was published**:
 
    ```bash
    VERSION="2.6.1-canary.5"  # The failed version
@@ -625,7 +635,7 @@ If a canary release fails after some packages were published but before others:
    done
    ```
 
-2. **Option A - Deprecate and re-release**: If few packages were published, deprecate them and trigger a new canary:
+3. **Deprecate and re-release**: If a published package has different integrity, that version cannot be resumed safely. Deprecate the partial release and trigger a new canary:
 
    ```bash
    # Deprecate the partial release
@@ -636,7 +646,7 @@ If a canary release fails after some packages were published but before others:
    # Merge any PR to main to trigger a new canary release
    ```
 
-3. **Option B - Manual completion**: If most packages were published, manually publish the rest:
+4. **Manual completion**: If automated recovery is unavailable, publish the missing packages from the preserved staging branch:
 
    ```bash
    # Ensure you're on the staging branch

--- a/packages/turbo-releaser/src/config.ts
+++ b/packages/turbo-releaser/src/config.ts
@@ -10,7 +10,6 @@ export const supportedPlatforms: Array<Platform> = [
 ];
 
 export const releasePackages = [
-  { name: "turbo", directory: "packages/turbo", tarball: "turbo" },
   {
     name: "create-turbo",
     directory: "packages/create-turbo",
@@ -50,7 +49,8 @@ export const releasePackages = [
     name: "@turbo/types",
     directory: "packages/turbo-types",
     tarball: "turbo-types"
-  }
+  },
+  { name: "turbo", directory: "packages/turbo", tarball: "turbo" }
 ] as const;
 
 export const releaseBuildFilters = releasePackages

--- a/packages/turbo-releaser/src/e2e.test.ts
+++ b/packages/turbo-releaser/src/e2e.test.ts
@@ -1,8 +1,16 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { test } from "node:test";
 import path from "node:path";
 import { tmpdir, arch as osArch, platform } from "node:os";
-import { access, mkdir, realpath, rm, writeFile } from "node:fs/promises";
+import {
+  access,
+  mkdir,
+  readFile,
+  realpath,
+  rm,
+  writeFile
+} from "node:fs/promises";
 import { execFileSync, execSync } from "node:child_process";
 import { constants } from "node:fs";
 import operations from "./operations";
@@ -27,13 +35,28 @@ test("produces installable archive", async () => {
     "#!/bin/bash\necho Invoked fake turbo!"
   );
 
-  const tarPath = await operations.packPlatform({
+  const artifact = await operations.packPlatform({
     platform: { os, arch },
     version: "0.1.2",
     srcDir: tempDir,
     packagePrefix: "@turbo"
   });
-  assert.ok(path.isAbsolute(tarPath));
+  assert.equal(artifact.packageName, `@turbo/${os}-${humanArch}`);
+  assert.equal(artifact.version, "0.1.2");
+  assert.ok(path.isAbsolute(artifact.tarball));
+  const firstIntegrity = createHash("sha512")
+    .update(new Uint8Array(await readFile(artifact.tarball)))
+    .digest("base64");
+  const rebuiltArtifact = await operations.packPlatform({
+    platform: { os, arch },
+    version: "0.1.2",
+    srcDir: tempDir,
+    packagePrefix: "@turbo"
+  });
+  const rebuiltIntegrity = createHash("sha512")
+    .update(new Uint8Array(await readFile(rebuiltArtifact.tarball)))
+    .digest("base64");
+  assert.equal(rebuiltIntegrity, firstIntegrity);
 
   // Make a fake repo to install the tarball in
   const fakeRepo = path.join(tempDir, "fake-repo");
@@ -42,7 +65,7 @@ test("produces installable archive", async () => {
     path.join(fakeRepo, "package.json"),
     JSON.stringify({ name: "fake-repo" })
   );
-  execFileSync("npm", ["install", tarPath], { cwd: fakeRepo });
+  execFileSync("npm", ["install", artifact.tarball], { cwd: fakeRepo });
 
   // The scoped platform package installs the binary at a known path.
   // In production, the main `turbo` package resolves it via require.resolve.

--- a/packages/turbo-releaser/src/native.ts
+++ b/packages/turbo-releaser/src/native.ts
@@ -19,6 +19,14 @@ export const nodeOSLookup: Record<SupportedOS, NpmOs> = {
   windows: "win32"
 };
 
+export function getNativePackageName(
+  packagePrefix: string,
+  { os, arch }: Platform
+) {
+  const separator = packagePrefix.startsWith("@") ? "/" : "-";
+  return `${packagePrefix}${separator}${os}-${archToHuman[arch]}`;
+}
+
 const templateDir = path.join(__dirname, "..", "template");
 
 async function generateNativePackage({
@@ -61,9 +69,8 @@ async function generateNativePackage({
 
   console.log("Generating package.json...");
   const isScoped = packagePrefix.startsWith("@");
-  const separator = isScoped ? "/" : "-";
   const packageJson: Record<string, unknown> = {
-    name: `${packagePrefix}${separator}${os}-${archToHuman[arch]}`,
+    name: getNativePackageName(packagePrefix, platform),
     version,
     description:
       description ||
@@ -110,4 +117,4 @@ function resolveOutputDir(outputDir: string, outputBaseDir: string) {
 
 // Exported asn an object instead of export keyword, so that these functions
 // can be mocked in tests.
-export default { generateNativePackage, archToHuman };
+export default { generateNativePackage, getNativePackageName, archToHuman };

--- a/packages/turbo-releaser/src/npm.test.ts
+++ b/packages/turbo-releaser/src/npm.test.ts
@@ -1,56 +1,271 @@
 import assert from "node:assert/strict";
-import { describe, it, mock } from "node:test";
+import { createHash } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, it, mock } from "node:test";
 import { publishWithRetries } from "./npm";
 
+const tempDirectories: Array<string> = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true }))
+  );
+});
+
+async function createTarball() {
+  const directory = await mkdtemp(path.join(tmpdir(), "turbo-releaser-npm-"));
+  tempDirectories.push(directory);
+  const contents = new TextEncoder().encode("release artifact");
+  const tarball = path.join(directory, "package.tgz");
+  await writeFile(tarball, contents);
+  return {
+    tarball,
+    integrity: `sha512-${createHash("sha512").update(contents).digest("base64")}`
+  };
+}
+
+const missing = {
+  status: 1,
+  stdout: "",
+  stderr: "npm error code E404"
+};
+
+function registryMetadata(
+  integrity: string,
+  tagVersion = "1.0.0",
+  npmTag = "latest"
+) {
+  return JSON.stringify({
+    "dist.integrity": integrity,
+    "dist.attestations": {
+      provenance: { predicateType: "https://slsa.dev/provenance/v1" }
+    },
+    [`dist-tags.${npmTag}`]: tagVersion
+  });
+}
+
 describe("publishWithRetries", () => {
-  it("retries npm provenance failures", async () => {
-    let attempts = 0;
+  it("publishes a missing package", async () => {
+    const { tarball } = await createTarball();
     const spawn = mock.fn(
-      (_command: string, _args: Array<string>, _options: object) => {
-        attempts += 1;
+      (_command: string, args: Array<string>, _options: object) =>
+        args[0] === "view"
+          ? missing
+          : { status: 0, stdout: "published", stderr: "" }
+    );
+
+    await publishWithRetries({
+      packageName: "@turbo/example",
+      version: "1.0.0",
+      tarball,
+      npmTag: "latest",
+      dependencies: { spawn, wait: async () => undefined }
+    });
+
+    assert.equal(
+      spawn.mock.calls.filter(({ arguments: args }) => args[1][0] === "publish")
+        .length,
+      1
+    );
+  });
+
+  it("skips an existing package with matching integrity", async () => {
+    const { tarball, integrity } = await createTarball();
+    const mismatchedIntegrity = `sha512-${createHash("sha512").update("different").digest("base64")}`;
+    const spawn = mock.fn(
+      (_command: string, _args: Array<string>, _options: object) => ({
+        status: 0,
+        stdout: registryMetadata(`${mismatchedIntegrity} ${integrity}`),
+        stderr: ""
+      })
+    );
+
+    await publishWithRetries({
+      packageName: "turbo",
+      version: "1.0.0",
+      tarball,
+      npmTag: "latest",
+      dependencies: { spawn, wait: async () => undefined }
+    });
+
+    assert.equal(spawn.mock.callCount(), 1);
+  });
+
+  it("fails closed when the registry lookup fails", async () => {
+    const { tarball } = await createTarball();
+    const spawn = mock.fn(
+      (_command: string, _args: Array<string>, _options: object) => ({
+        status: 1,
+        stdout: "",
+        stderr: "npm error code E401"
+      })
+    );
+
+    await assert.rejects(
+      publishWithRetries({
+        packageName: "turbo",
+        version: "1.0.0",
+        tarball,
+        npmTag: "latest",
+        dependencies: { spawn, wait: async () => undefined }
+      }),
+      /Unable to check whether turbo@1\.0\.0 exists/
+    );
+    assert.equal(spawn.mock.callCount(), 1);
+  });
+
+  it("accepts a package committed before npm reported failure", async () => {
+    const { tarball, integrity } = await createTarball();
+    let lookupCount = 0;
+    const spawn = mock.fn(
+      (_command: string, args: Array<string>, _options: object) => {
+        if (args[0] === "publish") {
+          return { status: 1, stdout: "", stderr: "socket closed" };
+        }
+        lookupCount += 1;
+        return lookupCount === 1
+          ? missing
+          : {
+              status: 0,
+              stdout: registryMetadata(integrity),
+              stderr: ""
+            };
+      }
+    );
+
+    await publishWithRetries({
+      packageName: "turbo",
+      version: "1.0.0",
+      tarball,
+      npmTag: "latest",
+      dependencies: { spawn, wait: async () => undefined }
+    });
+
+    assert.equal(
+      spawn.mock.calls.filter(({ arguments: args }) => args[1][0] === "publish")
+        .length,
+      1
+    );
+  });
+
+  it("rejects an existing package with different contents", async () => {
+    const { tarball } = await createTarball();
+    const integrity = `sha512-${createHash("sha512").update("different").digest("base64")}`;
+    const spawn = mock.fn(
+      (_command: string, _args: Array<string>, _options: object) => ({
+        status: 0,
+        stdout: registryMetadata(integrity),
+        stderr: ""
+      })
+    );
+
+    await assert.rejects(
+      publishWithRetries({
+        packageName: "turbo",
+        version: "1.0.0",
+        tarball,
+        npmTag: "latest",
+        dependencies: { spawn, wait: async () => undefined }
+      }),
+      /different contents/
+    );
+    assert.equal(spawn.mock.callCount(), 1);
+  });
+
+  it("rejects an existing package when the requested tag points elsewhere", async () => {
+    const { tarball, integrity } = await createTarball();
+    const spawn = mock.fn(
+      (_command: string, _args: Array<string>, _options: object) => ({
+        status: 0,
+        stdout: registryMetadata(integrity, "0.9.0"),
+        stderr: ""
+      })
+    );
+
+    await assert.rejects(
+      publishWithRetries({
+        packageName: "turbo",
+        version: "1.0.0",
+        tarball,
+        npmTag: "latest",
+        dependencies: { spawn, wait: async () => undefined }
+      }),
+      /npm tag latest points to 0\.9\.0/
+    );
+  });
+
+  it("retries transient lookups while reconciling a failed publish", async () => {
+    const { tarball, integrity } = await createTarball();
+    let lookupCount = 0;
+    const spawn = mock.fn(
+      (_command: string, args: Array<string>, _options: object) => {
+        if (args[0] === "publish") {
+          return { status: 1, stdout: "", stderr: "socket closed" };
+        }
+        lookupCount += 1;
+        if (lookupCount === 1) {
+          return missing;
+        }
+        if (lookupCount === 2) {
+          return { status: 1, stdout: "", stderr: "npm error code E500" };
+        }
         return {
-          status: attempts < 3 ? 1 : 0,
-          stdout: "",
-          stderr: attempts < 3 ? "TLOG_CREATE_ENTRY_ERROR" : "published"
+          status: 0,
+          stdout: registryMetadata(integrity),
+          stderr: ""
         };
       }
     );
     const wait = mock.fn((_milliseconds: number) => Promise.resolve());
 
     await publishWithRetries({
-      packageName: "turbo@1.0.0",
-      tarball: "/tmp/turbo.tgz",
+      packageName: "turbo",
+      version: "1.0.0",
+      tarball,
       npmTag: "latest",
       dependencies: { spawn, wait }
     });
 
-    assert.equal(spawn.mock.callCount(), 3);
     assert.deepEqual(
       wait.mock.calls.map(({ arguments: args }) => args[0]),
-      [10_000, 20_000]
+      [2000]
     );
   });
 
-  it("does not retry unrelated failures", async () => {
+  it("retries provenance failures when the package is still missing", async () => {
+    const { tarball } = await createTarball();
+    let publishAttempts = 0;
     const spawn = mock.fn(
-      (_command: string, _args: Array<string>, _options: object) => ({
-        status: 1,
-        stdout: "",
-        stderr: "npm authentication failed"
-      })
+      (_command: string, args: Array<string>, _options: object) => {
+        if (args[0] === "view") {
+          return missing;
+        }
+        publishAttempts += 1;
+        return {
+          status: publishAttempts < 3 ? 1 : 0,
+          stdout: "",
+          stderr: publishAttempts < 3 ? "TLOG_CREATE_ENTRY_ERROR" : "published"
+        };
+      }
     );
     const wait = mock.fn((_milliseconds: number) => Promise.resolve());
 
-    await assert.rejects(
-      publishWithRetries({
-        packageName: "turbo@1.0.0",
-        tarball: "/tmp/turbo.tgz",
-        npmTag: "latest",
-        dependencies: { spawn, wait }
-      }),
-      /npm publish failed/
+    await publishWithRetries({
+      packageName: "turbo",
+      version: "1.0.0",
+      tarball,
+      npmTag: "latest",
+      dependencies: { spawn, wait }
+    });
+
+    assert.equal(publishAttempts, 3);
+    assert.deepEqual(
+      wait.mock.calls.map(({ arguments: args }) => args[0]),
+      [2000, 4000, 10_000, 2000, 4000, 20_000]
     );
-    assert.equal(spawn.mock.callCount(), 1);
-    assert.equal(wait.mock.callCount(), 0);
   });
 });

--- a/packages/turbo-releaser/src/npm.ts
+++ b/packages/turbo-releaser/src/npm.ts
@@ -1,41 +1,86 @@
 import { spawnSync } from "node:child_process";
+import { createHash, timingSafeEqual } from "node:crypto";
+import { readFile } from "node:fs/promises";
 import { setTimeout } from "node:timers/promises";
 
 const PROVENANCE_ERROR = /TLOG_CREATE_ENTRY_ERROR|error creating tlog entry/;
+const NOT_FOUND_ERROR = /\bcode E404\b/;
 const NPM_OUTPUT_BUFFER_BYTES = 50 * 1024 * 1024;
+const NPM_REGISTRY = "https://registry.npmjs.org";
+const SUPPORTED_INTEGRITY_ALGORITHMS = ["sha512", "sha384", "sha256"] as const;
+
+interface SpawnResult {
+  status: number | null;
+  stdout: string | null;
+  stderr: string | null;
+  error?: Error;
+}
 
 interface PublishDependencies {
   spawn: (
     command: string,
     args: Array<string>,
     options: { encoding: "utf8"; maxBuffer: number }
-  ) => { status: number | null; stdout: string | null; stderr: string | null };
+  ) => SpawnResult;
   wait: (milliseconds: number) => Promise<unknown>;
 }
 
+type RegistryPackage =
+  | { status: "missing" }
+  | { status: "published"; integrity: string; tagVersion: string };
+
+const defaultDependencies: PublishDependencies = {
+  spawn: (command, args, options) => spawnSync(command, args, options),
+  wait: setTimeout
+};
+
 export async function publishWithRetries({
   packageName,
+  version,
   tarball,
   npmTag,
   accessPublic = false,
-  dependencies = {
-    spawn: (command, args, options) => spawnSync(command, args, options),
-    wait: setTimeout
-  }
+  dependencies = defaultDependencies
 }: {
   packageName: string;
+  version: string;
   tarball: string;
   npmTag: string;
   accessPublic?: boolean;
   dependencies?: PublishDependencies;
 }) {
+  const packageSpec = `${packageName}@${version}`;
+  const tarballContents = new Uint8Array(await readFile(tarball));
   const maxAttempts = 3;
 
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const existingPackage = lookupPackage(packageSpec, npmTag, dependencies);
+    if (existingPackage.status === "published") {
+      verifyPublishedPackage(
+        packageSpec,
+        version,
+        tarballContents,
+        npmTag,
+        existingPackage
+      );
+      console.log(
+        `${packageSpec} already exists with matching integrity. Skipping.`
+      );
+      return;
+    }
+
     console.log(
-      `Publishing ${packageName} (attempt ${attempt}/${maxAttempts})`
+      `Publishing ${packageSpec} (attempt ${attempt}/${maxAttempts})`
     );
-    const args = ["publish", "-ddd", "--tag", npmTag, tarball];
+    const args = [
+      "publish",
+      "-ddd",
+      "--registry",
+      NPM_REGISTRY,
+      "--tag",
+      npmTag,
+      tarball
+    ];
     if (accessPublic) {
       args.push("--access", "public");
     }
@@ -46,21 +91,196 @@ export async function publishWithRetries({
     process.stdout.write(result.stdout ?? "");
     process.stderr.write(result.stderr ?? "");
 
-    if (result.status === 0) {
+    if (result.status === 0 && !result.error) {
+      return;
+    }
+
+    if (
+      await publishedAfterFailure(
+        packageSpec,
+        version,
+        tarballContents,
+        npmTag,
+        dependencies
+      )
+    ) {
+      console.log(
+        `${packageSpec} was published despite npm reporting an error.`
+      );
       return;
     }
 
     const output = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
     if (!PROVENANCE_ERROR.test(output) || attempt === maxAttempts) {
       throw new Error(
-        `npm publish failed for ${packageName} with status ${result.status ?? "unknown"}`
+        `npm publish failed for ${packageSpec} with status ${result.status ?? "unknown"}`,
+        { cause: result.error }
       );
     }
 
     const delaySeconds = attempt * 10;
     console.log(
-      `Retrying ${packageName} after npm provenance tlog failure in ${delaySeconds} seconds...`
+      `Retrying ${packageSpec} after npm provenance tlog failure in ${delaySeconds} seconds...`
     );
     await dependencies.wait(delaySeconds * 1000);
+  }
+}
+
+function lookupPackage(
+  packageSpec: string,
+  npmTag: string,
+  dependencies: PublishDependencies
+): RegistryPackage {
+  const tagField = `dist-tags.${npmTag}`;
+  const result = dependencies.spawn(
+    "npm",
+    [
+      "view",
+      packageSpec,
+      "dist.integrity",
+      "dist.attestations",
+      tagField,
+      "--json",
+      "--registry",
+      NPM_REGISTRY
+    ],
+    {
+      encoding: "utf8",
+      maxBuffer: NPM_OUTPUT_BUFFER_BYTES
+    }
+  );
+  if (result.status !== 0 || result.error) {
+    const output = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+    if (NOT_FOUND_ERROR.test(output)) {
+      return { status: "missing" };
+    }
+    throw new Error(
+      `Unable to check whether ${packageSpec} exists on npm (status ${result.status ?? "unknown"})`,
+      { cause: result.error }
+    );
+  }
+
+  let metadata: unknown;
+  try {
+    metadata = JSON.parse(result.stdout ?? "");
+  } catch (error) {
+    throw new Error(`npm returned invalid metadata for ${packageSpec}`, {
+      cause: error
+    });
+  }
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    throw new Error(`npm returned invalid metadata for ${packageSpec}`);
+  }
+  const integrity = Reflect.get(metadata, "dist.integrity") as unknown;
+  const attestations = Reflect.get(metadata, "dist.attestations") as unknown;
+  const tagVersion = Reflect.get(metadata, tagField) as unknown;
+  if (typeof integrity !== "string" || integrity.length === 0) {
+    throw new Error(`npm returned no integrity metadata for ${packageSpec}`);
+  }
+  if (typeof tagVersion !== "string" || tagVersion.length === 0) {
+    throw new Error(`npm tag ${npmTag} does not point to ${packageSpec}`);
+  }
+  if (
+    !attestations ||
+    typeof attestations !== "object" ||
+    Reflect.get(attestations, "provenance") === undefined
+  ) {
+    throw new Error(
+      `npm returned no provenance attestation for ${packageSpec}`
+    );
+  }
+  return { status: "published", integrity, tagVersion };
+}
+
+async function publishedAfterFailure(
+  packageSpec: string,
+  version: string,
+  tarballContents: Uint8Array,
+  npmTag: string,
+  dependencies: PublishDependencies
+) {
+  let lastLookupError: unknown;
+  for (let check = 1; check <= 3; check += 1) {
+    if (check > 1) {
+      await dependencies.wait((check - 1) * 2000);
+    }
+    let existingPackage: RegistryPackage;
+    try {
+      existingPackage = lookupPackage(packageSpec, npmTag, dependencies);
+      lastLookupError = undefined;
+    } catch (error) {
+      lastLookupError = error;
+      continue;
+    }
+    if (existingPackage.status === "published") {
+      verifyPublishedPackage(
+        packageSpec,
+        version,
+        tarballContents,
+        npmTag,
+        existingPackage
+      );
+      return true;
+    }
+  }
+  if (lastLookupError) {
+    throw new Error(`Unable to reconcile failed publish for ${packageSpec}`, {
+      cause: lastLookupError
+    });
+  }
+  return false;
+}
+
+function verifyPublishedPackage(
+  packageSpec: string,
+  version: string,
+  tarballContents: Uint8Array,
+  npmTag: string,
+  registryPackage: Extract<RegistryPackage, { status: "published" }>
+) {
+  verifyIntegrity(packageSpec, tarballContents, registryPackage.integrity);
+  if (registryPackage.tagVersion !== version) {
+    throw new Error(
+      `${packageSpec} exists with matching integrity, but npm tag ${npmTag} points to ${registryPackage.tagVersion}.`
+    );
+  }
+}
+
+function verifyIntegrity(
+  packageSpec: string,
+  tarballContents: Uint8Array,
+  registryIntegrity: string
+) {
+  const entries = registryIntegrity
+    .trim()
+    .split(/\s+/)
+    .map((entry) =>
+      /^(sha512|sha384|sha256)-([A-Za-z0-9+/]+={0,2})$/.exec(entry)
+    )
+    .filter((entry) => entry !== null);
+  const algorithm = SUPPORTED_INTEGRITY_ALGORITHMS.find((candidate) =>
+    entries.some((entry) => entry[1] === candidate)
+  );
+  if (!algorithm) {
+    throw new Error(
+      `npm returned unsupported integrity metadata for ${packageSpec}: ${registryIntegrity}`
+    );
+  }
+
+  const actual = new Uint8Array(
+    createHash(algorithm).update(tarballContents).digest()
+  );
+  const matches = entries
+    .filter((entry) => entry[1] === algorithm)
+    .some((entry) => {
+      const expected = new Uint8Array(Buffer.from(entry[2], "base64"));
+      return (
+        expected.length === actual.length && timingSafeEqual(expected, actual)
+      );
+    });
+  if (!matches) {
+    throw new Error(
+      `${packageSpec} already exists on npm with different contents. This version cannot be resumed safely.`
+    );
   }
 }

--- a/packages/turbo-releaser/src/operations.ts
+++ b/packages/turbo-releaser/src/operations.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import { execFileSync } from "node:child_process";
 import * as tar from "tar";
 import native from "./native";
-import type { Platform } from "./types";
+import type { NpmPackageArtifact, Platform } from "./types";
 import { publishWithRetries } from "./npm";
 
 export interface PackOptions {
@@ -58,7 +58,7 @@ async function packPlatform({
   binaryName: binaryBaseName = "turbo",
   srcDirPrefix = "dist",
   description
-}: PackOptions): Promise<string> {
+}: PackOptions): Promise<NpmPackageArtifact> {
   validateVersion(version);
   validatePackagePrefix(packagePrefix);
   validatePathSegment("binary name", binaryBaseName);
@@ -107,16 +107,25 @@ async function packPlatform({
     {
       gzip: true,
       file: tarPath,
-      cwd: tarballDir
+      cwd: tarballDir,
+      portable: true,
+      mtime: new Date(0)
     },
     [npmDirName]
   );
 
   console.log(`Artifact created: ${tarPath}`);
-  return path.resolve(tarPath);
+  return {
+    packageName: native.getNativePackageName(packagePrefix, platform),
+    version,
+    tarball: path.resolve(tarPath)
+  };
 }
 
-async function publishArtifacts(artifacts: Array<string>, npmTag: string) {
+async function publishArtifacts(
+  artifacts: Array<NpmPackageArtifact>,
+  npmTag: string
+) {
   validateNpmTag(npmTag);
 
   for (const artifact of artifacts) {
@@ -125,8 +134,7 @@ async function publishArtifacts(artifacts: Array<string>, npmTag: string) {
     }).trim();
     console.log(`npm version: ${npmVersion}`);
     await publishWithRetries({
-      packageName: artifact,
-      tarball: artifact,
+      ...artifact,
       npmTag,
       accessPublic: true
     });

--- a/packages/turbo-releaser/src/packager.test.ts
+++ b/packages/turbo-releaser/src/packager.test.ts
@@ -3,15 +3,19 @@ import assert from "node:assert/strict";
 import { packAndPublish } from "./packager";
 import type { Platform } from "./types";
 import operations from "./operations";
+import type { NpmPackageArtifact } from "./types";
 
 describe("packager", () => {
   describe("packAndPublish", () => {
     it("should pack and publish for all platforms when skipPublish is false", async (t) => {
-      const mockPackPlatform = mock.fn(() =>
-        Promise.resolve("/path/to/artifact.tgz")
-      );
-      const mockPublishArtifacts = mock.fn((_paths: Array<string>) =>
-        Promise.resolve()
+      const artifact: NpmPackageArtifact = {
+        packageName: "@turbo/darwin-64",
+        version: "1.0.0",
+        tarball: "/path/to/artifact.tgz"
+      };
+      const mockPackPlatform = mock.fn(() => Promise.resolve(artifact));
+      const mockPublishArtifacts = mock.fn(
+        (_artifacts: Array<NpmPackageArtifact>) => Promise.resolve()
       );
       t.mock.method(operations, "packPlatform", mockPackPlatform);
       t.mock.method(operations, "publishArtifacts", mockPublishArtifacts);
@@ -28,14 +32,18 @@ describe("packager", () => {
       assert.equal(mockPackPlatform.mock.calls.length, 2);
       assert.equal(mockPublishArtifacts.mock.calls.length, 1);
       assert.deepEqual(mockPublishArtifacts.mock.calls[0].arguments, [
-        ["/path/to/artifact.tgz", "/path/to/artifact.tgz"],
+        [artifact, artifact],
         "latest"
       ]);
     });
 
     it("should pack but not publish when skipPublish is true", async (t) => {
       const mockPackPlatform = mock.fn(() =>
-        Promise.resolve("/path/to/artifact.tgz")
+        Promise.resolve({
+          packageName: "@turbo/darwin-64",
+          version: "1.0.0",
+          tarball: "/path/to/artifact.tgz"
+        })
       );
       const mockPublishArtifacts = mock.fn();
 

--- a/packages/turbo-releaser/src/packager.ts
+++ b/packages/turbo-releaser/src/packager.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import type { Platform } from "./types";
+import type { NpmPackageArtifact, Platform } from "./types";
 import operations from "./operations";
 
 interface PackAndPublishOptions {
@@ -26,7 +26,7 @@ export async function packAndPublish({
   description
 }: PackAndPublishOptions) {
   console.log("Starting packAndPublish process...");
-  const artifacts: Array<string> = [];
+  const artifacts: Array<NpmPackageArtifact> = [];
 
   for (const platform of platforms) {
     console.log(`Processing platform: ${platform.os}-${platform.arch}`);

--- a/packages/turbo-releaser/src/publish.test.ts
+++ b/packages/turbo-releaser/src/publish.test.ts
@@ -72,11 +72,9 @@ describe("publishRelease", () => {
     await mkdir(root, { recursive: true });
     await writeFile(path.join(root, "version.txt"), "1.2.3\nlatest\n");
 
-    const run = mock.fn((command: string, args: Array<string>) => {
-      if (command === "npm" && args[0] === "view") {
-        throw new Error("not found");
-      }
-    });
+    const run = mock.fn(
+      (_command: string, _args: Array<string>, _options: object) => undefined
+    );
     const publish = mock.fn(
       (_options: Parameters<typeof publishWithRetries>[0]) => Promise.resolve()
     );
@@ -97,38 +95,8 @@ describe("publishRelease", () => {
 
     assert.deepEqual(
       publish.mock.calls.map(({ arguments: args }) => args[0].packageName),
-      releasePackages.map(({ name }) => `${name}@1.2.3`)
+      releasePackages.map(({ name }) => name)
     );
-  });
-
-  it("refuses to publish an existing turbo version", async () => {
-    const root = path.join(tmpdir(), "turbo-releaser-existing-test");
-    await rm(root, { recursive: true, force: true });
-    await mkdir(root, { recursive: true });
-    await writeFile(path.join(root, "version.txt"), "1.2.3\nlatest\n");
-
-    await assert.rejects(
-      publishRelease({
-        repoRoot: root,
-        artifactsDir: "release-artifacts",
-        versionPath: "version.txt",
-        skipPublish: false,
-        dependencies: {
-          run: mock.fn(
-            (_command: string, _args: Array<string>, _options: object) =>
-              undefined
-          ),
-          packAndPublish: mock.fn(
-            (_options: Parameters<typeof packAndPublish>[0]) =>
-              Promise.resolve()
-          ),
-          publishWithRetries: mock.fn(
-            (_options: Parameters<typeof publishWithRetries>[0]) =>
-              Promise.resolve()
-          )
-        }
-      }),
-      /turbo@1\.2\.3 already exists/
-    );
+    assert.equal(publish.mock.calls.at(-1)?.arguments[0].packageName, "turbo");
   });
 });

--- a/packages/turbo-releaser/src/publish.ts
+++ b/packages/turbo-releaser/src/publish.ts
@@ -80,34 +80,12 @@ export async function publishRelease({
     return;
   }
 
-  const existingVersion = npmVersionExists(version, root, dependencies.run);
-  if (existingVersion) {
-    throw new Error(
-      `turbo@${version} already exists on npm. A previous release may still be merging.`
-    );
-  }
-
   for (const releasePackage of releasePackages) {
     await dependencies.publishWithRetries({
-      packageName: `${releasePackage.name}@${version}`,
+      packageName: releasePackage.name,
+      version,
       tarball: path.join(root, `${releasePackage.tarball}-${version}.tgz`),
       npmTag
     });
-  }
-}
-
-function npmVersionExists(
-  version: string,
-  cwd: string,
-  run: PublishReleaseDependencies["run"]
-): boolean {
-  try {
-    run("npm", ["view", `turbo@${version}`, "version"], {
-      cwd,
-      stdio: "ignore"
-    });
-    return true;
-  } catch {
-    return false;
   }
 }

--- a/packages/turbo-releaser/src/types.ts
+++ b/packages/turbo-releaser/src/types.ts
@@ -7,3 +7,9 @@ export interface Platform {
   os: SupportedOS;
   arch: SupportedArch;
 }
+
+export interface NpmPackageArtifact {
+  packageName: string;
+  version: string;
+  tarball: string;
+}


### PR DESCRIPTION
## Summary

- Make npm publishing resumable per package by verifying registry integrity, provenance presence, and the requested dist-tag before skipping existing versions.
- Reconcile ambiguous publish failures against npm, generate deterministic native archives, and publish `turbo` last.
- Preserve recovery refs after publishing starts, wait for GitHub tag visibility, and make GitHub release creation idempotent.
- Document partial-release recovery procedures.

## Testing

- `pnpm --filter @turbo/releaser test`
- `pnpm --filter @turbo/releaser check-types`
- `pnpm --filter @turbo/releaser build`
- `pnpm exec oxfmt --check ...`
- YAML parsing for `.github/workflows/turborepo-release.yml`
- Pre-push hooks (`format`, `check:toml`)