### PR TITLE
ci: Parallelize environment setup steps

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,11 +44,19 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Environment
-        uses: ./.github/actions/setup-environment
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          node: "false"
+      - parallel:
+          - name: Setup Rust
+            uses: ./.github/actions/setup-rust
+            with:
+              shared-cache-key: turborepo-debug-build
+              save-cache: true
+              github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+          - name: Setup Zig
+            uses: ./.github/actions/setup-zig
+
+          - name: Setup capnproto
+            uses: ./.github/actions/setup-capnproto
 
       - name: Run cargo clippy
         run: cargo lint
@@ -83,14 +91,15 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Turborepo Remote Cache
-        if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7 # main
-        with:
-          team: ${{ vars.TURBO_TEAM }}
+      - parallel:
+          - name: Set up Turborepo Remote Cache
+            if: github.event.pull_request.head.repo.full_name == github.repository
+            uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7 # main
+            with:
+              team: ${{ vars.TURBO_TEAM }}
 
-      - name: "Setup Node"
-        uses: ./.github/actions/setup-node
+          - name: "Setup Node"
+            uses: ./.github/actions/setup-node
 
       - name: Install Global Turbo
         uses: ./.github/actions/install-global-turbo

--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -81,17 +81,18 @@ jobs:
         if: ${{ matrix.settings.prepare }}
         run: ${{ matrix.settings.prepare }}
 
-      - name: Setup capnproto
-        uses: ./.github/actions/setup-capnproto
+      - parallel:
+          - name: Setup capnproto
+            uses: ./.github/actions/setup-capnproto
 
-      - name: Rust Setup
-        uses: ./.github/actions/setup-rust
-        with:
-          github-token: ${{ github.token }}
-          targets: ${{ matrix.settings.target }}
+          - name: Rust Setup
+            uses: ./.github/actions/setup-rust
+            with:
+              github-token: ${{ github.token }}
+              targets: ${{ matrix.settings.target }}
 
-      - name: Setup Zig
-        uses: ./.github/actions/setup-zig
+          - name: Setup Zig
+            uses: ./.github/actions/setup-zig
 
       - name: Build Setup
         shell: bash
@@ -122,11 +123,6 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
           persist-credentials: false
 
-      - name: Setup Node
-        uses: ./.github/actions/setup-node
-        with:
-          extra-flags: "--frozen-lockfile"
-
       - name: Validate manual publish ref
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish && !inputs.dry_run }}
         env:
@@ -137,41 +133,47 @@ jobs:
             exit 1
           fi
 
-      - name: Download darwin arm64 LSP
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: turborepo-lsp-aarch64-apple-darwin
-          path: packages/turbo-vsc/out/artifacts/turborepo-lsp-aarch64-apple-darwin
+      - parallel:
+          - name: Setup Node
+            uses: ./.github/actions/setup-node
+            with:
+              extra-flags: "--frozen-lockfile"
 
-      - name: Download darwin x64 LSP
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: turborepo-lsp-x86_64-apple-darwin
-          path: packages/turbo-vsc/out/artifacts/turborepo-lsp-x86_64-apple-darwin
+          - name: Download darwin arm64 LSP
+            uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+            with:
+              name: turborepo-lsp-aarch64-apple-darwin
+              path: packages/turbo-vsc/out/artifacts/turborepo-lsp-aarch64-apple-darwin
 
-      - name: Download linux arm64 LSP
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: turborepo-lsp-aarch64-unknown-linux-musl
-          path: packages/turbo-vsc/out/artifacts/turborepo-lsp-aarch64-unknown-linux-musl
+          - name: Download darwin x64 LSP
+            uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+            with:
+              name: turborepo-lsp-x86_64-apple-darwin
+              path: packages/turbo-vsc/out/artifacts/turborepo-lsp-x86_64-apple-darwin
 
-      - name: Download linux x64 LSP
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: turborepo-lsp-x86_64-unknown-linux-musl
-          path: packages/turbo-vsc/out/artifacts/turborepo-lsp-x86_64-unknown-linux-musl
+          - name: Download linux arm64 LSP
+            uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+            with:
+              name: turborepo-lsp-aarch64-unknown-linux-musl
+              path: packages/turbo-vsc/out/artifacts/turborepo-lsp-aarch64-unknown-linux-musl
 
-      - name: Download win32 arm64 LSP
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: turborepo-lsp-aarch64-pc-windows-msvc
-          path: packages/turbo-vsc/out/artifacts/turborepo-lsp-aarch64-pc-windows-msvc
+          - name: Download linux x64 LSP
+            uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+            with:
+              name: turborepo-lsp-x86_64-unknown-linux-musl
+              path: packages/turbo-vsc/out/artifacts/turborepo-lsp-x86_64-unknown-linux-musl
 
-      - name: Download win32 x64 LSP
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: turborepo-lsp-x86_64-pc-windows-msvc
-          path: packages/turbo-vsc/out/artifacts/turborepo-lsp-x86_64-pc-windows-msvc
+          - name: Download win32 arm64 LSP
+            uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+            with:
+              name: turborepo-lsp-aarch64-pc-windows-msvc
+              path: packages/turbo-vsc/out/artifacts/turborepo-lsp-aarch64-pc-windows-msvc
+
+          - name: Download win32 x64 LSP
+            uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+            with:
+              name: turborepo-lsp-x86_64-pc-windows-msvc
+              path: packages/turbo-vsc/out/artifacts/turborepo-lsp-x86_64-pc-windows-msvc
 
       - name: Stamp extension version
         id: version
@@ -307,16 +309,17 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
           persist-credentials: false
 
-      - name: Setup Node
-        uses: ./.github/actions/setup-node
-        with:
-          extra-flags: "--frozen-lockfile"
+      - parallel:
+          - name: Setup Node
+            uses: ./.github/actions/setup-node
+            with:
+              extra-flags: "--frozen-lockfile"
 
-      - name: Download VSIX
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: turbo-vsc-${{ needs.package-vscode.outputs.version }}
-          path: packages/turbo-vsc
+          - name: Download VSIX
+            uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+            with:
+              name: turbo-vsc-${{ needs.package-vscode.outputs.version }}
+              path: packages/turbo-vsc
 
       - name: Publish VSIX
         working-directory: packages/turbo-vsc

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -116,21 +116,22 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Set up Turborepo Remote Cache
-        if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7 # main
-        with:
-          team: ${{ vars.TURBO_TEAM }}
+      - parallel:
+          - name: Set up Turborepo Remote Cache
+            if: github.event.pull_request.head.repo.full_name == github.repository
+            uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7 # main
+            with:
+              team: ${{ vars.TURBO_TEAM }}
 
-      - name: "Setup Node"
-        uses: ./.github/actions/setup-node
-        with:
-          node-version: ${{ matrix.node-version }}
-        env:
-          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+          - name: "Setup Node"
+            uses: ./.github/actions/setup-node
+            with:
+              node-version: ${{ matrix.node-version }}
+            env:
+              PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
 
-      - name: Install Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+          - name: Install Bun
+            uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install Global Turbo
         uses: ./.github/actions/install-global-turbo

--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -117,23 +117,24 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Setup Rust
-        uses: ./.github/actions/setup-rust
-        with:
-          targets: ${{ matrix.settings.target }}
-          github-token: ${{ github.token }}
-        if: ${{ !matrix.settings.install }}
+      - parallel:
+          - name: Setup Rust
+            uses: ./.github/actions/setup-rust
+            with:
+              targets: ${{ matrix.settings.target }}
+              github-token: ${{ github.token }}
+            if: ${{ !matrix.settings.install }}
 
-      - name: Setup Node
-        uses: ./.github/actions/setup-node
-        with:
-          enable-corepack: false
-        if: ${{ !matrix.settings.install }}
+          - name: Setup Node
+            uses: ./.github/actions/setup-node
+            with:
+              enable-corepack: false
+            if: ${{ !matrix.settings.install }}
 
-      - name: Setup capnproto
-        uses: ./.github/actions/setup-capnproto
-        with:
-          use-cache: ${{ !matrix.settings.install }}
+          - name: Setup capnproto
+            uses: ./.github/actions/setup-capnproto
+            with:
+              use-cache: ${{ !matrix.settings.install }}
 
       - name: Setup toolchain
         run: ${{ matrix.settings.setup }}
@@ -171,11 +172,17 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Setup Node
-        uses: ./.github/actions/setup-node
-        with:
-          enable-corepack: false
-          package-install: false
+      - parallel:
+          - name: Setup Node
+            uses: ./.github/actions/setup-node
+            with:
+              enable-corepack: false
+              package-install: false
+
+          - name: Download Artifacts
+            uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+            with:
+              path: native-packages
 
       - name: Configure npm
         run: |
@@ -205,11 +212,6 @@ jobs:
             --message "library release: ${{ steps.version.outputs.version }}" \
             --all-tracked \
             --include-untracked
-
-      - name: Download Artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          path: native-packages
 
       - name: Move artifacts into place
         run: |

--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -182,7 +182,7 @@ jobs:
           - name: Download Artifacts
             uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
             with:
-              path: native-packages
+              path: ${{ runner.temp }}/native-packages
 
       - name: Configure npm
         run: |
@@ -215,14 +215,14 @@ jobs:
 
       - name: Move artifacts into place
         run: |
-          mv native-packages/turbo-library-aarch64-apple-darwin/@turbo/repository.darwin-arm64.node packages/turbo-repository/npm/darwin-arm64/
-          mv native-packages/turbo-library-x86_64-apple-darwin/@turbo/repository.darwin-x64.node packages/turbo-repository/npm/darwin-x64/
-          mv native-packages/turbo-library-aarch64-unknown-linux-gnu/@turbo/repository.linux-arm64-gnu.node packages/turbo-repository/npm/linux-arm64-gnu/
-          mv native-packages/turbo-library-aarch64-unknown-linux-musl/@turbo/repository.linux-arm64-musl.node packages/turbo-repository/npm/linux-arm64-musl/
-          mv native-packages/turbo-library-x86_64-unknown-linux-gnu/@turbo/repository.linux-x64-gnu.node packages/turbo-repository/npm/linux-x64-gnu/
-          mv native-packages/turbo-library-x86_64-unknown-linux-musl/@turbo/repository.linux-x64-musl.node packages/turbo-repository/npm/linux-x64-musl/
-          mv native-packages/turbo-library-aarch64-pc-windows-msvc/@turbo/repository.win32-arm64-msvc.node packages/turbo-repository/npm/win32-arm64-msvc/
-          mv native-packages/turbo-library-x86_64-pc-windows-msvc/@turbo/repository.win32-x64-msvc.node packages/turbo-repository/npm/win32-x64-msvc/
+          mv "$RUNNER_TEMP/native-packages/turbo-library-aarch64-apple-darwin/@turbo/repository.darwin-arm64.node" packages/turbo-repository/npm/darwin-arm64/
+          mv "$RUNNER_TEMP/native-packages/turbo-library-x86_64-apple-darwin/@turbo/repository.darwin-x64.node" packages/turbo-repository/npm/darwin-x64/
+          mv "$RUNNER_TEMP/native-packages/turbo-library-aarch64-unknown-linux-gnu/@turbo/repository.linux-arm64-gnu.node" packages/turbo-repository/npm/linux-arm64-gnu/
+          mv "$RUNNER_TEMP/native-packages/turbo-library-aarch64-unknown-linux-musl/@turbo/repository.linux-arm64-musl.node" packages/turbo-repository/npm/linux-arm64-musl/
+          mv "$RUNNER_TEMP/native-packages/turbo-library-x86_64-unknown-linux-gnu/@turbo/repository.linux-x64-gnu.node" packages/turbo-repository/npm/linux-x64-gnu/
+          mv "$RUNNER_TEMP/native-packages/turbo-library-x86_64-unknown-linux-musl/@turbo/repository.linux-x64-musl.node" packages/turbo-repository/npm/linux-x64-musl/
+          mv "$RUNNER_TEMP/native-packages/turbo-library-aarch64-pc-windows-msvc/@turbo/repository.win32-arm64-msvc.node" packages/turbo-repository/npm/win32-arm64-msvc/
+          mv "$RUNNER_TEMP/native-packages/turbo-library-x86_64-pc-windows-msvc/@turbo/repository.win32-x64-msvc.node" packages/turbo-repository/npm/win32-x64-msvc/
 
       - name: Build Meta Package
         run: |

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -167,46 +167,48 @@ jobs:
             exit 1
           fi
 
-      - uses: ./.github/actions/setup-node
-        with:
-          enable-corepack: false
+      - parallel:
+          - name: Setup Node
+            uses: ./.github/actions/setup-node
+            with:
+              enable-corepack: false
+
+          - name: Get base SHA
+            id: base-sha
+            run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+          - name: Get previous tag
+            id: previous-tag
+            env:
+              INCREMENT: ${{ github.event_name == 'schedule' && 'prerelease' || inputs.increment }}
+            run: |
+              # For minor/major releases, compare against the previous minor/major
+              # release (vX.Y.0) so notes include all patches since then.
+              # For patch releases, compare against the latest stable tag.
+              # For canary releases, compare against the latest canary tag.
+              if [[ "$INCREMENT" == "minor" || "$INCREMENT" == "major" ]]; then
+                PREV_TAG=$(git ls-remote --tags origin 'refs/tags/v*' \
+                  | awk '{print $2}' | sed 's|refs/tags/||' | grep -v '\^{}$' \
+                  | grep -v canary | grep -E 'v[0-9]+\.[0-9]+\.0$' | sort -V | tail -n 1)
+              elif [[ "$INCREMENT" == "patch" ]]; then
+                PREV_TAG=$(git ls-remote --tags origin 'refs/tags/v*' \
+                  | awk '{print $2}' | sed 's|refs/tags/||' | grep -v '\^{}$' \
+                  | grep -v canary | sort -V | tail -n 1)
+              else
+                PREV_TAG=$(git ls-remote --tags origin 'refs/tags/v*-canary.*' \
+                  | awk '{print $2}' | sed 's|refs/tags/||' | grep -v '\^{}$' \
+                  | sort -V | tail -n 1)
+                if [ -z "$PREV_TAG" ]; then
+                  PREV_TAG=$(git ls-remote --tags origin 'refs/tags/v*' \
+                    | awk '{print $2}' | sed 's|refs/tags/||' | grep -v '\^{}$' \
+                    | grep -v canary | sort -V | tail -n 1)
+                fi
+              fi
+              echo "tag=$PREV_TAG" >> $GITHUB_OUTPUT
+              echo "Previous tag: $PREV_TAG"
 
       - name: Build release tool
         run: pnpm --filter @turbo/releaser build
-
-      - name: Get base SHA
-        id: base-sha
-        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-
-      - name: Get previous tag
-        id: previous-tag
-        env:
-          INCREMENT: ${{ github.event_name == 'schedule' && 'prerelease' || inputs.increment }}
-        run: |
-          # For minor/major releases, compare against the previous minor/major
-          # release (vX.Y.0) so notes include all patches since then.
-          # For patch releases, compare against the latest stable tag.
-          # For canary releases, compare against the latest canary tag.
-          if [[ "$INCREMENT" == "minor" || "$INCREMENT" == "major" ]]; then
-            PREV_TAG=$(git ls-remote --tags origin 'refs/tags/v*' \
-              | awk '{print $2}' | sed 's|refs/tags/||' | grep -v '\^{}$' \
-              | grep -v canary | grep -E 'v[0-9]+\.[0-9]+\.0$' | sort -V | tail -n 1)
-          elif [[ "$INCREMENT" == "patch" ]]; then
-            PREV_TAG=$(git ls-remote --tags origin 'refs/tags/v*' \
-              | awk '{print $2}' | sed 's|refs/tags/||' | grep -v '\^{}$' \
-              | grep -v canary | sort -V | tail -n 1)
-          else
-            PREV_TAG=$(git ls-remote --tags origin 'refs/tags/v*-canary.*' \
-              | awk '{print $2}' | sed 's|refs/tags/||' | grep -v '\^{}$' \
-              | sort -V | tail -n 1)
-            if [ -z "$PREV_TAG" ]; then
-              PREV_TAG=$(git ls-remote --tags origin 'refs/tags/v*' \
-                | awk '{print $2}' | sed 's|refs/tags/||' | grep -v '\^{}$' \
-                | grep -v canary | sort -V | tail -n 1)
-            fi
-          fi
-          echo "tag=$PREV_TAG" >> $GITHUB_OUTPUT
-          echo "Previous tag: $PREV_TAG"
 
       - name: Clear stale staging branch (if requested)
         if: ${{ inputs.clear-staging-branch }}
@@ -424,47 +426,48 @@ jobs:
         if: ${{ contains(matrix.settings.target, 'apple-darwin') }}
         run: cargo install apple-codesign --version 0.29.0 --locked
 
-      - name: Write Apple signing certificate
-        if: ${{ contains(matrix.settings.target, 'apple-darwin') }}
-        shell: bash
-        env:
-          APPLE_CERT_DATA: ${{ secrets.APPLE_CERT_DATA }}
-          APPLE_CERT_PATH: ${{ runner.temp }}/apple-certificate.p12
-        run: |
-          set -euo pipefail
-          umask 077
-          if [[ -z "$APPLE_CERT_DATA" ]]; then
-            echo "::error::APPLE_CERT_DATA secret is empty or unavailable"
-            exit 1
-          fi
-          printf '%s' "$APPLE_CERT_DATA" | base64 --decode > "$APPLE_CERT_PATH"
-          chmod 600 "$APPLE_CERT_PATH"
-          if [[ ! -s "$APPLE_CERT_PATH" ]]; then
-            echo "::error::Decoded Apple certificate is empty"
-            exit 1
-          fi
-          echo "APPLE_CERT_PATH=$APPLE_CERT_PATH" >> "$GITHUB_ENV"
+      - parallel:
+          - name: Write Apple signing certificate
+            if: ${{ contains(matrix.settings.target, 'apple-darwin') }}
+            shell: bash
+            env:
+              APPLE_CERT_DATA: ${{ secrets.APPLE_CERT_DATA }}
+              APPLE_CERT_PATH: ${{ runner.temp }}/apple-certificate.p12
+            run: |
+              set -euo pipefail
+              umask 077
+              if [[ -z "$APPLE_CERT_DATA" ]]; then
+                echo "::error::APPLE_CERT_DATA secret is empty or unavailable"
+                exit 1
+              fi
+              printf '%s' "$APPLE_CERT_DATA" | base64 --decode > "$APPLE_CERT_PATH"
+              chmod 600 "$APPLE_CERT_PATH"
+              if [[ ! -s "$APPLE_CERT_PATH" ]]; then
+                echo "::error::Decoded Apple certificate is empty"
+                exit 1
+              fi
+              echo "APPLE_CERT_PATH=$APPLE_CERT_PATH" >> "$GITHUB_ENV"
 
-      - name: Write Apple notarization API key
-        if: ${{ contains(matrix.settings.target, 'apple-darwin') }}
-        shell: bash
-        env:
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
-          APPLE_API_KEY_PATH: ${{ runner.temp }}/apple-api-key.json
-        run: |
-          set -euo pipefail
-          umask 077
-          if [[ -z "$APPLE_API_KEY" ]]; then
-            echo "::error::APPLE_API_KEY secret is empty or unavailable"
-            exit 1
-          fi
-          printf '%s' "$APPLE_API_KEY" | base64 --decode > "$APPLE_API_KEY_PATH"
-          chmod 600 "$APPLE_API_KEY_PATH"
-          if [[ ! -s "$APPLE_API_KEY_PATH" ]]; then
-            echo "::error::Decoded Apple API key is empty"
-            exit 1
-          fi
-          echo "APPLE_API_KEY_PATH=$APPLE_API_KEY_PATH" >> "$GITHUB_ENV"
+          - name: Write Apple notarization API key
+            if: ${{ contains(matrix.settings.target, 'apple-darwin') }}
+            shell: bash
+            env:
+              APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+              APPLE_API_KEY_PATH: ${{ runner.temp }}/apple-api-key.json
+            run: |
+              set -euo pipefail
+              umask 077
+              if [[ -z "$APPLE_API_KEY" ]]; then
+                echo "::error::APPLE_API_KEY secret is empty or unavailable"
+                exit 1
+              fi
+              printf '%s' "$APPLE_API_KEY" | base64 --decode > "$APPLE_API_KEY_PATH"
+              chmod 600 "$APPLE_API_KEY_PATH"
+              if [[ ! -s "$APPLE_API_KEY_PATH" ]]; then
+                echo "::error::Decoded Apple API key is empty"
+                exit 1
+              fi
+              echo "APPLE_API_KEY_PATH=$APPLE_API_KEY_PATH" >> "$GITHUB_ENV"
 
       - name: Sign macOS binary
         if: ${{ contains(matrix.settings.target, 'apple-darwin') }}
@@ -553,20 +556,21 @@ jobs:
             with:
               path: rust-artifacts
 
-      - name: Install Global Turbo
-        uses: ./.github/actions/install-global-turbo
-        with:
-          turbo-version: ${{ inputs.ci-tag-override || '' }}
+      - parallel:
+          - name: Install Global Turbo
+            uses: ./.github/actions/install-global-turbo
+            with:
+              turbo-version: ${{ inputs.ci-tag-override || '' }}
 
-      - name: Move Rust artifacts into place
-        run: |
-          mkdir release-artifacts
-          mv rust-artifacts/turbo-aarch64-apple-darwin release-artifacts/dist-darwin-arm64
-          mv rust-artifacts/turbo-aarch64-unknown-linux-musl release-artifacts/dist-linux-arm64
-          cp -r rust-artifacts/turbo-x86_64-pc-windows-msvc release-artifacts/dist-windows-arm64
-          mv rust-artifacts/turbo-x86_64-unknown-linux-musl release-artifacts/dist-linux-x64
-          mv rust-artifacts/turbo-x86_64-apple-darwin release-artifacts/dist-darwin-x64
-          mv rust-artifacts/turbo-x86_64-pc-windows-msvc release-artifacts/dist-windows-x64
+          - name: Move Rust artifacts into place
+            run: |
+              mkdir release-artifacts
+              mv rust-artifacts/turbo-aarch64-apple-darwin release-artifacts/dist-darwin-arm64
+              mv rust-artifacts/turbo-aarch64-unknown-linux-musl release-artifacts/dist-linux-arm64
+              cp -r rust-artifacts/turbo-x86_64-pc-windows-msvc release-artifacts/dist-windows-arm64
+              mv rust-artifacts/turbo-x86_64-unknown-linux-musl release-artifacts/dist-linux-x64
+              mv rust-artifacts/turbo-x86_64-apple-darwin release-artifacts/dist-darwin-x64
+              mv rust-artifacts/turbo-x86_64-pc-windows-msvc release-artifacts/dist-windows-x64
 
       - name: Ensure npm version
         run: npm install -g npm@11.5.1
@@ -702,17 +706,18 @@ jobs:
           filter: blob:none
           persist-credentials: false
 
-      - name: Get version and compute subdomain
-        id: version
-        run: |
-          VERSION=$(head -n 1 version.txt)
-          # Transform version to valid subdomain (replace dots with dashes, prepend v)
-          SUBDOMAIN=$(echo "v${VERSION}" | tr '.' '-')
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "subdomain=${SUBDOMAIN}" >> $GITHUB_OUTPUT
+      - parallel:
+          - name: Get version and compute subdomain
+            id: version
+            run: |
+              VERSION=$(head -n 1 version.txt)
+              # Transform version to valid subdomain (replace dots with dashes, prepend v)
+              SUBDOMAIN=$(echo "v${VERSION}" | tr '.' '-')
+              echo "version=${VERSION}" >> $GITHUB_OUTPUT
+              echo "subdomain=${SUBDOMAIN}" >> $GITHUB_OUTPUT
 
-      - name: Install Vercel CLI
-        run: npm install -g vercel@53.1.0
+          - name: Install Vercel CLI
+            run: npm install -g vercel@53.1.0
 
       - name: Find Vercel deployment for SHA
         id: find-deployment

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -339,16 +339,16 @@ jobs:
           filter: blob:none
           persist-credentials: false
 
-      - name: Setup Environment
-        uses: ./.github/actions/setup-environment
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          rust: "false"
-          capnproto: "false"
-          node-extra-flags: "--no-frozen-lockfile"
+      - parallel:
+          - name: Setup Node
+            uses: ./.github/actions/setup-node
+            with:
+              extra-flags: "--no-frozen-lockfile"
+            env:
+              PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
 
-      - name: Install Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+          - name: Install Bun
+            uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install Global Turbo
         uses: ./.github/actions/install-global-turbo
@@ -391,26 +391,27 @@ jobs:
           filter: blob:none
           persist-credentials: false
 
-      - name: Setup Protoc
-        uses: ./.github/actions/setup-protoc
-        with:
-          version: "26.x"
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - parallel:
+          - name: Setup Protoc
+            uses: ./.github/actions/setup-protoc
+            with:
+              version: "26.x"
+              github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup capnproto
-        uses: ./.github/actions/setup-capnproto
+          - name: Setup capnproto
+            uses: ./.github/actions/setup-capnproto
 
-      - name: Rust Setup
-        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
-        with:
-          target: ${{ matrix.settings.target }}
-          # needed to not make it override the defaults
-          rustflags: ""
-          # we want more specific settings
-          cache: false
+          - name: Rust Setup
+            uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
+            with:
+              target: ${{ matrix.settings.target }}
+              # needed to not make it override the defaults
+              rustflags: ""
+              # we want more specific settings
+              cache: false
 
-      - name: Setup Zig
-        uses: ./.github/actions/setup-zig
+          - name: Setup Zig
+            uses: ./.github/actions/setup-zig
 
       - name: Build Setup
         if: ${{ matrix.settings.setup }}
@@ -540,20 +541,22 @@ jobs:
           filter: blob:none
           persist-credentials: false
 
-      - uses: ./.github/actions/setup-node
-        with:
-          enable-corepack: false
-          extra-flags: "--no-frozen-lockfile"
+      - parallel:
+          - name: Setup Node
+            uses: ./.github/actions/setup-node
+            with:
+              enable-corepack: false
+              extra-flags: "--no-frozen-lockfile"
+
+          - name: Download Rust artifacts
+            uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+            with:
+              path: rust-artifacts
 
       - name: Install Global Turbo
         uses: ./.github/actions/install-global-turbo
         with:
           turbo-version: ${{ inputs.ci-tag-override || '' }}
-
-      - name: Download Rust artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          path: rust-artifacts
 
       - name: Move Rust artifacts into place
         run: |

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -98,10 +98,24 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Environment
-        uses: ./.github/actions/setup-environment
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - parallel:
+          - name: Setup Node
+            uses: ./.github/actions/setup-node
+            env:
+              PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+
+          - name: Setup Rust
+            uses: ./.github/actions/setup-rust
+            with:
+              shared-cache-key: turborepo-debug-build
+              save-cache: true
+              github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+          - name: Setup Zig
+            uses: ./.github/actions/setup-zig
+
+          - name: Setup capnproto
+            uses: ./.github/actions/setup-capnproto
 
       - name: Install Global Turbo
         uses: ./.github/actions/install-global-turbo
@@ -171,37 +185,52 @@ jobs:
         with:
           persist-credentials: false
 
-      # Exchanges a GitHub OIDC token for a short-lived Remote Cache access
-      # token, exported as TURBO_TOKEN/TURBO_TEAM for subsequent steps.
-      # Pushes and same-repository PRs can mint OIDC tokens. Fork PRs remain
-      # local-only. With credentials present, turbo caches the test task
-      # remotely; Cargo reuses state from the target-cache restore below.
-      - name: Set up Turborepo Remote Cache
-        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7 # main
-        with:
-          team: ${{ vars.TURBO_TEAM }}
+      - parallel:
+          # Exchanges a GitHub OIDC token for a short-lived Remote Cache access
+          # token, exported as TURBO_TOKEN/TURBO_TEAM for subsequent steps.
+          # Pushes and same-repository PRs can mint OIDC tokens. Fork PRs remain
+          # local-only. With credentials present, turbo caches the test task
+          # remotely; Cargo reuses state from the target-cache restore below.
+          - name: Set up Turborepo Remote Cache
+            if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+            uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7 # main
+            with:
+              team: ${{ vars.TURBO_TEAM }}
 
-      - name: Setup Environment
-        uses: ./.github/actions/setup-environment
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          node-version: "18.20.2"
-          package-install: "false"
-          rust-cache: "false"
+          - name: Setup Node
+            uses: ./.github/actions/setup-node
+            with:
+              node-version: "18.20.2"
+              package-install: "false"
+            env:
+              PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
 
-      - name: Restore Cargo target
-        id: cargo-target-restore
-        if: matrix.os.name == 'ubuntu'
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: target
-          key: cargo-target-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml', '.cargo/config.toml', 'Cargo.lock') }}-${{ hashFiles('Cargo.toml', 'crates/**', 'packages/turbo-repository/rust/**', 'version.txt') }}
-          restore-keys: |
-            cargo-target-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml', '.cargo/config.toml', 'Cargo.lock') }}-
+          - name: Setup Rust
+            uses: ./.github/actions/setup-rust
+            with:
+              shared-cache-key: turborepo-debug-build
+              save-cache: true
+              cache: "false"
+              github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Install Bun
-        uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
+          - name: Setup Zig
+            uses: ./.github/actions/setup-zig
+
+          - name: Setup capnproto
+            uses: ./.github/actions/setup-capnproto
+
+          - name: Restore Cargo target
+            id: cargo-target-restore
+            if: matrix.os.name == 'ubuntu'
+            uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+            with:
+              path: target
+              key: cargo-target-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml', '.cargo/config.toml', 'Cargo.lock') }}-${{ hashFiles('Cargo.toml', 'crates/**', 'packages/turbo-repository/rust/**', 'version.txt') }}
+              restore-keys: |
+                cargo-target-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml', '.cargo/config.toml', 'Cargo.lock') }}-
+
+          - name: Install Bun
+            uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
 
       - name: Install cargo-nextest
         if: runner.os == 'Windows'
@@ -260,20 +289,21 @@ jobs:
         with:
           persist-credentials: false
 
-      # Exchanges a GitHub OIDC token for a short-lived Remote Cache access
-      # token, exported as TURBO_TOKEN/TURBO_TEAM for subsequent steps.
-      - name: Set up Turborepo Remote Cache
-        uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7 # main
-        with:
-          team: ${{ vars.TURBO_TEAM }}
+      - parallel:
+          # Exchanges a GitHub OIDC token for a short-lived Remote Cache access
+          # token, exported as TURBO_TOKEN/TURBO_TEAM for subsequent steps.
+          - name: Set up Turborepo Remote Cache
+            uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7 # main
+            with:
+              team: ${{ vars.TURBO_TEAM }}
 
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: "20"
+          - name: Setup Node.js
+            uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+            with:
+              node-version: "20"
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+          - name: Setup pnpm
+            uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
 
       - name: Install dependencies
         run: pnpm install
@@ -308,23 +338,37 @@ jobs:
         with:
           persist-credentials: false
 
-      # Exchanges a GitHub OIDC token for a short-lived Remote Cache access
-      # token, exported as TURBO_TOKEN/TURBO_TEAM for subsequent steps.
-      # Pushes and same-repository PRs can mint OIDC tokens. Fork PRs remain
-      # local-only.
-      - name: Set up Turborepo Remote Cache
-        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7 # main
-        with:
-          team: ${{ vars.TURBO_TEAM }}
+      - parallel:
+          # Exchanges a GitHub OIDC token for a short-lived Remote Cache access
+          # token, exported as TURBO_TOKEN/TURBO_TEAM for subsequent steps.
+          # Pushes and same-repository PRs can mint OIDC tokens. Fork PRs remain
+          # local-only.
+          - name: Set up Turborepo Remote Cache
+            if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+            uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7 # main
+            with:
+              team: ${{ vars.TURBO_TEAM }}
 
-      - name: Setup Environment
-        uses: ./.github/actions/setup-environment
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          - name: Setup Node
+            uses: ./.github/actions/setup-node
+            env:
+              PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
 
-      - name: Install Bun
-        uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
+          - name: Setup Rust
+            uses: ./.github/actions/setup-rust
+            with:
+              shared-cache-key: turborepo-debug-build
+              save-cache: true
+              github-token: ${{ secrets.GITHUB_TOKEN }}
+
+          - name: Setup Zig
+            uses: ./.github/actions/setup-zig
+
+          - name: Setup capnproto
+            uses: ./.github/actions/setup-capnproto
+
+          - name: Install Bun
+            uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
 
       - name: Install Global Turbo
         uses: ./.github/actions/install-global-turbo
@@ -363,21 +407,36 @@ jobs:
         with:
           persist-credentials: false
 
-      # Exchanges a GitHub OIDC token for a short-lived Remote Cache access
-      # token, exported as TURBO_TOKEN/TURBO_TEAM for subsequent steps.
-      # Pushes and same-repository PRs can mint OIDC tokens. Fork PRs remain
-      # local-only.
-      - name: Set up Turborepo Remote Cache
-        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7 # main
-        with:
-          team: ${{ vars.TURBO_TEAM }}
+      - parallel:
+          # Exchanges a GitHub OIDC token for a short-lived Remote Cache access
+          # token, exported as TURBO_TOKEN/TURBO_TEAM for subsequent steps.
+          # Pushes and same-repository PRs can mint OIDC tokens. Fork PRs remain
+          # local-only.
+          - name: Set up Turborepo Remote Cache
+            if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+            uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7 # main
+            with:
+              team: ${{ vars.TURBO_TEAM }}
 
-      - name: Setup Environment
-        uses: ./.github/actions/setup-environment
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          node-version: ${{ matrix.node-version }}
+          - name: Setup Node
+            uses: ./.github/actions/setup-node
+            with:
+              node-version: ${{ matrix.node-version }}
+            env:
+              PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+
+          - name: Setup Rust
+            uses: ./.github/actions/setup-rust
+            with:
+              shared-cache-key: turborepo-debug-build
+              save-cache: true
+              github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+          - name: Setup Zig
+            uses: ./.github/actions/setup-zig
+
+          - name: Setup capnproto
+            uses: ./.github/actions/setup-capnproto
 
       - name: Install Global Turbo
         uses: ./.github/actions/install-global-turbo

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -232,26 +232,27 @@ jobs:
           - name: Install Bun
             uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
 
-      - name: Install cargo-nextest
-        if: runner.os == 'Windows'
-        shell: cmd
-        run: |
-          curl -L -o "%TEMP%\nextest.zip" "https://get.nexte.st/latest/windows"
-          tar -xf "%TEMP%\nextest.zip" -C "%USERPROFILE%\.cargo\bin"
+      - parallel:
+          - name: Install cargo-nextest
+            if: runner.os == 'Windows'
+            shell: cmd
+            run: |
+              curl -L -o "%TEMP%\nextest.zip" "https://get.nexte.st/latest/windows"
+              tar -xf "%TEMP%\nextest.zip" -C "%USERPROFILE%\.cargo\bin"
 
-      - name: Install cargo-nextest
-        if: runner.os != 'Windows'
-        uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532
-        with:
-          tool: nextest
+          - name: Install cargo-nextest
+            if: runner.os != 'Windows'
+            uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532
+            with:
+              tool: nextest
 
-      - name: Configure Insta workspace root
-        if: runner.os == 'Windows'
-        shell: bash
-        run: echo "INSTA_WORKSPACE_ROOT=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
+          - name: Configure Insta workspace root
+            if: runner.os == 'Windows'
+            shell: bash
+            run: echo "INSTA_WORKSPACE_ROOT=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
 
-      - name: Install Global Turbo
-        uses: ./.github/actions/install-global-turbo
+          - name: Install Global Turbo
+            uses: ./.github/actions/install-global-turbo
 
       # The nextest invocation (and its excludes) lives in turbo.json as
       # the turborepo-crates#test command; dogfooding the task command

--- a/.github/workflows/update-examples-on-release.yml
+++ b/.github/workflows/update-examples-on-release.yml
@@ -24,19 +24,15 @@ jobs:
           filter: blob:none
           persist-credentials: false
 
-      - uses: ./.github/actions/setup-node
+      - parallel:
+          - name: Setup Node
+            uses: ./.github/actions/setup-node
 
-      - name: Upgrade corepack
-        shell: bash
-        run: |
-          npm install --force --global corepack@0.32.0
-          npm config get prefix >> $GITHUB_PATH
-
-      - name: Make branch
-        id: branch
-        run: |
-          git checkout -b post-release-bump-examples
-          echo "STAGE_BRANCH=$(git branch --show-current)" >> $GITHUB_OUTPUT
+          - name: Make branch
+            id: branch
+            run: |
+              git checkout -b post-release-bump-examples
+              echo "STAGE_BRANCH=$(git branch --show-current)" >> $GITHUB_OUTPUT
 
       - name: Run upgrade script
         run: bash scripts/update-examples-dep.sh


### PR DESCRIPTION
## Summary

- Run independent toolchain, package manager, cache, artifact, and release metadata setup steps concurrently.
- Expand the composite environment setup at workflow call sites because GitHub does not support `parallel` inside composite actions.
- Add second-stage groups where installs depend on Node or Rust setup, including Turbo and cargo-nextest.
- Preserve security, package-manager, Cargo, artifact, and OS package-manager ordering boundaries.
- Remove a redundant Corepack installation from the examples update workflow.

## Testing

- `pnpm exec oxfmt --check .github/workflows/lint.yml .github/workflows/lsp.yml .github/workflows/test-js-packages.yml .github/workflows/turborepo-library-release.yml .github/workflows/turborepo-release.yml .github/workflows/turborepo-test.yml .github/workflows/update-examples-on-release.yml`
- Pre-push hooks: formatting and TOML checks
- YAML parsing and parallel-group structural validation
- DevOps review of dependency, filesystem, secret, and package-manager boundaries

`actionlint` was not used because its latest release does not yet recognize GitHub Actions’ new `parallel` syntax.