### PR TITLE
docs: Fix llms.txt links to page markdown routes

### DIFF
--- a/apps/docs/app/[lang]/llms.txt/route.ts
+++ b/apps/docs/app/[lang]/llms.txt/route.ts
@@ -15,13 +15,13 @@ export const GET = async (
   const links = pages
     .sort((a, b) => a.url.localeCompare(b.url))
     .map((page) => {
-      let mdPath = page.url.replace(/^\/docs/, "");
-      // Handle index pages
-      if (mdPath === "" || mdPath.endsWith("/")) {
-        mdPath = mdPath + "index.md";
-      } else {
-        mdPath = mdPath + ".md";
-      }
+      // Link each page's .md route under its real URL (for example
+      // /docs/acknowledgments.md); stripping the /docs prefix produced
+      // links that 404.
+      const mdPath =
+        page.url === "/docs" || page.url.endsWith("/")
+          ? `${page.url.replace(/\/$/, "")}/index.md`
+          : `${page.url}.md`;
       return `- [${page.data.title}](${mdPath}): ${page.data.description ?? ""}`;
     });
 


### PR DESCRIPTION
### Description

Every link emitted by [turborepo.dev/llms.txt](https://turborepo.dev/llms.txt) 404s. The route strips the `/docs` prefix from page URLs before appending `.md`:

- `/acknowledgments.md` → 404 (real page: [`/docs/acknowledgments.md`](https://turborepo.dev/docs/acknowledgments.md))
- the root entry emits a relative `index.md` → resolves to `/index.md` → 404 (real page: [`/docs/index.md`](https://turborepo.dev/docs/index.md))

Found while ingesting every Vercel docs property's machine-readable output into docsgraph.

### Fix

Link each page's `.md` route under its real URL (`page.url + ".md"`, with `/docs` → `/docs/index.md` for the root). `llms-full.txt` already links `page.url` directly and is unaffected.

Verified against production URL shapes: `page.url` values are `/docs`-prefixed (see llms-full.txt output), and `/docs/support-policy.md`, `/docs/acknowledgments.md`, `/docs/index.md` all return 200 today.

Related: a geistdocs-side regression check for this class of bug (every root-relative link in llms.txt/sitemap.md must resolve) is landing in vercel/geistdocs#208. Separately, the docs app's geistdocs pin (1.13.0) predates the 1.14.x basePath and last-modified fixes — worth bumping when convenient.