### PR TITLE
perf: Cache telemetry salt instead of re-reading config on every hash

### DIFF
--- a/crates/turborepo-telemetry/src/config.rs
+++ b/crates/turborepo-telemetry/src/config.rs
@@ -111,16 +111,20 @@ impl TelemetryConfig {
     }
 
     pub fn one_way_hash(input: &str) -> String {
-        match TelemetryConfig::with_default_config_path() {
-            Ok(config) => config.one_way_hash_with_config_salt(input),
-            Err(_) => TelemetryConfig::one_way_hash_with_tmp_salt(input),
+        // The salt is generated once and then never changes for the lifetime
+        // of the config file, so read it once per process instead of
+        // re-reading and re-parsing the config file on every call — this
+        // runs several times per task during a run.
+        static CONFIG_SALT: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
+        let salt = CONFIG_SALT.get_or_init(|| {
+            TelemetryConfig::with_default_config_path()
+                .ok()
+                .map(|config| config.config.telemetry_salt)
+        });
+        match salt {
+            Some(salt) => one_way_hash_with_salt(salt, input),
+            None => TelemetryConfig::one_way_hash_with_tmp_salt(input),
         }
-    }
-
-    /// Obfuscate with the config salt - this is used for all sensitive event
-    /// data
-    fn one_way_hash_with_config_salt(&self, input: &str) -> String {
-        one_way_hash_with_salt(&self.config.telemetry_salt, input)
     }
 
     /// Obfuscate with a temporary salt - this is used as a fallback when the

--- a/crates/turborepo-telemetry/src/events/task.rs
+++ b/crates/turborepo-telemetry/src/events/task.rs
@@ -64,7 +64,16 @@ impl EventBuilder for PackageTaskEventBuilder {
     }
 
     fn child(&self) -> Self {
-        Self::new(&self.package, &self.task).with_parent(self)
+        // `package` and `task` are already obfuscated where required by
+        // `new`; reuse them instead of re-deriving (re-hashing them would
+        // also mislabel the child with double-hashed values).
+        Self {
+            id: Uuid::new_v4().to_string(),
+            package: self.package.clone(),
+            task: self.task.clone(),
+            parent_id: Some(self.id.clone()),
+            is_ci: self.is_ci,
+        }
     }
 }
 


### PR DESCRIPTION
### Problem

`TelemetryConfig::one_way_hash` — used to obfuscate package and task names in telemetry events — calls `TelemetryConfig::with_default_config_path()` on every invocation. Each call stats, reads, and JSON-parses `telemetry.json` from disk (via the `config` crate builder) just to extract the salt.

In release builds this runs on hot paths:

- `PackageTaskEventBuilder::new` calls `one_way_hash` for the package name (and for non-allowlisted task names).
- Builders are constructed ~4× per task during a run: twice in the parallel hashing phase (`precompute_task_hashes`) and twice in the serial dispatch loop (`queue_task`).

On a run of 100 tasks, that's ~400 config file reads + JSON parses per `turbo run`, a good share of them on the serial dispatch path. Debug builds never hit this (`cfg!(debug_assertions)` skips obfuscation), which is likely why it went unnoticed.

Additionally, `PackageTaskEventBuilder::child()` re-ran `new()` on the parent's already-obfuscated fields, so child events re-hashed the hash: they paid the cost twice *and* reported a double-hashed package name that doesn't match their parent's.

### Fix

- Cache the salt in a `OnceLock` inside `one_way_hash`. The salt is generated once on first run and never changes for the lifetime of the config file, so a process-lifetime cache is safe. If config loading fails, the existing per-call temporary-salt fallback is preserved: each failure still generates a fresh salt, keeping those events unlinkable, as before.
- `child()` now copies the parent's already-obfuscated `package`/`task` fields and only generates a fresh event id.

### Behavior change

Child telemetry events now carry the same (single-hashed) obfuscated package name as their parent, instead of a double-hashed one. This is a data-quality fix — parent and child events for the same task are now correlatable by package — but the reported value changes for anything that consumed the old double-hashed field.

### Results

Scoped benchmark: this change only, measured against an otherwise-identical baseline binary. Synthetic 100-package pnpm monorepo (one `build` task per package = 100 tasks), release build, hyperfine `-N` with 100 runs, verified in both run orders.

**Wall clock, `turbo run build --dry=json`:** 70.7 ms → 64.3 ms (**~9% faster**, 1.10 ± 0.06). Fully-cached runs show a consistent directional win of similar absolute size, with wider variance from cache-restore I/O.

**Profile spans** (Chrome trace via `--profile`, fully-cached run, median of 3):

| Span | Before | After |
|---|---|---|
| `queue_task` self (serial dispatch loop) | 8.0 ms | 2.3 ms |
| `precompute_task_hashes` self | 7.6 ms | 1.8 ms |

~400 `telemetry.json` reads + JSON parses eliminated per run; the serial dispatch loop no longer touches disk per task.

### Testing

- `cargo test -p turborepo-telemetry` passes.
- Verified `--dry=json` task hashes are byte-identical before/after on both the benchmark fixture and this repository (telemetry obfuscation does not feed cache keys).

### Follow-up

The Node port of this module (`packages/turbo-telemetry/src/config.ts`, noted in the crate header) has the same per-call config-read pattern and could adopt the same memoization.
