### PR TITLE
fix: Resolve gitdir for linked worktrees in repo index

### DIFF
--- a/crates/turborepo-scm/src/repo_index.rs
+++ b/crates/turborepo-scm/src/repo_index.rs
@@ -91,11 +91,15 @@ impl RepoGitIndex {
     fn new_from_gix_index(git: &GitRepo) -> Result<Self, Error> {
         use rayon::prelude::*;
 
-        let git_dir = git.root.join_component(".git");
+        // Resolve the actual git dir: in a linked worktree `.git` is a
+        // pointer file and the per-worktree index lives elsewhere. Without
+        // this, worktrees silently lost the gix fast path and fell back to
+        // one `git ls-tree` + `git status` subprocess per package.
+        let git_dir = crate::worktree::resolve_git_dir(&git.root)?;
         let index_path = git_dir.join_component("index");
 
         if !index_path.exists() {
-            return Err(Error::git_error("no .git/index file found"));
+            return Err(Error::git_error("no git index file found"));
         }
 
         let index = gix_index::File::at(

--- a/crates/turborepo-scm/src/repo_index.rs
+++ b/crates/turborepo-scm/src/repo_index.rs
@@ -91,10 +91,6 @@ impl RepoGitIndex {
     fn new_from_gix_index(git: &GitRepo) -> Result<Self, Error> {
         use rayon::prelude::*;
 
-        // Resolve the actual git dir: in a linked worktree `.git` is a
-        // pointer file and the per-worktree index lives elsewhere. Without
-        // this, worktrees silently lost the gix fast path and fell back to
-        // one `git ls-tree` + `git status` subprocess per package.
         let git_dir = crate::worktree::resolve_git_dir(&git.root)?;
         let index_path = git_dir.join_component("index");
 

--- a/crates/turborepo-scm/src/worktree.rs
+++ b/crates/turborepo-scm/src/worktree.rs
@@ -103,6 +103,44 @@ impl WorktreeInfo {
     }
 }
 
+/// Resolve the git directory for a repository root, handling both a main
+/// worktree (`.git` is a directory) and a linked worktree (`.git` is a
+/// `gitdir: <path>` pointer file). The per-worktree files — most notably
+/// `index` — live in the resolved directory.
+pub fn resolve_git_dir(worktree_root: &AbsoluteSystemPath) -> Result<AbsoluteSystemPathBuf, Error> {
+    let dot_git = worktree_root.join_component(".git");
+    let dot_git_meta = std::fs::symlink_metadata(dot_git.as_std_path())
+        .map_err(|e| Error::git_error(format!("failed to stat .git: {}", e)))?;
+
+    if dot_git_meta.is_dir() {
+        return Ok(dot_git);
+    }
+    if !dot_git_meta.is_file() {
+        return Err(Error::git_error(
+            ".git exists but is neither a directory nor a file",
+        ));
+    }
+
+    let content = std::fs::read_to_string(dot_git.as_std_path())
+        .map_err(|e| Error::git_error(format!("failed to read .git file: {}", e)))?;
+    let gitdir_path = content
+        .strip_prefix("gitdir: ")
+        .ok_or_else(|| {
+            Error::git_error(format!(
+                ".git file has unexpected format (expected 'gitdir: ...'): {:?}",
+                content.trim()
+            ))
+        })?
+        .trim();
+
+    if std::path::Path::new(gitdir_path).is_absolute() {
+        Ok(AbsoluteSystemPathBuf::try_from(gitdir_path)?)
+    } else {
+        let resolved = worktree_root.as_std_path().join(gitdir_path);
+        Ok(AbsoluteSystemPathBuf::try_from(resolved.as_path())?.to_realpath()?)
+    }
+}
+
 /// Walk up from `path` looking for a directory that contains a `.git` entry.
 fn find_git_ancestor(path: &AbsoluteSystemPath) -> Result<AbsoluteSystemPathBuf, Error> {
     let mut current = path.to_owned();
@@ -229,6 +267,67 @@ mod tests {
         assert_eq!(info.main_worktree_root, repo_root);
         assert_eq!(info.git_root, worktree_path);
         assert!(info.is_linked_worktree());
+    }
+
+    #[test]
+    fn test_resolve_git_dir_main_and_linked() {
+        let (_tmp, repo_root) = tmp_dir();
+        setup_repository(&repo_root);
+
+        // Main worktree: .git directory.
+        let main_git_dir = resolve_git_dir(&repo_root).unwrap();
+        assert_eq!(main_git_dir, repo_root.join_component(".git"));
+
+        let worktree_path = repo_root.join_component("worktree-gitdir");
+        require_git_cmd(
+            &repo_root,
+            &[
+                "worktree",
+                "add",
+                worktree_path.as_str(),
+                "-b",
+                "test-branch-gitdir",
+            ],
+        );
+
+        // Linked worktree: .git is a pointer file; the resolved gitdir holds
+        // the per-worktree index.
+        let linked_git_dir = resolve_git_dir(&worktree_path).unwrap();
+        assert_ne!(linked_git_dir, worktree_path.join_component(".git"));
+        assert!(linked_git_dir.join_component("index").exists());
+    }
+
+    #[test]
+    fn test_gix_repo_index_works_in_linked_worktree() {
+        let (_tmp, repo_root) = tmp_dir();
+        setup_repository(&repo_root);
+
+        let worktree_path = repo_root.join_component("worktree-index");
+        require_git_cmd(
+            &repo_root,
+            &[
+                "worktree",
+                "add",
+                worktree_path.as_str(),
+                "-b",
+                "test-branch-index",
+            ],
+        );
+
+        // The gix fast path must work from a linked worktree; before the
+        // `.git` pointer file was resolved, this returned None and every
+        // package fell back to git subprocesses.
+        let scm = crate::SCM::new(&worktree_path);
+        let index = scm
+            .build_tracked_repo_index_eager()
+            .expect("tracked repo index should build in a linked worktree");
+        let (hashes, _to_hash) = index
+            .get_package_hashes(&turbopath::RelativeUnixPathBuf::new("").unwrap())
+            .unwrap();
+        assert!(
+            hashes.keys().any(|path| path.as_str() == "README.md"),
+            "committed file should be present in the worktree index: {hashes:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Problem

`RepoGitIndex::new_from_gix_index` hardcodes the index location as `<git_root>/.git/index`. That's only correct for a main worktree. In a **linked git worktree**, `.git` is a `gitdir: <path>` pointer file, so the lookup fails and the gix fast path silently bails — `build_tracked_repo_index_eager()` returns `None`, and every package falls back to spawning `git ls-tree` and `git status` subprocesses.

Nothing surfaces this: worktree users just get a quietly degraded run. On this repository checked out as a linked worktree (28 packages), a `--profile` trace shows what that costs per run:

| Span | Without fix | With fix |
|---|---|---|
| `append_git_status` (28 subprocess calls) | 259.9 ms | — |
| `git_ls_tree` (subprocess calls) | 90.6 ms | — |
| `new_from_gix_index` | — | 8.8 ms |
| `hash_scope` (hashing phase wall) | 83.2 ms | 42.3 ms |

The subprocess count scales with package count, and the per-call cost scales with git's stat-cache staleness. In a stale-stat state (e.g. right after a branch switch or rebase — the normal state for freshly created worktrees and CI), the same comparison measured `turbo run build --dry=json` at **1.265 s → 1.053 s (1.20×)**; with a fully warm git stat cache the wall delta narrows to ~4% (1.009 s → 973 ms) since `cargo metadata` dominates this particular repo.

### Fix

Resolve the actual git dir with a new `worktree::resolve_git_dir()` helper: `.git`-as-directory resolves as before (main worktrees unaffected), `.git`-as-file is parsed as a `gitdir:` pointer (same parsing rules as `WorktreeInfo::detect`, including relative-path resolution), and the per-worktree index at `<gitdir>/index` is used.

### Testing

- New regression test `test_gix_repo_index_works_in_linked_worktree`: creates a repo plus a linked worktree via `git worktree add`, and asserts the tracked repo index builds and contains committed files. Verified to fail without the fix and pass with it.
- New `test_resolve_git_dir_main_and_linked` covers both `.git` shapes, asserting the linked worktree's resolved gitdir contains an `index`.
- `cargo test -p turborepo-scm` passes (193 tests).
- Task hashes verified byte-identical with and without the fix via `--dry=json` on this repository (the fix changes *how* hashes are computed, not their values).
