### PR TITLE
ci: Restore Cargo targets on all test platforms

### DIFF
--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -233,7 +233,6 @@ jobs:
 
           - name: Restore Cargo target
             id: cargo-target-restore
-            if: matrix.os.name == 'ubuntu'
             uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
             with:
               path: target
@@ -272,12 +271,12 @@ jobs:
       - name: Run tests
         timeout-minutes: 20
         env:
-          FORCE_ARG: ${{ matrix.os.name == 'ubuntu' && github.event_name == 'push' && steps.cargo-target-restore.outputs.cache-matched-key == '' && '--force' || '' }}
+          FORCE_ARG: ${{ github.event_name == 'push' && steps.cargo-target-restore.outputs.cache-matched-key == '' && '--force' || '' }}
         run: turbo run test --filter=turborepo-crates --env-mode=loose --log-order=stream $FORCE_ARG -- --partition hash:${{ matrix.shard }}/2
         shell: bash
 
       - name: Save Cargo target
-        if: matrix.os.name == 'ubuntu' && matrix.shard == 1 && github.event_name == 'push' && steps.cargo-target-restore.outputs.cache-hit != 'true'
+        if: matrix.shard == 1 && github.event_name == 'push' && steps.cargo-target-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: target

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ When making changes to the codebase, check if the following docs need updates:
 
 - Test and lint workflows do not pre-classify changed paths. PR jobs run consistently and use the Turborepo task graph and cache where applicable.
 - Same-repository PRs authenticate to Remote Cache through OIDC; fork PRs remain local-only.
-- Rust CI restores full Cargo target state on Ubuntu from trusted `main` snapshots; only `main` writes. Repository sccache dogfooding is disabled.
+- Rust CI restores full Cargo target state on Ubuntu, macOS, and Windows from trusted `main` snapshots; only `main` writes. Repository sccache dogfooding is disabled.
 - Linux Rust shards include `terminal-control` black-box TUI integration tests; known regressions remain explicitly ignored.
 - Example validation remains push-only because it requires Vercel credentials and project state.
 


### PR DESCRIPTION
## Why

Rust test jobs on macOS and Windows currently compile without restoring the full Cargo target snapshot used by Ubuntu, making PR builds slower.

## What

- Restore OS- and architecture-specific Cargo target snapshots on Ubuntu, macOS, and Windows.
- Allow shard 1 on trusted `main` pushes to seed each platform snapshot.
- Keep pull requests, including forks, restore-only.
- Leave release workflows unchanged.

## Testing

- `pnpm exec oxfmt --check .github/workflows/turborepo-test.yml AGENTS.md`
- Pre-push formatting and TOML checks