### PR TITLE
feat: Resolve remote base refs behind future flag

### DIFF
--- a/apps/docs/content/docs/reference/configuration.mdx
+++ b/apps/docs/content/docs/reference/configuration.mdx
@@ -362,6 +362,24 @@ In this example, if only `README.md` changed in a package, `build` would not run
   selected, regardless of individual task `inputs`.
 </Callout>
 
+#### `resolveRemoteBaseRefs`
+
+Default: `false`
+
+Fall back to `origin/<branch>` when an inferred base branch is not available as a local ref. This is useful in CI environments that use detached checkouts and only create remote-tracking refs.
+
+Local refs continue to take precedence. This flag only affects inferred base refs, including the base branch reported by GitHub Actions and the default `main` or `master` branch. Explicit refs provided through `TURBO_SCM_BASE` are used unchanged.
+
+```jsonc title="./turbo.json"
+{
+  "futureFlags": {
+    "resolveRemoteBaseRefs": true,
+  },
+}
+```
+
+For example, when GitHub Actions reports `main` as the pull request base but the checkout only contains `origin/main`, Turborepo will use `origin/main` for `--affected` comparisons.
+
 #### `watchUsingTaskInputs`
 
 Default: `false`

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -479,11 +479,13 @@ impl RunBuilder {
         let repo_index_task = {
             let repo_root = self.repo_root.clone();
             let git_root = self.opts.git_root.clone();
+            let resolve_remote_base_refs = self.opts.future_flags.resolve_remote_base_refs;
             tokio::task::spawn_blocking(move || {
                 let scm = match git_root {
                     Some(root) => SCM::new_with_git_root(&repo_root, root),
                     None => SCM::new(&repo_root),
-                };
+                }
+                .with_remote_base_ref_fallback(resolve_remote_base_refs);
                 // The tracked half of the repo index only needs `.git/index`.
                 let tracked_index = {
                     let _span = tracing::info_span!("build_tracked_repo_index_gix").entered();

--- a/crates/turborepo-schema-gen/src/main.rs
+++ b/crates/turborepo-schema-gen/src/main.rs
@@ -769,6 +769,14 @@ export interface FutureFlags {
    */
   affectedUsingTaskInputs?: boolean;
   /**
+   * Fall back to `origin/<branch>` when an inferred base branch is not
+   * available as a local ref. This supports detached checkouts in CI where
+   * only remote-tracking refs are present.
+   *
+   * @defaultValue `false`
+   */
+  resolveRemoteBaseRefs?: boolean;
+  /**
    * Use task-level `inputs` globs to determine which tasks to re-run when
    * files change in `turbo watch`. When enabled, only tasks whose declared
    * inputs match the changed files are re-executed, rather than re-running

--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -491,24 +491,41 @@ impl GitRepo {
             // because at this point we know we're in a GITHUB CI environment
             // and we should really know by now what the base ref is
             // so it's better to just error if something went wrong
-            return match self
-                .execute_git_command(&["rev-parse", "--end-of-options", &github_base_ref], "")
-            {
+            let local_result =
+                self.execute_git_command(&["rev-parse", "--end-of-options", &github_base_ref], "");
+            match local_result {
                 Ok(_) => {
                     eprintln!("Resolved base ref from GitHub Actions event: {github_base_ref}");
-                    Ok(github_base_ref)
+                    return Ok(github_base_ref);
                 }
-                Err(e) => {
+                Err(local_error) if self.resolve_remote_base_refs => {
+                    let remote_ref = format!("origin/{github_base_ref}");
+                    match self
+                        .execute_git_command(&["rev-parse", "--end-of-options", &remote_ref], "")
+                    {
+                        Ok(_) => {
+                            eprintln!("Resolved base ref from GitHub Actions event: {remote_ref}");
+                            return Ok(remote_ref);
+                        }
+                        Err(remote_error) => eprintln!(
+                            "Failed to resolve base ref '{github_base_ref}' ({local_error}) or \
+                             '{remote_ref}' ({remote_error}) from GitHub Actions event"
+                        ),
+                    }
+                }
+                Err(error) => {
                     eprintln!(
                         "Failed to resolve base ref '{github_base_ref}' from GitHub Actions \
-                         event: {e}"
+                         event: {error}"
                     );
-                    Err(Error::UnableToResolveRef)
                 }
-            };
+            }
+            return Err(Error::UnableToResolveRef);
         }
 
-        default_base_ref(|branch| self.execute_git_command(&["rev-parse", branch], "").is_ok())
+        default_base_ref(self.resolve_remote_base_refs, |branch| {
+            self.execute_git_command(&["rev-parse", branch], "").is_ok()
+        })
     }
 
     fn changed_files(
@@ -629,13 +646,18 @@ impl GitRepo {
     }
 }
 
-fn default_base_ref(mut branch_exists: impl FnMut(&str) -> bool) -> Result<String, Error> {
-    if branch_exists("main") {
-        return Ok("main".to_string());
-    }
-
-    if branch_exists("master") {
-        return Ok("master".to_string());
+fn default_base_ref(
+    resolve_remote_base_refs: bool,
+    mut branch_exists: impl FnMut(&str) -> bool,
+) -> Result<String, Error> {
+    for branch in ["main", "master"] {
+        if branch_exists(branch) {
+            return Ok(branch.to_string());
+        }
+        let remote_ref = format!("origin/{branch}");
+        if resolve_remote_base_refs && branch_exists(&remote_ref) {
+            return Ok(remote_ref);
+        }
     }
 
     Err(Error::UnableToResolveRef)
@@ -1249,19 +1271,78 @@ mod tests {
 
     #[test]
     fn test_default_base_ref_resolution() {
-        for (branches, expected) in [
-            (vec!["main"], Some("main")),
-            (vec!["master"], Some("master")),
-            (vec!["ziltoid"], None),
-            (vec!["ziltoid", "main"], Some("main")),
-            (vec!["ziltoid", "master"], Some("master")),
-            (vec!["ziltoid", "master", "main"], Some("main")),
+        for (resolve_remote_base_refs, branches, expected) in [
+            (false, vec!["main"], Some("main")),
+            (false, vec!["master"], Some("master")),
+            (false, vec!["origin/main"], None),
+            (true, vec!["origin/main"], Some("origin/main")),
+            (true, vec!["origin/master"], Some("origin/master")),
+            (true, vec!["master", "origin/main"], Some("origin/main")),
+            (true, vec!["main", "origin/main"], Some("main")),
+            (true, vec!["ziltoid"], None),
         ] {
             let branches = HashSet::<&str>::from_iter(branches);
-            let actual = default_base_ref(|branch| branches.contains(branch)).ok();
+            let actual =
+                default_base_ref(resolve_remote_base_refs, |branch| branches.contains(branch)).ok();
 
             assert_eq!(actual.as_deref(), expected);
         }
+    }
+
+    #[test]
+    fn test_github_base_ref_remote_fallback_respects_flag() -> Result<(), Error> {
+        let (repo_root, repo_path) = setup_repository(Some("main"))?;
+        let root = AbsoluteSystemPathBuf::try_from(repo_root.path()).unwrap();
+        let file = root.join_component("todo.txt");
+        file.create_with_contents("test remote base ref fallback")?;
+        let commit = commit_file(&repo_path, Path::new("todo.txt"), None);
+
+        run_git(&repo_path, &["checkout", "--detach", &commit]);
+        run_git(&repo_path, &["branch", "-D", "main"]);
+        run_git(
+            &repo_path,
+            &["update-ref", "refs/remotes/origin/main", &commit],
+        );
+
+        let github_env = || CIEnv {
+            is_github_actions: true,
+            github_base_ref: Ok("main".to_string()),
+            github_event_path: Err(VarError::NotPresent),
+        };
+        let mut git = GitRepo::find(&root).unwrap();
+
+        assert_matches!(
+            git.resolve_base(None, github_env()),
+            Err(Error::UnableToResolveRef)
+        );
+
+        git.resolve_remote_base_refs = true;
+        assert_eq!(
+            git.resolve_base(None, github_env())?,
+            "origin/main".to_string()
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_github_base_ref_remote_fallback_errors_when_refs_are_missing() -> Result<(), Error> {
+        let (repo_root, repo_path) = setup_repository(Some("main"))?;
+        let root = AbsoluteSystemPathBuf::try_from(repo_root.path()).unwrap();
+        let file = root.join_component("todo.txt");
+        file.create_with_contents("test missing base refs")?;
+        commit_file(&repo_path, Path::new("todo.txt"), None);
+
+        let mut git = GitRepo::find(&root).unwrap();
+        git.resolve_remote_base_refs = true;
+        let env = CIEnv {
+            is_github_actions: true,
+            github_base_ref: Ok("missing".to_string()),
+            github_event_path: Err(VarError::NotPresent),
+        };
+
+        assert_matches!(git.resolve_base(None, env), Err(Error::UnableToResolveRef));
+        Ok(())
     }
 
     #[test]
@@ -2351,6 +2432,7 @@ mod tests {
             root: root.to_owned(),
             bin,
             attrs: std::sync::OnceLock::new(),
+            resolve_remote_base_refs: false,
             slowest_files: None,
         }
     }

--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -231,6 +231,7 @@ pub struct GitRepo {
     root: AbsoluteSystemPathBuf,
     bin: AbsoluteSystemPathBuf,
     attrs: OnceLock<Option<crlf::GitAttrs>>,
+    resolve_remote_base_refs: bool,
     /// Optional recorder for the slowest-to-hash files. Set by long-running
     /// consumers (the file watcher) so they can diagnose a stalled startup.
     slowest_files: Option<std::sync::Arc<SlowestFiles>>,
@@ -250,6 +251,7 @@ impl Clone for GitRepo {
             root: self.root.clone(),
             bin: self.bin.clone(),
             attrs: OnceLock::new(),
+            resolve_remote_base_refs: self.resolve_remote_base_refs,
             slowest_files: self.slowest_files.clone(),
         }
     }
@@ -284,6 +286,7 @@ impl GitRepo {
             root,
             bin,
             attrs: OnceLock::new(),
+            resolve_remote_base_refs: false,
             slowest_files: None,
         })
     }
@@ -355,6 +358,7 @@ impl SCM {
                 root: git_root,
                 bin,
                 attrs: OnceLock::new(),
+                resolve_remote_base_refs: false,
                 slowest_files: None,
             }),
             Err(e) => {
@@ -365,6 +369,13 @@ impl SCM {
                 SCM::Manual
             }
         }
+    }
+
+    pub fn with_remote_base_ref_fallback(mut self, enabled: bool) -> Self {
+        if let SCM::Git(git) = &mut self {
+            git.resolve_remote_base_refs = enabled;
+        }
+        self
     }
 
     /// Attach a recorder that tracks the slowest-to-hash files. Long-running

--- a/crates/turborepo-scm/src/repo_index.rs
+++ b/crates/turborepo-scm/src/repo_index.rs
@@ -1691,6 +1691,7 @@ mod tests {
             root: root.clone(),
             bin: root,
             attrs: OnceLock::new(),
+            resolve_remote_base_refs: false,
             slowest_files: None,
         }
     }

--- a/crates/turborepo-turbo-json/src/future_flags.rs
+++ b/crates/turborepo-turbo-json/src/future_flags.rs
@@ -57,6 +57,11 @@ pub struct FutureFlags {
     /// selecting all tasks in changed packages.
     #[serde(default)]
     pub affected_using_task_inputs: bool,
+    /// Fall back to `origin/<branch>` when an inferred base branch is not
+    /// available as a local ref. This supports detached checkouts in CI where
+    /// only remote-tracking refs are present.
+    #[serde(default)]
+    pub resolve_remote_base_refs: bool,
     /// Use task-level `inputs` globs to determine which tasks to re-run when
     /// files change in `turbo watch`. When enabled, only tasks whose declared
     /// inputs match the changed files are re-executed, rather than re-running
@@ -158,18 +163,18 @@ impl TS for FutureFlags {
 
     fn inline() -> String {
         "{ errorsOnlyShowHash?: boolean, experimentalObservability?: boolean, longerSignatureKey?: \
-         boolean, affectedUsingTaskInputs?: boolean, watchUsingTaskInputs?: boolean, \
-         pruneIncludesGlobalFiles?: boolean, filterUsingTasks?: boolean, \
-         strictTaskEntrypointSelection?: boolean, globalConfiguration?: boolean, \
+         boolean, affectedUsingTaskInputs?: boolean, resolveRemoteBaseRefs?: boolean, \
+         watchUsingTaskInputs?: boolean, pruneIncludesGlobalFiles?: boolean, filterUsingTasks?: \
+         boolean, strictTaskEntrypointSelection?: boolean, globalConfiguration?: boolean, \
          experimentalCargoWorkspaces?: boolean, experimentalTaskCommand?: boolean }"
             .to_string()
     }
 
     fn inline_flattened() -> String {
         "{ errorsOnlyShowHash?: boolean, experimentalObservability?: boolean, longerSignatureKey?: \
-         boolean, affectedUsingTaskInputs?: boolean, watchUsingTaskInputs?: boolean, \
-         pruneIncludesGlobalFiles?: boolean, filterUsingTasks?: boolean, \
-         strictTaskEntrypointSelection?: boolean, globalConfiguration?: boolean, \
+         boolean, affectedUsingTaskInputs?: boolean, resolveRemoteBaseRefs?: boolean, \
+         watchUsingTaskInputs?: boolean, pruneIncludesGlobalFiles?: boolean, filterUsingTasks?: \
+         boolean, strictTaskEntrypointSelection?: boolean, globalConfiguration?: boolean, \
          experimentalCargoWorkspaces?: boolean, experimentalTaskCommand?: boolean }"
             .to_string()
     }
@@ -177,18 +182,20 @@ impl TS for FutureFlags {
     fn decl() -> String {
         "type FutureFlags = { errorsOnlyShowHash?: boolean, experimentalObservability?: boolean, \
          longerSignatureKey?: boolean, affectedUsingTaskInputs?: boolean, watchUsingTaskInputs?: \
-         boolean, pruneIncludesGlobalFiles?: boolean, filterUsingTasks?: boolean, \
-         strictTaskEntrypointSelection?: boolean, globalConfiguration?: boolean, \
-         experimentalCargoWorkspaces?: boolean, experimentalTaskCommand?: boolean };"
+         boolean, resolveRemoteBaseRefs?: boolean, pruneIncludesGlobalFiles?: boolean, \
+         filterUsingTasks?: boolean, strictTaskEntrypointSelection?: boolean, \
+         globalConfiguration?: boolean, experimentalCargoWorkspaces?: boolean, \
+         experimentalTaskCommand?: boolean };"
             .to_string()
     }
 
     fn decl_concrete() -> String {
         "type FutureFlags = { errorsOnlyShowHash?: boolean, experimentalObservability?: boolean, \
          longerSignatureKey?: boolean, affectedUsingTaskInputs?: boolean, watchUsingTaskInputs?: \
-         boolean, pruneIncludesGlobalFiles?: boolean, filterUsingTasks?: boolean, \
-         strictTaskEntrypointSelection?: boolean, globalConfiguration?: boolean, \
-         experimentalCargoWorkspaces?: boolean, experimentalTaskCommand?: boolean };"
+         boolean, resolveRemoteBaseRefs?: boolean, pruneIncludesGlobalFiles?: boolean, \
+         filterUsingTasks?: boolean, strictTaskEntrypointSelection?: boolean, \
+         globalConfiguration?: boolean, experimentalCargoWorkspaces?: boolean, \
+         experimentalTaskCommand?: boolean };"
             .to_string()
     }
 

--- a/crates/turborepo-turbo-json/src/lib.rs
+++ b/crates/turborepo-turbo-json/src/lib.rs
@@ -783,6 +783,35 @@ mod tests {
     }
 
     #[test]
+    fn test_deserialize_future_flags_resolve_remote_base_refs() {
+        let json = r#"{
+            "tasks": {},
+            "futureFlags": {
+                "resolveRemoteBaseRefs": true
+            }
+        }"#;
+
+        let (deserialized, diagnostics) = deserialize_from_json_str(
+            json,
+            JsonParserOptions::default().with_allow_comments(),
+            "turbo.json",
+        );
+        assert!(diagnostics.is_empty());
+        let raw_turbo_json: RawTurboJson = deserialized.unwrap();
+        assert!(
+            raw_turbo_json
+                .future_flags
+                .as_ref()
+                .unwrap()
+                .as_inner()
+                .resolve_remote_base_refs
+        );
+
+        let turbo_json = TurboJson::try_from(raw_turbo_json).unwrap();
+        assert!(turbo_json.future_flags.resolve_remote_base_refs);
+    }
+
+    #[test]
     fn test_is_root_config_with_root_path() {
         let turbo_json = TurboJson {
             path: Some("turbo.json".into()),

--- a/packages/turbo-types/schemas/schema.json
+++ b/packages/turbo-types/schemas/schema.json
@@ -330,6 +330,11 @@
           "default": false,
           "type": "boolean"
         },
+        "resolveRemoteBaseRefs": {
+          "description": "Fall back to `origin/<branch>` when an inferred base branch is not available as a local ref. This supports detached checkouts in CI where only remote-tracking refs are present.",
+          "default": false,
+          "type": "boolean"
+        },
         "strictTaskEntrypointSelection": {
           "description": "Select requested task entrypoints according to whether the task resolves a command in the repository. When any package can run a requested task, packages without a command are not used as entrypoints. Tasks with no command anywhere remain available for graph-only orchestration, and missing tasks reached as dependencies remain in the Task Graph.",
           "default": false,

--- a/packages/turbo-types/schemas/schema.v2.json
+++ b/packages/turbo-types/schemas/schema.v2.json
@@ -286,6 +286,11 @@
           "default": false,
           "type": "boolean"
         },
+        "resolveRemoteBaseRefs": {
+          "description": "Fall back to `origin/<branch>` when an inferred base branch is not available as a local ref. This supports detached checkouts in CI where only remote-tracking refs are present.",
+          "default": false,
+          "type": "boolean"
+        },
         "errorsOnlyShowHash": {
           "description": "When using `outputLogs: \"errors-only\"`, show task hashes when tasks complete successfully. This provides visibility into which tasks are running without showing full output logs.",
           "default": false,

--- a/packages/turbo-types/src/types/config-v2.ts
+++ b/packages/turbo-types/src/types/config-v2.ts
@@ -267,6 +267,14 @@ export interface FutureFlags {
    */
   affectedUsingTaskInputs?: boolean;
   /**
+   * Fall back to `origin/<branch>` when an inferred base branch is not
+   * available as a local ref. This supports detached checkouts in CI where
+   * only remote-tracking refs are present.
+   *
+   * @defaultValue `false`
+   */
+  resolveRemoteBaseRefs?: boolean;
+  /**
    * Use task-level `inputs` globs to determine which tasks to re-run when
    * files change in `turbo watch`. When enabled, only tasks whose declared
    * inputs match the changed files are re-executed, rather than re-running


### PR DESCRIPTION
## Summary

- Add `futureFlags.resolveRemoteBaseRefs` to opt into resolving inferred base branches through `origin/<branch>` when local refs are unavailable.
- Preserve explicit-ref and local-ref precedence while supporting detached CI checkouts.
- Add behavior, configuration, schema, type, and documentation coverage.

Reimplements the intent of #10732 behind a future flag.

## Testing

- `cargo +nightly-2026-05-22 test -p turborepo-scm`
- `cargo +nightly-2026-05-22 test -p turborepo-turbo-json test_deserialize_future_flags_resolve_remote_base_refs`
- `cargo +nightly-2026-05-22 check -p turborepo-lib`
- `cargo +nightly-2026-05-22 lint`
- `cargo +nightly-2026-05-22 fmt --all -- --check`
- `cargo +nightly-2026-05-22 run -p turborepo-schema-gen -- verify --schema packages/turbo-types/schemas/schema.json --typescript packages/turbo-types/src/types/config-v2.ts`
- `pnpm exec oxfmt --check apps/docs/content/docs/reference/configuration.mdx packages/turbo-types/src/types/config-v2.ts`
