### PR TITLE
refactor: Define external resolution contracts

### DIFF
--- a/crates/turborepo-repository/src/external_resolution.rs
+++ b/crates/turborepo-repository/src/external_resolution.rs
@@ -1,0 +1,587 @@
+//! Parser-neutral external dependency declarations and exact resolutions.
+
+// Producer and repository-knowledge wiring intentionally lands after these
+// contracts, so the crate-private validated views are not consumed yet.
+#![allow(dead_code)]
+
+use std::collections::HashSet;
+
+use turbopath::{AnchoredSystemPath, AnchoredSystemPathBuf};
+
+use crate::{
+    knowledge::{RelationshipKnowledge, RepositoryKnowledge},
+    relationships::{DependencyKind, RelationshipTarget},
+    toolchain::ToolchainId,
+};
+
+/// One effective unresolved external declaration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExternalDeclaration {
+    source: String,
+    declaration_name: String,
+    package_name: String,
+    specifier: String,
+    kind: DependencyKind,
+}
+
+impl ExternalDeclaration {
+    pub fn source(&self) -> &str {
+        &self.source
+    }
+
+    pub fn declaration_name(&self) -> &str {
+        &self.declaration_name
+    }
+
+    pub fn package_name(&self) -> &str {
+        &self.package_name
+    }
+
+    pub fn specifier(&self) -> &str {
+        &self.specifier
+    }
+
+    pub fn kind(&self) -> DependencyKind {
+        self.kind
+    }
+}
+
+/// Immutable declaration-side input to external resolution producers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ExternalDeclarationView {
+    declarations: Box<[ExternalDeclaration]>,
+}
+
+impl ExternalDeclarationView {
+    pub(crate) fn build(relationships: &RelationshipKnowledge) -> Self {
+        let mut declarations = Vec::new();
+        for group in relationships.groups() {
+            let mut seen = HashSet::new();
+            for relationship in group.relationships() {
+                if !seen.insert(relationship.declaration_name()) {
+                    continue;
+                }
+                if !matches!(
+                    relationship.kind(),
+                    DependencyKind::Production | DependencyKind::Development
+                ) {
+                    continue;
+                }
+                let RelationshipTarget::UnresolvedExternal { name, specifier } =
+                    relationship.target()
+                else {
+                    continue;
+                };
+                declarations.push(ExternalDeclaration {
+                    source: group.source().to_string(),
+                    declaration_name: relationship.declaration_name().to_string(),
+                    package_name: name.clone(),
+                    specifier: specifier.clone(),
+                    kind: relationship.kind(),
+                });
+            }
+        }
+        Self {
+            declarations: declarations.into_boxed_slice(),
+        }
+    }
+
+    pub(crate) fn declarations(&self) -> &[ExternalDeclaration] {
+        &self.declarations
+    }
+}
+
+/// An exact, opaque external package identity.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ExternalPackageIdentity {
+    key: String,
+    version: String,
+}
+
+impl ExternalPackageIdentity {
+    pub fn new(key: impl Into<String>, version: impl Into<String>) -> Self {
+        Self {
+            key: key.into(),
+            version: version.into(),
+        }
+    }
+
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+}
+
+/// Why a resolved generation is incomplete.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolutionIncompleteReason {
+    code: String,
+    message: String,
+}
+
+impl ResolutionIncompleteReason {
+    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+        }
+    }
+
+    pub fn code(&self) -> &str {
+        &self.code
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+/// Whether all declarations in a resolution domain were resolved.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolutionCompleteness {
+    Complete,
+    Partial(ResolutionIncompleteReason),
+}
+
+/// Why no terminal resolution data is available for a domain.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolutionUnavailableReason {
+    code: String,
+    message: String,
+}
+
+impl ResolutionUnavailableReason {
+    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+        }
+    }
+
+    pub fn code(&self) -> &str {
+        &self.code
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+/// Stable producer-supplied identity for one resolved domain generation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolutionFingerprint(String);
+
+impl ResolutionFingerprint {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Exact external identities attributed to one authoritative package.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackageResolution {
+    package: String,
+    identities: Vec<ExternalPackageIdentity>,
+}
+
+impl PackageResolution {
+    pub fn new(
+        package: impl Into<String>,
+        identities: impl IntoIterator<Item = ExternalPackageIdentity>,
+    ) -> Self {
+        Self {
+            package: package.into(),
+            identities: identities.into_iter().collect(),
+        }
+    }
+
+    pub fn package(&self) -> &str {
+        &self.package
+    }
+
+    pub fn identities(&self) -> &[ExternalPackageIdentity] {
+        &self.identities
+    }
+}
+
+/// Terminal resolution data for one domain.
+///
+/// `Resolved` with an empty package set is intentionally distinct from
+/// `Unavailable`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExternalResolutionData {
+    Resolved {
+        completeness: ResolutionCompleteness,
+        fingerprint: ResolutionFingerprint,
+        packages: Vec<PackageResolution>,
+    },
+    Unavailable(ResolutionUnavailableReason),
+}
+
+/// One parser-neutral external resolution domain contributed by a toolchain.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExternalResolutionDomain {
+    toolchain: ToolchainId,
+    root: AnchoredSystemPathBuf,
+    definition_sources: Vec<AnchoredSystemPathBuf>,
+    data: ExternalResolutionData,
+}
+
+impl ExternalResolutionDomain {
+    pub fn new(
+        toolchain: ToolchainId,
+        root: AnchoredSystemPathBuf,
+        definition_sources: impl IntoIterator<Item = AnchoredSystemPathBuf>,
+        data: ExternalResolutionData,
+    ) -> Self {
+        Self {
+            toolchain,
+            root,
+            definition_sources: definition_sources.into_iter().collect(),
+            data,
+        }
+    }
+
+    pub fn toolchain(&self) -> &ToolchainId {
+        &self.toolchain
+    }
+
+    pub fn root(&self) -> &AnchoredSystemPath {
+        &self.root
+    }
+
+    pub fn definition_sources(&self) -> &[AnchoredSystemPathBuf] {
+        &self.definition_sources
+    }
+
+    pub fn data(&self) -> &ExternalResolutionData {
+        &self.data
+    }
+}
+
+/// Lifecycle state for resolution production, kept separate from terminal
+/// generation data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExternalResolutionStatus {
+    Pending,
+    Resolving,
+    Complete,
+}
+
+/// A validated, immutable generation of external resolution knowledge.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ExternalResolutionGeneration {
+    domains: Box<[ExternalResolutionDomain]>,
+}
+
+impl ExternalResolutionGeneration {
+    pub(crate) fn build(
+        repository: &RepositoryKnowledge,
+        mut domains: Vec<ExternalResolutionDomain>,
+    ) -> Result<Self, ExternalResolutionError> {
+        for domain in &mut domains {
+            domain.definition_sources.sort();
+            domain.definition_sources.dedup();
+            if let ExternalResolutionData::Resolved { packages, .. } = &mut domain.data {
+                for package in packages.iter_mut() {
+                    package.identities.sort();
+                    package.identities.dedup();
+                }
+                packages.sort_by(|left, right| left.package.cmp(&right.package));
+            }
+        }
+        domains.sort_by(|left, right| {
+            left.toolchain
+                .cmp(&right.toolchain)
+                .then_with(|| left.root.cmp(&right.root))
+        });
+
+        if let Some(duplicate) = domains
+            .windows(2)
+            .find(|pair| pair[0].toolchain == pair[1].toolchain)
+        {
+            return Err(ExternalResolutionError::DuplicateDomain {
+                toolchain: duplicate[0].toolchain.clone(),
+            });
+        }
+
+        for domain in &mut domains {
+            if !repository.workspace_roots().any(|root| {
+                root.toolchain() == &domain.toolchain && root.path() == domain.root.as_ref()
+            }) {
+                return Err(ExternalResolutionError::UnknownDomain {
+                    toolchain: domain.toolchain.clone(),
+                    root: domain.root.clone(),
+                });
+            }
+
+            let ExternalResolutionData::Resolved { packages, .. } = &mut domain.data else {
+                continue;
+            };
+            if let Some(duplicate) = packages
+                .windows(2)
+                .find(|pair| pair[0].package == pair[1].package)
+            {
+                return Err(ExternalResolutionError::DuplicatePackage {
+                    toolchain: domain.toolchain.clone(),
+                    identity: duplicate[0].package.clone(),
+                });
+            }
+            for package in packages {
+                let is_authoritative = (package.package() == "//"
+                    && repository.root_javascript_scope().is_some())
+                    || repository.scope(package.package()).is_some();
+                if !is_authoritative {
+                    return Err(ExternalResolutionError::UnknownPackage {
+                        toolchain: domain.toolchain.clone(),
+                        identity: package.package.clone(),
+                    });
+                }
+            }
+        }
+        Ok(Self {
+            domains: domains.into_boxed_slice(),
+        })
+    }
+
+    pub(crate) fn domains(&self) -> &[ExternalResolutionDomain] {
+        &self.domains
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub(crate) enum ExternalResolutionError {
+    #[error("toolchain {toolchain} contributed multiple external resolution domains")]
+    DuplicateDomain { toolchain: ToolchainId },
+    #[error("toolchain {toolchain} contributed unknown resolution domain root {root}")]
+    UnknownDomain {
+        toolchain: ToolchainId,
+        root: AnchoredSystemPathBuf,
+    },
+    #[error("toolchain {toolchain} resolved unknown package {identity}")]
+    UnknownPackage {
+        toolchain: ToolchainId,
+        identity: String,
+    },
+    #[error("toolchain {toolchain} resolved package {identity} more than once")]
+    DuplicatePackage {
+        toolchain: ToolchainId,
+        identity: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use turbopath::AbsoluteSystemPathBuf;
+
+    use super::*;
+    use crate::{
+        knowledge::{
+            PackageScopeObservation, RelationshipGroup, ScopeKind, WorkspaceRootObservation,
+        },
+        relationships::Relationship,
+        toolchain::WorkspaceRoot,
+    };
+
+    fn repository() -> RepositoryKnowledge {
+        let root =
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+        RepositoryKnowledge::build(
+            &root,
+            Some(Some("root".to_string())),
+            &[
+                PackageScopeObservation {
+                    identity: Some("app".to_string()),
+                    definition_path: root.join_components(&["apps", "app", "package.json"]),
+                    toolchain: ToolchainId::JAVASCRIPT,
+                    scope_kind: ScopeKind::Package,
+                },
+                PackageScopeObservation {
+                    identity: Some("crate".to_string()),
+                    definition_path: root.join_components(&["crates", "crate", "Cargo.toml"]),
+                    toolchain: ToolchainId::RUST,
+                    scope_kind: ScopeKind::Package,
+                },
+            ],
+            &[
+                WorkspaceRootObservation::new(
+                    WorkspaceRoot::new("npm", root.clone()),
+                    ToolchainId::JAVASCRIPT,
+                ),
+                WorkspaceRootObservation::new(
+                    WorkspaceRoot::new("cargo", root.clone()),
+                    ToolchainId::RUST,
+                ),
+            ],
+        )
+        .unwrap()
+    }
+
+    fn resolved(packages: Vec<PackageResolution>) -> ExternalResolutionData {
+        ExternalResolutionData::Resolved {
+            completeness: ResolutionCompleteness::Complete,
+            fingerprint: ResolutionFingerprint::new("fingerprint"),
+            packages,
+        }
+    }
+
+    #[test]
+    fn declaration_view_preserves_effective_external_declarations() {
+        let repository = repository();
+        let relationships = RelationshipKnowledge::build(
+            &repository,
+            vec![RelationshipGroup::new(
+                "app",
+                vec![
+                    Relationship::new(
+                        "alias",
+                        DependencyKind::Production,
+                        RelationshipTarget::UnresolvedExternal {
+                            name: "package".to_string(),
+                            specifier: "1.0.0".to_string(),
+                        },
+                    ),
+                    Relationship::new(
+                        "alias",
+                        DependencyKind::Development,
+                        RelationshipTarget::UnresolvedExternal {
+                            name: "ignored-duplicate".to_string(),
+                            specifier: "2.0.0".to_string(),
+                        },
+                    ),
+                    Relationship::new(
+                        "peer",
+                        DependencyKind::Peer { optional: false },
+                        RelationshipTarget::UnresolvedExternal {
+                            name: "peer".to_string(),
+                            specifier: "3.0.0".to_string(),
+                        },
+                    ),
+                ],
+            )],
+        )
+        .unwrap();
+
+        let view = ExternalDeclarationView::build(&relationships);
+        assert_eq!(view.declarations().len(), 1);
+        let declaration = &view.declarations()[0];
+        assert_eq!(declaration.source(), "app");
+        assert_eq!(declaration.declaration_name(), "alias");
+        assert_eq!(declaration.package_name(), "package");
+        assert_eq!(declaration.specifier(), "1.0.0");
+        assert_eq!(declaration.kind(), DependencyKind::Production);
+    }
+
+    #[test]
+    fn resolved_empty_is_distinct_from_unavailable() {
+        let complete_empty = ExternalResolutionGeneration::build(
+            &repository(),
+            vec![ExternalResolutionDomain::new(
+                ToolchainId::JAVASCRIPT,
+                AnchoredSystemPathBuf::default(),
+                [AnchoredSystemPathBuf::from_raw("package-lock.json").unwrap()],
+                resolved(Vec::new()),
+            )],
+        )
+        .unwrap();
+        let unavailable = ExternalResolutionGeneration::build(
+            &repository(),
+            vec![ExternalResolutionDomain::new(
+                ToolchainId::JAVASCRIPT,
+                AnchoredSystemPathBuf::default(),
+                [AnchoredSystemPathBuf::from_raw("package-lock.json").unwrap()],
+                ExternalResolutionData::Unavailable(ResolutionUnavailableReason::new(
+                    "missing-definition",
+                    "package-lock.json does not exist",
+                )),
+            )],
+        )
+        .unwrap();
+
+        assert_ne!(complete_empty, unavailable);
+    }
+
+    #[test]
+    fn generation_normalizes_all_ordering() {
+        let source_a = AnchoredSystemPathBuf::from_raw("a.lock").unwrap();
+        let source_z = AnchoredSystemPathBuf::from_raw("z.lock").unwrap();
+        let identity_a = ExternalPackageIdentity::new("a", "1");
+        let identity_z = ExternalPackageIdentity::new("z", "2");
+        let make = |reverse: bool| {
+            let (sources, identities) = if reverse {
+                (
+                    vec![source_z.clone(), source_a.clone(), source_z.clone()],
+                    vec![identity_z.clone(), identity_a.clone(), identity_z.clone()],
+                )
+            } else {
+                (
+                    vec![source_a.clone(), source_z.clone()],
+                    vec![identity_a.clone(), identity_z.clone()],
+                )
+            };
+            let javascript = ExternalResolutionDomain::new(
+                ToolchainId::JAVASCRIPT,
+                AnchoredSystemPathBuf::default(),
+                sources,
+                resolved(vec![PackageResolution::new("app", identities)]),
+            );
+            let rust = ExternalResolutionDomain::new(
+                ToolchainId::RUST,
+                AnchoredSystemPathBuf::default(),
+                [AnchoredSystemPathBuf::from_raw("Cargo.lock").unwrap()],
+                resolved(vec![PackageResolution::new("crate", Vec::new())]),
+            );
+            let domains = if reverse {
+                vec![rust, javascript]
+            } else {
+                vec![javascript, rust]
+            };
+            ExternalResolutionGeneration::build(&repository(), domains).unwrap()
+        };
+
+        let ordered = make(false);
+        let reversed = make(true);
+        assert_eq!(ordered, reversed);
+        assert_eq!(ordered.domains()[0].toolchain(), &ToolchainId::JAVASCRIPT);
+        let ExternalResolutionData::Resolved { packages, .. } = ordered.domains()[0].data() else {
+            panic!("expected resolved data")
+        };
+        assert_eq!(packages[0].identities(), &[identity_a, identity_z]);
+    }
+
+    #[test]
+    fn generation_rejects_duplicate_domains_and_unknown_packages() {
+        let domain = || {
+            ExternalResolutionDomain::new(
+                ToolchainId::JAVASCRIPT,
+                AnchoredSystemPathBuf::default(),
+                Vec::new(),
+                resolved(Vec::new()),
+            )
+        };
+        assert!(matches!(
+            ExternalResolutionGeneration::build(&repository(), vec![domain(), domain()]),
+            Err(ExternalResolutionError::DuplicateDomain { toolchain })
+                if toolchain == ToolchainId::JAVASCRIPT
+        ));
+
+        let unknown = ExternalResolutionDomain::new(
+            ToolchainId::RUST,
+            AnchoredSystemPathBuf::default(),
+            Vec::new(),
+            resolved(vec![PackageResolution::new("missing", Vec::new())]),
+        );
+        assert!(matches!(
+            ExternalResolutionGeneration::build(&repository(), vec![unknown]),
+            Err(ExternalResolutionError::UnknownPackage { identity, .. })
+                if identity == "missing"
+        ));
+    }
+}

--- a/crates/turborepo-repository/src/lib.rs
+++ b/crates/turborepo-repository/src/lib.rs
@@ -14,6 +14,7 @@
 pub mod cargo;
 pub mod change_mapper;
 pub mod discovery;
+pub mod external_resolution;
 pub mod inference;
 mod knowledge;
 mod manifest_parser;

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -151,6 +151,14 @@ Represents the workspace structure and package dependencies:
   consumers pay no construction cost. They expose only authoritative package
   identities plus the always-present root Turbo task namespace, never the
   package graph's structural root sentinel.
+- Defines parser-neutral external declaration and resolution contracts for the
+  next migration phase. Resolution domains retain their native definition
+  sources, exact opaque package identities, completeness, stable fingerprint,
+  and explicit unavailable reason. Validation rejects unknown package
+  identities and multiple domains from one toolchain, and normalizes retained
+  ordering. Resolved-empty terminal data remains distinct from unavailable
+  data, while pending/resolving/complete lifecycle status is modeled
+  separately. Producers and consumers are not wired to these contracts yet.
 - Performs ecosystem-specific lockfile analysis
 - Builds dependency relationships between workspace packages
 - Validates that all non-root packages have a `name` field


### PR DESCRIPTION
## Summary

- add a parser-neutral view of effective external declarations
- define validated external resolution generations with authoritative package identities, exact opaque identities, definition sources, completeness, fingerprints, and explicit unavailable reasons
- distinguish resolved-empty terminal data from unavailable data and keep lifecycle status separate
- normalize generation ordering and reject duplicate same-toolchain domains, duplicate package results, unknown domains, and unknown package identities
- document the staged external-resolution architecture

Closes TURBO-5804.

## Testing

- `cargo test -p turborepo-repository external_resolution`
- `cargo clippy -p turborepo-repository --all-targets -- -D warnings`
- `cargo test -p turborepo-repository` (363 passed; two unrelated devbox-environment failures: a missing lockfile fixture and ANSI bytes in an Insta snapshot)
- pre-push `format` and `check:toml` hooks