### PR TITLE
refactor: Build JavaScript external resolution generations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9041,6 +9041,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
+ "sha2",
  "tempfile",
  "test-case",
  "thiserror 2.0.18",

--- a/crates/turborepo-repository/Cargo.toml
+++ b/crates/turborepo-repository/Cargo.toml
@@ -26,6 +26,7 @@ rust-ini = "0.20.0"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }
+sha2 = { workspace = true }
 thiserror = { workspace = true }
 tokio.workspace = true
 toml_edit = { workspace = true }

--- a/crates/turborepo-repository/src/external_resolution.rs
+++ b/crates/turborepo-repository/src/external_resolution.rs
@@ -1,9 +1,5 @@
 //! Parser-neutral external dependency declarations and exact resolutions.
 
-// Producer and repository-knowledge wiring intentionally lands after these
-// contracts, so the crate-private validated views are not consumed yet.
-#![allow(dead_code)]
-
 use std::collections::HashSet;
 
 use turbopath::{AnchoredSystemPath, AnchoredSystemPathBuf};
@@ -351,6 +347,7 @@ impl ExternalResolutionGeneration {
         })
     }
 
+    #[cfg(test)]
     pub(crate) fn domains(&self) -> &[ExternalResolutionDomain] {
         &self.domains
     }

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -5,20 +5,27 @@ use std::{
 
 use miette::{Diagnostic, Report};
 use petgraph::graph::{Graph, NodeIndex};
-use tracing::{Instrument, warn};
+use sha2::{Digest, Sha256};
+use tracing::warn;
 use turbopath::{
     AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPath, AnchoredSystemPathBuf,
 };
 use turborepo_lockfiles::Lockfile;
 
 use super::{
-    PackageGraph, PackageInfo, PackageName, PackageNode,
+    JavaScriptResolutionKnowledge, JavaScriptResolutionSnapshot, PackageGraph, PackageInfo,
+    PackageName, PackageNode,
     dep_splitter::{DependencySplitter, WorkspacePathIndex},
 };
 use crate::{
     discovery::{
         self, CachingPackageDiscovery, LocalPackageDiscoveryBuilder, PackageDiscovery,
         PackageDiscoveryBuilder,
+    },
+    external_resolution::{
+        ExternalDeclarationView, ExternalPackageIdentity, ExternalResolutionData,
+        ExternalResolutionDomain, ExternalResolutionGeneration, PackageResolution,
+        ResolutionCompleteness, ResolutionFingerprint, ResolutionUnavailableReason,
     },
     knowledge::{
         PackageScopeObservation, RelationshipGroup, RelationshipKnowledge, RepositoryKnowledge,
@@ -88,6 +95,8 @@ pub enum Error {
     MissingRepositoryKnowledge,
     #[error("repository relationship knowledge was not constructed")]
     MissingRelationshipKnowledge,
+    #[error("external resolution generation failed: {0}")]
+    ExternalResolution(String),
     #[error("package or aggregate scope at {path} uses reserved root identity //")]
     ReservedRootIdentity { path: AnchoredSystemPathBuf },
     #[error("relationship source {identity} has no authoritative repository scope")]
@@ -393,6 +402,7 @@ struct BuildState<'a, S, T> {
     /// [`PackageGraphBuilder::root_package_json`].
     root_package_json: Option<PackageJson>,
     lockfile: Option<Box<dyn Lockfile>>,
+    package_manager: Option<PackageManager>,
     package_jsons: Option<HashMap<AbsoluteSystemPathBuf, PackageJson>>,
     defer_closures: bool,
     closure_hasher: Option<ClosureHasher>,
@@ -666,6 +676,7 @@ where
             relationship_knowledge: None,
             native_relationships: HashMap::new(),
             lockfile,
+            package_manager: None,
             package_jsons,
             root_package_json,
             defer_closures,
@@ -819,6 +830,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             native_relationships,
             root_package_json,
             lockfile,
+            package_manager,
             javascript,
             toolchains,
             defer_closures,
@@ -834,6 +846,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             native_relationships,
             root_package_json,
             lockfile,
+            package_manager,
             javascript,
             toolchains,
             defer_closures,
@@ -919,7 +932,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             knowledge,
             relationship_knowledge,
             relationship_projections: std::sync::OnceLock::new(),
-            deferred_closures: std::sync::Mutex::new(None),
+            javascript_resolution: std::sync::Mutex::new(JavaScriptResolutionKnowledge::absent()),
             external_dep_to_internal_dependents: std::sync::OnceLock::new(),
             root_internal_dependencies: std::sync::OnceLock::new(),
             toolchains,
@@ -1094,6 +1107,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
             native_relationships: HashMap::new(),
             root_package_json,
             lockfile,
+            package_manager,
             defer_closures,
             closure_hasher,
             package_jsons: None,
@@ -1139,6 +1153,128 @@ fn scope_definition_path<'a>(
     }
 }
 
+fn build_failure(error: Error) -> discovery::Error {
+    discovery::Error::Failed(Box::new(error))
+}
+
+fn javascript_resolution_packages(
+    knowledge: &RepositoryKnowledge,
+) -> Vec<(&str, &AnchoredSystemPath)> {
+    let mut packages = Vec::new();
+    if knowledge.root_javascript_scope().is_some() {
+        packages.push((super::ROOT_PKG_NAME, knowledge.repository_directory()));
+    }
+    packages.extend(
+        knowledge
+            .scopes()
+            .filter(|scope| scope.toolchain() == &ToolchainId::JAVASCRIPT)
+            .map(|scope| (scope.identity(), scope.directory())),
+    );
+    packages.sort_unstable_by_key(|(identity, _)| *identity);
+    packages
+}
+
+fn fingerprint_package_resolutions(packages: &[PackageResolution]) -> ResolutionFingerprint {
+    fn update(hasher: &mut Sha256, value: &str) {
+        hasher.update((value.len() as u64).to_le_bytes());
+        hasher.update(value.as_bytes());
+    }
+
+    let mut hasher = Sha256::new();
+    for package in packages {
+        update(&mut hasher, package.package());
+        for identity in package.identities() {
+            update(&mut hasher, identity.key());
+            update(&mut hasher, identity.version());
+        }
+    }
+    ResolutionFingerprint::new(format!("{:x}", hasher.finalize()))
+}
+
+fn unavailable_javascript_resolution(
+    knowledge: &RepositoryKnowledge,
+    definition_source: AnchoredSystemPathBuf,
+    code: &str,
+    message: String,
+    warning: Option<String>,
+) -> Result<JavaScriptResolutionSnapshot, String> {
+    let domain = ExternalResolutionDomain::new(
+        ToolchainId::JAVASCRIPT,
+        AnchoredSystemPathBuf::default(),
+        [definition_source],
+        ExternalResolutionData::Unavailable(ResolutionUnavailableReason::new(code, message)),
+    );
+    let generation = ExternalResolutionGeneration::build(knowledge, vec![domain])
+        .map_err(|error| error.to_string())?;
+    Ok(JavaScriptResolutionSnapshot {
+        generation: Arc::new(generation),
+        closures: HashMap::new(),
+        hashes: HashMap::new(),
+        warning,
+    })
+}
+
+fn resolve_javascript_dependencies(
+    knowledge: &RepositoryKnowledge,
+    lockfile: &dyn Lockfile,
+    external_dependencies: HashMap<String, BTreeMap<String, String>>,
+    definition_source: AnchoredSystemPathBuf,
+    closure_hasher: Option<&ClosureHasher>,
+) -> Result<JavaScriptResolutionSnapshot, String> {
+    let closures = match turborepo_lockfiles::all_transitive_closures_sorted(
+        lockfile,
+        external_dependencies,
+        false,
+    ) {
+        Ok(closures) => closures,
+        Err(error) => {
+            let message = error.to_string();
+            return unavailable_javascript_resolution(
+                knowledge,
+                definition_source,
+                "closure-unavailable",
+                message.clone(),
+                Some(message),
+            );
+        }
+    };
+    let hashes = closure_hasher
+        .map(|hasher| hasher(&closures))
+        .unwrap_or_default();
+    let packages = javascript_resolution_packages(knowledge)
+        .into_iter()
+        .map(|(identity, directory)| {
+            let exact_identities = closures
+                .get(directory.to_unix().as_str())
+                .into_iter()
+                .flatten()
+                .map(|package| {
+                    ExternalPackageIdentity::new(package.key.clone(), package.version.clone())
+                });
+            PackageResolution::new(identity, exact_identities)
+        })
+        .collect::<Vec<_>>();
+    let fingerprint = fingerprint_package_resolutions(&packages);
+    let domain = ExternalResolutionDomain::new(
+        ToolchainId::JAVASCRIPT,
+        AnchoredSystemPathBuf::default(),
+        [definition_source],
+        ExternalResolutionData::Resolved {
+            completeness: ResolutionCompleteness::Complete,
+            fingerprint,
+            packages,
+        },
+    );
+    let generation = ExternalResolutionGeneration::build(knowledge, vec![domain])
+        .map_err(|error| error.to_string())?;
+    Ok(JavaScriptResolutionSnapshot {
+        generation: Arc::new(generation),
+        closures,
+        hashes,
+        warning: None,
+    })
+}
+
 impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
     fn all_external_dependencies(
         &self,
@@ -1147,75 +1283,33 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             .knowledge
             .as_deref()
             .ok_or(Error::MissingRepositoryKnowledge)?;
-        self.assembler
-            .package_payloads
-            .iter()
-            // Only JavaScript packages participate in the JS lockfile's
-            // external-dependency closures. This map is keyed by directory,
-            // and a non-JS package can share a directory with a JS one (the
-            // synthetic Cargo workspace package lives at the repo root, like
-            // the root package) — including both would let HashMap iteration
-            // order decide which entry survives, flipping the root's
-            // external-dependency hash run to run.
-            .filter_map(|(name, entry)| {
-                let (directory, toolchain) = scope_directory_and_toolchain(knowledge, name)?;
-                (toolchain == &ToolchainId::JAVASCRIPT).then_some((directory, entry))
-            })
-            .map(|(directory, entry)| {
-                let workspace_path = directory.to_unix();
-                let workspace_string = workspace_path.as_str();
-                let external_deps = entry
-                    .unresolved_external_dependencies
-                    .as_ref()
-                    .map(|deps| {
-                        deps.iter()
-                            .map(|(name, version)| (name.to_string(), version.to_string()))
-                            .collect()
-                    })
-                    .unwrap_or_default();
-                Ok((workspace_string.to_string(), external_deps))
-            })
-            .collect()
-    }
-
-    #[tracing::instrument(skip_all)]
-    fn populate_transitive_dependencies(&mut self) -> Result<(), Error> {
-        let Some(lockfile) = self.lockfile.as_deref() else {
-            return Ok(());
-        };
-
-        // We cannot ignore missing packages in this context, it would indicate a
-        // malformed or stale lockfile.
-        let mut closures = turborepo_lockfiles::all_transitive_closures_sorted(
-            lockfile,
-            self.all_external_dependencies()?,
-            false,
-        )?;
-        let mut hashes = self
-            .closure_hasher
-            .as_ref()
-            .map(|hasher| hasher(&closures))
-            .unwrap_or_default();
-        let knowledge = self
-            .knowledge
+        let relationships = self
+            .relationship_knowledge
             .as_deref()
-            .ok_or(Error::MissingRepositoryKnowledge)?;
-        for (name, entry) in &mut self.assembler.package_payloads {
-            // Mirror of the filter in all_external_dependencies: a non-JS
-            // package sharing a directory with a JS package must not steal
-            // its closure.
-            let Some((directory, toolchain)) = scope_directory_and_toolchain(knowledge, name)
-            else {
+            .ok_or(Error::MissingRelationshipKnowledge)?;
+        let mut by_source: BTreeMap<String, BTreeMap<String, String>> =
+            javascript_resolution_packages(knowledge)
+                .into_iter()
+                .map(|(identity, _)| (identity.to_string(), BTreeMap::new()))
+                .collect();
+        for declaration in ExternalDeclarationView::build(relationships).declarations() {
+            let Some(dependencies) = by_source.get_mut(declaration.source()) else {
                 continue;
             };
-            if toolchain != &ToolchainId::JAVASCRIPT {
-                continue;
-            }
-            let dir = directory.to_unix().to_string();
-            entry.transitive_dependencies = closures.remove(&dir);
-            entry.external_deps_hash = hashes.remove(&dir);
+            dependencies
+                .entry(declaration.package_name().to_string())
+                .or_insert_with(|| declaration.specifier().to_string());
         }
-        Ok(())
+
+        Ok(by_source
+            .into_iter()
+            .filter_map(|(identity, dependencies)| {
+                let name = package_name_from_identity(&identity);
+                let (directory, toolchain) = scope_directory_and_toolchain(knowledge, &name)?;
+                (toolchain == &ToolchainId::JAVASCRIPT)
+                    .then(|| (directory.to_unix().to_string(), dependencies))
+            })
+            .collect())
     }
 
     #[tracing::instrument(skip(self))]
@@ -1226,69 +1320,110 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
         // consumers (microfrontends config, turbo.json preloading, engine
         // construction) overlap with the closure work instead of waiting
         // behind it. `PackageGraph::ensure_transitive_closures` joins.
-        let mut deferred_closures = None;
-        let arc_lockfile: Option<Arc<dyn Lockfile>> = if self.defer_closures {
-            let lockfile: Option<Arc<dyn Lockfile>> = self.lockfile.take().map(Arc::from);
-            if let Some(lockfile) = lockfile.clone() {
+        let knowledge = self
+            .knowledge
+            .clone()
+            .ok_or_else(|| build_failure(Error::MissingRepositoryKnowledge))?;
+        let package_manager = self.package_manager.clone();
+        if let (Some(javascript), Some(package_manager)) = (&self.javascript, &package_manager) {
+            javascript.set_resolved_package_manager(package_manager.clone());
+        }
+        let definition_source = package_manager
+            .as_ref()
+            .map(|package_manager| AnchoredSystemPathBuf::from_raw(package_manager.lockfile_name()))
+            .transpose()
+            .map_err(Error::from)
+            .map_err(build_failure)?;
+        let arc_lockfile: Option<Arc<dyn Lockfile>> = self.lockfile.take().map(Arc::from);
+        let mut javascript_resolution = JavaScriptResolutionKnowledge::absent();
+
+        if let Some(definition_source) = definition_source {
+            if let Some(lockfile) = arc_lockfile.clone() {
                 match self.all_external_dependencies() {
-                    Ok(external_deps) => {
+                    Ok(external_dependencies) if self.defer_closures => {
                         let (tx, rx) = std::sync::mpsc::sync_channel(1);
                         let hasher = self.closure_hasher.clone();
+                        let resolution_knowledge = Arc::clone(&knowledge);
+                        let deferred_source = definition_source.clone();
                         let spawned = std::thread::Builder::new()
                             .name("turbo-closures".into())
                             .spawn(move || {
-                                let result = turborepo_lockfiles::all_transitive_closures_sorted(
+                                let result = resolve_javascript_dependencies(
+                                    &resolution_knowledge,
                                     lockfile.as_ref(),
-                                    external_deps,
-                                    false,
-                                )
-                                .map(|closures| {
-                                    let hashes = hasher
-                                        .as_ref()
-                                        .map(|hasher| hasher(&closures))
-                                        .unwrap_or_default();
-                                    super::DeferredClosures { closures, hashes }
-                                });
-                                let _ = tx.send(result.map_err(|e| e.to_string()));
+                                    external_dependencies,
+                                    deferred_source,
+                                    hasher.as_ref(),
+                                );
+                                let _ = tx.send(result);
                             });
                         match spawned {
-                            Ok(_) => deferred_closures = Some(rx),
-                            Err(e) => {
-                                warn!("Unable to spawn transitive closure thread: {}", e);
+                            Ok(_) => {
+                                javascript_resolution =
+                                    JavaScriptResolutionKnowledge::resolving(rx);
+                            }
+                            Err(error) => {
+                                warn!("Unable to spawn transitive closure thread: {}", error);
+                                let snapshot = unavailable_javascript_resolution(
+                                    &knowledge,
+                                    definition_source,
+                                    "worker-unavailable",
+                                    error.to_string(),
+                                    None,
+                                )
+                                .map_err(|message| {
+                                    build_failure(Error::ExternalResolution(message))
+                                })?;
+                                javascript_resolution =
+                                    JavaScriptResolutionKnowledge::complete(snapshot.generation);
                             }
                         }
                     }
-                    Err(e) => {
-                        warn!("Unable to calculate transitive closures: {}", e);
+                    Ok(external_dependencies) => {
+                        let mut snapshot = turborepo_rayon_compat::block_in_place(|| {
+                            resolve_javascript_dependencies(
+                                &knowledge,
+                                lockfile.as_ref(),
+                                external_dependencies,
+                                definition_source,
+                                self.closure_hasher.as_ref(),
+                            )
+                        })
+                        .map_err(|message| build_failure(Error::ExternalResolution(message)))?;
+                        if let Some(warning) = snapshot.warning.take() {
+                            warn!("Unable to calculate transitive closures: {}", warning);
+                        }
+                        let generation = Arc::clone(&snapshot.generation);
+                        snapshot.project_legacy(&mut self.assembler.package_payloads, &knowledge);
+                        javascript_resolution = JavaScriptResolutionKnowledge::complete(generation);
+                    }
+                    Err(error) => {
+                        warn!("Unable to calculate transitive closures: {}", error);
+                        let snapshot = unavailable_javascript_resolution(
+                            &knowledge,
+                            definition_source,
+                            "declarations-unavailable",
+                            error.to_string(),
+                            None,
+                        )
+                        .map_err(|message| build_failure(Error::ExternalResolution(message)))?;
+                        javascript_resolution =
+                            JavaScriptResolutionKnowledge::complete(snapshot.generation);
                     }
                 }
+            } else {
+                let snapshot = unavailable_javascript_resolution(
+                    &knowledge,
+                    definition_source,
+                    "lockfile-unavailable",
+                    "JavaScript lockfile could not be read or parsed".to_string(),
+                    None,
+                )
+                .map_err(|message| build_failure(Error::ExternalResolution(message)))?;
+                javascript_resolution =
+                    JavaScriptResolutionKnowledge::complete(snapshot.generation);
             }
-            lockfile
-        } else {
-            if let Err(e) =
-                turborepo_rayon_compat::block_in_place(|| self.populate_transitive_dependencies())
-            {
-                warn!("Unable to calculate transitive closures: {}", e);
-            }
-            self.lockfile.take().map(Arc::from)
-        };
-        // A pure Cargo workspace has no JavaScript toolchain, hence no package
-        // manager to resolve.
-        let package_manager = match &self.javascript {
-            Some(javascript) => {
-                let package_manager = javascript
-                    .package_manager()
-                    .instrument(tracing::debug_span!("package discovery"))
-                    .await?
-                    .with_resolved_nub_lockfile(self.repo_root);
-                // Command resolution is synchronous; record the resolved
-                // package manager on the toolchain so it does not re-run
-                // discovery.
-                javascript.set_resolved_package_manager(package_manager.clone());
-                Some(package_manager)
-            }
-            None => None,
-        };
+        }
         let Self {
             assembler,
             knowledge,
@@ -1322,7 +1457,7 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             knowledge,
             relationship_knowledge,
             relationship_projections: std::sync::OnceLock::new(),
-            deferred_closures: std::sync::Mutex::new(deferred_closures),
+            javascript_resolution: std::sync::Mutex::new(javascript_resolution),
             external_dep_to_internal_dependents: std::sync::OnceLock::new(),
             root_internal_dependencies: std::sync::OnceLock::new(),
             toolchains,

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -16,6 +16,7 @@ use turborepo_lockfiles::Lockfile;
 
 use crate::{
     discovery::LocalPackageDiscoveryBuilder,
+    external_resolution::{ExternalResolutionGeneration, ExternalResolutionStatus},
     knowledge::{RelationshipKnowledge, RepositoryKnowledge},
     package_json::PackageJson,
     package_manager::PackageManager,
@@ -35,17 +36,87 @@ pub use crate::package_json::DependencyKind;
 
 pub const ROOT_PKG_NAME: &str = "//";
 
-/// Background transitive-closure result: per-workspace sorted closures and
-/// their external-dependency hashes, keyed by workspace unix directory.
-pub(crate) struct DeferredClosures {
+/// One JavaScript resolution snapshot and its temporary compatibility
+/// projection. Both inline and deferred production create this exact shape.
+pub(crate) struct JavaScriptResolutionSnapshot {
+    pub generation: Arc<ExternalResolutionGeneration>,
     pub closures: HashMap<String, Vec<Arc<turborepo_lockfiles::Package>>>,
     pub hashes: HashMap<String, String>,
+    pub warning: Option<String>,
 }
 
-/// Channel end delivering the background transitive-closure result, or a
-/// rendered error message.
-pub(crate) type DeferredClosuresReceiver =
-    std::sync::mpsc::Receiver<Result<DeferredClosures, String>>;
+impl JavaScriptResolutionSnapshot {
+    pub(crate) fn project_legacy(
+        &mut self,
+        package_payloads: &mut HashMap<PackageName, PackageInfo>,
+        knowledge: &RepositoryKnowledge,
+    ) {
+        for (name, info) in package_payloads {
+            let facts = match name {
+                PackageName::Root => knowledge
+                    .root_javascript_scope()
+                    .map(|scope| (knowledge.repository_directory(), scope.toolchain())),
+                PackageName::Other(name) => knowledge
+                    .scope(name)
+                    .map(|scope| (scope.directory(), scope.toolchain())),
+            };
+            let Some((directory, toolchain)) = facts else {
+                continue;
+            };
+            if toolchain != &crate::toolchain::ToolchainId::JAVASCRIPT {
+                continue;
+            }
+            let directory = directory.to_unix();
+            info.transitive_dependencies = self.closures.remove(directory.as_str());
+            info.external_deps_hash = self.hashes.remove(directory.as_str());
+        }
+    }
+}
+
+pub(crate) type DeferredResolutionReceiver =
+    std::sync::mpsc::Receiver<Result<JavaScriptResolutionSnapshot, String>>;
+
+#[derive(Debug)]
+pub(crate) struct JavaScriptResolutionKnowledge {
+    status: ExternalResolutionStatus,
+    generation: Option<Arc<ExternalResolutionGeneration>>,
+    receiver: Option<DeferredResolutionReceiver>,
+}
+
+impl JavaScriptResolutionKnowledge {
+    pub(crate) fn absent() -> Self {
+        Self {
+            status: ExternalResolutionStatus::Complete,
+            generation: None,
+            receiver: None,
+        }
+    }
+
+    pub(crate) fn complete(generation: Arc<ExternalResolutionGeneration>) -> Self {
+        Self {
+            status: ExternalResolutionStatus::Complete,
+            generation: Some(generation),
+            receiver: None,
+        }
+    }
+
+    pub(crate) fn resolving(receiver: DeferredResolutionReceiver) -> Self {
+        Self {
+            status: ExternalResolutionStatus::Resolving,
+            generation: None,
+            receiver: Some(receiver),
+        }
+    }
+
+    fn take_receiver(&mut self) -> Option<DeferredResolutionReceiver> {
+        self.receiver.take()
+    }
+
+    fn finish(&mut self, generation: Option<Arc<ExternalResolutionGeneration>>) {
+        self.status = ExternalResolutionStatus::Complete;
+        self.generation = generation;
+    }
+}
 
 #[derive(Debug)]
 pub struct PackageGraph {
@@ -64,10 +135,10 @@ pub struct PackageGraph {
     #[allow(dead_code)]
     relationship_knowledge: Arc<RelationshipKnowledge>,
     relationship_projections: OnceLock<projections::RelationshipProjections>,
-    /// Receiver for background transitive-closure computation when the graph
-    /// was built with deferred closures. Consumed (exactly once) by
+    /// The sole owner of JavaScript external-resolution lifecycle and terminal
+    /// knowledge. Deferred production is joined exactly once by
     /// [`Self::ensure_transitive_closures`].
-    deferred_closures: Mutex<Option<DeferredClosuresReceiver>>,
+    javascript_resolution: Mutex<JavaScriptResolutionKnowledge>,
     external_dep_to_internal_dependents:
         OnceLock<HashMap<turborepo_lockfiles::Package, HashSet<PackageNode>>>,
     /// Lazily computed internal dependencies of the root package. They are
@@ -775,50 +846,58 @@ impl PackageGraph {
     /// consumer of `PackageInfo::transitive_dependencies` runs.
     pub fn ensure_transitive_closures(&mut self) {
         let receiver = self
-            .deferred_closures
+            .javascript_resolution
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .take();
+            .take_receiver();
         let Some(receiver) = receiver else {
             return;
         };
         match receiver.recv() {
-            Ok(Ok(DeferredClosures {
-                mut closures,
-                mut hashes,
-            })) => {
-                let knowledge = &self.knowledge;
-                for (name, info) in &mut self.package_payloads {
-                    // Mirror of the filter in the inline path
-                    // (`populate_transitive_dependencies`): a non-JS package
-                    // sharing a directory with a JS package must not steal
-                    // its closure.
-                    let facts = match name {
-                        PackageName::Root => knowledge
-                            .root_javascript_scope()
-                            .map(|scope| (knowledge.repository_directory(), scope.toolchain())),
-                        PackageName::Other(name) => knowledge
-                            .scope(name)
-                            .map(|scope| (scope.directory(), scope.toolchain())),
-                    };
-                    let Some((directory, toolchain)) = facts else {
-                        continue;
-                    };
-                    if toolchain != &crate::toolchain::ToolchainId::JAVASCRIPT {
-                        continue;
-                    }
-                    let dir = directory.to_unix();
-                    info.transitive_dependencies = closures.remove(dir.as_str());
-                    info.external_deps_hash = hashes.remove(dir.as_str());
+            Ok(Ok(mut snapshot)) => {
+                if let Some(warning) = snapshot.warning.take() {
+                    tracing::warn!("Unable to calculate transitive closures: {}", warning);
                 }
+                let generation = Arc::clone(&snapshot.generation);
+                snapshot.project_legacy(&mut self.package_payloads, &self.knowledge);
+                self.javascript_resolution
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .finish(Some(generation));
             }
             Ok(Err(e)) => {
                 tracing::warn!("Unable to calculate transitive closures: {}", e);
+                self.javascript_resolution
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .finish(None);
             }
             Err(_) => {
                 tracing::warn!("transitive closure thread disappeared without a result");
+                self.javascript_resolution
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .finish(None);
             }
         }
+    }
+
+    pub fn external_resolution_status(&self) -> ExternalResolutionStatus {
+        self.javascript_resolution
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .status
+    }
+
+    #[cfg(test)]
+    pub(crate) fn external_resolution_generation(
+        &self,
+    ) -> Option<Arc<ExternalResolutionGeneration>> {
+        self.javascript_resolution
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .generation
+            .clone()
     }
 
     pub fn package_json(&self, package: &PackageName) -> Option<&PackageJson> {
@@ -1793,6 +1872,72 @@ mod test {
         );
     }
 
+    #[tokio::test]
+    async fn javascript_resolution_distinguishes_resolved_empty_from_unavailable() {
+        let root =
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+        let root_package = || PackageJson::from_value(json!({ "name": "root" })).unwrap();
+
+        let resolved = PackageGraph::builder(&root, root_package())
+            .with_package_discovery(MockDiscovery)
+            .with_lockfile(Some(Box::new(MockLockfile {})))
+            .build()
+            .await
+            .unwrap();
+        let resolved_generation = resolved
+            .external_resolution_generation()
+            .expect("resolved generation should be retained");
+        let resolved_domain = &resolved_generation.domains()[0];
+        assert_eq!(
+            resolved_domain.definition_sources()[0].as_str(),
+            "package-lock.json"
+        );
+        let crate::external_resolution::ExternalResolutionData::Resolved {
+            completeness,
+            fingerprint,
+            packages,
+        } = resolved_domain.data()
+        else {
+            panic!("expected resolved terminal data")
+        };
+        assert_eq!(
+            completeness,
+            &crate::external_resolution::ResolutionCompleteness::Complete
+        );
+        assert!(!fingerprint.as_str().is_empty());
+        assert_eq!(packages.len(), 1);
+        assert_eq!(packages[0].package(), ROOT_PKG_NAME);
+        assert!(packages[0].identities().is_empty());
+        assert_eq!(
+            resolved
+                .package_payloads
+                .get(&PackageName::Root)
+                .and_then(|info| info.transitive_dependencies.as_deref()),
+            Some(&[][..])
+        );
+
+        let unavailable = PackageGraph::builder(&root, root_package())
+            .with_package_discovery(MockDiscovery)
+            .build()
+            .await
+            .unwrap();
+        let unavailable_generation = unavailable
+            .external_resolution_generation()
+            .expect("unavailable generation should be retained");
+        let crate::external_resolution::ExternalResolutionData::Unavailable(reason) =
+            unavailable_generation.domains()[0].data()
+        else {
+            panic!("expected unavailable terminal data")
+        };
+        assert_eq!(reason.code(), "lockfile-unavailable");
+        assert!(
+            unavailable
+                .package_payloads
+                .get(&PackageName::Root)
+                .is_some_and(|info| info.transitive_dependencies.is_none())
+        );
+    }
+
     /// A graph built with deferred closures must, after
     /// `ensure_transitive_closures`, be indistinguishable from one built
     /// inline.
@@ -1863,6 +2008,19 @@ mod test {
         .await
         .unwrap();
 
+        assert_eq!(
+            inline.external_resolution_status(),
+            ExternalResolutionStatus::Complete
+        );
+        assert_eq!(
+            deferred.external_resolution_status(),
+            ExternalResolutionStatus::Resolving
+        );
+        let inline_generation = inline
+            .external_resolution_generation()
+            .expect("inline resolution should be available");
+        assert_eq!(inline_generation.domains().len(), 1);
+
         // Before the join, closures are absent.
         assert!(
             deferred
@@ -1875,6 +2033,17 @@ mod test {
         deferred.ensure_transitive_closures();
         // Idempotent.
         deferred.ensure_transitive_closures();
+
+        assert_eq!(
+            deferred.external_resolution_status(),
+            ExternalResolutionStatus::Complete
+        );
+        assert_eq!(
+            inline_generation,
+            deferred
+                .external_resolution_generation()
+                .expect("deferred resolution should be available after joining")
+        );
 
         for (name, info) in &inline.package_payloads {
             let deferred_info = deferred.package_payloads.get(name).unwrap();

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -151,14 +151,15 @@ Represents the workspace structure and package dependencies:
   consumers pay no construction cost. They expose only authoritative package
   identities plus the always-present root Turbo task namespace, never the
   package graph's structural root sentinel.
-- Defines parser-neutral external declaration and resolution contracts for the
-  next migration phase. Resolution domains retain their native definition
-  sources, exact opaque package identities, completeness, stable fingerprint,
-  and explicit unavailable reason. Validation rejects unknown package
-  identities and multiple domains from one toolchain, and normalizes retained
-  ordering. Resolved-empty terminal data remains distinct from unavailable
-  data, while pending/resolving/complete lifecycle status is modeled
-  separately. Producers and consumers are not wired to these contracts yet.
+- Produces JavaScript external-resolution knowledge from the normalized
+  external declaration view. Inline and deferred lockfile closure calculation
+  create the same immutable snapshot, including exact opaque identities,
+  definition source, completeness, and a stable fingerprint. Missing,
+  unparseable, or incomplete lockfile resolution produces explicit unavailable
+  terminal data rather than a resolved-empty set. A single resolution owner
+  tracks lifecycle status, and the snapshot projects the temporary
+  `PackageInfo` closure/hash fields, keeping legacy consumers byte-compatible
+  until their migration.
 - Performs ecosystem-specific lockfile analysis
 - Builds dependency relationships between workspace packages
 - Validates that all non-root packages have a `name` field


### PR DESCRIPTION
## Summary

- derive JavaScript lockfile inputs from normalized external declarations and produce validated resolution generations with exact identities, definition sources, completeness, and stable fingerprints
- unify inline and deferred closure calculation behind one resolution owner and one immutable snapshot while preserving speculative reads and warning behavior
- project legacy `PackageInfo` closure and hash fields from that snapshot so existing consumers remain byte-compatible
- retain explicit unavailable generations instead of conflating missing or failed resolution with resolved-empty data
- update the package graph architecture documentation

Closes TURBO-5805.

## Testing

- `NO_COLOR=1 LC_ALL=C.UTF-8 cargo test -p turborepo-repository` (366 passed)
- `cargo clippy -p turborepo-repository --all-targets -- -D warnings`
- `cargo test -p turborepo-task-hash external`
- `cargo test -p turbo --test final_hash_contract lockfile_aware_hashes`
- pre-push `format` and `check:toml` hooks