### PR TITLE
refactor: Contribute Cargo external resolutions

### DIFF
--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -42,6 +42,10 @@ use serde::Deserialize;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
 
 use crate::{
+    external_resolution::{
+        ExternalPackageIdentity, ExternalResolutionData, ExternalResolutionDomain,
+        PackageResolution, ResolutionCompleteness, ResolutionFingerprint,
+    },
     package_json::{DependencyKind, PackageJson},
     relationships::Relationship,
     toolchain::{
@@ -133,6 +137,20 @@ pub enum Error {
     RustcOutputUtf8(#[from] std::str::Utf8Error),
     #[error("invalid `rustc -vV` output: {reason}")]
     InvalidRustcOutput { reason: &'static str },
+    #[error(transparent)]
+    ResolutionPath(#[from] turbopath::PathError),
+}
+
+fn package_resolution(
+    package: impl Into<String>,
+    identities: &HashSet<turborepo_lockfiles::Package>,
+) -> PackageResolution {
+    PackageResolution::new(
+        package,
+        identities.iter().map(|identity| {
+            ExternalPackageIdentity::new(identity.key.clone(), identity.version.clone())
+        }),
+    )
 }
 
 fn parse_rustc_info(stdout: &[u8]) -> Result<(turborepo_lockfiles::Package, String), Error> {
@@ -1709,6 +1727,7 @@ impl Toolchain for CargoToolchain {
                 .collect();
 
             let mut packages = Vec::with_capacity(crates.len() + 1);
+            let mut resolutions = Vec::with_capacity(crates.len() + 1);
             let mut crate_names = Vec::with_capacity(crates.len());
             for cargo_crate in crates {
                 let relationships = cargo_crate
@@ -1747,6 +1766,10 @@ impl Toolchain for CargoToolchain {
                     .into_iter()
                     .chain(std::iter::once(rustc.clone()))
                     .collect();
+                resolutions.push(package_resolution(
+                    cargo_crate.name.clone(),
+                    &external_dependencies,
+                ));
                 crate_names.push(cargo_crate.name.clone());
                 packages.push(
                     DiscoveredPackage::package(
@@ -1779,6 +1802,10 @@ impl Toolchain for CargoToolchain {
                     .into_iter()
                     .map(|name| Relationship::internal(name, DependencyKind::Production))
                     .collect();
+                resolutions.push(package_resolution(
+                    workspace_name.clone(),
+                    &workspace_externals,
+                ));
                 packages.push(
                     DiscoveredPackage::aggregate(
                         workspace_name,
@@ -1792,7 +1819,21 @@ impl Toolchain for CargoToolchain {
                 );
             }
 
-            Ok(DiscoveredPackages::new(packages, workspace_roots))
+            let fingerprint = ResolutionFingerprint::from_packages(&resolutions);
+            let resolution = ExternalResolutionDomain::new(
+                ToolchainId::RUST,
+                AnchoredSystemPathBuf::default(),
+                [AnchoredSystemPathBuf::from_raw(CARGO_LOCK)
+                    .map_err(Error::from)
+                    .map_err(|error| toolchain::Error::Failed(Box::new(error)))?],
+                ExternalResolutionData::Resolved {
+                    completeness: ResolutionCompleteness::Complete,
+                    fingerprint,
+                    packages: resolutions,
+                },
+            );
+            Ok(DiscoveredPackages::new(packages, workspace_roots)
+                .with_external_resolution(resolution))
         })
     }
 }
@@ -3691,10 +3732,31 @@ release: 1.96.0-nightly\n",
         let toolchain = CargoToolchain::new(root.clone());
         assert_eq!(toolchain.id(), ToolchainId::RUST);
 
-        let (packages, roots) = toolchain.discover_packages().await.unwrap().into_parts();
+        let (packages, roots, resolutions) =
+            toolchain.discover_packages().await.unwrap().into_parts();
         assert_eq!(roots.len(), 1);
         assert_eq!(roots[0].kind(), "cargo");
         assert_eq!(roots[0].path(), root.as_ref());
+        assert_eq!(resolutions.len(), 1);
+        assert_eq!(resolutions[0].toolchain(), &ToolchainId::RUST);
+        assert_eq!(resolutions[0].definition_sources()[0].as_str(), CARGO_LOCK);
+        let ExternalResolutionData::Resolved {
+            completeness,
+            fingerprint,
+            packages: resolution_packages,
+        } = resolutions[0].data()
+        else {
+            panic!("Cargo resolution must be complete")
+        };
+        assert_eq!(completeness, &ResolutionCompleteness::Complete);
+        assert!(!fingerprint.as_str().is_empty());
+        assert_eq!(resolution_packages.len(), 4);
+        assert!(resolution_packages.iter().all(|package| {
+            package
+                .identities()
+                .iter()
+                .any(|identity| identity.key() == "rustc")
+        }));
         let mut packages: Vec<_> = packages
             .into_iter()
             .map(DiscoveredPackage::into_parts)
@@ -3766,9 +3828,11 @@ release: 1.96.0-nightly\n",
     async fn test_cargo_toolchain_empty_without_manifest() {
         let (_tmp, root) = tempdir_root();
         let toolchain = CargoToolchain::new(root);
-        let (packages, roots) = toolchain.discover_packages().await.unwrap().into_parts();
+        let (packages, roots, resolutions) =
+            toolchain.discover_packages().await.unwrap().into_parts();
         assert!(packages.is_empty());
         assert!(roots.is_empty());
+        assert!(resolutions.is_empty());
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -3777,9 +3841,11 @@ release: 1.96.0-nightly\n",
         write(&root, &["Cargo.toml"], "[workspace]\nmembers = []\n");
 
         let toolchain = CargoToolchain::new(root);
-        let (packages, roots) = toolchain.discover_packages().await.unwrap().into_parts();
+        let (packages, roots, resolutions) =
+            toolchain.discover_packages().await.unwrap().into_parts();
         assert!(packages.is_empty());
         assert_eq!(roots.len(), 1);
+        assert!(resolutions.is_empty());
     }
 
     fn package_info(name: &str) -> crate::package_graph::PackageInfo {

--- a/crates/turborepo-repository/src/external_resolution.rs
+++ b/crates/turborepo-repository/src/external_resolution.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashSet;
 
+use sha2::{Digest, Sha256};
 use turbopath::{AnchoredSystemPath, AnchoredSystemPathBuf};
 
 use crate::{
@@ -177,6 +178,27 @@ impl ResolutionFingerprint {
 
     pub fn as_str(&self) -> &str {
         &self.0
+    }
+
+    pub(crate) fn from_packages(packages: &[PackageResolution]) -> Self {
+        fn update(hasher: &mut Sha256, value: &str) {
+            hasher.update((value.len() as u64).to_le_bytes());
+            hasher.update(value.as_bytes());
+        }
+
+        let mut packages: Vec<_> = packages.iter().collect();
+        packages.sort_unstable_by_key(|package| package.package());
+        let mut hasher = Sha256::new();
+        for package in packages {
+            update(&mut hasher, package.package());
+            let mut identities: Vec<_> = package.identities().iter().collect();
+            identities.sort_unstable();
+            for identity in identities {
+                update(&mut hasher, identity.key());
+                update(&mut hasher, identity.version());
+            }
+        }
+        Self::new(format!("{:x}", hasher.finalize()))
     }
 }
 

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -5,7 +5,6 @@ use std::{
 
 use miette::{Diagnostic, Report};
 use petgraph::graph::{Graph, NodeIndex};
-use sha2::{Digest, Sha256};
 use tracing::warn;
 use turbopath::{
     AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPath, AnchoredSystemPathBuf,
@@ -13,7 +12,7 @@ use turbopath::{
 use turborepo_lockfiles::Lockfile;
 
 use super::{
-    JavaScriptResolutionKnowledge, JavaScriptResolutionSnapshot, PackageGraph, PackageInfo,
+    ExternalResolutionKnowledge, JavaScriptResolutionSnapshot, PackageGraph, PackageInfo,
     PackageName, PackageNode,
     dep_splitter::{DependencySplitter, WorkspacePathIndex},
 };
@@ -398,6 +397,7 @@ struct BuildState<'a, S, T> {
     knowledge: Option<Arc<RepositoryKnowledge>>,
     relationship_knowledge: Option<Arc<RelationshipKnowledge>>,
     native_relationships: HashMap<String, Vec<Relationship>>,
+    native_external_resolutions: Vec<ExternalResolutionDomain>,
     /// The root `package.json`, absent for a pure Cargo workspace. See
     /// [`PackageGraphBuilder::root_package_json`].
     root_package_json: Option<PackageJson>,
@@ -675,6 +675,7 @@ where
             knowledge: None,
             relationship_knowledge: None,
             native_relationships: HashMap::new(),
+            native_external_resolutions: Vec::new(),
             lockfile,
             package_manager: None,
             package_jsons,
@@ -776,7 +777,9 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
                 continue;
             }
             let output = toolchain.discover_packages().await?;
-            let (packages, roots) = output.into_parts();
+            let (packages, roots, external_resolutions) = output.into_parts();
+            self.native_external_resolutions
+                .extend(external_resolutions);
             workspace_roots.extend(
                 roots
                     .into_iter()
@@ -828,6 +831,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             knowledge,
             relationship_knowledge,
             native_relationships,
+            native_external_resolutions,
             root_package_json,
             lockfile,
             package_manager,
@@ -844,6 +848,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             knowledge,
             relationship_knowledge,
             native_relationships,
+            native_external_resolutions,
             root_package_json,
             lockfile,
             package_manager,
@@ -863,6 +868,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             knowledge,
             relationship_knowledge: _,
             native_relationships: _,
+            native_external_resolutions: _,
             root_package_json,
             lockfile,
             javascript,
@@ -932,7 +938,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             knowledge,
             relationship_knowledge,
             relationship_projections: std::sync::OnceLock::new(),
-            javascript_resolution: std::sync::Mutex::new(JavaScriptResolutionKnowledge::absent()),
+            external_resolution: std::sync::Mutex::new(ExternalResolutionKnowledge::absent()),
             external_dep_to_internal_dependents: std::sync::OnceLock::new(),
             root_internal_dependencies: std::sync::OnceLock::new(),
             toolchains,
@@ -1090,6 +1096,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
             assembler,
             knowledge,
             relationship_knowledge,
+            native_external_resolutions,
             root_package_json,
             javascript,
             toolchains,
@@ -1105,6 +1112,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
             relationship_knowledge,
             // Native contributions were consumed before lockfile setup.
             native_relationships: HashMap::new(),
+            native_external_resolutions,
             root_package_json,
             lockfile,
             package_manager,
@@ -1174,25 +1182,9 @@ fn javascript_resolution_packages(
     packages
 }
 
-fn fingerprint_package_resolutions(packages: &[PackageResolution]) -> ResolutionFingerprint {
-    fn update(hasher: &mut Sha256, value: &str) {
-        hasher.update((value.len() as u64).to_le_bytes());
-        hasher.update(value.as_bytes());
-    }
-
-    let mut hasher = Sha256::new();
-    for package in packages {
-        update(&mut hasher, package.package());
-        for identity in package.identities() {
-            update(&mut hasher, identity.key());
-            update(&mut hasher, identity.version());
-        }
-    }
-    ResolutionFingerprint::new(format!("{:x}", hasher.finalize()))
-}
-
 fn unavailable_javascript_resolution(
     knowledge: &RepositoryKnowledge,
+    mut domains: Vec<ExternalResolutionDomain>,
     definition_source: AnchoredSystemPathBuf,
     code: &str,
     message: String,
@@ -1204,7 +1196,8 @@ fn unavailable_javascript_resolution(
         [definition_source],
         ExternalResolutionData::Unavailable(ResolutionUnavailableReason::new(code, message)),
     );
-    let generation = ExternalResolutionGeneration::build(knowledge, vec![domain])
+    domains.push(domain);
+    let generation = ExternalResolutionGeneration::build(knowledge, domains)
         .map_err(|error| error.to_string())?;
     Ok(JavaScriptResolutionSnapshot {
         generation: Arc::new(generation),
@@ -1216,6 +1209,7 @@ fn unavailable_javascript_resolution(
 
 fn resolve_javascript_dependencies(
     knowledge: &RepositoryKnowledge,
+    mut domains: Vec<ExternalResolutionDomain>,
     lockfile: &dyn Lockfile,
     external_dependencies: HashMap<String, BTreeMap<String, String>>,
     definition_source: AnchoredSystemPathBuf,
@@ -1231,6 +1225,7 @@ fn resolve_javascript_dependencies(
             let message = error.to_string();
             return unavailable_javascript_resolution(
                 knowledge,
+                domains,
                 definition_source,
                 "closure-unavailable",
                 message.clone(),
@@ -1254,7 +1249,7 @@ fn resolve_javascript_dependencies(
             PackageResolution::new(identity, exact_identities)
         })
         .collect::<Vec<_>>();
-    let fingerprint = fingerprint_package_resolutions(&packages);
+    let fingerprint = ResolutionFingerprint::from_packages(&packages);
     let domain = ExternalResolutionDomain::new(
         ToolchainId::JAVASCRIPT,
         AnchoredSystemPathBuf::default(),
@@ -1265,7 +1260,8 @@ fn resolve_javascript_dependencies(
             packages,
         },
     );
-    let generation = ExternalResolutionGeneration::build(knowledge, vec![domain])
+    domains.push(domain);
+    let generation = ExternalResolutionGeneration::build(knowledge, domains)
         .map_err(|error| error.to_string())?;
     Ok(JavaScriptResolutionSnapshot {
         generation: Arc::new(generation),
@@ -1335,7 +1331,8 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             .map_err(Error::from)
             .map_err(build_failure)?;
         let arc_lockfile: Option<Arc<dyn Lockfile>> = self.lockfile.take().map(Arc::from);
-        let mut javascript_resolution = JavaScriptResolutionKnowledge::absent();
+        let mut external_resolution = ExternalResolutionKnowledge::absent();
+        let mut native_external_resolutions = std::mem::take(&mut self.native_external_resolutions);
 
         if let Some(definition_source) = definition_source {
             if let Some(lockfile) = arc_lockfile.clone() {
@@ -1345,11 +1342,21 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
                         let hasher = self.closure_hasher.clone();
                         let resolution_knowledge = Arc::clone(&knowledge);
                         let deferred_source = definition_source.clone();
+                        let deferred_native_resolutions = Arc::new(std::sync::Mutex::new(
+                            std::mem::take(&mut native_external_resolutions),
+                        ));
+                        let thread_native_resolutions = Arc::clone(&deferred_native_resolutions);
                         let spawned = std::thread::Builder::new()
                             .name("turbo-closures".into())
                             .spawn(move || {
+                                let native_resolutions = std::mem::take(
+                                    &mut *thread_native_resolutions
+                                        .lock()
+                                        .unwrap_or_else(|poisoned| poisoned.into_inner()),
+                                );
                                 let result = resolve_javascript_dependencies(
                                     &resolution_knowledge,
+                                    native_resolutions,
                                     lockfile.as_ref(),
                                     external_dependencies,
                                     deferred_source,
@@ -1359,13 +1366,17 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
                             });
                         match spawned {
                             Ok(_) => {
-                                javascript_resolution =
-                                    JavaScriptResolutionKnowledge::resolving(rx);
+                                external_resolution = ExternalResolutionKnowledge::resolving(rx);
                             }
                             Err(error) => {
                                 warn!("Unable to spawn transitive closure thread: {}", error);
                                 let snapshot = unavailable_javascript_resolution(
                                     &knowledge,
+                                    std::mem::take(
+                                        &mut *deferred_native_resolutions
+                                            .lock()
+                                            .unwrap_or_else(|poisoned| poisoned.into_inner()),
+                                    ),
                                     definition_source,
                                     "worker-unavailable",
                                     error.to_string(),
@@ -1374,8 +1385,8 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
                                 .map_err(|message| {
                                     build_failure(Error::ExternalResolution(message))
                                 })?;
-                                javascript_resolution =
-                                    JavaScriptResolutionKnowledge::complete(snapshot.generation);
+                                external_resolution =
+                                    ExternalResolutionKnowledge::complete(snapshot.generation);
                             }
                         }
                     }
@@ -1383,6 +1394,7 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
                         let mut snapshot = turborepo_rayon_compat::block_in_place(|| {
                             resolve_javascript_dependencies(
                                 &knowledge,
+                                std::mem::take(&mut native_external_resolutions),
                                 lockfile.as_ref(),
                                 external_dependencies,
                                 definition_source,
@@ -1395,34 +1407,40 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
                         }
                         let generation = Arc::clone(&snapshot.generation);
                         snapshot.project_legacy(&mut self.assembler.package_payloads, &knowledge);
-                        javascript_resolution = JavaScriptResolutionKnowledge::complete(generation);
+                        external_resolution = ExternalResolutionKnowledge::complete(generation);
                     }
                     Err(error) => {
                         warn!("Unable to calculate transitive closures: {}", error);
                         let snapshot = unavailable_javascript_resolution(
                             &knowledge,
+                            std::mem::take(&mut native_external_resolutions),
                             definition_source,
                             "declarations-unavailable",
                             error.to_string(),
                             None,
                         )
                         .map_err(|message| build_failure(Error::ExternalResolution(message)))?;
-                        javascript_resolution =
-                            JavaScriptResolutionKnowledge::complete(snapshot.generation);
+                        external_resolution =
+                            ExternalResolutionKnowledge::complete(snapshot.generation);
                     }
                 }
             } else {
                 let snapshot = unavailable_javascript_resolution(
                     &knowledge,
+                    std::mem::take(&mut native_external_resolutions),
                     definition_source,
                     "lockfile-unavailable",
                     "JavaScript lockfile could not be read or parsed".to_string(),
                     None,
                 )
                 .map_err(|message| build_failure(Error::ExternalResolution(message)))?;
-                javascript_resolution =
-                    JavaScriptResolutionKnowledge::complete(snapshot.generation);
+                external_resolution = ExternalResolutionKnowledge::complete(snapshot.generation);
             }
+        } else if !native_external_resolutions.is_empty() {
+            let generation =
+                ExternalResolutionGeneration::build(&knowledge, native_external_resolutions)
+                    .map_err(|error| build_failure(Error::ExternalResolution(error.to_string())))?;
+            external_resolution = ExternalResolutionKnowledge::complete(Arc::new(generation));
         }
         let Self {
             assembler,
@@ -1457,7 +1475,7 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             knowledge,
             relationship_knowledge,
             relationship_projections: std::sync::OnceLock::new(),
-            javascript_resolution: std::sync::Mutex::new(javascript_resolution),
+            external_resolution: std::sync::Mutex::new(external_resolution),
             external_dep_to_internal_dependents: std::sync::OnceLock::new(),
             root_internal_dependencies: std::sync::OnceLock::new(),
             toolchains,

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -77,13 +77,13 @@ pub(crate) type DeferredResolutionReceiver =
     std::sync::mpsc::Receiver<Result<JavaScriptResolutionSnapshot, String>>;
 
 #[derive(Debug)]
-pub(crate) struct JavaScriptResolutionKnowledge {
+pub(crate) struct ExternalResolutionKnowledge {
     status: ExternalResolutionStatus,
     generation: Option<Arc<ExternalResolutionGeneration>>,
     receiver: Option<DeferredResolutionReceiver>,
 }
 
-impl JavaScriptResolutionKnowledge {
+impl ExternalResolutionKnowledge {
     pub(crate) fn absent() -> Self {
         Self {
             status: ExternalResolutionStatus::Complete,
@@ -135,10 +135,10 @@ pub struct PackageGraph {
     #[allow(dead_code)]
     relationship_knowledge: Arc<RelationshipKnowledge>,
     relationship_projections: OnceLock<projections::RelationshipProjections>,
-    /// The sole owner of JavaScript external-resolution lifecycle and terminal
-    /// knowledge. Deferred production is joined exactly once by
+    /// The sole owner of external-resolution lifecycle and terminal knowledge
+    /// across toolchains. Deferred JavaScript production is joined once by
     /// [`Self::ensure_transitive_closures`].
-    javascript_resolution: Mutex<JavaScriptResolutionKnowledge>,
+    external_resolution: Mutex<ExternalResolutionKnowledge>,
     external_dep_to_internal_dependents:
         OnceLock<HashMap<turborepo_lockfiles::Package, HashSet<PackageNode>>>,
     /// Lazily computed internal dependencies of the root package. They are
@@ -846,7 +846,7 @@ impl PackageGraph {
     /// consumer of `PackageInfo::transitive_dependencies` runs.
     pub fn ensure_transitive_closures(&mut self) {
         let receiver = self
-            .javascript_resolution
+            .external_resolution
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .take_receiver();
@@ -860,21 +860,21 @@ impl PackageGraph {
                 }
                 let generation = Arc::clone(&snapshot.generation);
                 snapshot.project_legacy(&mut self.package_payloads, &self.knowledge);
-                self.javascript_resolution
+                self.external_resolution
                     .lock()
                     .unwrap_or_else(|poisoned| poisoned.into_inner())
                     .finish(Some(generation));
             }
             Ok(Err(e)) => {
                 tracing::warn!("Unable to calculate transitive closures: {}", e);
-                self.javascript_resolution
+                self.external_resolution
                     .lock()
                     .unwrap_or_else(|poisoned| poisoned.into_inner())
                     .finish(None);
             }
             Err(_) => {
                 tracing::warn!("transitive closure thread disappeared without a result");
-                self.javascript_resolution
+                self.external_resolution
                     .lock()
                     .unwrap_or_else(|poisoned| poisoned.into_inner())
                     .finish(None);
@@ -883,7 +883,7 @@ impl PackageGraph {
     }
 
     pub fn external_resolution_status(&self) -> ExternalResolutionStatus {
-        self.javascript_resolution
+        self.external_resolution
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .status
@@ -893,7 +893,7 @@ impl PackageGraph {
     pub(crate) fn external_resolution_generation(
         &self,
     ) -> Option<Arc<ExternalResolutionGeneration>> {
-        self.javascript_resolution
+        self.external_resolution
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .generation
@@ -2549,7 +2549,9 @@ version = "0.1.0"
         // Several iterations: the closure-attribution regression this guards
         // was decided by HashMap iteration order, roughly a coin flip per
         // process/build.
-        for _ in 0..8 {
+        let mut expected_cargo_fingerprint = None;
+        for iteration in 0..8 {
+            let defer_resolution = iteration % 2 == 1;
             let mut pkg_graph = PackageGraph::builder(
                 &root,
                 PackageJson::from_value(json!({ "name": "root", "dependencies": { "a": "1" } }))
@@ -2566,9 +2568,11 @@ version = "0.1.0"
             }))
             .with_lockfile(Some(Box::new(MockLockfile {})))
             .with_toolchain(crate::cargo::CargoToolchain::new(root.clone()))
+            .defer_transitive_closures(defer_resolution)
             .build()
             .await
             .unwrap();
+            pkg_graph.ensure_transitive_closures();
 
             assert!(pkg_graph.validate().is_ok());
             assert!(pkg_graph.package_task_contexts().all(|context| {
@@ -2723,6 +2727,58 @@ version = "0.1.0"
                 "the cargo workspace package must not carry JS lockfile entries, got {:?}",
                 workspace_pkg.transitive_dependencies
             );
+
+            let resolution = pkg_graph
+                .external_resolution_generation()
+                .expect("mixed repository should retain external resolution knowledge");
+            assert_eq!(resolution.domains().len(), 2);
+            let cargo_domain = resolution
+                .domains()
+                .iter()
+                .find(|domain| domain.toolchain() == &crate::toolchain::ToolchainId::RUST)
+                .expect("Cargo should contribute one resolution domain");
+            assert_eq!(cargo_domain.definition_sources()[0].as_str(), "Cargo.lock");
+            let crate::external_resolution::ExternalResolutionData::Resolved {
+                completeness,
+                fingerprint,
+                packages,
+            } = cargo_domain.data()
+            else {
+                panic!("Cargo resolution must be available")
+            };
+            assert_eq!(
+                completeness,
+                &crate::external_resolution::ResolutionCompleteness::Complete
+            );
+            if let Some(expected) = &expected_cargo_fingerprint {
+                assert_eq!(fingerprint, expected);
+            } else {
+                expected_cargo_fingerprint = Some(fingerprint.clone());
+            }
+            assert_eq!(packages.len(), 4);
+            for package in packages {
+                assert!(
+                    package
+                        .identities()
+                        .iter()
+                        .any(|identity| identity.key() == "rustc"),
+                    "{} must include the compiler identity",
+                    package.package()
+                );
+                let legacy: HashSet<_> = pkg_graph
+                    .package_info(&PackageName::from(package.package()))
+                    .and_then(|info| info.transitive_dependencies.as_ref())
+                    .into_iter()
+                    .flatten()
+                    .map(|identity| (identity.key.as_str(), identity.version.as_str()))
+                    .collect();
+                let normalized: HashSet<_> = package
+                    .identities()
+                    .iter()
+                    .map(|identity| (identity.key(), identity.version()))
+                    .collect();
+                assert_eq!(normalized, legacy);
+            }
         }
     }
 
@@ -2741,6 +2797,14 @@ version = "0.1.0"
             .unwrap();
 
         assert!(pkg_graph.validate().is_ok());
+        let resolution = pkg_graph
+            .external_resolution_generation()
+            .expect("pure Cargo repository should retain external resolution knowledge");
+        assert_eq!(resolution.domains().len(), 1);
+        assert_eq!(
+            resolution.domains()[0].toolchain(),
+            &crate::toolchain::ToolchainId::RUST
+        );
         assert!(
             pkg_graph.relationship_projections.get().is_none(),
             "relationship projections must remain lazy for current consumers"

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -51,6 +51,7 @@ use turborepo_errors::Spanned;
 
 use crate::{
     discovery::{self, PackageDiscovery},
+    external_resolution::ExternalResolutionDomain,
     package_json::PackageJson,
     package_manager::PackageManager,
     relationships::Relationship,
@@ -181,6 +182,7 @@ impl WorkspaceRoot {
 pub struct DiscoveredPackages {
     packages: Vec<DiscoveredPackage>,
     workspace_roots: Vec<WorkspaceRoot>,
+    external_resolutions: Vec<ExternalResolutionDomain>,
 }
 
 impl DiscoveredPackages {
@@ -188,7 +190,13 @@ impl DiscoveredPackages {
         Self {
             packages,
             workspace_roots,
+            external_resolutions: Vec::new(),
         }
+    }
+
+    pub fn with_external_resolution(mut self, resolution: ExternalResolutionDomain) -> Self {
+        self.external_resolutions.push(resolution);
+        self
     }
 
     pub fn packages(&self) -> &[DiscoveredPackage] {
@@ -199,8 +207,18 @@ impl DiscoveredPackages {
         &self.workspace_roots
     }
 
-    pub fn into_parts(self) -> (Vec<DiscoveredPackage>, Vec<WorkspaceRoot>) {
-        (self.packages, self.workspace_roots)
+    pub fn into_parts(
+        self,
+    ) -> (
+        Vec<DiscoveredPackage>,
+        Vec<WorkspaceRoot>,
+        Vec<ExternalResolutionDomain>,
+    ) {
+        (
+            self.packages,
+            self.workspace_roots,
+            self.external_resolutions,
+        )
     }
 }
 

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -151,15 +151,17 @@ Represents the workspace structure and package dependencies:
   consumers pay no construction cost. They expose only authoritative package
   identities plus the always-present root Turbo task namespace, never the
   package graph's structural root sentinel.
-- Produces JavaScript external-resolution knowledge from the normalized
-  external declaration view. Inline and deferred lockfile closure calculation
-  create the same immutable snapshot, including exact opaque identities,
-  definition source, completeness, and a stable fingerprint. Missing,
-  unparseable, or incomplete lockfile resolution produces explicit unavailable
-  terminal data rather than a resolved-empty set. A single resolution owner
-  tracks lifecycle status, and the snapshot projects the temporary
-  `PackageInfo` closure/hash fields, keeping legacy consumers byte-compatible
-  until their migration.
+- Produces shared JavaScript and Cargo external-resolution knowledge. JavaScript
+  consumes the normalized external declaration view; inline and deferred
+  lockfile closure calculation create the same immutable snapshot. Cargo
+  contributes per-crate closures, the aggregate workspace union, and the full
+  `rustc -vV` identity from the same sets used by compatibility payloads. Cargo
+  keeps missing, stale, or invalid lockfile and compiler identity failures
+  fatal. Core validates the combined domains and retains exact opaque
+  identities, definition sources, completeness, and stable fingerprints. A
+  single resolution owner tracks lifecycle status, and the snapshot projects
+  temporary `PackageInfo` closure/hash fields byte-compatibly until consumer
+  migration.
 - Performs ecosystem-specific lockfile analysis
 - Builds dependency relationships between workspace packages
 - Validates that all non-root packages have a `name` field


### PR DESCRIPTION
## Summary

- contribute Cargo per-crate closures and aggregate workspace unions to the shared external-resolution generation
- include the full `rustc -vV` identity and `Cargo.lock` definition source in each complete Cargo domain
- combine Cargo domains with inline or deferred JavaScript resolution under one lifecycle owner
- derive stable fingerprints with deterministic package and exact-identity ordering
- continue projecting legacy `PackageInfo` sets from the same Cargo data while preserving fatal lockfile and compiler failures
- update the package graph architecture documentation

Closes TURBO-5806.

## Testing

- `NO_COLOR=1 LC_ALL=C.UTF-8 cargo test -p turborepo-repository` (366 passed)
- `cargo clippy -p turborepo-repository --all-targets -- -D warnings`
- `NO_COLOR=1 LC_ALL=C.UTF-8 cargo test -p turbo --test cargo_workspace_test` (57 passed)
- `cargo test -p turborepo-task-hash external`
- `NO_COLOR=1 LC_ALL=C.UTF-8 cargo test -p turbo --test final_hash_contract lockfile_aware_hashes`
- pre-push `format`, `check:toml`, and `turborepo-crates#format` hooks