### PR TITLE
refactor: Migrate external declaration consumers

### DIFF
--- a/crates/turborepo-boundaries/src/imports.rs
+++ b/crates/turborepo-boundaries/src/imports.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 
 use camino::Utf8Path;
 use miette::{NamedSource, SourceSpan};
@@ -9,8 +9,8 @@ use turbo_trace::ImportType;
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf, PathRelation, RelativeUnixPath};
 use turborepo_errors::Spanned;
 use turborepo_repository::{
+    external_resolution::PackageExternalDeclarations,
     package_graph::{PackageName, PackageNode},
-    package_json::PackageJson,
 };
 use unrs_resolver::{ResolveError, Resolver};
 
@@ -22,8 +22,7 @@ pub struct DependencyLocations<'a> {
     // The containing package's name. We allow a package to import itself per JavaScript convention
     pub(crate) package: &'a PackageName,
     pub(crate) internal_dependencies: &'a HashSet<&'a PackageNode>,
-    pub(crate) package_json: &'a PackageJson,
-    pub(crate) unresolved_external_dependencies: Option<&'a BTreeMap<String, String>>,
+    pub(crate) external_declarations: PackageExternalDeclarations<'a>,
     pub(crate) implicit_dependencies: &'a HashMap<String, Spanned<()>>,
     pub(crate) global_implicit_dependencies: &'a HashMap<String, Spanned<()>>,
 }
@@ -37,39 +36,11 @@ impl<'a> DependencyLocations<'a> {
         // JavaScript convention
         self.package == package_name.as_package_name()
             || self.internal_dependencies.contains(package_name)
-            || self
-                .unresolved_external_dependencies
-                .is_some_and(|external_dependencies| {
-                    external_dependencies.contains_key(package_name.as_package_name().as_str())
-                })
-            || self
-                .package_json
-                .dependencies
-                .as_ref()
-                .is_some_and(|dependencies| {
-                    dependencies.contains_key(package_name.as_package_name().as_str())
-                })
-            || self
-                .package_json
-                .dev_dependencies
-                .as_ref()
-                .is_some_and(|dev_dependencies| {
-                    dev_dependencies.contains_key(package_name.as_package_name().as_str())
-                })
-            || self
-                .package_json
-                .peer_dependencies
-                .as_ref()
-                .is_some_and(|peer_dependencies| {
-                    peer_dependencies.contains_key(package_name.as_package_name().as_str())
-                })
-            || self
-                .package_json
-                .optional_dependencies
-                .as_ref()
-                .is_some_and(|optional_dependencies| {
-                    optional_dependencies.contains_key(package_name.as_package_name().as_str())
-                })
+            || self.external_declarations.iter().any(|declaration| {
+                let package_name = package_name.as_package_name().as_str();
+                declaration.declaration_name() == package_name
+                    || declaration.package_name() == package_name
+            })
             || self
                 .implicit_dependencies
                 .contains_key(package_name.as_package_name().as_str())
@@ -450,11 +421,66 @@ pub(crate) fn check_package_import(
 
 #[cfg(test)]
 mod test {
+    use std::collections::BTreeMap;
+
     use test_case::test_case;
     use turbo_trace::Tracer;
+    use turborepo_repository::{
+        external_resolution::ExternalDeclaration, package_json::PackageJson,
+    };
 
     use super::*;
     use crate::BoundariesResult;
+
+    fn declarations(package_json: &PackageJson) -> Vec<ExternalDeclaration> {
+        package_json
+            .dependencies_with_kind()
+            .map(|(name, specifier, kind)| {
+                ExternalDeclaration::new("my-app", name, name, specifier, kind)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn declaration_projection_accepts_alias_targets_and_all_dependency_kinds() {
+        let package = PackageName::from("my-app");
+        let declarations = vec![
+            ExternalDeclaration::new(
+                "my-app",
+                "alias",
+                "target",
+                "npm:target@1",
+                turborepo_repository::relationships::DependencyKind::Production,
+            ),
+            ExternalDeclaration::new(
+                "my-app",
+                "optional",
+                "optional",
+                "1",
+                turborepo_repository::relationships::DependencyKind::Optional,
+            ),
+            ExternalDeclaration::new(
+                "my-app",
+                "peer",
+                "peer",
+                "1",
+                turborepo_repository::relationships::DependencyKind::Peer { optional: false },
+            ),
+        ];
+        let locations = DependencyLocations {
+            package: &package,
+            internal_dependencies: &HashSet::new(),
+            external_declarations: PackageExternalDeclarations::new(&declarations, "my-app"),
+            implicit_dependencies: &HashMap::new(),
+            global_implicit_dependencies: &HashMap::new(),
+        };
+
+        for dependency in ["alias", "target", "optional", "peer"] {
+            assert!(
+                locations.is_dependency(&PackageNode::Workspace(PackageName::from(dependency)))
+            );
+        }
+    }
 
     #[test_case("bun", true ; "bun bare import")]
     #[test_case("bun:test", true ; "bun test module")]
@@ -586,12 +612,12 @@ mod test {
         let internal_deps = HashSet::new();
         let implicit_deps = HashMap::new();
         let global_implicit_deps = HashMap::new();
+        let declarations = declarations(&package_json);
 
         let dependency_locations = DependencyLocations {
             package: &package_name,
             internal_dependencies: &internal_deps,
-            package_json: &package_json,
-            unresolved_external_dependencies: None,
+            external_declarations: PackageExternalDeclarations::new(&declarations, "my-app"),
             implicit_dependencies: &implicit_deps,
             global_implicit_dependencies: &global_implicit_deps,
         };
@@ -634,12 +660,12 @@ mod test {
         let internal_deps = HashSet::new();
         let implicit_deps = HashMap::new();
         let global_implicit_deps = HashMap::new();
+        let declarations = declarations(&package_json);
 
         let dependency_locations = DependencyLocations {
             package: &package_name,
             internal_dependencies: &internal_deps,
-            package_json: &package_json,
-            unresolved_external_dependencies: None,
+            external_declarations: PackageExternalDeclarations::new(&declarations, "my-app"),
             implicit_dependencies: &implicit_deps,
             global_implicit_dependencies: &global_implicit_deps,
         };
@@ -683,12 +709,12 @@ mod test {
         let internal_deps = HashSet::new();
         let implicit_deps = HashMap::new();
         let global_implicit_deps = HashMap::new();
+        let declarations = declarations(&package_json);
 
         let dependency_locations = DependencyLocations {
             package: &package_name,
             internal_dependencies: &internal_deps,
-            package_json: &package_json,
-            unresolved_external_dependencies: None,
+            external_declarations: PackageExternalDeclarations::new(&declarations, "my-app"),
             implicit_dependencies: &implicit_deps,
             global_implicit_dependencies: &global_implicit_deps,
         };

--- a/crates/turborepo-boundaries/src/lib.rs
+++ b/crates/turborepo-boundaries/src/lib.rs
@@ -28,6 +28,7 @@ use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 use turborepo_errors::Spanned;
 use turborepo_log::Subsystem;
 use turborepo_repository::{
+    external_resolution::PackageExternalDeclarations,
     package_graph::{PackageGraph, PackageGraphNodeKind, PackageInfo, PackageName, PackageNode},
     toolchain::ToolchainId,
 };
@@ -50,6 +51,12 @@ pub trait PackageGraphProvider: Send + Sync {
     fn package_scopes(&self) -> Box<dyn Iterator<Item = PackageScope<'_>> + '_>;
     /// Phase 2 compatibility payload used only for dependency information.
     fn package_info(&self, name: &PackageName) -> Option<&PackageInfo>;
+    fn external_declarations<'a>(
+        &'a self,
+        name: &'a PackageName,
+    ) -> PackageExternalDeclarations<'a> {
+        PackageExternalDeclarations::new(&[], name.as_str())
+    }
     fn immediate_dependencies(&self, node: &PackageNode) -> Option<HashSet<&PackageNode>>;
     fn dependencies(&self, node: &PackageNode) -> Box<dyn Iterator<Item = &PackageNode> + '_>;
     fn ancestors(&self, node: &PackageNode) -> Box<dyn Iterator<Item = &PackageNode> + '_>;
@@ -74,6 +81,13 @@ impl PackageGraphProvider for PackageGraph {
 
     fn package_info(&self, name: &PackageName) -> Option<&PackageInfo> {
         PackageGraph::package_info(self, name)
+    }
+
+    fn external_declarations<'a>(
+        &'a self,
+        name: &'a PackageName,
+    ) -> PackageExternalDeclarations<'a> {
+        PackageGraph::external_declarations(self, name)
     }
 
     fn immediate_dependencies(&self, node: &PackageNode) -> Option<HashSet<&PackageNode>> {
@@ -613,7 +627,6 @@ impl BoundariesChecker {
         let file_result = Self::check_package_files(
             ctx,
             package_name,
-            package_info,
             package_directory,
             &implicit_dependencies,
             global_implicit_dependencies,
@@ -641,7 +654,6 @@ impl BoundariesChecker {
     fn check_package_files<G, T>(
         ctx: &BoundariesContext<'_, G, T>,
         package_name: &PackageName,
-        package_info: &PackageInfo,
         package_directory: &turbopath::AnchoredSystemPath,
         implicit_dependencies: &HashMap<String, Spanned<()>>,
         global_implicit_dependencies: &HashMap<String, Spanned<()>>,
@@ -701,12 +713,9 @@ impl BoundariesChecker {
         let dependency_locations = DependencyLocations {
             package: package_name,
             internal_dependencies: &internal_dependencies,
-            package_json: &package_info.package_json,
+            external_declarations: ctx.pkg_dep_graph.external_declarations(package_name),
             implicit_dependencies,
             global_implicit_dependencies,
-            unresolved_external_dependencies: package_info
-                .unresolved_external_dependencies
-                .as_ref(),
         };
 
         type FileResult = Result<(Vec<BoundariesDiagnostic>, Vec<String>), Error>;

--- a/crates/turborepo-frameworks/src/lib.rs
+++ b/crates/turborepo-frameworks/src/lib.rs
@@ -5,7 +5,9 @@
 use std::{collections::HashMap, sync::OnceLock};
 
 use serde::Deserialize;
-use turborepo_repository::package_graph::PackageInfo;
+use turborepo_repository::{
+    external_resolution::PackageExternalDeclarations, relationships::DependencyKind,
+};
 
 #[derive(Debug, PartialEq, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -85,30 +87,24 @@ fn get_frameworks() -> Result<&'static [Framework], &'static serde_json::Error> 
 }
 
 impl Matcher {
-    pub fn test(&self, workspace: &PackageInfo, is_monorepo: bool) -> bool {
-        // In the case where we're not in a monorepo, i.e. single package mode,
-        // `unresolved_external_dependencies` is not populated. In which case we
-        // check both `dependencies` and `devDependencies` so that frameworks
-        // installed as dev dependencies (e.g. Vite, Astro, SvelteKit) are
-        // correctly detected.
+    pub fn test(&self, declarations: PackageExternalDeclarations<'_>, is_monorepo: bool) -> bool {
         let has_dep = |dep: &str| -> bool {
-            if is_monorepo {
-                workspace
-                    .unresolved_external_dependencies
-                    .as_ref()
-                    .is_some_and(|deps| deps.contains_key(dep))
-            } else {
-                workspace
-                    .package_json
-                    .dependencies
-                    .as_ref()
-                    .is_some_and(|deps| deps.contains_key(dep))
-                    || workspace
-                        .package_json
-                        .dev_dependencies
-                        .as_ref()
-                        .is_some_and(|deps| deps.contains_key(dep))
-            }
+            declarations.iter().any(|declaration| {
+                let kind_matches = if is_monorepo {
+                    !matches!(declaration.kind(), DependencyKind::Peer { .. })
+                } else {
+                    matches!(
+                        declaration.kind(),
+                        DependencyKind::Production | DependencyKind::Development
+                    )
+                };
+                let name = if is_monorepo {
+                    declaration.package_name()
+                } else {
+                    declaration.declaration_name()
+                };
+                kind_matches && name == dep
+            })
         };
 
         match self.strategy {
@@ -137,12 +133,15 @@ impl std::fmt::Display for Slug {
     }
 }
 
-pub fn infer_framework(workspace: &PackageInfo, is_monorepo: bool) -> Option<&Framework> {
+pub fn infer_framework(
+    declarations: PackageExternalDeclarations<'_>,
+    is_monorepo: bool,
+) -> Option<&Framework> {
     let frameworks = get_frameworks().ok()?;
 
     frameworks
         .iter()
-        .find(|framework| framework.dependency_match.test(workspace, is_monorepo))
+        .find(|framework| framework.dependency_match.test(declarations, is_monorepo))
 }
 
 #[cfg(test)]
@@ -151,7 +150,11 @@ mod tests {
     use std::collections::{BTreeMap, HashMap};
 
     use test_case::test_case;
-    use turborepo_repository::{package_graph::PackageInfo, package_json::PackageJson};
+    use turborepo_repository::{
+        external_resolution::{ExternalDeclaration, PackageExternalDeclarations},
+        package_graph::PackageInfo,
+        package_json::PackageJson,
+    };
 
     use super::*;
 
@@ -331,8 +334,91 @@ mod tests {
         expected: Option<&Framework>,
         is_monorepo: bool,
     ) {
-        let framework = infer_framework(&workspace_info, is_monorepo);
+        let declarations = if is_monorepo {
+            workspace_info
+                .unresolved_external_dependencies
+                .iter()
+                .flatten()
+                .map(|(name, specifier)| {
+                    ExternalDeclaration::new(
+                        "workspace",
+                        name,
+                        name,
+                        specifier,
+                        DependencyKind::Production,
+                    )
+                })
+                .collect::<Vec<_>>()
+        } else {
+            workspace_info
+                .package_json
+                .dependencies
+                .iter()
+                .flatten()
+                .map(|(name, specifier)| (name, specifier, DependencyKind::Production))
+                .chain(
+                    workspace_info
+                        .package_json
+                        .dev_dependencies
+                        .iter()
+                        .flatten()
+                        .map(|(name, specifier)| (name, specifier, DependencyKind::Development)),
+                )
+                .map(|(name, specifier, kind)| {
+                    ExternalDeclaration::new("workspace", name, name, specifier, kind)
+                })
+                .collect()
+        };
+        let framework = infer_framework(
+            PackageExternalDeclarations::new(&declarations, "workspace"),
+            is_monorepo,
+        );
         assert_eq!(framework, expected);
+    }
+
+    #[test]
+    fn aliases_and_peer_declarations_preserve_framework_behavior() {
+        let declarations = vec![
+            ExternalDeclaration::new(
+                "workspace",
+                "next-alias",
+                "next",
+                "npm:next@latest",
+                DependencyKind::Production,
+            ),
+            ExternalDeclaration::new(
+                "workspace",
+                "blitz",
+                "blitz",
+                "*",
+                DependencyKind::Peer { optional: false },
+            ),
+        ];
+        let view = PackageExternalDeclarations::new(&declarations, "workspace");
+
+        assert_eq!(
+            infer_framework(view, true),
+            Some(get_framework_by_slug("nextjs"))
+        );
+        assert_eq!(infer_framework(view, false), None);
+    }
+
+    #[test]
+    fn optional_declarations_preserve_single_package_behavior() {
+        let declarations = vec![ExternalDeclaration::new(
+            "workspace",
+            "next",
+            "next",
+            "latest",
+            DependencyKind::Optional,
+        )];
+        let view = PackageExternalDeclarations::new(&declarations, "workspace");
+
+        assert_eq!(
+            infer_framework(view, true),
+            Some(get_framework_by_slug("nextjs"))
+        );
+        assert_eq!(infer_framework(view, false), None);
     }
 
     #[test]

--- a/crates/turborepo-query/src/package_graph.rs
+++ b/crates/turborepo-query/src/package_graph.rs
@@ -44,7 +44,7 @@ impl From<DependencyKind> for DependencyKindGraphQL {
     fn from(kind: DependencyKind) -> Self {
         Self {
             kind: match kind {
-                DependencyKind::Production => "production".to_string(),
+                DependencyKind::Production | DependencyKind::Optional => "production".to_string(),
                 DependencyKind::Development => "development".to_string(),
                 DependencyKind::Peer { optional } => {
                     if optional {

--- a/crates/turborepo-repository/src/external_resolution.rs
+++ b/crates/turborepo-repository/src/external_resolution.rs
@@ -1,6 +1,9 @@
 //! Parser-neutral external dependency declarations and exact resolutions.
 
-use std::collections::HashSet;
+use std::{
+    collections::{HashMap, HashSet},
+    ops::Range,
+};
 
 use sha2::{Digest, Sha256};
 use turbopath::{AnchoredSystemPath, AnchoredSystemPathBuf};
@@ -22,6 +25,22 @@ pub struct ExternalDeclaration {
 }
 
 impl ExternalDeclaration {
+    pub fn new(
+        source: impl Into<String>,
+        declaration_name: impl Into<String>,
+        package_name: impl Into<String>,
+        specifier: impl Into<String>,
+        kind: DependencyKind,
+    ) -> Self {
+        Self {
+            source: source.into(),
+            declaration_name: declaration_name.into(),
+            package_name: package_name.into(),
+            specifier: specifier.into(),
+            kind,
+        }
+    }
+
     pub fn source(&self) -> &str {
         &self.source
     }
@@ -44,24 +63,21 @@ impl ExternalDeclaration {
 }
 
 /// Immutable declaration-side input to external resolution producers.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct ExternalDeclarationView {
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ExternalDeclarations {
     declarations: Box<[ExternalDeclaration]>,
+    ranges: HashMap<String, Range<usize>>,
 }
 
-impl ExternalDeclarationView {
+impl ExternalDeclarations {
     pub(crate) fn build(relationships: &RelationshipKnowledge) -> Self {
         let mut declarations = Vec::new();
+        let mut ranges = HashMap::new();
         for group in relationships.groups() {
+            let start = declarations.len();
             let mut seen = HashSet::new();
             for relationship in group.relationships() {
                 if !seen.insert(relationship.declaration_name()) {
-                    continue;
-                }
-                if !matches!(
-                    relationship.kind(),
-                    DependencyKind::Production | DependencyKind::Development
-                ) {
                     continue;
                 }
                 let RelationshipTarget::UnresolvedExternal { name, specifier } =
@@ -69,22 +85,54 @@ impl ExternalDeclarationView {
                 else {
                     continue;
                 };
-                declarations.push(ExternalDeclaration {
-                    source: group.source().to_string(),
-                    declaration_name: relationship.declaration_name().to_string(),
-                    package_name: name.clone(),
-                    specifier: specifier.clone(),
-                    kind: relationship.kind(),
-                });
+                declarations.push(ExternalDeclaration::new(
+                    group.source(),
+                    relationship.declaration_name(),
+                    name,
+                    specifier,
+                    relationship.kind(),
+                ));
             }
+            ranges.insert(group.source().to_string(), start..declarations.len());
         }
         Self {
             declarations: declarations.into_boxed_slice(),
+            ranges,
         }
     }
 
-    pub(crate) fn declarations(&self) -> &[ExternalDeclaration] {
+    pub fn declarations(&self) -> &[ExternalDeclaration] {
         &self.declarations
+    }
+
+    pub fn for_package<'a>(&'a self, source: &'a str) -> PackageExternalDeclarations<'a> {
+        let declarations = self
+            .ranges
+            .get(source)
+            .map(|range| &self.declarations[range.clone()])
+            .unwrap_or_default();
+        PackageExternalDeclarations::new(declarations, source)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct PackageExternalDeclarations<'a> {
+    declarations: &'a [ExternalDeclaration],
+    source: &'a str,
+}
+
+impl<'a> PackageExternalDeclarations<'a> {
+    pub fn new(declarations: &'a [ExternalDeclaration], source: &'a str) -> Self {
+        Self {
+            declarations,
+            source,
+        }
+    }
+
+    pub fn iter(self) -> impl DoubleEndedIterator<Item = &'a ExternalDeclaration> + Clone + 'a {
+        self.declarations
+            .iter()
+            .filter(move |declaration| declaration.source() == self.source)
     }
 }
 
@@ -488,8 +536,8 @@ mod tests {
         )
         .unwrap();
 
-        let view = ExternalDeclarationView::build(&relationships);
-        assert_eq!(view.declarations().len(), 1);
+        let view = ExternalDeclarations::build(&relationships);
+        assert_eq!(view.declarations().len(), 2);
         let declaration = &view.declarations()[0];
         assert_eq!(declaration.source(), "app");
         assert_eq!(declaration.declaration_name(), "alias");

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -22,7 +22,7 @@ use crate::{
         PackageDiscoveryBuilder,
     },
     external_resolution::{
-        ExternalDeclarationView, ExternalPackageIdentity, ExternalResolutionData,
+        ExternalDeclarations, ExternalPackageIdentity, ExternalResolutionData,
         ExternalResolutionDomain, ExternalResolutionGeneration, PackageResolution,
         ResolutionCompleteness, ResolutionFingerprint, ResolutionUnavailableReason,
     },
@@ -542,13 +542,21 @@ impl PackageGraphAssembler {
                 match (relationship.kind(), relationship.target()) {
                     (DependencyKind::Peer { .. }, _) => {}
                     (
-                        DependencyKind::Production | DependencyKind::Development,
+                        DependencyKind::Production
+                        | DependencyKind::Optional
+                        | DependencyKind::Development,
                         RelationshipTarget::Internal(target),
                     ) => {
-                        internal.entry(target).or_insert(relationship.kind());
+                        let kind = match relationship.kind() {
+                            DependencyKind::Optional => DependencyKind::Production,
+                            kind => kind,
+                        };
+                        internal.entry(target).or_insert(kind);
                     }
                     (
-                        DependencyKind::Production | DependencyKind::Development,
+                        DependencyKind::Production
+                        | DependencyKind::Optional
+                        | DependencyKind::Development,
                         RelationshipTarget::UnresolvedExternal { name, specifier },
                     ) => {
                         external
@@ -900,8 +908,32 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
                 )?)
             }
         };
-        let relationship_knowledge =
-            Arc::new(RelationshipKnowledge::build(&knowledge, Vec::new())?);
+        let relationship_groups = root_package_json
+            .as_ref()
+            .map(|package_json| {
+                RelationshipGroup::new(
+                    "//",
+                    package_json
+                        .dependencies_with_kind()
+                        .map(|(name, specifier, kind)| {
+                            Relationship::new(
+                                name,
+                                kind,
+                                RelationshipTarget::UnresolvedExternal {
+                                    name: name.clone(),
+                                    specifier: specifier.clone(),
+                                },
+                            )
+                        })
+                        .collect(),
+                )
+            })
+            .into_iter()
+            .collect();
+        let relationship_knowledge = Arc::new(RelationshipKnowledge::build(
+            &knowledge,
+            relationship_groups,
+        )?);
         let PackageGraphAssembly {
             package_payloads,
             workspace_graph,
@@ -937,6 +969,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             package_manager,
             knowledge,
             relationship_knowledge,
+            external_declarations: std::sync::OnceLock::new(),
             relationship_projections: std::sync::OnceLock::new(),
             external_resolution: std::sync::Mutex::new(ExternalResolutionKnowledge::absent()),
             external_dep_to_internal_dependents: std::sync::OnceLock::new(),
@@ -1288,7 +1321,10 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
                 .into_iter()
                 .map(|(identity, _)| (identity.to_string(), BTreeMap::new()))
                 .collect();
-        for declaration in ExternalDeclarationView::build(relationships).declarations() {
+        for declaration in ExternalDeclarations::build(relationships).declarations() {
+            if matches!(declaration.kind(), DependencyKind::Peer { .. }) {
+                continue;
+            }
             let Some(dependencies) = by_source.get_mut(declaration.source()) else {
                 continue;
             };
@@ -1474,6 +1510,7 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             lockfile: arc_lockfile,
             knowledge,
             relationship_knowledge,
+            external_declarations: std::sync::OnceLock::new(),
             relationship_projections: std::sync::OnceLock::new(),
             external_resolution: std::sync::Mutex::new(external_resolution),
             external_dep_to_internal_dependents: std::sync::OnceLock::new(),
@@ -1999,6 +2036,24 @@ mod test {
             &root,
             PackageJson {
                 name: Some(Spanned::new("user-facing-root-name".into())),
+                dependencies: Some(
+                    [("prod".to_string(), "1".to_string())]
+                        .into_iter()
+                        .collect(),
+                ),
+                optional_dependencies: Some(
+                    [("optional".to_string(), "1".to_string())]
+                        .into_iter()
+                        .collect(),
+                ),
+                dev_dependencies: Some(
+                    [("dev".to_string(), "1".to_string())].into_iter().collect(),
+                ),
+                peer_dependencies: Some(
+                    [("peer".to_string(), "1".to_string())]
+                        .into_iter()
+                        .collect(),
+                ),
                 ..Default::default()
             },
         )
@@ -2022,6 +2077,19 @@ mod test {
         let contexts = graph.package_task_contexts().collect::<Vec<_>>();
         assert_eq!(contexts.len(), 1);
         assert_eq!(contexts[0].package(), &PackageName::Root);
+        assert_eq!(
+            contexts[0]
+                .external_declarations()
+                .iter()
+                .map(|declaration| (declaration.declaration_name(), declaration.kind()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("prod", DependencyKind::Production),
+                ("optional", DependencyKind::Optional),
+                ("dev", DependencyKind::Development),
+                ("peer", DependencyKind::Peer { optional: false }),
+            ]
+        );
         assert_eq!(
             graph
                 .package_dir(&PackageName::Root)

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -16,7 +16,10 @@ use turborepo_lockfiles::Lockfile;
 
 use crate::{
     discovery::LocalPackageDiscoveryBuilder,
-    external_resolution::{ExternalResolutionGeneration, ExternalResolutionStatus},
+    external_resolution::{
+        ExternalDeclarations, ExternalResolutionGeneration, ExternalResolutionStatus,
+        PackageExternalDeclarations,
+    },
     knowledge::{RelationshipKnowledge, RepositoryKnowledge},
     package_json::PackageJson,
     package_manager::PackageManager,
@@ -134,6 +137,7 @@ pub struct PackageGraph {
     /// unresolved external declaration maps.
     #[allow(dead_code)]
     relationship_knowledge: Arc<RelationshipKnowledge>,
+    external_declarations: OnceLock<ExternalDeclarations>,
     relationship_projections: OnceLock<projections::RelationshipProjections>,
     /// The sole owner of external-resolution lifecycle and terminal knowledge
     /// across toolchains. Deferred JavaScript production is joined once by
@@ -281,6 +285,7 @@ pub struct PackageTaskContext<'a> {
     repository_root: &'a AbsoluteSystemPath,
     directory: &'a AnchoredSystemPath,
     package_info: Option<&'a PackageInfo>,
+    external_declarations: &'a ExternalDeclarations,
     kind: PackageTaskContextKind,
     toolchain: Option<&'a crate::toolchain::ToolchainId>,
     requires_compatibility_payload: bool,
@@ -297,8 +302,10 @@ impl<'a> PackageTaskContext<'a> {
     #[cfg(test)]
     #[rustfmt::skip]
     pub(crate) fn new_for_test(package: PackageName, repository_root: &'a AbsoluteSystemPath, directory: &'a AnchoredSystemPath, package_info: Option<&'a PackageInfo>, kind: PackageTaskContextKind, toolchain: Option<&'a crate::toolchain::ToolchainId>) -> Self {
+        static EXTERNAL_DECLARATIONS: OnceLock<ExternalDeclarations> = OnceLock::new();
+        let external_declarations = EXTERNAL_DECLARATIONS.get_or_init(ExternalDeclarations::default);
         let requires_compatibility_payload = package != PackageName::Root || toolchain == Some(&crate::toolchain::ToolchainId::JAVASCRIPT);
-        Self { package, repository_root, directory, package_info, kind, toolchain, requires_compatibility_payload }
+        Self { package, repository_root, directory, package_info, external_declarations, kind, toolchain, requires_compatibility_payload }
     }
 
     pub fn package(&self) -> &PackageName {
@@ -315,6 +322,11 @@ impl<'a> PackageTaskContext<'a> {
 
     pub fn package_info(&self) -> Option<&'a PackageInfo> {
         self.package_info
+    }
+
+    pub fn external_declarations(&self) -> PackageExternalDeclarations<'_> {
+        self.external_declarations
+            .for_package(self.package.as_str())
     }
 
     pub fn kind(&self) -> PackageTaskContextKind {
@@ -358,6 +370,19 @@ pub struct ExternalDependencyChange {
 }
 
 impl PackageGraph {
+    fn external_declaration_view(&self) -> &ExternalDeclarations {
+        self.external_declarations
+            .get_or_init(|| ExternalDeclarations::build(&self.relationship_knowledge))
+    }
+
+    pub fn external_declarations<'a>(
+        &'a self,
+        package: &'a PackageName,
+    ) -> PackageExternalDeclarations<'a> {
+        self.external_declaration_view()
+            .for_package(package.as_str())
+    }
+
     fn relationship_projections(&self) -> &projections::RelationshipProjections {
         self.relationship_projections.get_or_init(|| {
             projections::RelationshipProjections::build(
@@ -712,6 +737,7 @@ impl PackageGraph {
             repository_root: self.knowledge.repository_root(),
             directory,
             package_info,
+            external_declarations: self.external_declaration_view(),
             kind,
             toolchain,
             requires_compatibility_payload,

--- a/crates/turborepo-repository/src/package_graph/projections.rs
+++ b/crates/turborepo-repository/src/package_graph/projections.rs
@@ -107,7 +107,9 @@ impl RelationshipIndex {
                 };
                 if !matches!(
                     kind,
-                    DependencyKind::Production | DependencyKind::Development
+                    DependencyKind::Production
+                        | DependencyKind::Optional
+                        | DependencyKind::Development
                 ) {
                     continue;
                 }
@@ -125,7 +127,9 @@ impl RelationshipIndex {
             prune_production[source.index()].extend(
                 effective_concrete
                     .iter()
-                    .filter(|(_, kind)| *kind == DependencyKind::Production)
+                    .filter(|(_, kind)| {
+                        matches!(kind, DependencyKind::Production | DependencyKind::Optional)
+                    })
                     .map(|(target, _)| *target),
             );
             prune_production[source.index()].extend(required_peers);

--- a/crates/turborepo-repository/src/package_json.rs
+++ b/crates/turborepo-repository/src/package_json.rs
@@ -95,8 +95,12 @@ impl PackageJson {
             .dependencies
             .iter()
             .flatten()
-            .chain(self.optional_dependencies.iter().flatten())
             .map(|(name, version)| (name, version, DependencyKind::Production));
+        let optional = self
+            .optional_dependencies
+            .iter()
+            .flatten()
+            .map(|(name, version)| (name, version, DependencyKind::Optional));
         let dev = self
             .dev_dependencies
             .iter()
@@ -115,7 +119,7 @@ impl PackageJson {
                     },
                 )
             });
-        normal.chain(dev).chain(peer)
+        normal.chain(optional).chain(dev).chain(peer)
     }
 
     pub fn is_optional_peer_dependency(&self, name: &str) -> bool {
@@ -229,6 +233,7 @@ mod test {
         let json = json!({
             "name": "test",
             "dependencies": { "prod-pkg": "1.0.0", "shared-pkg": "2.0.0" },
+            "optionalDependencies": { "optional-pkg": "1.0.0" },
             "devDependencies": { "dev-pkg": "1.0.0", "shared-pkg": "1.0.0" }
         });
         let pkg: PackageJson = PackageJson::from_value(json).unwrap();
@@ -237,6 +242,7 @@ mod test {
             kinds.entry(name.as_str()).or_insert(kind);
         }
         assert_eq!(kinds.get("prod-pkg"), Some(&DependencyKind::Production));
+        assert_eq!(kinds.get("optional-pkg"), Some(&DependencyKind::Optional));
         assert_eq!(kinds.get("dev-pkg"), Some(&DependencyKind::Development));
         assert_eq!(kinds.get("shared-pkg"), Some(&DependencyKind::Production));
     }

--- a/crates/turborepo-repository/src/relationships.rs
+++ b/crates/turborepo-repository/src/relationships.rs
@@ -7,6 +7,7 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DependencyKind {
     Production,
+    Optional,
     Development,
     Peer { optional: bool },
 }

--- a/crates/turborepo-task-hash/src/lib.rs
+++ b/crates/turborepo-task-hash/src/lib.rs
@@ -577,7 +577,7 @@ impl<'a, R: RunOptsHashInfo> TaskHasher<'a, R> {
 
         // See if we can infer a framework
         let framework = do_framework_inference
-            .then(|| workspace.and_then(|workspace| infer_framework(workspace, is_monorepo)))
+            .then(|| infer_framework(package_context.external_declarations(), is_monorepo))
             .flatten()
             .inspect(|framework| {
                 debug!("auto detected framework for {}", task_id.package());

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -161,7 +161,10 @@ Represents the workspace structure and package dependencies:
   identities, definition sources, completeness, and stable fingerprints. A
   single resolution owner tracks lifecycle status, and the snapshot projects
   temporary `PackageInfo` closure/hash fields byte-compatibly until consumer
-  migration.
+  migration. Framework inference and boundaries validation consume the
+  package-scoped declaration projection directly; aliases, duplicate
+  precedence, optional declarations, and peers remain explicit normalized
+  facts rather than raw manifest reads.
 - Performs ecosystem-specific lockfile analysis
 - Builds dependency relationships between workspace packages
 - Validates that all non-root packages have a `name` field


### PR DESCRIPTION
## Summary

- expose an indexed, package-scoped external declaration projection through `PackageGraph` and task contexts
- migrate framework inference and boundaries validation away from raw manifests and `unresolved_external_dependencies`
- preserve aliases, duplicate precedence, peers, and monorepo versus single-package framework behavior
- retain optional declarations explicitly while continuing to project them as production graph/query semantics
- construct root declaration knowledge in single-package mode
- document the declaration consumer cutover

Closes TURBO-5807.

## Testing

- `NO_COLOR=1 LC_ALL=C.UTF-8 cargo test -p turborepo-repository` (366 passed)
- `cargo test -p turborepo-frameworks` (21 passed)
- `cargo test -p turborepo-boundaries` (63 passed)
- `cargo test -p turborepo-task-hash` (21 passed)
- `cargo test -p turborepo-query` (9 passed)
- `NO_COLOR=1 LC_ALL=C.UTF-8 cargo test -p turbo --test final_hash_contract` (8 passed)
- `NO_COLOR=1 LC_ALL=C.UTF-8 cargo test -p turbo --test boundaries` (4 passed)
- strict Clippy for repository, frameworks, boundaries, and task hash
- pre-push `format`, `check:toml`, and `turborepo-crates#format` hooks