### PR TITLE
fix: Support fork PRs in review gate

### DIFF
--- a/scripts/validate-review-gate.mjs
+++ b/scripts/validate-review-gate.mjs
@@ -3,7 +3,6 @@
 import {
   CLI_PACKAGE_PATHS,
   LIBRARY_PACKAGE_PATHS,
-  getChangedFiles,
   run as validateRelease,
 } from "./validate-release-pr.mjs";
 
@@ -38,6 +37,20 @@ function isReleaseReviewPath(path) {
     LIBRARY_PACKAGE_PATHS.includes(path) ||
     /^skills\/turborepo\/.*\.md$/.test(path)
   );
+}
+
+async function hasNonReleasePath(repository, pullNumber) {
+  for (let page = 1; ; page += 1) {
+    const files = await github(
+      `/repos/${repository}/pulls/${pullNumber}/files?per_page=100&page=${page}`,
+    );
+    if (files.some(({ filename }) => !isReleaseReviewPath(filename))) {
+      return true;
+    }
+    if (files.length < 100) {
+      return false;
+    }
+  }
 }
 
 async function hasValidApproval(repository, pull) {
@@ -93,7 +106,6 @@ export async function run() {
   if (
     pull.base.ref !== pull.base.repo.default_branch ||
     pull.base.repo.full_name !== repository ||
-    pull.head.repo.full_name !== repository ||
     pull.state !== "open" ||
     pull.draft
   ) {
@@ -108,8 +120,7 @@ export async function run() {
     throw new Error("Review gate is not running on the dispatched SHA");
   }
 
-  const files = await getChangedFiles(repository, pull.base.sha, pull.head.sha);
-  if (files.some(({ filename }) => !isReleaseReviewPath(filename))) {
+  if (await hasNonReleasePath(repository, pull.number)) {
     console.log("Native team review policy applies to this pull request");
     return;
   }
@@ -117,6 +128,7 @@ export async function run() {
   const isAutomatedRelease =
     pull.user.login === "github-actions[bot]" &&
     pull.user.id === 41898282 &&
+    pull.head.repo.full_name === repository &&
     (/^staging-/.test(pull.head.ref) ||
       /^library-release\//.test(pull.head.ref));
   if (isAutomatedRelease) {

--- a/scripts/validate-review-gate.test.mjs
+++ b/scripts/validate-review-gate.test.mjs
@@ -11,7 +11,10 @@ const ENV_NAMES = [
   "EXPECTED_HEAD_SHA",
 ];
 
-async function withGitHub({ files, reviews = [], permission = "write" }, fn) {
+async function withGitHub(
+  { files, filePages, reviews = [], permission = "write" },
+  fn,
+) {
   const originalFetch = globalThis.fetch;
   const originalEnv = Object.fromEntries(
     ENV_NAMES.map((name) => [name, process.env[name]]),
@@ -35,12 +38,14 @@ async function withGitHub({ files, reviews = [], permission = "write" }, fn) {
   };
 
   globalThis.fetch = async (url) => {
-    const path = new URL(url).pathname;
+    const parsed = new URL(url);
+    const path = parsed.pathname;
     if (path.endsWith("/pulls/42")) {
       return response(pull);
     }
-    if (path.includes("/compare/")) {
-      return response({ files });
+    if (path.endsWith("/pulls/42/files")) {
+      const page = Number(parsed.searchParams.get("page"));
+      return response(filePages?.[page - 1] ?? files);
     }
     if (path.endsWith("/pulls/42/reviews")) {
       return response(reviews);
@@ -75,6 +80,28 @@ async function withGitHub({ files, reviews = [], permission = "write" }, fn) {
 test("defers non-release paths to the native team review policy", async () => {
   await withGitHub(
     { files: [{ filename: "crates/turborepo-lib/src/lib.rs" }] },
+    async () => assert.doesNotReject(run()),
+  );
+});
+
+test("defers fork PRs with non-release paths to native review", async () => {
+  await withGitHub(
+    { files: [{ filename: "crates/turborepo-lib/src/lib.rs" }] },
+    async (pull) => {
+      pull.head.repo.full_name = "contributor/turborepo";
+      await assert.doesNotReject(run());
+    },
+  );
+});
+
+test("finds non-release paths after the first page", async () => {
+  await withGitHub(
+    {
+      filePages: [
+        Array.from({ length: 100 }, () => ({ filename: "version.txt" })),
+        [{ filename: "crates/turborepo-lib/src/lib.rs" }],
+      ],
+    },
     async () => assert.doesNotReject(run()),
   );
 });


### PR DESCRIPTION
## Summary

- Classify review-exempt paths through the paginated pull-request files API.
- Allow fork PRs to defer non-release changes to native team review.
- Keep immutable compare/content validation exclusively for actual automated release PRs.

## Testing

- `node --test scripts/validate-review-gate.test.mjs scripts/validate-release-pr.test.mjs` (19 passing tests).
- Added regression coverage for fork PRs and non-release paths after the first 100 files.
- Full pre-push formatting, TOML, and Rust formatting checks.

## Rollout

The default-branch ruleset was restored to its original approval and required-check policy before this fix was prepared. The tokenless gate rules will not be re-enabled until this regression fix is merged and smoke-tested.