### PR TITLE
refactor: Migrate lockfile affectedness

### DIFF
--- a/crates/turborepo-repository/src/change_mapper/mod.rs
+++ b/crates/turborepo-repository/src/change_mapper/mod.rs
@@ -14,11 +14,8 @@ use tracing::debug;
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf};
 use wax::Program;
 
-use crate::{
-    package_graph::{
-        ChangedPackagesError, ExternalDependencyChange, PackageGraph, PackageName, WorkspacePackage,
-    },
-    package_manager::{PackageManager, yarnrc},
+use crate::package_graph::{
+    ChangedPackagesError, ExternalDependencyChange, PackageGraph, PackageName, WorkspacePackage,
 };
 
 mod package;
@@ -305,28 +302,9 @@ impl<'a, PD: PackageChangeMapper> ChangeMapper<'a, PD> {
         &self,
         lockfile_content: &[u8],
     ) -> Result<Vec<ExternalDependencyChange>, ChangeMapError> {
-        let yarnrc = if matches!(
-            self.pkg_graph.package_manager(),
-            Some(PackageManager::Berry)
-        ) {
-            Some(yarnrc::YarnRc::from_file(self.pkg_graph.repo_root())?)
-        } else {
-            None
-        };
-        let Some(package_manager) = self.pkg_graph.package_manager() else {
-            return Ok(Vec::new());
-        };
-        let Some(root_package_json) = self.pkg_graph.root_package_json() else {
-            return Ok(Vec::new());
-        };
-        let previous_lockfile =
-            package_manager.parse_lockfile(root_package_json, lockfile_content, yarnrc)?;
-
-        let additional_packages = self
-            .pkg_graph
-            .changed_packages_from_lockfile(previous_lockfile.as_ref())?;
-
-        Ok(additional_packages)
+        self.pkg_graph
+            .changed_packages_from_lockfile_contents(lockfile_content)
+            .map_err(Into::into)
     }
 
     pub fn lockfile_changed(
@@ -346,26 +324,8 @@ impl<'a, PD: PackageChangeMapper> ChangeMapper<'a, PD> {
 pub enum ChangeMapError {
     #[error(transparent)]
     Wax(#[from] wax::BuildError),
-    #[error("Package manager error: {0}")]
-    PackageManager(#[from] crate::package_manager::Error),
-    #[error("Yarn config error: {0}")]
-    Yarnrc(#[from] yarnrc::Error),
-    #[error("No lockfile")]
-    NoLockfile,
-    #[error("Missing compatibility payload for package {0}")]
-    MissingPackagePayload(PackageName),
-    #[error("Lockfile error: {0}")]
-    Lockfile(turborepo_lockfiles::Error),
-}
-
-impl From<ChangedPackagesError> for ChangeMapError {
-    fn from(value: ChangedPackagesError) -> Self {
-        match value {
-            ChangedPackagesError::NoLockfile => Self::NoLockfile,
-            ChangedPackagesError::MissingPackagePayload(name) => Self::MissingPackagePayload(name),
-            ChangedPackagesError::Lockfile(e) => Self::Lockfile(e),
-        }
-    }
+    #[error(transparent)]
+    ChangedPackages(#[from] ChangedPackagesError),
 }
 
 #[cfg(test)]

--- a/crates/turborepo-repository/src/external_resolution.rs
+++ b/crates/turborepo-repository/src/external_resolution.rs
@@ -1,7 +1,7 @@
 //! Parser-neutral external dependency declarations and exact resolutions.
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     ops::Range,
 };
 
@@ -492,6 +492,92 @@ pub(crate) enum ExternalResolutionError {
         toolchain: ToolchainId,
         identity: String,
     },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ExternalResolutionChanges {
+    All,
+    Packages(Vec<PackageResolutionChange>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PackageResolutionChange {
+    pub package: String,
+    pub added: Vec<ExternalPackageIdentity>,
+    pub removed: Vec<ExternalPackageIdentity>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub(crate) enum ExternalResolutionComparisonError {
+    #[error("external resolution unavailable")]
+    Unavailable,
+    #[error("previous external resolution is missing package {0}")]
+    MissingPackage(String),
+}
+
+/// Compares two complete, normalized resolution domains without knowing which
+/// ecosystem produced them.
+pub(crate) fn compare_resolution_data(
+    current: &ExternalResolutionData,
+    previous: &ExternalResolutionData,
+    invalidate_all: bool,
+    root_package: &str,
+) -> Result<ExternalResolutionChanges, ExternalResolutionComparisonError> {
+    fn resolved_packages(
+        data: &ExternalResolutionData,
+    ) -> Result<&[PackageResolution], ExternalResolutionComparisonError> {
+        match data {
+            ExternalResolutionData::Resolved {
+                completeness: ResolutionCompleteness::Complete,
+                packages,
+                ..
+            } => Ok(packages),
+            ExternalResolutionData::Resolved {
+                completeness: ResolutionCompleteness::Partial(_),
+                ..
+            }
+            | ExternalResolutionData::Unavailable(_) => {
+                Err(ExternalResolutionComparisonError::Unavailable)
+            }
+        }
+    }
+    let current = resolved_packages(current)?;
+    let previous = resolved_packages(previous)?;
+    if invalidate_all {
+        return Ok(ExternalResolutionChanges::All);
+    }
+
+    let previous_by_package: BTreeMap<_, _> = previous
+        .iter()
+        .map(|package| (package.package(), package))
+        .collect();
+    let mut changes = Vec::new();
+    for package in current {
+        let previous = previous_by_package.get(package.package()).ok_or_else(|| {
+            ExternalResolutionComparisonError::MissingPackage(package.package().to_string())
+        })?;
+        if package.identities() == previous.identities() {
+            continue;
+        }
+        if package.package() == root_package {
+            return Ok(ExternalResolutionChanges::All);
+        }
+
+        let previous: BTreeSet<_> = previous.identities().iter().collect();
+        let current: BTreeSet<_> = package.identities().iter().collect();
+        changes.push(PackageResolutionChange {
+            package: package.package().to_string(),
+            added: current
+                .difference(&previous)
+                .map(|identity| (*identity).clone())
+                .collect(),
+            removed: previous
+                .difference(&current)
+                .map(|identity| (*identity).clone())
+                .collect(),
+        });
+    }
+    Ok(ExternalResolutionChanges::Packages(changes))
 }
 
 #[cfg(test)]

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -12,9 +12,9 @@ use turbopath::{
 use turborepo_lockfiles::Lockfile;
 
 use super::{
-    ExternalResolutionKnowledge, JavaScriptResolutionSnapshot, PackageGraph, PackageInfo,
-    PackageName, PackageNode,
+    ExternalResolutionKnowledge, PackageGraph, PackageInfo, PackageName, PackageNode,
     dep_splitter::{DependencySplitter, WorkspacePathIndex},
+    javascript,
 };
 use crate::{
     discovery::{
@@ -22,9 +22,8 @@ use crate::{
         PackageDiscoveryBuilder,
     },
     external_resolution::{
-        ExternalDeclarations, ExternalPackageIdentity, ExternalResolutionData,
-        ExternalResolutionDomain, ExternalResolutionGeneration, PackageResolution,
-        ResolutionCompleteness, ResolutionFingerprint, ResolutionUnavailableReason,
+        ExternalResolutionData, ExternalResolutionDomain, ExternalResolutionGeneration,
+        ResolutionFingerprint,
     },
     knowledge::{
         PackageScopeObservation, RelationshipGroup, RelationshipKnowledge, RepositoryKnowledge,
@@ -1163,7 +1162,7 @@ pub type ClosureHasher = Arc<
         + Sync,
 >;
 
-fn apply_resolution_fingerprints(
+pub(super) fn apply_resolution_fingerprints(
     domains: &mut [ExternalResolutionDomain],
     hasher: Option<&ClosureHasher>,
 ) {
@@ -1199,20 +1198,6 @@ fn apply_resolution_fingerprints(
     }
 }
 
-fn scope_directory_and_toolchain<'a>(
-    knowledge: &'a RepositoryKnowledge,
-    name: &PackageName,
-) -> Option<(&'a AnchoredSystemPath, &'a ToolchainId)> {
-    match name {
-        PackageName::Root => knowledge
-            .root_javascript_scope()
-            .map(|scope| (knowledge.repository_directory(), scope.toolchain())),
-        PackageName::Other(name) => knowledge
-            .scope(name)
-            .map(|scope| (scope.directory(), scope.toolchain())),
-    }
-}
-
 fn scope_definition_path<'a>(
     knowledge: &'a RepositoryKnowledge,
     name: &PackageName,
@@ -1229,144 +1214,6 @@ fn build_failure(error: Error) -> discovery::Error {
     discovery::Error::Failed(Box::new(error))
 }
 
-fn javascript_resolution_packages(
-    knowledge: &RepositoryKnowledge,
-) -> Vec<(&str, &AnchoredSystemPath)> {
-    let mut packages = Vec::new();
-    if knowledge.root_javascript_scope().is_some() {
-        packages.push((super::ROOT_PKG_NAME, knowledge.repository_directory()));
-    }
-    packages.extend(
-        knowledge
-            .scopes()
-            .filter(|scope| scope.toolchain() == &ToolchainId::JAVASCRIPT)
-            .map(|scope| (scope.identity(), scope.directory())),
-    );
-    packages.sort_unstable_by_key(|(identity, _)| *identity);
-    packages
-}
-
-pub(super) fn javascript_external_dependencies(
-    knowledge: &RepositoryKnowledge,
-    relationships: &RelationshipKnowledge,
-) -> HashMap<String, BTreeMap<String, String>> {
-    let mut by_source: BTreeMap<String, BTreeMap<String, String>> =
-        javascript_resolution_packages(knowledge)
-            .into_iter()
-            .map(|(identity, _)| (identity.to_string(), BTreeMap::new()))
-            .collect();
-    for declaration in ExternalDeclarations::build(relationships).declarations() {
-        if matches!(declaration.kind(), DependencyKind::Peer { .. }) {
-            continue;
-        }
-        let Some(dependencies) = by_source.get_mut(declaration.source()) else {
-            continue;
-        };
-        dependencies
-            .entry(declaration.package_name().to_string())
-            .or_insert_with(|| declaration.specifier().to_string());
-    }
-
-    by_source
-        .into_iter()
-        .filter_map(|(identity, dependencies)| {
-            let name = package_name_from_identity(&identity);
-            let (directory, toolchain) = scope_directory_and_toolchain(knowledge, &name)?;
-            (toolchain == &ToolchainId::JAVASCRIPT)
-                .then(|| (directory.to_unix().to_string(), dependencies))
-        })
-        .collect()
-}
-
-fn unavailable_javascript_resolution(
-    knowledge: &RepositoryKnowledge,
-    mut domains: Vec<ExternalResolutionDomain>,
-    definition_source: AnchoredSystemPathBuf,
-    code: &str,
-    message: String,
-    warning: Option<String>,
-    closure_hasher: Option<&ClosureHasher>,
-) -> Result<JavaScriptResolutionSnapshot, String> {
-    let domain = ExternalResolutionDomain::new(
-        ToolchainId::JAVASCRIPT,
-        AnchoredSystemPathBuf::default(),
-        [definition_source],
-        ExternalResolutionData::Unavailable(ResolutionUnavailableReason::new(code, message)),
-    );
-    domains.push(domain);
-    apply_resolution_fingerprints(&mut domains, closure_hasher);
-    let generation = ExternalResolutionGeneration::build(knowledge, domains)
-        .map_err(|error| error.to_string())?;
-    Ok(JavaScriptResolutionSnapshot {
-        generation: Arc::new(generation),
-        closures: HashMap::new(),
-        warning,
-    })
-}
-
-pub(super) fn resolve_javascript_dependencies(
-    knowledge: &RepositoryKnowledge,
-    mut domains: Vec<ExternalResolutionDomain>,
-    lockfile: &dyn Lockfile,
-    external_dependencies: HashMap<String, BTreeMap<String, String>>,
-    ignore_missing_packages: bool,
-    definition_source: AnchoredSystemPathBuf,
-    closure_hasher: Option<&ClosureHasher>,
-) -> Result<JavaScriptResolutionSnapshot, String> {
-    let closures = match turborepo_lockfiles::all_transitive_closures_sorted(
-        lockfile,
-        external_dependencies,
-        ignore_missing_packages,
-    ) {
-        Ok(closures) => closures,
-        Err(error) => {
-            let message = error.to_string();
-            return unavailable_javascript_resolution(
-                knowledge,
-                domains,
-                definition_source,
-                "closure-unavailable",
-                message.clone(),
-                Some(message),
-                closure_hasher,
-            );
-        }
-    };
-    let packages = javascript_resolution_packages(knowledge)
-        .into_iter()
-        .map(|(identity, directory)| {
-            let exact_identities = closures
-                .get(directory.to_unix().as_str())
-                .into_iter()
-                .flatten()
-                .map(|package| {
-                    ExternalPackageIdentity::new(package.key.clone(), package.version.clone())
-                });
-            PackageResolution::new(identity, exact_identities)
-        })
-        .collect::<Vec<_>>();
-    let fingerprint = ResolutionFingerprint::from_packages(&packages);
-    let domain = ExternalResolutionDomain::new(
-        ToolchainId::JAVASCRIPT,
-        AnchoredSystemPathBuf::default(),
-        [definition_source],
-        ExternalResolutionData::Resolved {
-            completeness: ResolutionCompleteness::Complete,
-            fingerprint,
-            packages,
-        },
-    );
-    domains.push(domain);
-    apply_resolution_fingerprints(&mut domains, closure_hasher);
-    let generation = ExternalResolutionGeneration::build(knowledge, domains)
-        .map_err(|error| error.to_string())?;
-    Ok(JavaScriptResolutionSnapshot {
-        generation: Arc::new(generation),
-        closures,
-        warning: None,
-    })
-}
-
 impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
     fn all_external_dependencies(
         &self,
@@ -1379,7 +1226,7 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             .relationship_knowledge
             .as_deref()
             .ok_or(Error::MissingRelationshipKnowledge)?;
-        Ok(javascript_external_dependencies(knowledge, relationships))
+        Ok(javascript::external_dependencies(knowledge, relationships))
     }
 
     #[tracing::instrument(skip(self))]
@@ -1428,7 +1275,7 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
                                         .lock()
                                         .unwrap_or_else(|poisoned| poisoned.into_inner()),
                                 );
-                                let result = resolve_javascript_dependencies(
+                                let result = javascript::resolve_dependencies(
                                     &resolution_knowledge,
                                     native_resolutions,
                                     lockfile.as_ref(),
@@ -1445,7 +1292,7 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
                             }
                             Err(error) => {
                                 warn!("Unable to spawn transitive closure thread: {}", error);
-                                let snapshot = unavailable_javascript_resolution(
+                                let snapshot = javascript::unavailable_resolution(
                                     &knowledge,
                                     std::mem::take(
                                         &mut *deferred_native_resolutions
@@ -1468,7 +1315,7 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
                     }
                     Ok(external_dependencies) => {
                         let mut snapshot = turborepo_rayon_compat::block_in_place(|| {
-                            resolve_javascript_dependencies(
+                            javascript::resolve_dependencies(
                                 &knowledge,
                                 std::mem::take(&mut native_external_resolutions),
                                 lockfile.as_ref(),
@@ -1488,7 +1335,7 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
                     }
                     Err(error) => {
                         warn!("Unable to calculate transitive closures: {}", error);
-                        let snapshot = unavailable_javascript_resolution(
+                        let snapshot = javascript::unavailable_resolution(
                             &knowledge,
                             std::mem::take(&mut native_external_resolutions),
                             definition_source,
@@ -1503,7 +1350,7 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
                     }
                 }
             } else {
-                let snapshot = unavailable_javascript_resolution(
+                let snapshot = javascript::unavailable_resolution(
                     &knowledge,
                     std::mem::take(&mut native_external_resolutions),
                     definition_source,

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -1246,6 +1246,38 @@ fn javascript_resolution_packages(
     packages
 }
 
+pub(super) fn javascript_external_dependencies(
+    knowledge: &RepositoryKnowledge,
+    relationships: &RelationshipKnowledge,
+) -> HashMap<String, BTreeMap<String, String>> {
+    let mut by_source: BTreeMap<String, BTreeMap<String, String>> =
+        javascript_resolution_packages(knowledge)
+            .into_iter()
+            .map(|(identity, _)| (identity.to_string(), BTreeMap::new()))
+            .collect();
+    for declaration in ExternalDeclarations::build(relationships).declarations() {
+        if matches!(declaration.kind(), DependencyKind::Peer { .. }) {
+            continue;
+        }
+        let Some(dependencies) = by_source.get_mut(declaration.source()) else {
+            continue;
+        };
+        dependencies
+            .entry(declaration.package_name().to_string())
+            .or_insert_with(|| declaration.specifier().to_string());
+    }
+
+    by_source
+        .into_iter()
+        .filter_map(|(identity, dependencies)| {
+            let name = package_name_from_identity(&identity);
+            let (directory, toolchain) = scope_directory_and_toolchain(knowledge, &name)?;
+            (toolchain == &ToolchainId::JAVASCRIPT)
+                .then(|| (directory.to_unix().to_string(), dependencies))
+        })
+        .collect()
+}
+
 fn unavailable_javascript_resolution(
     knowledge: &RepositoryKnowledge,
     mut domains: Vec<ExternalResolutionDomain>,
@@ -1272,18 +1304,19 @@ fn unavailable_javascript_resolution(
     })
 }
 
-fn resolve_javascript_dependencies(
+pub(super) fn resolve_javascript_dependencies(
     knowledge: &RepositoryKnowledge,
     mut domains: Vec<ExternalResolutionDomain>,
     lockfile: &dyn Lockfile,
     external_dependencies: HashMap<String, BTreeMap<String, String>>,
+    ignore_missing_packages: bool,
     definition_source: AnchoredSystemPathBuf,
     closure_hasher: Option<&ClosureHasher>,
 ) -> Result<JavaScriptResolutionSnapshot, String> {
     let closures = match turborepo_lockfiles::all_transitive_closures_sorted(
         lockfile,
         external_dependencies,
-        false,
+        ignore_missing_packages,
     ) {
         Ok(closures) => closures,
         Err(error) => {
@@ -1346,32 +1379,7 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             .relationship_knowledge
             .as_deref()
             .ok_or(Error::MissingRelationshipKnowledge)?;
-        let mut by_source: BTreeMap<String, BTreeMap<String, String>> =
-            javascript_resolution_packages(knowledge)
-                .into_iter()
-                .map(|(identity, _)| (identity.to_string(), BTreeMap::new()))
-                .collect();
-        for declaration in ExternalDeclarations::build(relationships).declarations() {
-            if matches!(declaration.kind(), DependencyKind::Peer { .. }) {
-                continue;
-            }
-            let Some(dependencies) = by_source.get_mut(declaration.source()) else {
-                continue;
-            };
-            dependencies
-                .entry(declaration.package_name().to_string())
-                .or_insert_with(|| declaration.specifier().to_string());
-        }
-
-        Ok(by_source
-            .into_iter()
-            .filter_map(|(identity, dependencies)| {
-                let name = package_name_from_identity(&identity);
-                let (directory, toolchain) = scope_directory_and_toolchain(knowledge, &name)?;
-                (toolchain == &ToolchainId::JAVASCRIPT)
-                    .then(|| (directory.to_unix().to_string(), dependencies))
-            })
-            .collect())
+        Ok(javascript_external_dependencies(knowledge, relationships))
     }
 
     #[tracing::instrument(skip(self))]
@@ -1425,6 +1433,7 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
                                     native_resolutions,
                                     lockfile.as_ref(),
                                     external_dependencies,
+                                    false,
                                     deferred_source,
                                     hasher.as_ref(),
                                 );
@@ -1464,6 +1473,7 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
                                 std::mem::take(&mut native_external_resolutions),
                                 lockfile.as_ref(),
                                 external_dependencies,
+                                false,
                                 definition_source,
                                 self.closure_hasher.as_ref(),
                             )

--- a/crates/turborepo-repository/src/package_graph/javascript.rs
+++ b/crates/turborepo-repository/src/package_graph/javascript.rs
@@ -1,0 +1,355 @@
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Arc,
+};
+
+use turbopath::{AnchoredSystemPath, AnchoredSystemPathBuf};
+use turborepo_lockfiles::Lockfile;
+
+use super::{
+    ExternalDependencyChange, PackageGraph, PackageInfo, PackageName, ROOT_PKG_NAME,
+    WorkspacePackage,
+    builder::{ClosureHasher, apply_resolution_fingerprints},
+};
+use crate::{
+    external_resolution::{
+        ExternalDeclarations, ExternalPackageIdentity, ExternalResolutionChanges,
+        ExternalResolutionData, ExternalResolutionDomain, ExternalResolutionGeneration,
+        PackageResolution, ResolutionCompleteness, ResolutionFingerprint,
+        ResolutionUnavailableReason, compare_resolution_data,
+    },
+    knowledge::{RelationshipKnowledge, RepositoryKnowledge},
+    package_json::DependencyKind,
+    package_manager::PackageManager,
+    toolchain::ToolchainId,
+};
+
+/// One JavaScript resolution snapshot and its temporary compatibility
+/// projection. Both inline and deferred production create this exact shape.
+pub(super) struct ResolutionSnapshot {
+    pub generation: Arc<ExternalResolutionGeneration>,
+    pub closures: HashMap<String, Vec<Arc<turborepo_lockfiles::Package>>>,
+    pub warning: Option<String>,
+}
+
+impl ResolutionSnapshot {
+    pub(super) fn project_legacy(
+        &mut self,
+        package_payloads: &mut HashMap<PackageName, PackageInfo>,
+        knowledge: &RepositoryKnowledge,
+    ) {
+        let fingerprints = self
+            .generation
+            .domains()
+            .iter()
+            .find(|domain| domain.toolchain() == &ToolchainId::JAVASCRIPT)
+            .and_then(|domain| match domain.data() {
+                ExternalResolutionData::Resolved { packages, .. } => Some(
+                    packages
+                        .iter()
+                        .filter_map(|package| {
+                            package
+                                .fingerprint()
+                                .map(|fingerprint| (package.package(), fingerprint.as_str()))
+                        })
+                        .collect::<HashMap<_, _>>(),
+                ),
+                ExternalResolutionData::Unavailable(_) => None,
+            })
+            .unwrap_or_default();
+        for (name, info) in package_payloads {
+            let facts = scope_directory_and_toolchain(knowledge, name);
+            let Some((directory, toolchain)) = facts else {
+                continue;
+            };
+            if toolchain != &ToolchainId::JAVASCRIPT {
+                continue;
+            }
+            let directory = directory.to_unix();
+            info.transitive_dependencies = self.closures.remove(directory.as_str());
+            info.external_deps_hash = fingerprints
+                .get(name.as_str())
+                .map(|fingerprint| (*fingerprint).to_string());
+        }
+    }
+}
+
+pub(super) type DeferredResolutionReceiver =
+    std::sync::mpsc::Receiver<Result<ResolutionSnapshot, String>>;
+
+fn scope_directory_and_toolchain<'a>(
+    knowledge: &'a RepositoryKnowledge,
+    name: &PackageName,
+) -> Option<(&'a AnchoredSystemPath, &'a ToolchainId)> {
+    match name {
+        PackageName::Root => knowledge
+            .root_javascript_scope()
+            .map(|scope| (knowledge.repository_directory(), scope.toolchain())),
+        PackageName::Other(name) => knowledge
+            .scope(name)
+            .map(|scope| (scope.directory(), scope.toolchain())),
+    }
+}
+
+fn resolution_packages(knowledge: &RepositoryKnowledge) -> Vec<(&str, &AnchoredSystemPath)> {
+    let mut packages = Vec::new();
+    if knowledge.root_javascript_scope().is_some() {
+        packages.push((ROOT_PKG_NAME, knowledge.repository_directory()));
+    }
+    packages.extend(
+        knowledge
+            .scopes()
+            .filter(|scope| scope.toolchain() == &ToolchainId::JAVASCRIPT)
+            .map(|scope| (scope.identity(), scope.directory())),
+    );
+    packages.sort_unstable_by_key(|(identity, _)| *identity);
+    packages
+}
+
+pub(super) fn external_dependencies(
+    knowledge: &RepositoryKnowledge,
+    relationships: &RelationshipKnowledge,
+) -> HashMap<String, BTreeMap<String, String>> {
+    let mut by_source: BTreeMap<String, BTreeMap<String, String>> = resolution_packages(knowledge)
+        .into_iter()
+        .map(|(identity, _)| (identity.to_string(), BTreeMap::new()))
+        .collect();
+    for declaration in ExternalDeclarations::build(relationships).declarations() {
+        if matches!(declaration.kind(), DependencyKind::Peer { .. }) {
+            continue;
+        }
+        let Some(dependencies) = by_source.get_mut(declaration.source()) else {
+            continue;
+        };
+        dependencies
+            .entry(declaration.package_name().to_string())
+            .or_insert_with(|| declaration.specifier().to_string());
+    }
+
+    by_source
+        .into_iter()
+        .filter_map(|(identity, dependencies)| {
+            let name = PackageName::from(identity.as_str());
+            let (directory, toolchain) = scope_directory_and_toolchain(knowledge, &name)?;
+            (toolchain == &ToolchainId::JAVASCRIPT)
+                .then(|| (directory.to_unix().to_string(), dependencies))
+        })
+        .collect()
+}
+
+pub(super) fn unavailable_resolution(
+    knowledge: &RepositoryKnowledge,
+    mut domains: Vec<ExternalResolutionDomain>,
+    definition_source: AnchoredSystemPathBuf,
+    code: &str,
+    message: String,
+    warning: Option<String>,
+    closure_hasher: Option<&ClosureHasher>,
+) -> Result<ResolutionSnapshot, String> {
+    domains.push(ExternalResolutionDomain::new(
+        ToolchainId::JAVASCRIPT,
+        AnchoredSystemPathBuf::default(),
+        [definition_source],
+        ExternalResolutionData::Unavailable(ResolutionUnavailableReason::new(code, message)),
+    ));
+    apply_resolution_fingerprints(&mut domains, closure_hasher);
+    let generation = ExternalResolutionGeneration::build(knowledge, domains)
+        .map_err(|error| error.to_string())?;
+    Ok(ResolutionSnapshot {
+        generation: Arc::new(generation),
+        closures: HashMap::new(),
+        warning,
+    })
+}
+
+pub(super) fn resolve_dependencies(
+    knowledge: &RepositoryKnowledge,
+    mut domains: Vec<ExternalResolutionDomain>,
+    lockfile: &dyn Lockfile,
+    external_dependencies: HashMap<String, BTreeMap<String, String>>,
+    ignore_missing_packages: bool,
+    definition_source: AnchoredSystemPathBuf,
+    closure_hasher: Option<&ClosureHasher>,
+) -> Result<ResolutionSnapshot, String> {
+    let closures = match turborepo_lockfiles::all_transitive_closures_sorted(
+        lockfile,
+        external_dependencies,
+        ignore_missing_packages,
+    ) {
+        Ok(closures) => closures,
+        Err(error) => {
+            let message = error.to_string();
+            return unavailable_resolution(
+                knowledge,
+                domains,
+                definition_source,
+                "closure-unavailable",
+                message.clone(),
+                Some(message),
+                closure_hasher,
+            );
+        }
+    };
+    let packages = resolution_packages(knowledge)
+        .into_iter()
+        .map(|(identity, directory)| {
+            let exact_identities = closures
+                .get(directory.to_unix().as_str())
+                .into_iter()
+                .flatten()
+                .map(|package| {
+                    ExternalPackageIdentity::new(package.key.clone(), package.version.clone())
+                });
+            PackageResolution::new(identity, exact_identities)
+        })
+        .collect::<Vec<_>>();
+    let fingerprint = ResolutionFingerprint::from_packages(&packages);
+    domains.push(ExternalResolutionDomain::new(
+        ToolchainId::JAVASCRIPT,
+        AnchoredSystemPathBuf::default(),
+        [definition_source],
+        ExternalResolutionData::Resolved {
+            completeness: ResolutionCompleteness::Complete,
+            fingerprint,
+            packages,
+        },
+    ));
+    apply_resolution_fingerprints(&mut domains, closure_hasher);
+    let generation = ExternalResolutionGeneration::build(knowledge, domains)
+        .map_err(|error| error.to_string())?;
+    Ok(ResolutionSnapshot {
+        generation: Arc::new(generation),
+        closures,
+        warning: None,
+    })
+}
+
+fn resolution_data(
+    generation: &ExternalResolutionGeneration,
+) -> Result<&ExternalResolutionData, ChangedPackagesError> {
+    generation
+        .domains()
+        .iter()
+        .find(|domain| domain.toolchain() == &ToolchainId::JAVASCRIPT)
+        .map(ExternalResolutionDomain::data)
+        .ok_or(ChangedPackagesError::ResolutionUnavailable)
+}
+
+impl PackageGraph {
+    pub fn changed_packages_from_lockfile_contents(
+        &self,
+        previous_lockfile_contents: &[u8],
+    ) -> Result<Vec<ExternalDependencyChange>, ChangedPackagesError> {
+        let package_manager = self
+            .package_manager()
+            .ok_or(ChangedPackagesError::NoLockfile)?;
+        let root_package_json = self
+            .root_package_json()
+            .ok_or(ChangedPackagesError::NoLockfile)?;
+        let yarnrc = matches!(package_manager, PackageManager::Berry)
+            .then(|| crate::package_manager::yarnrc::YarnRc::from_file(self.repo_root()))
+            .transpose()?;
+        let previous = package_manager.parse_lockfile(
+            root_package_json,
+            previous_lockfile_contents,
+            yarnrc,
+        )?;
+        self.changed_packages_from_lockfile(previous.as_ref())
+    }
+
+    /// Returns packages whose normalized external resolution changed from the
+    /// provided previous lockfile. Callers remain responsible for detecting
+    /// descriptor changes independently.
+    pub fn changed_packages_from_lockfile(
+        &self,
+        previous_lockfile: &dyn Lockfile,
+    ) -> Result<Vec<ExternalDependencyChange>, ChangedPackagesError> {
+        let current_lockfile = self.lockfile().ok_or(ChangedPackagesError::NoLockfile)?;
+        let package_manager = self
+            .package_manager()
+            .ok_or(ChangedPackagesError::NoLockfile)?;
+        let definition_source = AnchoredSystemPathBuf::from_raw(package_manager.lockfile_name())?;
+        let previous_resolution = resolve_dependencies(
+            &self.knowledge,
+            Vec::new(),
+            previous_lockfile,
+            external_dependencies(&self.knowledge, &self.relationship_knowledge),
+            true,
+            definition_source,
+            None,
+        )
+        .map_err(ChangedPackagesError::Resolution)?;
+        let current_resolution = self
+            .external_resolution
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let changes = compare_resolution_data(
+            resolution_data(
+                current_resolution
+                    .generation
+                    .as_deref()
+                    .ok_or(ChangedPackagesError::ResolutionUnavailable)?,
+            )?,
+            resolution_data(&previous_resolution.generation)?,
+            current_lockfile.global_change(previous_lockfile),
+            ROOT_PKG_NAME,
+        )
+        .map_err(|_| ChangedPackagesError::ResolutionUnavailable)?;
+
+        let all_changes = || {
+            self.package_task_contexts()
+                .map(|context| ExternalDependencyChange {
+                    package: WorkspacePackage {
+                        name: context.package().clone(),
+                        path: context.directory().to_owned(),
+                    },
+                    added: Vec::new(),
+                    removed: Vec::new(),
+                })
+                .collect()
+        };
+        let ExternalResolutionChanges::Packages(changes) = changes else {
+            return Ok(all_changes());
+        };
+        changes
+            .into_iter()
+            .map(|change| {
+                let name = PackageName::from(change.package);
+                let context = self
+                    .package_task_context(&name)
+                    .ok_or(ChangedPackagesError::ResolutionUnavailable)?;
+                let to_lockfile_package = |identity: ExternalPackageIdentity| {
+                    turborepo_lockfiles::Package::new(identity.key(), identity.version())
+                };
+                Ok(ExternalDependencyChange {
+                    package: WorkspacePackage {
+                        name,
+                        path: context.directory().to_owned(),
+                    },
+                    added: change.added.into_iter().map(to_lockfile_package).collect(),
+                    removed: change
+                        .removed
+                        .into_iter()
+                        .map(to_lockfile_package)
+                        .collect(),
+                })
+            })
+            .collect()
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ChangedPackagesError {
+    #[error("No lockfile")]
+    NoLockfile,
+    #[error("External resolution unavailable")]
+    ResolutionUnavailable,
+    #[error("External resolution failed: {0}")]
+    Resolution(String),
+    #[error(transparent)]
+    Path(#[from] turbopath::PathError),
+    #[error("Package manager error: {0}")]
+    PackageManager(#[from] crate::package_manager::Error),
+    #[error("Yarn config error: {0}")]
+    Yarnrc(#[from] crate::package_manager::yarnrc::Error),
+}

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     fmt,
     sync::{Arc, Mutex, OnceLock},
 };
@@ -10,7 +10,6 @@ use petgraph::{
     visit::EdgeRef,
 };
 use serde::Serialize;
-use tracing::debug;
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPath, AnchoredSystemPathBuf};
 use turborepo_lockfiles::Lockfile;
 
@@ -18,7 +17,8 @@ use crate::{
     discovery::LocalPackageDiscoveryBuilder,
     external_resolution::{
         ExternalDeclarations, ExternalResolutionData, ExternalResolutionGeneration,
-        ExternalResolutionStatus, PackageExternalDeclarations, PackageResolutionState,
+        ExternalResolutionStatus, PackageExternalDeclarations, PackageResolution,
+        PackageResolutionState, ResolutionCompleteness,
     },
     knowledge::{RelationshipKnowledge, RepositoryKnowledge},
     package_json::PackageJson,
@@ -389,6 +389,30 @@ pub struct ExternalDependencyChange {
     pub added: Vec<turborepo_lockfiles::Package>,
     /// Dependencies that were removed from the package
     pub removed: Vec<turborepo_lockfiles::Package>,
+}
+
+fn resolved_javascript_packages(
+    generation: &ExternalResolutionGeneration,
+) -> Result<&[PackageResolution], ChangedPackagesError> {
+    let domain = generation
+        .domains()
+        .iter()
+        .find(|domain| domain.toolchain() == &crate::toolchain::ToolchainId::JAVASCRIPT)
+        .ok_or(ChangedPackagesError::ResolutionUnavailable)?;
+    match domain.data() {
+        ExternalResolutionData::Resolved {
+            completeness: ResolutionCompleteness::Complete,
+            packages,
+            ..
+        } => Ok(packages),
+        ExternalResolutionData::Resolved {
+            completeness: ResolutionCompleteness::Partial(_),
+            ..
+        }
+        | ExternalResolutionData::Unavailable(_) => {
+            Err(ChangedPackagesError::ResolutionUnavailable)
+        }
+    }
 }
 
 impl PackageGraph {
@@ -993,6 +1017,14 @@ impl PackageGraph {
             .clone()
     }
 
+    #[cfg(test)]
+    pub(crate) fn remove_external_resolution_for_test(&mut self) {
+        self.external_resolution
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .generation = None;
+    }
+
     pub fn package_json(&self, package: &PackageName) -> Option<&PackageJson> {
         let entry = self.package_payloads.get(package)?;
         Some(&entry.package_json)
@@ -1291,124 +1323,122 @@ impl PackageGraph {
             .collect()
     }
 
-    /// Returns a list of changed packages based on the contents of a previous
-    /// `Lockfile`. This assumes that none of the package.json in the package
-    /// change, it is the responsibility of the caller to verify this.
+    pub fn changed_packages_from_lockfile_contents(
+        &self,
+        previous_lockfile_contents: &[u8],
+    ) -> Result<Vec<ExternalDependencyChange>, ChangedPackagesError> {
+        let package_manager = self
+            .package_manager()
+            .ok_or(ChangedPackagesError::NoLockfile)?;
+        let root_package_json = self
+            .root_package_json()
+            .ok_or(ChangedPackagesError::NoLockfile)?;
+        let yarnrc = matches!(package_manager, PackageManager::Berry)
+            .then(|| crate::package_manager::yarnrc::YarnRc::from_file(self.repo_root()))
+            .transpose()?;
+        let previous = package_manager.parse_lockfile(
+            root_package_json,
+            previous_lockfile_contents,
+            yarnrc,
+        )?;
+        self.changed_packages_from_lockfile(previous.as_ref())
+    }
+
+    /// Returns packages whose normalized external resolution changed from the
+    /// provided previous lockfile. Callers remain responsible for detecting
+    /// descriptor changes independently.
     pub fn changed_packages_from_lockfile(
         &self,
-        previous: &dyn Lockfile,
+        previous_lockfile: &dyn Lockfile,
     ) -> Result<Vec<ExternalDependencyChange>, ChangedPackagesError> {
         let current = self.lockfile().ok_or(ChangedPackagesError::NoLockfile)?;
+        let package_manager = self
+            .package_manager()
+            .ok_or(ChangedPackagesError::NoLockfile)?;
+        let definition_source = AnchoredSystemPathBuf::from_raw(package_manager.lockfile_name())?;
+        let previous_resolution = builder::resolve_javascript_dependencies(
+            &self.knowledge,
+            Vec::new(),
+            previous_lockfile,
+            builder::javascript_external_dependencies(
+                &self.knowledge,
+                &self.relationship_knowledge,
+            ),
+            true,
+            definition_source,
+            None,
+        )
+        .map_err(ChangedPackagesError::Resolution)?;
+        let current_resolution = self
+            .external_resolution
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let current_packages = resolved_javascript_packages(
+            current_resolution
+                .generation
+                .as_deref()
+                .ok_or(ChangedPackagesError::ResolutionUnavailable)?,
+        )?;
+        let previous_packages = resolved_javascript_packages(&previous_resolution.generation)?;
 
-        for context in self.package_task_contexts() {
-            if context.requires_compatibility_payload() && context.package_info().is_none() {
-                return Err(ChangedPackagesError::MissingPackagePayload(
-                    context.package().clone(),
-                ));
-            }
-        }
-
-        let external_deps = self
-            .package_task_contexts()
-            .filter_map(|context| {
-                let info = context.package_info()?;
-                let dep = info.unresolved_external_dependencies.as_ref()?;
-                Some((
-                    context.directory().to_unix().to_string(),
-                    dep.iter()
-                        .map(|(name, version)| (name.to_owned(), version.to_owned()))
-                        .collect(),
-                ))
-            })
-            .collect::<HashMap<_, BTreeMap<_, _>>>();
-
-        // We're comparing to a previous lockfile, it's possible that a package was
-        // added and thus won't exist in the previous lockfile. In that case,
-        // we're fine to ignore it. Assuming there is not a commit with a stale
-        // lockfile, the same commit should add the package, so it will get
-        // picked up as changed.
-        let closures =
-            turborepo_lockfiles::all_transitive_closures_sorted(previous, external_deps, true)?;
-
-        let global_change = current.global_change(previous);
-
-        let changed = if global_change {
-            None
-        } else {
+        let all_changes = || {
             self.package_task_contexts()
-                .filter_map(|context| {
-                    let info = context.package_info()?;
-                    let name = context.package().clone();
-                    let package_dir = context.directory();
-                    let previous_closure = closures.get(package_dir.to_unix().as_str());
-                    // Both closures are sorted by (key, version), so `Vec`
-                    // equality is set equality here.
-                    let not_equal = previous_closure != info.transitive_dependencies.as_ref();
-                    if not_equal {
-                        let empty = Vec::new();
-                        let prev_deps = previous_closure.unwrap_or(&empty);
-                        let curr_deps = info.transitive_dependencies.as_ref().unwrap_or(&empty);
-                        let prev_set: HashSet<&turborepo_lockfiles::Package> =
-                            prev_deps.iter().map(|pkg| &**pkg).collect();
-                        let curr_set: HashSet<&turborepo_lockfiles::Package> =
-                            curr_deps.iter().map(|pkg| &**pkg).collect();
-                        debug!(
-                            "package {name} has differing closure: {:?}",
-                            prev_set.symmetric_difference(&curr_set)
-                        );
-                        // {a, b} -> {a, c}
-                        // b was removed
-                        // c was added
-                        let added = curr_set
-                            .difference(&prev_set)
-                            .map(|pkg| (*pkg).clone())
-                            .sorted()
-                            .collect::<Vec<_>>();
-                        let removed = prev_set
-                            .difference(&curr_set)
-                            .map(|pkg| (*pkg).clone())
-                            .sorted()
-                            .collect::<Vec<_>>();
-                        Some((name, package_dir, added, removed))
-                    } else {
-                        None
-                    }
-                })
-                .map(|(name, package_dir, added, removed)| match name {
-                    PackageName::Other(n) => {
-                        let w_name = PackageName::Other(n.to_owned());
-                        let package = WorkspacePackage {
-                            name: w_name.clone(),
-                            path: package_dir.to_owned(),
-                        };
-                        Some(ExternalDependencyChange {
-                            package,
-                            added,
-                            removed,
-                        })
-                    }
-                    // if the root package has changed, then we should report `None`
-                    // since all packages need to be revalidated
-                    PackageName::Root => None,
-                })
-                .collect::<Option<Vec<_>>>()
-        };
-
-        Ok(changed.unwrap_or_else(|| {
-            self.package_task_contexts()
-                .map(|context| {
-                    let package = WorkspacePackage {
+                .map(|context| ExternalDependencyChange {
+                    package: WorkspacePackage {
                         name: context.package().clone(),
                         path: context.directory().to_owned(),
-                    };
-                    ExternalDependencyChange {
-                        package,
-                        added: Vec::new(),
-                        removed: Vec::new(),
-                    }
+                    },
+                    added: Vec::new(),
+                    removed: Vec::new(),
                 })
                 .collect()
-        }))
+        };
+        if current.global_change(previous_lockfile) {
+            return Ok(all_changes());
+        }
+
+        let previous_by_package: HashMap<_, _> = previous_packages
+            .iter()
+            .map(|package| (package.package(), package))
+            .collect();
+        let mut changed = Vec::new();
+        for package in current_packages {
+            let previous = previous_by_package
+                .get(package.package())
+                .ok_or(ChangedPackagesError::ResolutionUnavailable)?;
+            if package.identities() == previous.identities() {
+                continue;
+            }
+            if package.package() == ROOT_PKG_NAME {
+                return Ok(all_changes());
+            }
+
+            let previous: BTreeSet<_> = previous.identities().iter().collect();
+            let current: BTreeSet<_> = package.identities().iter().collect();
+            let to_lockfile_package =
+                |identity: &&crate::external_resolution::ExternalPackageIdentity| {
+                    turborepo_lockfiles::Package::new(identity.key(), identity.version())
+                };
+            let name = PackageName::from(package.package());
+            let context = self
+                .package_task_context(&name)
+                .ok_or(ChangedPackagesError::ResolutionUnavailable)?;
+            changed.push(ExternalDependencyChange {
+                package: WorkspacePackage {
+                    name,
+                    path: context.directory().to_owned(),
+                },
+                added: current
+                    .difference(&previous)
+                    .map(to_lockfile_package)
+                    .collect(),
+                removed: previous
+                    .difference(&current)
+                    .map(to_lockfile_package)
+                    .collect(),
+            });
+        }
+        Ok(changed)
     }
 
     pub fn internal_dependencies_for_external_dependency(
@@ -1484,8 +1514,16 @@ impl PackageGraph {
 pub enum ChangedPackagesError {
     #[error("No lockfile")]
     NoLockfile,
-    #[error("Missing compatibility payload for package {0}")]
-    MissingPackagePayload(PackageName),
+    #[error("External resolution unavailable")]
+    ResolutionUnavailable,
+    #[error("External resolution failed: {0}")]
+    Resolution(String),
+    #[error(transparent)]
+    Path(#[from] turbopath::PathError),
+    #[error("Package manager error: {0}")]
+    PackageManager(#[from] crate::package_manager::Error),
+    #[error("Yarn config error: {0}")]
+    Yarnrc(#[from] crate::package_manager::yarnrc::Error),
     #[error("Lockfile error")]
     Lockfile(#[from] turborepo_lockfiles::Error),
 }
@@ -1540,7 +1578,13 @@ mod test {
     use turborepo_errors::Spanned;
 
     use super::*;
-    use crate::discovery::PackageDiscovery;
+    use crate::{
+        change_mapper::{
+            AllPackageChangeReason, ChangeMapper, GlobalDepsPackageChangeMapper, LockfileContents,
+            PackageChanges,
+        },
+        discovery::PackageDiscovery,
+    };
 
     struct MockDiscovery;
     impl PackageDiscovery for MockDiscovery {
@@ -1583,14 +1627,26 @@ mod test {
     }
 
     fn apply_patch(dir: &Path, target: &str, patch_file: &str) {
-        let status = Command::new("patch")
-            .args([target, patch_file])
+        let patch = fs::read_to_string(dir.join(patch_file))
+            .unwrap()
+            .lines()
+            .map(|line| {
+                line.strip_prefix("+++ ")
+                    .map_or_else(|| line.to_string(), |_| format!("+++ {target}"))
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+            + "\n";
+        let rewritten = tempfile::NamedTempFile::new().unwrap();
+        fs::write(rewritten.path(), patch).unwrap();
+        let status = Command::new("git")
+            .args(["apply", "--unsafe-paths"])
+            .arg(rewritten.path())
             .current_dir(dir)
             .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
             .status()
             .unwrap();
-        assert!(status.success(), "patch {target} {patch_file} failed");
+        assert!(status.success(), "git apply {patch_file} failed");
     }
 
     fn setup_lockfile_aware_fixture(dir: &Path, pm_name: &str) {
@@ -1683,6 +1739,7 @@ mod test {
             let root_package_json =
                 PackageJson::load(&root.join_component("package.json")).unwrap();
 
+            let previous_contents = fs::read(tempdir.path().join(lockfile)).unwrap();
             let previous = package_manager
                 .read_lockfile(&root, &root_package_json)
                 .unwrap();
@@ -1702,12 +1759,45 @@ mod test {
                 vec![PackageName::from("b")],
                 "{pm_name}: dependency lockfile change should only affect b"
             );
+
+            {
+                let detector =
+                    GlobalDepsPackageChangeMapper::new(&dep_graph, std::iter::empty::<&str>())
+                        .unwrap();
+                let mapper = ChangeMapper::new(&dep_graph, Vec::new(), detector);
+                assert_eq!(
+                    mapper
+                        .changed_packages(
+                            HashSet::new(),
+                            LockfileContents::Changed(b"invalid lockfile".to_vec()),
+                        )
+                        .unwrap(),
+                    PackageChanges::All(AllPackageChangeReason::LockfileChangeDetectionFailed)
+                );
+            }
+
             let missing = PackageName::from("b");
             assert!(dep_graph.remove_package_info_for_test(&missing).is_some());
-            assert!(matches!(
-                dep_graph.changed_packages_from_lockfile(previous.as_ref()),
-                Err(ChangedPackagesError::MissingPackagePayload(name)) if name == missing
-            ));
+            assert_eq!(
+                dep_graph
+                    .changed_packages_from_lockfile(previous.as_ref())
+                    .unwrap()
+                    .into_iter()
+                    .map(|change| change.package.name)
+                    .collect::<Vec<_>>(),
+                vec![missing]
+            );
+
+            dep_graph.remove_external_resolution_for_test();
+            let detector =
+                GlobalDepsPackageChangeMapper::new(&dep_graph, std::iter::empty::<&str>()).unwrap();
+            let mapper = ChangeMapper::new(&dep_graph, Vec::new(), detector);
+            assert_eq!(
+                mapper
+                    .changed_packages(HashSet::new(), LockfileContents::Changed(previous_contents),)
+                    .unwrap(),
+                PackageChanges::All(AllPackageChangeReason::LockfileChangeDetectionFailed)
+            );
 
             let previous_dep = package_manager
                 .read_lockfile(&root, &root_package_json)
@@ -1724,7 +1814,8 @@ mod test {
                 .map(|change| change.package.name.clone())
                 .collect::<HashSet<_>>();
             assert!(
-                root_changed_names.contains(&PackageName::from("a"))
+                root_changed_names.contains(&PackageName::Root)
+                    && root_changed_names.contains(&PackageName::from("a"))
                     && root_changed_names.contains(&PackageName::from("b")),
                 "{pm_name}: root lockfile change should affect all workspaces: \
                  {root_changed_names:?}"

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     fmt,
     sync::{Arc, Mutex, OnceLock},
 };
@@ -17,8 +17,7 @@ use crate::{
     discovery::LocalPackageDiscoveryBuilder,
     external_resolution::{
         ExternalDeclarations, ExternalResolutionData, ExternalResolutionGeneration,
-        ExternalResolutionStatus, PackageExternalDeclarations, PackageResolution,
-        PackageResolutionState, ResolutionCompleteness,
+        ExternalResolutionStatus, PackageExternalDeclarations, PackageResolutionState,
     },
     knowledge::{RelationshipKnowledge, RepositoryKnowledge},
     package_json::PackageJson,
@@ -27,9 +26,11 @@ use crate::{
 
 pub mod builder;
 mod dep_splitter;
+mod javascript;
 mod projections;
 
 pub use builder::{Error, PackageGraphBuilder};
+pub use javascript::ChangedPackagesError;
 pub use projections::{
     AffectedRelationships, FilteringRelationships, HashRelationships, OrderingRelationships,
     PruneDependencyMode, PruneRelationships, RelationshipProjectionError,
@@ -39,77 +40,17 @@ pub use crate::package_json::DependencyKind;
 
 pub const ROOT_PKG_NAME: &str = "//";
 
-/// One JavaScript resolution snapshot and its temporary compatibility
-/// projection. Both inline and deferred production create this exact shape.
-pub(crate) struct JavaScriptResolutionSnapshot {
-    pub generation: Arc<ExternalResolutionGeneration>,
-    pub closures: HashMap<String, Vec<Arc<turborepo_lockfiles::Package>>>,
-    pub warning: Option<String>,
-}
-
-impl JavaScriptResolutionSnapshot {
-    pub(crate) fn project_legacy(
-        &mut self,
-        package_payloads: &mut HashMap<PackageName, PackageInfo>,
-        knowledge: &RepositoryKnowledge,
-    ) {
-        let fingerprints = self
-            .generation
-            .domains()
-            .iter()
-            .find(|domain| domain.toolchain() == &crate::toolchain::ToolchainId::JAVASCRIPT)
-            .and_then(|domain| match domain.data() {
-                crate::external_resolution::ExternalResolutionData::Resolved {
-                    packages, ..
-                } => Some(
-                    packages
-                        .iter()
-                        .filter_map(|package| {
-                            package
-                                .fingerprint()
-                                .map(|fingerprint| (package.package(), fingerprint.as_str()))
-                        })
-                        .collect::<HashMap<_, _>>(),
-                ),
-                crate::external_resolution::ExternalResolutionData::Unavailable(_) => None,
-            })
-            .unwrap_or_default();
-        for (name, info) in package_payloads {
-            let facts = match name {
-                PackageName::Root => knowledge
-                    .root_javascript_scope()
-                    .map(|scope| (knowledge.repository_directory(), scope.toolchain())),
-                PackageName::Other(name) => knowledge
-                    .scope(name)
-                    .map(|scope| (scope.directory(), scope.toolchain())),
-            };
-            let Some((directory, toolchain)) = facts else {
-                continue;
-            };
-            if toolchain != &crate::toolchain::ToolchainId::JAVASCRIPT {
-                continue;
-            }
-            let directory = directory.to_unix();
-            info.transitive_dependencies = self.closures.remove(directory.as_str());
-            info.external_deps_hash = fingerprints
-                .get(name.as_str())
-                .map(|fingerprint| (*fingerprint).to_string());
-        }
-    }
-}
-
-pub(crate) type DeferredResolutionReceiver =
-    std::sync::mpsc::Receiver<Result<JavaScriptResolutionSnapshot, String>>;
+type DeferredResolutionReceiver = javascript::DeferredResolutionReceiver;
 
 #[derive(Debug)]
-pub(crate) struct ExternalResolutionKnowledge {
+struct ExternalResolutionKnowledge {
     status: ExternalResolutionStatus,
     generation: Option<Arc<ExternalResolutionGeneration>>,
     receiver: Option<DeferredResolutionReceiver>,
 }
 
 impl ExternalResolutionKnowledge {
-    pub(crate) fn absent() -> Self {
+    fn absent() -> Self {
         Self {
             status: ExternalResolutionStatus::Complete,
             generation: None,
@@ -117,7 +58,7 @@ impl ExternalResolutionKnowledge {
         }
     }
 
-    pub(crate) fn complete(generation: Arc<ExternalResolutionGeneration>) -> Self {
+    fn complete(generation: Arc<ExternalResolutionGeneration>) -> Self {
         Self {
             status: ExternalResolutionStatus::Complete,
             generation: Some(generation),
@@ -125,7 +66,7 @@ impl ExternalResolutionKnowledge {
         }
     }
 
-    pub(crate) fn resolving(receiver: DeferredResolutionReceiver) -> Self {
+    fn resolving(receiver: DeferredResolutionReceiver) -> Self {
         Self {
             status: ExternalResolutionStatus::Resolving,
             generation: None,
@@ -389,30 +330,6 @@ pub struct ExternalDependencyChange {
     pub added: Vec<turborepo_lockfiles::Package>,
     /// Dependencies that were removed from the package
     pub removed: Vec<turborepo_lockfiles::Package>,
-}
-
-fn resolved_javascript_packages(
-    generation: &ExternalResolutionGeneration,
-) -> Result<&[PackageResolution], ChangedPackagesError> {
-    let domain = generation
-        .domains()
-        .iter()
-        .find(|domain| domain.toolchain() == &crate::toolchain::ToolchainId::JAVASCRIPT)
-        .ok_or(ChangedPackagesError::ResolutionUnavailable)?;
-    match domain.data() {
-        ExternalResolutionData::Resolved {
-            completeness: ResolutionCompleteness::Complete,
-            packages,
-            ..
-        } => Ok(packages),
-        ExternalResolutionData::Resolved {
-            completeness: ResolutionCompleteness::Partial(_),
-            ..
-        }
-        | ExternalResolutionData::Unavailable(_) => {
-            Err(ChangedPackagesError::ResolutionUnavailable)
-        }
-    }
 }
 
 impl PackageGraph {
@@ -1323,124 +1240,6 @@ impl PackageGraph {
             .collect()
     }
 
-    pub fn changed_packages_from_lockfile_contents(
-        &self,
-        previous_lockfile_contents: &[u8],
-    ) -> Result<Vec<ExternalDependencyChange>, ChangedPackagesError> {
-        let package_manager = self
-            .package_manager()
-            .ok_or(ChangedPackagesError::NoLockfile)?;
-        let root_package_json = self
-            .root_package_json()
-            .ok_or(ChangedPackagesError::NoLockfile)?;
-        let yarnrc = matches!(package_manager, PackageManager::Berry)
-            .then(|| crate::package_manager::yarnrc::YarnRc::from_file(self.repo_root()))
-            .transpose()?;
-        let previous = package_manager.parse_lockfile(
-            root_package_json,
-            previous_lockfile_contents,
-            yarnrc,
-        )?;
-        self.changed_packages_from_lockfile(previous.as_ref())
-    }
-
-    /// Returns packages whose normalized external resolution changed from the
-    /// provided previous lockfile. Callers remain responsible for detecting
-    /// descriptor changes independently.
-    pub fn changed_packages_from_lockfile(
-        &self,
-        previous_lockfile: &dyn Lockfile,
-    ) -> Result<Vec<ExternalDependencyChange>, ChangedPackagesError> {
-        let current = self.lockfile().ok_or(ChangedPackagesError::NoLockfile)?;
-        let package_manager = self
-            .package_manager()
-            .ok_or(ChangedPackagesError::NoLockfile)?;
-        let definition_source = AnchoredSystemPathBuf::from_raw(package_manager.lockfile_name())?;
-        let previous_resolution = builder::resolve_javascript_dependencies(
-            &self.knowledge,
-            Vec::new(),
-            previous_lockfile,
-            builder::javascript_external_dependencies(
-                &self.knowledge,
-                &self.relationship_knowledge,
-            ),
-            true,
-            definition_source,
-            None,
-        )
-        .map_err(ChangedPackagesError::Resolution)?;
-        let current_resolution = self
-            .external_resolution
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let current_packages = resolved_javascript_packages(
-            current_resolution
-                .generation
-                .as_deref()
-                .ok_or(ChangedPackagesError::ResolutionUnavailable)?,
-        )?;
-        let previous_packages = resolved_javascript_packages(&previous_resolution.generation)?;
-
-        let all_changes = || {
-            self.package_task_contexts()
-                .map(|context| ExternalDependencyChange {
-                    package: WorkspacePackage {
-                        name: context.package().clone(),
-                        path: context.directory().to_owned(),
-                    },
-                    added: Vec::new(),
-                    removed: Vec::new(),
-                })
-                .collect()
-        };
-        if current.global_change(previous_lockfile) {
-            return Ok(all_changes());
-        }
-
-        let previous_by_package: HashMap<_, _> = previous_packages
-            .iter()
-            .map(|package| (package.package(), package))
-            .collect();
-        let mut changed = Vec::new();
-        for package in current_packages {
-            let previous = previous_by_package
-                .get(package.package())
-                .ok_or(ChangedPackagesError::ResolutionUnavailable)?;
-            if package.identities() == previous.identities() {
-                continue;
-            }
-            if package.package() == ROOT_PKG_NAME {
-                return Ok(all_changes());
-            }
-
-            let previous: BTreeSet<_> = previous.identities().iter().collect();
-            let current: BTreeSet<_> = package.identities().iter().collect();
-            let to_lockfile_package =
-                |identity: &&crate::external_resolution::ExternalPackageIdentity| {
-                    turborepo_lockfiles::Package::new(identity.key(), identity.version())
-                };
-            let name = PackageName::from(package.package());
-            let context = self
-                .package_task_context(&name)
-                .ok_or(ChangedPackagesError::ResolutionUnavailable)?;
-            changed.push(ExternalDependencyChange {
-                package: WorkspacePackage {
-                    name,
-                    path: context.directory().to_owned(),
-                },
-                added: current
-                    .difference(&previous)
-                    .map(to_lockfile_package)
-                    .collect(),
-                removed: previous
-                    .difference(&current)
-                    .map(to_lockfile_package)
-                    .collect(),
-            });
-        }
-        Ok(changed)
-    }
-
     pub fn internal_dependencies_for_external_dependency(
         &self,
         external_package: &turborepo_lockfiles::Package,
@@ -1508,24 +1307,6 @@ impl PackageGraph {
         let entry = self.package_payloads.get(package)?;
         entry.unresolved_external_dependencies.as_ref()
     }
-}
-
-#[derive(thiserror::Error, Debug)]
-pub enum ChangedPackagesError {
-    #[error("No lockfile")]
-    NoLockfile,
-    #[error("External resolution unavailable")]
-    ResolutionUnavailable,
-    #[error("External resolution failed: {0}")]
-    Resolution(String),
-    #[error(transparent)]
-    Path(#[from] turbopath::PathError),
-    #[error("Package manager error: {0}")]
-    PackageManager(#[from] crate::package_manager::Error),
-    #[error("Yarn config error: {0}")]
-    Yarnrc(#[from] crate::package_manager::yarnrc::Error),
-    #[error("Lockfile error")]
-    Lockfile(#[from] turborepo_lockfiles::Error),
 }
 
 impl fmt::Display for PackageName {

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -161,10 +161,14 @@ Represents the workspace structure and package dependencies:
   identities, definition sources, completeness, and stable fingerprints. A
   single resolution owner tracks lifecycle status. Task hashing consumes the
   stored byte-compatible package resolution fingerprint and preserves explicit
-  unavailable states without closure fallback hashing. The snapshot projects
-  temporary `PackageInfo` closure/hash fields for the remaining global-hash and
-  summary migrations. Framework inference and boundaries validation consume the
-  package-scoped declaration projection directly; aliases, duplicate
+  unavailable states without closure fallback hashing. Lockfile affectedness
+  resolves the current declarations against the previous lockfile with the same
+  producer, then compares normalized package identities; unavailable, parse, and
+  comparison failures retain the conservative all-packages fallback. The
+  snapshot projects temporary `PackageInfo` closure/hash fields for the remaining
+  global-hash and summary migrations. Framework inference and boundaries
+  validation consume the package-scoped declaration projection directly;
+  aliases, duplicate
   precedence, optional declarations, and peers remain explicit normalized
   facts rather than raw manifest reads.
 - Performs ecosystem-specific lockfile analysis

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -161,11 +161,13 @@ Represents the workspace structure and package dependencies:
   identities, definition sources, completeness, and stable fingerprints. A
   single resolution owner tracks lifecycle status. Task hashing consumes the
   stored byte-compatible package resolution fingerprint and preserves explicit
-  unavailable states without closure fallback hashing. Lockfile affectedness
-  resolves the current declarations against the previous lockfile with the same
-  producer, then compares normalized package identities; unavailable, parse, and
-  comparison failures retain the conservative all-packages fallback. The
-  snapshot projects temporary `PackageInfo` closure/hash fields for the remaining
+  unavailable states without closure fallback hashing. The JavaScript adapter
+  owns package-manager configuration, previous-lockfile parsing, and resolution
+  through the same producer used at graph construction. Core compares the
+  resulting normalized package identities without parser or ecosystem knowledge;
+  unavailable, parse, and comparison failures retain the conservative
+  all-packages fallback. The snapshot projects temporary `PackageInfo`
+  closure/hash fields for the remaining
   global-hash and summary migrations. Framework inference and boundaries
   validation consume the package-scoped declaration projection directly;
   aliases, duplicate


### PR DESCRIPTION
## Summary

- resolve current declarations against previous lockfile contents through the shared JavaScript resolution producer
- isolate package-manager configuration, lockfile parsing, and JavaScript resolution in the JavaScript package-graph adapter
- compare normalized per-package identities through a parser-neutral core comparator
- preserve scoped dependency attribution, root and global invalidation, and new-package behavior
- preserve conservative all-package fallback for parse, unavailable-resolution, and comparison failures
- remove affectedness reads from compatibility `PackageInfo` declaration and closure fields
- cover npm, pnpm, Yarn Classic, Berry, and Bun
- document the affectedness ownership boundary and consumer migration

Closes TURBO-5809.

## Testing

- `NO_COLOR=1 LC_ALL=C.UTF-8 cargo test -p turborepo-repository` (367 passed)
- `NO_COLOR=1 LC_ALL=C.UTF-8 cargo test -p turborepo-scope` (100 passed)
- `NO_COLOR=1 LC_ALL=C.UTF-8 cargo test -p turbo --test affected_test` (27 passed)
- `NO_COLOR=1 LC_ALL=C.UTF-8 cargo test -p turbo --test lockfile_new_package_test`
- `NO_COLOR=1 LC_ALL=C.UTF-8 cargo test -p turbo --test affected_rdeps_test`
- `NO_COLOR=1 LC_ALL=C.UTF-8 cargo test -p turborepo-lib classify_lockfile_change_returns_packages_changed`
- `NO_COLOR=1 LC_ALL=C.UTF-8 cargo test -p turbo --test final_hash_contract` (8 passed)
- `cargo clippy -p turborepo-repository -p turborepo-scope -p turborepo-lib -p turbo --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- pre-push `format`, `check:toml`, and `turborepo-crates#format` hooks
