### PR TITLE
refactor: Complete JavaScript external-resolution migration

### DIFF
--- a/crates/turborepo-boundaries/src/lib.rs
+++ b/crates/turborepo-boundaries/src/lib.rs
@@ -1060,18 +1060,12 @@ mod tests {
                 PackageName::Other("pkg-a".into()),
                 PackageInfo {
                     package_json: Default::default(),
-                    unresolved_external_dependencies: None,
-                    transitive_dependencies: None,
-                    ..Default::default()
                 },
             ),
             (
                 PackageName::Other("pkg-b".into()),
                 PackageInfo {
                     package_json: Default::default(),
-                    unresolved_external_dependencies: None,
-                    transitive_dependencies: None,
-                    ..Default::default()
                 },
             ),
         ];

--- a/crates/turborepo-boundaries/src/tags.rs
+++ b/crates/turborepo-boundaries/src/tags.rs
@@ -451,9 +451,6 @@ mod tests {
                 turbopath::AnchoredSystemPathBuf::from_raw(format!("packages/{name}")).unwrap(),
                 PackageInfo {
                     package_json: PackageJson::default(),
-                    unresolved_external_dependencies: None,
-                    transitive_dependencies: None,
-                    ..Default::default()
                 },
             ));
         }

--- a/crates/turborepo-frameworks/src/lib.rs
+++ b/crates/turborepo-frameworks/src/lib.rs
@@ -178,10 +178,10 @@ mod tests {
     #[test_case(PackageInfo::default(), None, true; "empty dependencies")]
     #[test_case(
         PackageInfo {
-            unresolved_external_dependencies: Some(
-                vec![("blitz".to_string(), "*".to_string())].into_iter().collect()
-            ),
-            ..Default::default()
+            package_json: PackageJson {
+                dependencies: deps(&[("blitz", "*")]),
+                ..Default::default()
+            },
         },
         Some(get_framework_by_slug("blitzjs")),
         true;
@@ -189,13 +189,10 @@ mod tests {
     )]
     #[test_case(
         PackageInfo {
-            unresolved_external_dependencies: Some(
-                vec![("blitz", "*"), ("next", "*")]
-                    .into_iter()
-                    .map(|(s1, s2)| (s1.to_string(), s2.to_string()))
-                    .collect()
-            ),
-            ..Default::default()
+            package_json: PackageJson {
+                dependencies: deps(&[("blitz", "*"), ("next", "*")]),
+                ..Default::default()
+            },
         },
         Some(get_framework_by_slug("blitzjs")),
         true;
@@ -203,13 +200,10 @@ mod tests {
     )]
     #[test_case(
         PackageInfo {
-            unresolved_external_dependencies: Some(
-                vec![("next", "*")]
-                    .into_iter()
-                    .map(|(s1, s2)| (s1.to_string(), s2.to_string()))
-                    .collect()
-            ),
-            ..Default::default()
+            package_json: PackageJson {
+                dependencies: deps(&[("next", "*")]),
+                ..Default::default()
+            },
         },
         Some(get_framework_by_slug("nextjs")),
         true;
@@ -217,13 +211,10 @@ mod tests {
     )]
     #[test_case(
         PackageInfo {
-            unresolved_external_dependencies: Some(
-                vec![("solid-js", "*"), ("solid-start", "*")]
-                    .into_iter()
-                    .map(|(s1, s2)| (s1.to_string(), s2.to_string()))
-                    .collect()
-            ),
-            ..Default::default()
+            package_json: PackageJson {
+                dependencies: deps(&[("solid-js", "*"), ("solid-start", "*")]),
+                ..Default::default()
+            },
         },
         Some(get_framework_by_slug("solidstart")),
         true;
@@ -231,13 +222,10 @@ mod tests {
     )]
     #[test_case(
         PackageInfo {
-            unresolved_external_dependencies: Some(
-                vec![("nuxt3", "*")]
-                    .into_iter()
-                    .map(|(s1, s2)| (s1.to_string(), s2.to_string()))
-                    .collect()
-            ),
-            ..Default::default()
+            package_json: PackageJson {
+                dependencies: deps(&[("nuxt", "*")]),
+                ..Default::default()
+            },
         },
         Some(get_framework_by_slug("nuxtjs")),
         true;
@@ -245,13 +233,10 @@ mod tests {
     )]
     #[test_case(
         PackageInfo {
-            unresolved_external_dependencies: Some(
-                vec![("react-scripts", "*")]
-                    .into_iter()
-                    .map(|(s1, s2)| (s1.to_string(), s2.to_string()))
-                    .collect()
-            ),
-            ..Default::default()
+            package_json: PackageJson {
+                dependencies: deps(&[("react-scripts", "*")]),
+                ..Default::default()
+            },
         },
         Some(get_framework_by_slug("create-react-app")),
         true;
@@ -259,16 +244,15 @@ mod tests {
     )]
     #[test_case(
         PackageInfo {
-            package_json: PackageJson {
-              dependencies: Some(
+              package_json: PackageJson {
+                            dependencies: Some(
                 vec![("next", "*")]
                     .into_iter()
                     .map(|(s1, s2)| (s1.to_string(), s2.to_string()))
                     .collect()
               ),
-              ..Default::default()
-            },
-            ..Default::default()
+                            ..Default::default()
+              },
         },
         Some(get_framework_by_slug("nextjs")),
         false;
@@ -276,16 +260,15 @@ mod tests {
     )]
     #[test_case(
         PackageInfo {
-            package_json: PackageJson {
-              dev_dependencies: Some(
+              package_json: PackageJson {
+                            dev_dependencies: Some(
                 vec![("vite", "*")]
                     .into_iter()
                     .map(|(s1, s2)| (s1.to_string(), s2.to_string()))
                     .collect()
               ),
-              ..Default::default()
-            },
-            ..Default::default()
+                            ..Default::default()
+              },
         },
         Some(get_framework_by_slug("vite")),
         false;
@@ -294,11 +277,10 @@ mod tests {
     #[test_case(PackageInfo::default(), None, false; "empty dependencies in non-monorepo")]
     #[test_case(
         PackageInfo {
-            package_json: PackageJson {
-                dev_dependencies: deps(&[("vite", "*")]),
-                ..Default::default()
-            },
-            ..Default::default()
+                package_json: PackageJson {
+                                dev_dependencies: deps(&[("vite", "*")]),
+                                ..Default::default()
+                },
         },
         None,
         true;
@@ -306,12 +288,11 @@ mod tests {
     )]
     #[test_case(
         PackageInfo {
-            package_json: PackageJson {
-                dependencies: deps(&[("solid-js", "*")]),
+                package_json: PackageJson {
+                                dependencies: deps(&[("solid-js", "*")]),
                 dev_dependencies: deps(&[("solid-start", "*")]),
-                ..Default::default()
-            },
-            ..Default::default()
+                                ..Default::default()
+                },
         },
         Some(get_framework_by_slug("solidstart")),
         false;
@@ -319,11 +300,10 @@ mod tests {
     )]
     #[test_case(
         PackageInfo {
-            package_json: PackageJson {
-                dev_dependencies: deps(&[("react-scripts", "*")]),
-                ..Default::default()
-            },
-            ..Default::default()
+                package_json: PackageJson {
+                                dev_dependencies: deps(&[("react-scripts", "*")]),
+                                ..Default::default()
+                },
         },
         Some(get_framework_by_slug("create-react-app")),
         false;
@@ -336,7 +316,8 @@ mod tests {
     ) {
         let declarations = if is_monorepo {
             workspace_info
-                .unresolved_external_dependencies
+                .package_json
+                .dependencies
                 .iter()
                 .flatten()
                 .map(|(name, specifier)| {
@@ -367,7 +348,7 @@ mod tests {
                 .map(|(name, specifier, kind)| {
                     ExternalDeclaration::new("workspace", name, name, specifier, kind)
                 })
-                .collect()
+                .collect::<Vec<_>>()
         };
         let framework = infer_framework(
             PackageExternalDeclarations::new(&declarations, "workspace"),

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -1284,9 +1284,9 @@ impl<'a> Prune<'a> {
     fn lockfile_keys(&self, workspaces: &[PackageName]) -> Result<Vec<String>, Error> {
         let mut keys = self
             .package_graph
-            .transitive_external_dependencies(workspaces.iter())
+            .external_package_identities_for_packages(workspaces.iter())
             .into_iter()
-            .map(|pkg| pkg.key.clone())
+            .map(|identity| identity.key().to_string())
             .collect::<HashSet<_>>();
 
         let lockfile = self

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -839,14 +839,20 @@ impl<'a> Prune<'a> {
             trace!("target: {}", context.package());
             trace!("workspace directory: {}", context.directory());
             trace!("workspace definition: {definition_path}");
-            if let Some(payload) = context.package_info() {
-                trace!(
-                    "external dependencies: {:?}",
-                    &payload.unresolved_external_dependencies
-                );
-            } else if context.requires_compatibility_payload() {
+            if context.requires_compatibility_payload() && context.package_info().is_none() {
                 return Err(Error::MissingPackagePayload(context.package().clone()));
             }
+            let declarations: Vec<_> = package_graph
+                .external_declarations(context.package())
+                .iter()
+                .map(|declaration| {
+                    (
+                        declaration.package_name().to_string(),
+                        declaration.specifier().to_string(),
+                    )
+                })
+                .collect();
+            trace!("external dependencies: {:?}", declarations);
         }
 
         // A JavaScript project must have a lockfile to subgraph. A pure Cargo

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -564,13 +564,6 @@ impl RunBuilder {
                 PackageGraph::builder_optional(&self.repo_root, root_package_json.clone())
                     .with_single_package_mode(self.opts.run_opts.single_package)
                     .with_allow_no_package_manager(self.opts.repo_opts.allow_no_package_manager)
-                    // Transitive closures compute on a background thread while
-                    // microfrontends config, turbo.json preloading, and other
-                    // package-list consumers run. Joined by the
-                    // `ensure_transitive_closures` call before package filtering,
-                    // the earliest possible consumer (`--affected` with a changed
-                    // lockfile compares closures).
-                    .defer_transitive_closures(true)
                     .with_closure_hasher(std::sync::Arc::new(
                         turborepo_task_hash::hash_sorted_closures,
                     ));
@@ -788,27 +781,9 @@ impl RunBuilder {
             turbo_json_loader.preload_all();
         });
 
-        // Package filtering reads transitive closures only when a git-based
-        // selector may compare lockfile closures: `--affected`, or a
-        // `--filter` containing a git range (bracket syntax). Joining the
-        // background closure computation here in only those cases lets the
-        // common run keep overlapping it with filtering and engine
-        // construction; the unconditional join below runs before the first
-        // universal consumer (task hashing).
-        let scope_may_read_closures = self.opts.scope_opts.affected_range.is_some()
-            || self
-                .opts
-                .scope_opts
-                .filter_patterns
-                .iter()
-                .any(|pattern| pattern.contains('['));
-        if scope_may_read_closures {
-            crate::rayon_compat::block_in_place(|| {
-                let _span = tracing::info_span!("ensure_transitive_closures").entered();
-                pkg_dep_graph.ensure_transitive_closures();
-            });
-        }
-
+        // Resolution knowledge is complete at package-graph construction, so
+        // scope filtering can read lockfile-affected packages without joining
+        // deferred closure work.
         let (filtered_pkgs, filter_mode, unqualified_entrypoint_packages) = {
             let _span = tracing::info_span!("calculate_filtered_packages").entered();
             Self::calculate_filtered_packages(
@@ -1121,15 +1096,6 @@ impl RunBuilder {
                 .instrument(tracing::info_span!("capture_scm_state")),
             );
         }
-
-        // Unconditional join point for the background transitive-closure
-        // computation (idempotent when the conditional join above already
-        // ran). The graph is immutable once inside `Run`, and its first
-        // closure consumer (external dependency hashing) runs shortly after.
-        crate::rayon_compat::block_in_place(|| {
-            let _span = tracing::info_span!("ensure_transitive_closures").entered();
-            pkg_dep_graph.ensure_transitive_closures();
-        });
 
         Ok((
             Run {

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -37,9 +37,8 @@ use turborepo_run_summary::{ObservabilityHandle, RunTracker};
 use turborepo_scm::{RepoGitIndex, SCM};
 use turborepo_signals::{ShutdownReason, SignalHandler};
 use turborepo_task_hash::{
-    collect_global_file_hash_inputs, compute_external_deps_hashes, get_external_deps_hash,
-    get_internal_deps_hash, global_hash::GLOBAL_CACHE_KEY, GlobalHashableInputs,
-    PackageInputsHashes,
+    collect_global_file_hash_inputs, compute_external_deps_hashes, get_internal_deps_hash,
+    global_hash::GLOBAL_CACHE_KEY, GlobalHashableInputs, PackageInputsHashes,
 };
 use turborepo_telemetry::events::generic::GenericEventBuilder;
 use turborepo_types::{EnvMode, UIMode};
@@ -1216,11 +1215,15 @@ impl Run {
                 s.spawn(|_| {
                     let _span =
                         tracing::info_span!("collect_global_file_hash_inputs_task").entered();
+                    let resolution_file_fallback = self
+                        .pkg_dep_graph
+                        .external_resolution_global_file_fallback()
+                        .unwrap_or_default();
                     global_file_result = Some(collect_global_file_hash_inputs(
                         root_workspace,
                         &self.repo_root,
                         self.pkg_dep_graph.package_manager(),
-                        self.pkg_dep_graph.lockfile(),
+                        &resolution_file_fallback,
                         self.root_turbo_json.global_deps_for_hash(),
                         &self.env_at_execution_start,
                         &self.root_turbo_json.global_env,
@@ -1249,12 +1252,21 @@ impl Run {
             global_file_result.ok_or(Error::GlobalFileHashTaskIncomplete)??;
         let external_deps_hashes = external_deps_hashes.transpose()?;
 
-        let root_external_dependencies_hash = is_monorepo.then(|| {
-            root_workspace
-                .external_deps_hash
-                .clone()
-                .unwrap_or_else(|| get_external_deps_hash(&root_workspace.transitive_dependencies))
-        });
+        let root_external_dependencies_hash = if is_monorepo {
+            let cache = external_deps_hashes.as_ref().ok_or_else(|| {
+                turborepo_task_hash::Error::MissingExternalDependencyHash(PackageName::Root)
+            })?;
+            Some(
+                cache
+                    .get(PackageName::Root.as_str())
+                    .cloned()
+                    .ok_or_else(|| {
+                        turborepo_task_hash::Error::MissingExternalDependencyHash(PackageName::Root)
+                    })?,
+            )
+        } else {
+            None
+        };
 
         let pass_through_env = match env_mode {
             EnvMode::Loose => {

--- a/crates/turborepo-query/src/external_package.rs
+++ b/crates/turborepo-query/src/external_package.rs
@@ -1,40 +1,48 @@
 use std::sync::Arc;
 
 use async_graphql::Object;
+use turborepo_repository::external_resolution::ExternalPackageIdentity;
 
 use crate::{package::Package, Array, Error, QueryRun};
 
 #[derive(Clone)]
 pub struct ExternalPackage {
     run: Arc<dyn QueryRun>,
-    package: turborepo_lockfiles::Package,
+    identity: ExternalPackageIdentity,
 }
 
 impl ExternalPackage {
     pub fn new(run: Arc<dyn QueryRun>, package: turborepo_lockfiles::Package) -> Self {
-        Self { run, package }
+        let identity = run
+            .pkg_dep_graph()
+            .resolve_external_package_identity(&package)
+            .cloned()
+            .unwrap_or_else(|| {
+                ExternalPackageIdentity::new(package.key.clone(), package.version.clone())
+            });
+        Self { run, identity }
+    }
+
+    pub fn from_identity(run: Arc<dyn QueryRun>, identity: ExternalPackageIdentity) -> Self {
+        Self { run, identity }
     }
 
     pub fn human_name(&self) -> String {
-        self.run
-            .pkg_dep_graph()
-            .lockfile()
-            .and_then(|lockfile| lockfile.human_name(&self.package))
-            .unwrap_or_else(|| self.package.key.clone())
+        self.identity.display_name().to_string()
     }
 }
 
 #[Object]
 impl ExternalPackage {
     async fn name(&self) -> String {
-        self.human_name().to_string()
+        self.human_name()
     }
 
     async fn internal_dependents(&self) -> Result<Array<Package>, Error> {
         let Some(names) = self
             .run
             .pkg_dep_graph()
-            .internal_dependencies_for_external_dependency(&self.package)
+            .internal_dependencies_for_external_identity(&self.identity)
         else {
             return Ok(Array::from(Vec::new()));
         };

--- a/crates/turborepo-query/src/lib.rs
+++ b/crates/turborepo-query/src/lib.rs
@@ -772,15 +772,13 @@ impl RepositoryQuery {
     }
 
     async fn external_dependencies(&self) -> Result<Array<ExternalPackage>, Error> {
-        let pkg_dep_graph = self.run.pkg_dep_graph();
-        let all_package_names: Vec<_> = pkg_dep_graph
-            .package_scope_directories()
-            .map(|(name, _)| name)
-            .collect();
-        let mut packages = pkg_dep_graph
-            .transitive_external_dependencies(all_package_names.iter())
-            .into_iter()
-            .map(|pkg| ExternalPackage::new(self.run.clone(), pkg.clone()))
+        let mut packages = self
+            .run
+            .pkg_dep_graph()
+            .external_package_identities()
+            .iter()
+            .cloned()
+            .map(|identity| ExternalPackage::from_identity(self.run.clone(), identity))
             .collect::<Array<_>>();
         packages.sort_by_key(|pkg| pkg.human_name());
         Ok(packages)

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -3854,7 +3854,6 @@ release: 1.96.0-nightly\n",
                 name: Some(Spanned::new(name.to_string())),
                 ..Default::default()
             },
-            ..Default::default()
         }
     }
 

--- a/crates/turborepo-repository/src/external_resolution.rs
+++ b/crates/turborepo-repository/src/external_resolution.rs
@@ -137,10 +137,42 @@ impl<'a> PackageExternalDeclarations<'a> {
 }
 
 /// An exact, opaque external package identity.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+///
+/// Equality, ordering, and hashing are defined by `(key, version)` only.
+/// `human_name` is display metadata captured at observation time so query
+/// consumers do not re-read native lockfiles.
+#[derive(Debug, Clone)]
 pub struct ExternalPackageIdentity {
     key: String,
     version: String,
+    human_name: Option<String>,
+}
+
+impl PartialEq for ExternalPackageIdentity {
+    fn eq(&self, other: &Self) -> bool {
+        self.key == other.key && self.version == other.version
+    }
+}
+
+impl Eq for ExternalPackageIdentity {}
+
+impl PartialOrd for ExternalPackageIdentity {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ExternalPackageIdentity {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        (&self.key, &self.version).cmp(&(&other.key, &other.version))
+    }
+}
+
+impl std::hash::Hash for ExternalPackageIdentity {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.key.hash(state);
+        self.version.hash(state);
+    }
 }
 
 impl ExternalPackageIdentity {
@@ -148,7 +180,13 @@ impl ExternalPackageIdentity {
         Self {
             key: key.into(),
             version: version.into(),
+            human_name: None,
         }
+    }
+
+    pub fn with_human_name(mut self, human_name: impl Into<String>) -> Self {
+        self.human_name = Some(human_name.into());
+        self
     }
 
     pub fn key(&self) -> &str {
@@ -157,6 +195,15 @@ impl ExternalPackageIdentity {
 
     pub fn version(&self) -> &str {
         &self.version
+    }
+
+    /// Prefer the producer-supplied display name; otherwise the opaque key.
+    pub fn display_name(&self) -> &str {
+        self.human_name.as_deref().unwrap_or(&self.key)
+    }
+
+    pub fn human_name(&self) -> Option<&str> {
+        self.human_name.as_deref()
     }
 }
 

--- a/crates/turborepo-repository/src/external_resolution.rs
+++ b/crates/turborepo-repository/src/external_resolution.rs
@@ -435,7 +435,6 @@ impl ExternalResolutionDomain {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExternalResolutionStatus {
     Pending,
-    Resolving,
     Complete,
 }
 

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -1900,11 +1900,10 @@ mod test {
         );
     }
 
-    // Regression test: connect_internal_dependencies must produce correct
-    // graph edges and external deps regardless of iteration order or
-    // parallelism. This captures the exact edges and
-    // unresolved_external_dependencies so any refactor of the collection phase
-    // (e.g. rayon parallelization) is safe.
+    // Regression test: relationship projection must produce correct graph
+    // edges and external declaration views regardless of iteration order or
+    // parallelism. This captures edges and declaration projections so any
+    // refactor of the collection phase (e.g. rayon parallelization) is safe.
     #[tokio::test]
     async fn test_connect_internal_dependencies_produces_correct_edges() {
         let root =

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -50,7 +50,6 @@ pub struct PackageGraphBuilder<'a, T> {
     lockfile: Option<Box<dyn Lockfile>>,
     package_discovery: T,
     package_manager: Option<PackageManager>,
-    defer_closures: bool,
     closure_hasher: Option<ClosureHasher>,
     /// Toolchains registered in addition to JavaScript (e.g. Cargo when
     /// `futureFlags.experimentalCargoWorkspaces` is enabled). Their packages
@@ -244,7 +243,6 @@ impl<'a> PackageGraphBuilder<'a, LocalPackageDiscoveryBuilder> {
             package_jsons: None,
             lockfile: None,
             package_manager: None,
-            defer_closures: false,
             closure_hasher: None,
             extra_toolchains: Vec::new(),
         }
@@ -275,15 +273,6 @@ impl<'a, P> PackageGraphBuilder<'a, P> {
         package_jsons: Option<HashMap<AbsoluteSystemPathBuf, PackageJson>>,
     ) -> Self {
         self.package_jsons = package_jsons;
-        self
-    }
-
-    /// Defer transitive-closure computation to a background thread. The
-    /// resulting graph's `transitive_dependencies` are absent until
-    /// [`PackageGraph::ensure_transitive_closures`] is called; callers that
-    /// enable this own calling it before any closure consumer runs.
-    pub fn defer_transitive_closures(mut self, defer: bool) -> Self {
-        self.defer_closures = defer;
         self
     }
 
@@ -322,7 +311,6 @@ impl<'a, P> PackageGraphBuilder<'a, P> {
             lockfile: self.lockfile,
             package_discovery: discovery,
             package_manager: self.package_manager,
-            defer_closures: self.defer_closures,
             closure_hasher: self.closure_hasher,
             extra_toolchains: self.extra_toolchains,
         }
@@ -400,7 +388,6 @@ struct BuildState<'a, S, T> {
     lockfile: Option<Box<dyn Lockfile>>,
     package_manager: Option<PackageManager>,
     package_jsons: Option<HashMap<AbsoluteSystemPathBuf, PackageJson>>,
-    defer_closures: bool,
     closure_hasher: Option<ClosureHasher>,
     state: std::marker::PhantomData<S>,
     /// The JavaScript toolchain, typed. Package-manager resolution for
@@ -523,14 +510,13 @@ impl PackageGraphAssembler {
         for group in relationships.groups() {
             let identity = group.source();
             let name = package_name_from_identity(identity);
-            let entry = self.package_payloads.get_mut(&name).ok_or_else(|| {
-                Error::MissingCompatibilityPayload {
+            if !self.package_payloads.contains_key(&name) {
+                return Err(Error::MissingCompatibilityPayload {
                     name: identity.to_string(),
-                }
-            })?;
+                });
+            }
             let mut seen = HashSet::new();
             let mut internal = HashMap::<&str, DependencyKind>::new();
-            let mut external = BTreeMap::new();
             for relationship in group.relationships() {
                 if !seen.insert(relationship.declaration_name()) {
                     continue;
@@ -553,12 +539,8 @@ impl PackageGraphAssembler {
                         DependencyKind::Production
                         | DependencyKind::Optional
                         | DependencyKind::Development,
-                        RelationshipTarget::UnresolvedExternal { name, specifier },
-                    ) => {
-                        external
-                            .entry(name.clone())
-                            .or_insert_with(|| specifier.clone());
-                    }
+                        RelationshipTarget::UnresolvedExternal { .. },
+                    ) => {}
                 }
             }
             let node_idx = self
@@ -588,7 +570,6 @@ impl PackageGraphAssembler {
                 self.workspace_graph
                     .add_edge(node_idx, dependency_idx, kind);
             }
-            entry.unresolved_external_dependencies = Some(external);
         }
         Ok(())
     }
@@ -626,7 +607,6 @@ where
         let PackageGraphBuilder {
             repo_root,
             root_package_json,
-            defer_closures,
             closure_hasher,
             is_single_package: single,
 
@@ -641,10 +621,9 @@ where
         // registered nor queried for a package manager. The graph is built
         // entirely from the extra toolchains (Cargo).
         let no_javascript = root_package_json.is_none();
-        let root_package_info = root_package_json.clone().map(|package_json| PackageInfo {
-            package_json,
-            ..Default::default()
-        });
+        let root_package_info = root_package_json
+            .clone()
+            .map(|package_json| PackageInfo { package_json });
         let assembler = PackageGraphAssembler::new(root_package_info);
 
         // The discovery strategy is shared (via the JavaScript toolchain)
@@ -684,7 +663,6 @@ where
             package_manager: None,
             package_jsons,
             root_package_json,
-            defer_closures,
             closure_hasher,
             state: std::marker::PhantomData,
             javascript,
@@ -704,25 +682,13 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             scope_kind,
             descriptor: json,
             manifest_path,
-            external_dependencies,
+            external_dependencies: _,
             native_relationships,
         } = package.into_parts();
-        // Toolchain-resolved external identities (e.g. Cargo's per-crate
-        // lockfile closures), in the sorted representation the JS lockfile
-        // phase produces. That phase later fills this for JavaScript
-        // packages and never touches non-JS ones; the external-dependency
-        // hash is computed on demand from the sorted closure.
-        let transitive_dependencies = external_dependencies.map(|externals| {
-            let mut sorted: Vec<std::sync::Arc<turborepo_lockfiles::Package>> =
-                externals.into_iter().map(std::sync::Arc::new).collect();
-            sorted.sort_by(|a, b| (&a.key, &a.version).cmp(&(&b.key, &b.version)));
-            sorted
-        });
-        let entry = PackageInfo {
-            package_json: json,
-            transitive_dependencies,
-            ..Default::default()
-        };
+        // Toolchain-resolved external identities are contributed to the
+        // resolution generation separately; PackageInfo no longer carries
+        // closure/hash compatibility projections.
+        let entry = PackageInfo { package_json: json };
         let observation = PackageScopeObservation {
             identity: name.clone(),
             definition_path: manifest_path.clone(),
@@ -841,7 +807,6 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             package_manager,
             javascript,
             toolchains,
-            defer_closures,
             closure_hasher,
             ..
         } = self;
@@ -858,7 +823,6 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             package_manager,
             javascript,
             toolchains,
-            defer_closures,
             closure_hasher,
             package_jsons: None,
             state: std::marker::PhantomData,
@@ -1129,7 +1093,6 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
             root_package_json,
             javascript,
             toolchains,
-            defer_closures,
             closure_hasher,
             ..
         } = self;
@@ -1145,7 +1108,6 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
             root_package_json,
             lockfile,
             package_manager,
-            defer_closures,
             closure_hasher,
             package_jsons: None,
             state: std::marker::PhantomData,
@@ -1231,12 +1193,8 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
 
     #[tracing::instrument(skip(self))]
     async fn build_inner(mut self) -> Result<PackageGraph, discovery::Error> {
-        // Transitive closures are only consumed by task hashing and
-        // change-detection, well after graph construction. When deferral is
-        // requested, compute them on a background thread so package-list
-        // consumers (microfrontends config, turbo.json preloading, engine
-        // construction) overlap with the closure work instead of waiting
-        // behind it. `PackageGraph::ensure_transitive_closures` joins.
+        // External resolution is produced during repository construction and
+        // retained as an immutable generation. Readiness belongs to build().
         let knowledge = self
             .knowledge
             .clone()
@@ -1258,61 +1216,6 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
         if let Some(definition_source) = definition_source {
             if let Some(lockfile) = arc_lockfile.clone() {
                 match self.all_external_dependencies() {
-                    Ok(external_dependencies) if self.defer_closures => {
-                        let (tx, rx) = std::sync::mpsc::sync_channel(1);
-                        let hasher = self.closure_hasher.clone();
-                        let resolution_knowledge = Arc::clone(&knowledge);
-                        let deferred_source = definition_source.clone();
-                        let deferred_native_resolutions = Arc::new(std::sync::Mutex::new(
-                            std::mem::take(&mut native_external_resolutions),
-                        ));
-                        let thread_native_resolutions = Arc::clone(&deferred_native_resolutions);
-                        let spawned = std::thread::Builder::new()
-                            .name("turbo-closures".into())
-                            .spawn(move || {
-                                let native_resolutions = std::mem::take(
-                                    &mut *thread_native_resolutions
-                                        .lock()
-                                        .unwrap_or_else(|poisoned| poisoned.into_inner()),
-                                );
-                                let result = javascript::resolve_dependencies(
-                                    &resolution_knowledge,
-                                    native_resolutions,
-                                    lockfile.as_ref(),
-                                    external_dependencies,
-                                    false,
-                                    deferred_source,
-                                    hasher.as_ref(),
-                                );
-                                let _ = tx.send(result);
-                            });
-                        match spawned {
-                            Ok(_) => {
-                                external_resolution = ExternalResolutionKnowledge::resolving(rx);
-                            }
-                            Err(error) => {
-                                warn!("Unable to spawn transitive closure thread: {}", error);
-                                let snapshot = javascript::unavailable_resolution(
-                                    &knowledge,
-                                    std::mem::take(
-                                        &mut *deferred_native_resolutions
-                                            .lock()
-                                            .unwrap_or_else(|poisoned| poisoned.into_inner()),
-                                    ),
-                                    definition_source,
-                                    "worker-unavailable",
-                                    error.to_string(),
-                                    None,
-                                    self.closure_hasher.as_ref(),
-                                )
-                                .map_err(|message| {
-                                    build_failure(Error::ExternalResolution(message))
-                                })?;
-                                external_resolution =
-                                    ExternalResolutionKnowledge::complete(snapshot.generation);
-                            }
-                        }
-                    }
                     Ok(external_dependencies) => {
                         let mut snapshot = turborepo_rayon_compat::block_in_place(|| {
                             javascript::resolve_dependencies(
@@ -1329,9 +1232,8 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
                         if let Some(warning) = snapshot.warning.take() {
                             warn!("Unable to calculate transitive closures: {}", warning);
                         }
-                        let generation = Arc::clone(&snapshot.generation);
-                        snapshot.project_legacy(&mut self.assembler.package_payloads, &knowledge);
-                        external_resolution = ExternalResolutionKnowledge::complete(generation);
+                        external_resolution =
+                            ExternalResolutionKnowledge::complete(snapshot.generation);
                     }
                     Err(error) => {
                         warn!("Unable to calculate transitive closures: {}", error);
@@ -2206,31 +2108,60 @@ mod test {
         );
 
         // Verify external deps are recorded correctly
-        let web_info = graph.package_info(&web_name).unwrap();
-        let web_ext = web_info.unresolved_external_dependencies.as_ref().unwrap();
+        let web_ext: std::collections::BTreeMap<_, _> = graph
+            .external_declarations(&web_name)
+            .iter()
+            .map(|declaration| {
+                (
+                    declaration.package_name().to_string(),
+                    declaration.specifier().to_string(),
+                )
+            })
+            .collect();
         assert_eq!(web_ext.get("react").map(|v| v.as_str()), Some("^18.0.0"));
         assert!(
             !web_ext.contains_key("ui"),
             "ui should be internal, not external"
         );
 
-        let api_info = graph.package_info(&api_name).unwrap();
-        let api_ext = api_info.unresolved_external_dependencies.as_ref().unwrap();
+        let api_ext: std::collections::BTreeMap<_, _> = graph
+            .external_declarations(&api_name)
+            .iter()
+            .map(|declaration| {
+                (
+                    declaration.package_name().to_string(),
+                    declaration.specifier().to_string(),
+                )
+            })
+            .collect();
         assert_eq!(api_ext.get("express").map(|v| v.as_str()), Some("^4.0.0"));
         assert!(
             !api_ext.contains_key("utils"),
             "utils should be internal, not external"
         );
 
-        let ui_info = graph.package_info(&ui_name).unwrap();
-        let ui_ext = ui_info.unresolved_external_dependencies.as_ref().unwrap();
+        let ui_ext: std::collections::BTreeMap<_, _> = graph
+            .external_declarations(&ui_name)
+            .iter()
+            .map(|declaration| {
+                (
+                    declaration.package_name().to_string(),
+                    declaration.specifier().to_string(),
+                )
+            })
+            .collect();
         assert_eq!(ui_ext.get("csstype").map(|v| v.as_str()), Some("^3.0.0"));
 
-        let utils_info = graph.package_info(&utils_name).unwrap();
-        let utils_ext = utils_info
-            .unresolved_external_dependencies
-            .as_ref()
-            .unwrap();
+        let utils_ext: std::collections::BTreeMap<_, _> = graph
+            .external_declarations(&utils_name)
+            .iter()
+            .map(|declaration| {
+                (
+                    declaration.package_name().to_string(),
+                    declaration.specifier().to_string(),
+                )
+            })
+            .collect();
         assert!(
             utils_ext.is_empty(),
             "utils should have no external deps, got: {:?}",
@@ -2467,12 +2398,14 @@ mod test {
             b_deps
         );
 
-        let b_external = graph
-            .package_info(&b)
-            .unwrap()
-            .unresolved_external_dependencies
-            .as_ref()
-            .unwrap();
+        let b_external = {
+            let decls: std::collections::BTreeMap<_, _> = graph
+                .external_declarations(&b)
+                .iter()
+                .map(|d| (d.package_name().to_string(), d.specifier().to_string()))
+                .collect();
+            decls
+        };
         assert_eq!(
             b_external.get("buffer").map(|v| v.as_str()),
             Some("npm:buffer@6.0.3")
@@ -2590,12 +2523,14 @@ mod test {
         .unwrap();
 
         let a = PackageName::from("a");
-        let a_external = graph
-            .package_info(&a)
-            .unwrap()
-            .unresolved_external_dependencies
-            .as_ref()
-            .unwrap();
+        let a_external = {
+            let decls: std::collections::BTreeMap<_, _> = graph
+                .external_declarations(&a)
+                .iter()
+                .map(|d| (d.package_name().to_string(), d.specifier().to_string()))
+                .collect();
+            decls
+        };
         assert!(
             !a_external.contains_key("react"),
             "external peer dependency should not be retained as an external dep, got: {:?}",
@@ -2641,12 +2576,14 @@ mod test {
         .unwrap();
 
         let a = PackageName::from("a");
-        let a_external = graph
-            .package_info(&a)
-            .unwrap()
-            .unresolved_external_dependencies
-            .as_ref()
-            .unwrap();
+        let a_external = {
+            let decls: std::collections::BTreeMap<_, _> = graph
+                .external_declarations(&a)
+                .iter()
+                .map(|d| (d.package_name().to_string(), d.specifier().to_string()))
+                .collect();
+            decls
+        };
         assert!(
             !a_external.contains_key("react"),
             "optional peer should not be retained, got: {:?}",
@@ -2724,12 +2661,16 @@ mod test {
             "prune closure for app should include its regular dependency lib"
         );
 
-        let lib_external = graph
-            .package_info(&PackageName::from("lib"))
-            .unwrap()
-            .unresolved_external_dependencies
-            .as_ref()
-            .unwrap();
+        let lib_external: std::collections::BTreeMap<_, _> = graph
+            .external_declarations(&PackageName::from("lib"))
+            .iter()
+            .map(|declaration| {
+                (
+                    declaration.package_name().to_string(),
+                    declaration.specifier().to_string(),
+                )
+            })
+            .collect();
         assert!(
             !lib_external.contains_key("react"),
             "external peer should not be retained by package graph, got: {:?}",

--- a/crates/turborepo-repository/src/package_graph/dep_splitter.rs
+++ b/crates/turborepo-repository/src/package_graph/dep_splitter.rs
@@ -371,9 +371,6 @@ mod test {
                         version: Some(package_version.to_string()),
                         ..Default::default()
                     },
-                    unresolved_external_dependencies: None,
-                    transitive_dependencies: None,
-                    ..Default::default()
                 },
             );
             map.insert(
@@ -383,9 +380,6 @@ mod test {
                         version: Some("1.0.0".to_string()),
                         ..Default::default()
                     },
-                    unresolved_external_dependencies: None,
-                    transitive_dependencies: None,
-                    ..Default::default()
                 },
             );
             map.insert(
@@ -395,9 +389,6 @@ mod test {
                         version: Some("1.0.0".to_string()),
                         ..Default::default()
                     },
-                    unresolved_external_dependencies: None,
-                    transitive_dependencies: None,
-                    ..Default::default()
                 },
             );
             map.insert(
@@ -407,9 +398,6 @@ mod test {
                         version: Some("6.0.3".to_string()),
                         ..Default::default()
                     },
-                    unresolved_external_dependencies: None,
-                    transitive_dependencies: None,
-                    ..Default::default()
                 },
             );
             map
@@ -495,9 +483,6 @@ mod test {
                         version: Some("1.0.0".to_string()),
                         ..Default::default()
                     },
-                    unresolved_external_dependencies: None,
-                    transitive_dependencies: None,
-                    ..Default::default()
                 },
             );
             map
@@ -536,9 +521,6 @@ mod test {
                         version: Some("1.0.0".to_string()),
                         ..Default::default()
                     },
-                    unresolved_external_dependencies: None,
-                    transitive_dependencies: None,
-                    ..Default::default()
                 },
             );
             map
@@ -577,9 +559,6 @@ mod test {
                         version: Some("1.2.3".to_string()),
                         ..Default::default()
                     },
-                    unresolved_external_dependencies: None,
-                    transitive_dependencies: None,
-                    ..Default::default()
                 },
             );
             map
@@ -643,9 +622,6 @@ mod test {
                         version: Some("1.0.0".to_string()),
                         ..Default::default()
                     },
-                    unresolved_external_dependencies: None,
-                    transitive_dependencies: None,
-                    ..Default::default()
                 },
             );
             map
@@ -681,9 +657,6 @@ mod test {
                         version: Some("1.0.0".to_string()),
                         ..Default::default()
                     },
-                    unresolved_external_dependencies: None,
-                    transitive_dependencies: None,
-                    ..Default::default()
                 },
             );
             map

--- a/crates/turborepo-repository/src/package_graph/javascript.rs
+++ b/crates/turborepo-repository/src/package_graph/javascript.rs
@@ -198,7 +198,12 @@ pub(super) fn resolve_dependencies(
                 .into_iter()
                 .flatten()
                 .map(|package| {
-                    ExternalPackageIdentity::new(package.key.clone(), package.version.clone())
+                    let mut identity =
+                        ExternalPackageIdentity::new(package.key.clone(), package.version.clone());
+                    if let Some(human_name) = lockfile.human_name(package) {
+                        identity = identity.with_human_name(human_name);
+                    }
+                    identity
                 });
             PackageResolution::new(identity, exact_identities)
         })

--- a/crates/turborepo-repository/src/package_graph/javascript.rs
+++ b/crates/turborepo-repository/src/package_graph/javascript.rs
@@ -7,8 +7,7 @@ use turbopath::{AnchoredSystemPath, AnchoredSystemPathBuf};
 use turborepo_lockfiles::Lockfile;
 
 use super::{
-    ExternalDependencyChange, PackageGraph, PackageInfo, PackageName, ROOT_PKG_NAME,
-    WorkspacePackage,
+    ExternalDependencyChange, PackageGraph, PackageName, ROOT_PKG_NAME, WorkspacePackage,
     builder::{ClosureHasher, apply_resolution_fingerprints},
 };
 use crate::{
@@ -24,58 +23,13 @@ use crate::{
     toolchain::ToolchainId,
 };
 
-/// One JavaScript resolution snapshot and its temporary compatibility
-/// projection. Both inline and deferred production create this exact shape.
+/// One JavaScript resolution snapshot. Both production paths create this
+/// exact generation-backed shape; compatibility projections onto `PackageInfo`
+/// have been deleted.
 pub(super) struct ResolutionSnapshot {
     pub generation: Arc<ExternalResolutionGeneration>,
-    pub closures: HashMap<String, Vec<Arc<turborepo_lockfiles::Package>>>,
     pub warning: Option<String>,
 }
-
-impl ResolutionSnapshot {
-    pub(super) fn project_legacy(
-        &mut self,
-        package_payloads: &mut HashMap<PackageName, PackageInfo>,
-        knowledge: &RepositoryKnowledge,
-    ) {
-        let fingerprints = self
-            .generation
-            .domains()
-            .iter()
-            .find(|domain| domain.toolchain() == &ToolchainId::JAVASCRIPT)
-            .and_then(|domain| match domain.data() {
-                ExternalResolutionData::Resolved { packages, .. } => Some(
-                    packages
-                        .iter()
-                        .filter_map(|package| {
-                            package
-                                .fingerprint()
-                                .map(|fingerprint| (package.package(), fingerprint.as_str()))
-                        })
-                        .collect::<HashMap<_, _>>(),
-                ),
-                ExternalResolutionData::Unavailable(_) => None,
-            })
-            .unwrap_or_default();
-        for (name, info) in package_payloads {
-            let facts = scope_directory_and_toolchain(knowledge, name);
-            let Some((directory, toolchain)) = facts else {
-                continue;
-            };
-            if toolchain != &ToolchainId::JAVASCRIPT {
-                continue;
-            }
-            let directory = directory.to_unix();
-            info.transitive_dependencies = self.closures.remove(directory.as_str());
-            info.external_deps_hash = fingerprints
-                .get(name.as_str())
-                .map(|fingerprint| (*fingerprint).to_string());
-        }
-    }
-}
-
-pub(super) type DeferredResolutionReceiver =
-    std::sync::mpsc::Receiver<Result<ResolutionSnapshot, String>>;
 
 fn scope_directory_and_toolchain<'a>(
     knowledge: &'a RepositoryKnowledge,
@@ -157,7 +111,6 @@ pub(super) fn unavailable_resolution(
         .map_err(|error| error.to_string())?;
     Ok(ResolutionSnapshot {
         generation: Arc::new(generation),
-        closures: HashMap::new(),
         warning,
     })
 }
@@ -224,7 +177,6 @@ pub(super) fn resolve_dependencies(
         .map_err(|error| error.to_string())?;
     Ok(ResolutionSnapshot {
         generation: Arc::new(generation),
-        closures,
         warning: None,
     })
 }

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -16,8 +16,9 @@ use turborepo_lockfiles::Lockfile;
 use crate::{
     discovery::LocalPackageDiscoveryBuilder,
     external_resolution::{
-        ExternalDeclarations, ExternalResolutionData, ExternalResolutionGeneration,
-        ExternalResolutionStatus, PackageExternalDeclarations, PackageResolutionState,
+        ExternalDeclarations, ExternalPackageIdentity, ExternalResolutionData,
+        ExternalResolutionGeneration, ExternalResolutionStatus, PackageExternalDeclarations,
+        PackageResolutionState,
     },
     knowledge::{RelationshipKnowledge, RepositoryKnowledge},
     package_json::PackageJson,
@@ -106,8 +107,10 @@ pub struct PackageGraph {
     /// across toolchains. Deferred JavaScript production is joined once by
     /// [`Self::ensure_transitive_closures`].
     external_resolution: Mutex<ExternalResolutionKnowledge>,
-    external_dep_to_internal_dependents:
-        OnceLock<HashMap<turborepo_lockfiles::Package, HashSet<PackageNode>>>,
+    /// Lazy reverse index from exact external identities to internal
+    /// dependents. Built once from the resolution generation, not from
+    /// `PackageInfo` compatibility payloads.
+    external_dep_to_internal_dependents: OnceLock<ExternalDependencyIndex>,
     /// Lazily computed internal dependencies of the root package. They are
     /// implied dependencies of every package, so per-package operations like
     /// `dependencies` and `ancestors` consult them on every call; the set is
@@ -330,6 +333,15 @@ pub struct ExternalDependencyChange {
     pub added: Vec<turborepo_lockfiles::Package>,
     /// Dependencies that were removed from the package
     pub removed: Vec<turborepo_lockfiles::Package>,
+}
+
+/// Lazy reverse index from exact external identities to internal dependents.
+#[derive(Debug, Default)]
+struct ExternalDependencyIndex {
+    /// Unique identities retaining producer-supplied display names.
+    identities: Vec<ExternalPackageIdentity>,
+    /// Exact identity -> internal workspace dependents (including transitive).
+    dependents: HashMap<ExternalPackageIdentity, HashSet<PackageNode>>,
 }
 
 impl PackageGraph {
@@ -1240,46 +1252,126 @@ impl PackageGraph {
             .collect()
     }
 
+    /// Unique external package identities from the resolution generation.
+    ///
+    /// Display names are the producer-supplied human names captured during
+    /// observation. This is the query authority for external package listing.
+    pub fn external_package_identities(&self) -> &[ExternalPackageIdentity] {
+        &self.external_dependency_index().identities
+    }
+
+    /// Resolve a lockfile package to the generation identity that shares its
+    /// exact `(key, version)`, retaining any stored human name.
+    pub fn resolve_external_package_identity(
+        &self,
+        package: &turborepo_lockfiles::Package,
+    ) -> Option<&ExternalPackageIdentity> {
+        let needle = ExternalPackageIdentity::new(package.key.clone(), package.version.clone());
+        self.external_dependency_index()
+            .identities
+            .iter()
+            .find(|identity| *identity == &needle)
+    }
+
+    /// JavaScript-domain external identities only. Used by N-API lockfile
+    /// listing which historically filtered through the JS lockfile human-name
+    /// path and therefore excluded Cargo identities.
+    pub fn javascript_external_package_identities(&self) -> Vec<ExternalPackageIdentity> {
+        let Some(generation) = self.resolution_generation() else {
+            return Vec::new();
+        };
+        let mut seen = HashSet::new();
+        let mut identities = Vec::new();
+        for domain in generation.domains() {
+            if domain.toolchain() != &crate::toolchain::ToolchainId::JAVASCRIPT {
+                continue;
+            }
+            let ExternalResolutionData::Resolved { packages, .. } = domain.data() else {
+                continue;
+            };
+            for package in packages {
+                for identity in package.identities() {
+                    if seen.insert(identity.clone()) {
+                        identities.push(identity.clone());
+                    }
+                }
+            }
+        }
+        identities.sort();
+        identities
+    }
+
     pub fn internal_dependencies_for_external_dependency(
         &self,
         external_package: &turborepo_lockfiles::Package,
     ) -> Option<&HashSet<PackageNode>> {
-        // In order to answer this once we have to calculate the info for every external
-        // package so we store the results
-        let map = self
-            .external_dep_to_internal_dependents
-            .get_or_init(|| self.build_external_dep_to_internal_dependents_map());
-        map.get(external_package)
+        let identity = ExternalPackageIdentity::new(
+            external_package.key.clone(),
+            external_package.version.clone(),
+        );
+        self.internal_dependencies_for_external_identity(&identity)
     }
 
-    /// Builds a map from external dependencies to the set of internal workspace
-    /// packages that depend on them (including transitive dependents).
-    fn build_external_dep_to_internal_dependents_map(
+    pub fn internal_dependencies_for_external_identity(
         &self,
-    ) -> HashMap<turborepo_lockfiles::Package, HashSet<PackageNode>> {
-        // TODO: provide size hint from Lockfile trait
-        let mut map: HashMap<turborepo_lockfiles::Package, HashSet<PackageNode>> = HashMap::new();
-        // First find which packages directly depend on each external package
-        for context in self.package_task_contexts() {
-            let Some(info) = context.package_info() else {
-                debug_assert!(
-                    !context.requires_compatibility_payload(),
-                    "builder invariant: required package context has no payload"
-                );
+        identity: &ExternalPackageIdentity,
+    ) -> Option<&HashSet<PackageNode>> {
+        self.external_dependency_index().dependents.get(identity)
+    }
+
+    fn external_dependency_index(&self) -> &ExternalDependencyIndex {
+        self.external_dep_to_internal_dependents
+            .get_or_init(|| self.build_external_dependency_index())
+    }
+
+    fn resolution_generation(&self) -> Option<Arc<ExternalResolutionGeneration>> {
+        self.external_resolution
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .generation
+            .clone()
+    }
+
+    /// Builds a compact reverse index from the resolution generation.
+    fn build_external_dependency_index(&self) -> ExternalDependencyIndex {
+        let Some(generation) = self.resolution_generation() else {
+            return ExternalDependencyIndex::default();
+        };
+
+        let mut dependents: HashMap<ExternalPackageIdentity, HashSet<PackageNode>> = HashMap::new();
+        let mut identity_order: Vec<ExternalPackageIdentity> = Vec::new();
+        let mut seen_identities = HashSet::new();
+        let mut root_external_dependencies = HashSet::new();
+
+        for domain in generation.domains() {
+            let ExternalResolutionData::Resolved { packages, .. } = domain.data() else {
                 continue;
             };
-            for dep in info.transitive_dependencies.iter().flatten() {
-                let rdeps = map.entry((**dep).clone()).or_default();
-                rdeps.insert(PackageNode::Workspace(context.package().clone()));
+            for package_resolution in packages {
+                let workspace = PackageNode::Workspace(PackageName::from(
+                    package_resolution.package().to_string(),
+                ));
+                let is_root = package_resolution.package() == ROOT_PKG_NAME
+                    || package_resolution.package() == "//";
+                for identity in package_resolution.identities() {
+                    if seen_identities.insert(identity.clone()) {
+                        identity_order.push(identity.clone());
+                    }
+                    if is_root {
+                        root_external_dependencies.insert(identity.clone());
+                    }
+                    dependents
+                        .entry(identity.clone())
+                        .or_default()
+                        .insert(workspace.clone());
+                }
             }
         }
-        // Now trace through all ancestors of the direct dependants
+
+        identity_order.sort();
+
         let root_internal_dependencies = self.root_internal_dependencies();
-        let root_external_dependencies =
-            self.transitive_external_dependencies(Some(&PackageName::Root));
-        for (external_pkg, rdeps) in map.iter_mut() {
-            // If one of the reverse dependencies of this external package is a root
-            // dependency, everything depends on this
+        for (external_pkg, rdeps) in dependents.iter_mut() {
             if root_external_dependencies.contains(external_pkg)
                 || !root_internal_dependencies.is_disjoint(rdeps)
             {
@@ -1295,7 +1387,11 @@ impl PackageGraph {
                 rdeps.extend(transitive_rdeps.into_iter().cloned());
             }
         }
-        map
+
+        ExternalDependencyIndex {
+            identities: identity_order,
+            dependents,
+        }
     }
 
     // Returns a map of package name and version for external dependencies
@@ -1835,6 +1931,93 @@ mod test {
             pkg_graph.transitive_external_dependencies([&foo, &bar].iter().copied()),
             HashSet::from_iter(vec![&a, &b, &c,])
         );
+
+        let identities = pkg_graph.external_package_identities();
+        assert_eq!(
+            identities
+                .iter()
+                .map(|identity| (identity.key(), identity.version()))
+                .collect::<HashSet<_>>(),
+            HashSet::from([("key:a", "1"), ("key:b", "1"), ("key:c", "1")])
+        );
+
+        let a_dependents = pkg_graph
+            .internal_dependencies_for_external_dependency(&a)
+            .expect("a should have dependents");
+        assert!(a_dependents.contains(&PackageNode::Workspace(foo.clone())));
+        assert!(!a_dependents.contains(&PackageNode::Workspace(bar.clone())));
+
+        let c_dependents = pkg_graph
+            .internal_dependencies_for_external_identity(&ExternalPackageIdentity::new(
+                "key:c", "1",
+            ))
+            .expect("c should have dependents");
+        assert!(c_dependents.contains(&PackageNode::Workspace(foo)));
+        assert!(c_dependents.contains(&PackageNode::Workspace(bar)));
+    }
+
+    #[tokio::test]
+    async fn external_dependency_reverse_index_is_lazy_and_cached() {
+        let root =
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+        let mut package_jsons = HashMap::new();
+        for index in 0..64 {
+            package_jsons.insert(
+                root.join_components(&[&format!("package_{index}"), "package.json"]),
+                PackageJson::from_value(json!({
+                    "name": format!("pkg-{index}"),
+                    "dependencies": { "a": "1" }
+                }))
+                .unwrap(),
+            );
+        }
+        let pkg_graph = PackageGraph::builder(
+            &root,
+            PackageJson::from_value(json!({ "name": "root" })).unwrap(),
+        )
+        .with_package_discovery(MockDiscovery)
+        .with_package_jsons(Some(package_jsons))
+        .with_lockfile(Some(Box::new(MockLockfile {})))
+        .build()
+        .await
+        .unwrap();
+
+        let start = std::time::Instant::now();
+        let first = pkg_graph
+            .internal_dependencies_for_external_dependency(&turborepo_lockfiles::Package::new(
+                "key:a", "1",
+            ))
+            .expect("reverse index should resolve key:a");
+        let first_elapsed = start.elapsed();
+        assert!(first.len() >= 64);
+
+        let start = std::time::Instant::now();
+        let second = pkg_graph
+            .internal_dependencies_for_external_dependency(&turborepo_lockfiles::Package::new(
+                "key:a", "1",
+            ))
+            .expect("cached reverse index should resolve key:a");
+        let second_elapsed = start.elapsed();
+
+        assert!(std::ptr::eq(first, second));
+        assert!(
+            second_elapsed * 10 < first_elapsed.max(std::time::Duration::from_micros(50)),
+            "cached reverse-index lookup should be much cheaper than the first build \
+             (first={first_elapsed:?}, second={second_elapsed:?})"
+        );
+        assert!(
+            first_elapsed < std::time::Duration::from_secs(2),
+            "reverse-index build took too long: {first_elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn external_package_identity_equality_ignores_human_name() {
+        let left = ExternalPackageIdentity::new("key:a", "1").with_human_name("a@1");
+        let right = ExternalPackageIdentity::new("key:a", "1");
+        assert_eq!(left, right);
+        assert_eq!(left.display_name(), "a@1");
+        assert_eq!(right.display_name(), "key:a");
     }
 
     #[tokio::test]

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -10,7 +10,9 @@ use petgraph::{
     visit::EdgeRef,
 };
 use serde::Serialize;
-use turbopath::{AbsoluteSystemPath, AnchoredSystemPath, AnchoredSystemPathBuf};
+use turbopath::{
+    AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPath, AnchoredSystemPathBuf,
+};
 use turborepo_lockfiles::Lockfile;
 
 use crate::{
@@ -1302,6 +1304,33 @@ impl PackageGraph {
         identities
     }
 
+    /// Global-hash file fallback when JavaScript resolution is unavailable.
+    ///
+    /// Mirrors the historical behavior of hashing `package.json` plus the
+    /// package-manager lockfile path when a lockfile object was not loaded:
+    /// include the repository root `package.json` and any existing resolution
+    /// definition sources from the JavaScript domain.
+    pub fn external_resolution_global_file_fallback(&self) -> Option<Vec<AbsoluteSystemPathBuf>> {
+        let generation = self.resolution_generation()?;
+        let domain = generation
+            .domains()
+            .iter()
+            .find(|domain| domain.toolchain() == &crate::toolchain::ToolchainId::JAVASCRIPT)?;
+        match domain.data() {
+            ExternalResolutionData::Resolved { .. } => None,
+            ExternalResolutionData::Unavailable(_) => {
+                let mut paths = vec![self.repo_root().join_component("package.json")];
+                for source in domain.definition_sources() {
+                    let path = self.repo_root().resolve(source);
+                    if path.exists() {
+                        paths.push(path);
+                    }
+                }
+                Some(paths)
+            }
+        }
+    }
+
     /// Resolve a lockfile package to the generation identity that shares its
     /// exact `(key, version)`, retaining any stored human name.
     pub fn resolve_external_package_identity(
@@ -2142,6 +2171,21 @@ mod test {
                 .package_payloads
                 .get(&PackageName::Root)
                 .is_some_and(|info| info.transitive_dependencies.is_none())
+        );
+
+        let fallback = unavailable
+            .external_resolution_global_file_fallback()
+            .expect("unavailable JS resolution should expose a global file fallback");
+        assert!(
+            fallback
+                .iter()
+                .any(|path| path.file_name() == Some("package.json"))
+        );
+        assert!(
+            resolved
+                .external_resolution_global_file_fallback()
+                .is_none(),
+            "resolved domains must not use the global file fallback"
         );
     }
 

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{HashMap, HashSet},
     fmt,
     sync::{Arc, Mutex, OnceLock},
 };
@@ -43,13 +43,10 @@ pub use crate::package_json::DependencyKind;
 
 pub const ROOT_PKG_NAME: &str = "//";
 
-type DeferredResolutionReceiver = javascript::DeferredResolutionReceiver;
-
 #[derive(Debug)]
 struct ExternalResolutionKnowledge {
     status: ExternalResolutionStatus,
     generation: Option<Arc<ExternalResolutionGeneration>>,
-    receiver: Option<DeferredResolutionReceiver>,
 }
 
 impl ExternalResolutionKnowledge {
@@ -57,7 +54,6 @@ impl ExternalResolutionKnowledge {
         Self {
             status: ExternalResolutionStatus::Complete,
             generation: None,
-            receiver: None,
         }
     }
 
@@ -65,25 +61,7 @@ impl ExternalResolutionKnowledge {
         Self {
             status: ExternalResolutionStatus::Complete,
             generation: Some(generation),
-            receiver: None,
         }
-    }
-
-    fn resolving(receiver: DeferredResolutionReceiver) -> Self {
-        Self {
-            status: ExternalResolutionStatus::Resolving,
-            generation: None,
-            receiver: Some(receiver),
-        }
-    }
-
-    fn take_receiver(&mut self) -> Option<DeferredResolutionReceiver> {
-        self.receiver.take()
-    }
-
-    fn finish(&mut self, generation: Option<Arc<ExternalResolutionGeneration>>) {
-        self.status = ExternalResolutionStatus::Complete;
-        self.generation = generation;
     }
 }
 
@@ -105,9 +83,9 @@ pub struct PackageGraph {
     relationship_knowledge: Arc<RelationshipKnowledge>,
     external_declarations: OnceLock<ExternalDeclarations>,
     relationship_projections: OnceLock<projections::RelationshipProjections>,
-    /// The sole owner of external-resolution lifecycle and terminal knowledge
-    /// across toolchains. Deferred JavaScript production is joined once by
-    /// [`Self::ensure_transitive_closures`].
+    /// The sole owner of external-resolution terminal knowledge across
+    /// toolchains. Resolution is complete when the package graph is returned
+    /// from construction.
     external_resolution: Mutex<ExternalResolutionKnowledge>,
     /// Lazy reverse index from exact external identities to internal
     /// dependents. Built once from the resolution generation, not from
@@ -146,11 +124,12 @@ impl WorkspacePackage {
     }
 }
 
-/// Compatibility data retained for descriptor relationship classification,
-/// JavaScript lockfile resolution/hash state, and task consumers.
+/// Compatibility data retained for descriptor relationship classification
+/// and task consumers.
 ///
-/// Package identity, directory ownership, definition source, and provenance
-/// are authoritative in [`RepositoryKnowledge`], not in this projection.
+/// Package identity, directory ownership, definition source, provenance, and
+/// external-resolution state are authoritative in repository knowledge, not in
+/// this projection.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct PackageInfo {
     /// A temporary compatibility descriptor for relationship classification
@@ -158,20 +137,7 @@ pub struct PackageInfo {
     /// Its native `name` may be retained for later payload semantics, but must
     /// never be used as package identity or to derive paths or provenance.
     pub package_json: PackageJson,
-    pub unresolved_external_dependencies: Option<BTreeMap<PackageKey, PackageVersion>>, /* name -> version */
-    /// The workspace's external dependency closure, sorted by `Package`'s
-    /// `(key, version)` ordering. Members are `Arc`-shared across workspaces.
-    pub transitive_dependencies: Option<Vec<Arc<turborepo_lockfiles::Package>>>,
-    /// Hash of `transitive_dependencies`, precomputed by the JavaScript
-    /// lockfile phase so task hashing and run summaries never re-sort or
-    /// re-hash closures. When `None` with a `Some` closure (toolchain-
-    /// resolved closures, e.g. Cargo's), consumers compute the hash from
-    /// the sorted closure on demand.
-    pub external_deps_hash: Option<String>,
 }
-
-type PackageKey = String;
-type PackageVersion = String;
 
 // PackageName refers to a real package's name or the root package.
 // It's not the best name, because root isn't a real package, but it's
@@ -843,48 +809,6 @@ impl PackageGraph {
         self.lockfile.as_deref()
     }
 
-    /// Join the background transitive-closure computation (if the graph was
-    /// built with deferred closures) and install the results. Idempotent and
-    /// cheap when there is nothing to join. Must be called before any
-    /// consumer of `PackageInfo::transitive_dependencies` runs.
-    pub fn ensure_transitive_closures(&mut self) {
-        let receiver = self
-            .external_resolution
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .take_receiver();
-        let Some(receiver) = receiver else {
-            return;
-        };
-        match receiver.recv() {
-            Ok(Ok(mut snapshot)) => {
-                if let Some(warning) = snapshot.warning.take() {
-                    tracing::warn!("Unable to calculate transitive closures: {}", warning);
-                }
-                let generation = Arc::clone(&snapshot.generation);
-                snapshot.project_legacy(&mut self.package_payloads, &self.knowledge);
-                self.external_resolution
-                    .lock()
-                    .unwrap_or_else(|poisoned| poisoned.into_inner())
-                    .finish(Some(generation));
-            }
-            Ok(Err(e)) => {
-                tracing::warn!("Unable to calculate transitive closures: {}", e);
-                self.external_resolution
-                    .lock()
-                    .unwrap_or_else(|poisoned| poisoned.into_inner())
-                    .finish(None);
-            }
-            Err(_) => {
-                tracing::warn!("transitive closure thread disappeared without a result");
-                self.external_resolution
-                    .lock()
-                    .unwrap_or_else(|poisoned| poisoned.into_inner())
-                    .finish(None);
-            }
-        }
-    }
-
     pub fn external_resolution_status(&self) -> ExternalResolutionStatus {
         self.external_resolution
             .lock()
@@ -1241,19 +1165,6 @@ impl PackageGraph {
         visited
     }
 
-    pub fn transitive_external_dependencies<'a, I: IntoIterator<Item = &'a PackageName>>(
-        &self,
-        packages: I,
-    ) -> HashSet<&turborepo_lockfiles::Package> {
-        packages
-            .into_iter()
-            .filter_map(|package| self.package_payloads.get(package))
-            .filter_map(|entry| entry.transitive_dependencies.as_ref())
-            .flatten()
-            .map(|pkg| &**pkg)
-            .collect()
-    }
-
     /// Unique external package identities from the resolution generation.
     ///
     /// Display names are the producer-supplied human names captured during
@@ -1264,7 +1175,7 @@ impl PackageGraph {
 
     /// Exact external identities attributed to the given packages by the
     /// resolution generation. Used by prune lockfile-key unions so they no
-    /// longer read `PackageInfo::transitive_dependencies`.
+    /// read resolution generation identities.
     pub fn external_package_identities_for_packages<'a, I>(
         &self,
         packages: I,
@@ -1464,16 +1375,6 @@ impl PackageGraph {
             dependents,
         }
     }
-
-    // Returns a map of package name and version for external dependencies
-    #[allow(dead_code)]
-    fn external_dependencies(
-        &self,
-        package: &PackageName,
-    ) -> Option<&BTreeMap<PackageKey, PackageVersion>> {
-        let entry = self.package_payloads.get(package)?;
-        entry.unresolved_external_dependencies.as_ref()
-    }
 }
 
 impl fmt::Display for PackageName {
@@ -1519,7 +1420,7 @@ impl AsRef<str> for PackageName {
 
 #[cfg(test)]
 mod test {
-    use std::{fs, path::Path, process::Command};
+    use std::{collections::BTreeMap, fs, path::Path, process::Command};
 
     use serde_json::json;
     use turbopath::AbsoluteSystemPathBuf;
@@ -1847,13 +1748,16 @@ mod test {
             .iter()
             .collect::<HashSet<_>>()
         );
-        let b_external = pkg_graph
-            .package_payloads
-            .get(&PackageName::from("b"))
-            .unwrap()
-            .unresolved_external_dependencies
-            .as_ref()
-            .unwrap();
+        let b_external: std::collections::BTreeMap<_, _> = pkg_graph
+            .external_declarations(&PackageName::from("b"))
+            .iter()
+            .map(|declaration| {
+                (
+                    declaration.package_name().to_string(),
+                    declaration.specifier().to_string(),
+                )
+            })
+            .collect();
 
         let pkg_version = b_external.get("c").unwrap();
         assert_eq!(pkg_version, "1.2.3");
@@ -1978,30 +1882,9 @@ mod test {
         let foo = PackageName::from("foo");
         let bar = PackageName::from("bar");
 
-        let foo_deps = pkg_graph
-            .package_payloads
-            .get(&foo)
-            .unwrap()
-            .transitive_dependencies
-            .as_ref()
-            .unwrap();
-        let bar_deps = pkg_graph
-            .package_payloads
-            .get(&bar)
-            .unwrap()
-            .transitive_dependencies
-            .as_ref()
-            .unwrap();
         let a = turborepo_lockfiles::Package::new("key:a", "1");
-        let b = turborepo_lockfiles::Package::new("key:b", "1");
-        let c = turborepo_lockfiles::Package::new("key:c", "1");
-        // Closures are sorted by (key, version).
-        assert_eq!(foo_deps, &vec![Arc::new(a.clone()), Arc::new(c.clone())]);
-        assert_eq!(bar_deps, &vec![Arc::new(b.clone()), Arc::new(c.clone())]);
-        assert_eq!(
-            pkg_graph.transitive_external_dependencies([&foo, &bar].iter().copied()),
-            HashSet::from_iter(vec![&a, &b, &c,])
-        );
+        let _b = turborepo_lockfiles::Package::new("key:b", "1");
+        let _c = turborepo_lockfiles::Package::new("key:c", "1");
 
         let identities = pkg_graph.external_package_identities();
         assert_eq!(
@@ -2144,12 +2027,10 @@ mod test {
         assert_eq!(packages.len(), 1);
         assert_eq!(packages[0].package(), ROOT_PKG_NAME);
         assert!(packages[0].identities().is_empty());
-        assert_eq!(
+        assert!(
             resolved
-                .package_payloads
-                .get(&PackageName::Root)
-                .and_then(|info| info.transitive_dependencies.as_deref()),
-            Some(&[][..])
+                .external_package_identities_for_packages([&PackageName::Root])
+                .is_empty()
         );
 
         let unavailable = PackageGraph::builder(&root, root_package())
@@ -2168,9 +2049,8 @@ mod test {
         assert_eq!(reason.code(), "lockfile-unavailable");
         assert!(
             unavailable
-                .package_payloads
-                .get(&PackageName::Root)
-                .is_some_and(|info| info.transitive_dependencies.is_none())
+                .external_resolution_global_file_fallback()
+                .is_some()
         );
 
         let fallback = unavailable
@@ -2187,127 +2067,6 @@ mod test {
                 .is_none(),
             "resolved domains must not use the global file fallback"
         );
-    }
-
-    /// A graph built with deferred closures must, after
-    /// `ensure_transitive_closures`, be indistinguishable from one built
-    /// inline.
-    #[tokio::test]
-    async fn test_deferred_closures_match_inline() {
-        let root =
-            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
-        let package_jsons = || {
-            let mut map = HashMap::new();
-            map.insert(
-                root.join_components(&["package_a", "package.json"]),
-                PackageJson::from_value(json!({
-                    "name": "foo",
-                    "dependencies": { "a": "1" }
-                }))
-                .unwrap(),
-            );
-            map.insert(
-                root.join_components(&["package_b", "package.json"]),
-                PackageJson::from_value(json!({
-                    "name": "bar",
-                    "dependencies": { "b": "1" }
-                }))
-                .unwrap(),
-            );
-            map
-        };
-        let hasher: crate::package_graph::builder::ClosureHasher = Arc::new(|closures| {
-            closures
-                .iter()
-                .map(|(package, identities)| {
-                    let fingerprint = identities
-                        .iter()
-                        .map(|identity| format!("{}@{}", identity.key, identity.version))
-                        .collect::<Vec<_>>()
-                        .join(",");
-                    (package.clone(), fingerprint)
-                })
-                .collect()
-        });
-
-        let inline = PackageGraph::builder(
-            &root,
-            PackageJson::from_value(json!({ "name": "root" })).unwrap(),
-        )
-        .with_package_discovery(MockDiscovery)
-        .with_package_jsons(Some(package_jsons()))
-        .with_lockfile(Some(Box::new(MockLockfile {})))
-        .with_closure_hasher(hasher.clone())
-        .build()
-        .await
-        .unwrap();
-
-        let mut deferred = PackageGraph::builder(
-            &root,
-            PackageJson::from_value(json!({ "name": "root" })).unwrap(),
-        )
-        .with_package_discovery(MockDiscovery)
-        .with_package_jsons(Some(package_jsons()))
-        .with_lockfile(Some(Box::new(MockLockfile {})))
-        .defer_transitive_closures(true)
-        .with_closure_hasher(hasher)
-        .build()
-        .await
-        .unwrap();
-
-        assert_eq!(
-            inline.external_resolution_status(),
-            ExternalResolutionStatus::Complete
-        );
-        assert_eq!(
-            deferred.external_resolution_status(),
-            ExternalResolutionStatus::Resolving
-        );
-        let inline_generation = inline
-            .external_resolution_generation()
-            .expect("inline resolution should be available");
-        assert_eq!(inline_generation.domains().len(), 1);
-
-        // Before the join, closures are absent.
-        assert!(
-            deferred
-                .package_payloads
-                .values()
-                .all(|info| info.transitive_dependencies.is_none()),
-            "deferred graph must not have closures before ensure"
-        );
-
-        deferred.ensure_transitive_closures();
-        // Idempotent.
-        deferred.ensure_transitive_closures();
-
-        assert_eq!(
-            deferred.external_resolution_status(),
-            ExternalResolutionStatus::Complete
-        );
-        assert_eq!(
-            inline_generation,
-            deferred
-                .external_resolution_generation()
-                .expect("deferred resolution should be available after joining")
-        );
-
-        for (name, info) in &inline.package_payloads {
-            let deferred_info = deferred.package_payloads.get(name).unwrap();
-            assert_eq!(
-                info.transitive_dependencies, deferred_info.transitive_dependencies,
-                "closures must match for {name}"
-            );
-            assert_eq!(
-                info.external_deps_hash, deferred_info.external_deps_hash,
-                "external deps hashes must match for {name}"
-            );
-            assert_eq!(
-                info.external_deps_hash.is_some(),
-                info.transitive_dependencies.is_some(),
-                "hash must be present exactly when the closure is, for {name}"
-            );
-        }
     }
 
     #[tokio::test]
@@ -2798,7 +2557,7 @@ version = "0.1.0"
         // process/build.
         let mut expected_cargo_fingerprint = None;
         for iteration in 0..8 {
-            let defer_resolution = iteration % 2 == 1;
+            let _defer_resolution = iteration % 2 == 1;
             let mut pkg_graph = PackageGraph::builder(
                 &root,
                 PackageJson::from_value(json!({ "name": "root", "dependencies": { "a": "1" } }))
@@ -2815,11 +2574,9 @@ version = "0.1.0"
             }))
             .with_lockfile(Some(Box::new(MockLockfile {})))
             .with_toolchain(crate::cargo::CargoToolchain::new(root.clone()))
-            .defer_transitive_closures(defer_resolution)
             .build()
             .await
             .unwrap();
-            pkg_graph.ensure_transitive_closures();
 
             assert!(pkg_graph.validate().is_ok());
             assert!(pkg_graph.package_task_contexts().all(|context| {
@@ -2850,7 +2607,7 @@ version = "0.1.0"
                 pkg_graph.package_toolchain(&PackageName::from("js-pkg")),
                 Some(&crate::toolchain::ToolchainId::JAVASCRIPT)
             );
-            let workspace_pkg = pkg_graph.package_info(&PackageName::from("acme")).unwrap();
+            let _workspace_pkg = pkg_graph.package_info(&PackageName::from("acme")).unwrap();
             assert_eq!(
                 pkg_graph.package_toolchain(&PackageName::from("acme")),
                 Some(&crate::toolchain::ToolchainId::RUST)
@@ -2946,34 +2703,20 @@ version = "0.1.0"
                 "workspace package should depend on every crate, got {workspace_deps:?}"
             );
 
-            // The root's JS lockfile closure is attributed to the root, not
-            // stolen by the cargo workspace package sharing its directory.
-            let root_closure = pkg_graph
-                .package_info(&PackageName::Root)
-                .unwrap()
-                .transitive_dependencies
-                .as_ref()
-                .expect("root should have a lockfile closure");
-            // Closures are sorted by (key, version).
+            // The root's JS resolution identities are attributed to the root
+            // package, not stolen by the Cargo workspace package sharing its
+            // directory.
+            let root_identities =
+                pkg_graph.external_package_identities_for_packages([&PackageName::Root]);
             assert_eq!(
-                root_closure,
-                &vec![
-                    Arc::new(turborepo_lockfiles::Package::new("key:a", "1")),
-                    Arc::new(turborepo_lockfiles::Package::new("key:c", "1")),
-                ],
-            );
-            // Cargo packages carry toolchain-resolved closures (here just
-            // the rustc stamp — the fixture has no external dependencies),
-            // never JS lockfile entries.
-            assert!(
-                workspace_pkg
-                    .transitive_dependencies
+                root_identities
                     .iter()
-                    .flatten()
-                    .all(|package| package.key == "rustc"),
-                "the cargo workspace package must not carry JS lockfile entries, got {:?}",
-                workspace_pkg.transitive_dependencies
+                    .map(|identity| (identity.key(), identity.version()))
+                    .collect::<Vec<_>>(),
+                vec![("key:a", "1"), ("key:c", "1")],
             );
+            // Cargo packages contribute identities through the Rust resolution
+            // domain, never JS lockfile entries.
 
             let resolution = pkg_graph
                 .external_resolution_generation()
@@ -3012,19 +2755,15 @@ version = "0.1.0"
                     "{} must include the compiler identity",
                     package.package()
                 );
-                let legacy: HashSet<_> = pkg_graph
-                    .package_info(&PackageName::from(package.package()))
-                    .and_then(|info| info.transitive_dependencies.as_ref())
-                    .into_iter()
-                    .flatten()
-                    .map(|identity| (identity.key.as_str(), identity.version.as_str()))
-                    .collect();
-                let normalized: HashSet<_> = package
-                    .identities()
-                    .iter()
-                    .map(|identity| (identity.key(), identity.version()))
-                    .collect();
-                assert_eq!(normalized, legacy);
+                assert!(
+                    package
+                        .identities()
+                        .iter()
+                        .all(|identity| identity.key() == "rustc"),
+                    "{} should only carry the compiler identity in this fixture, got {:?}",
+                    package.package(),
+                    package.identities()
+                );
             }
         }
     }

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -1260,6 +1260,48 @@ impl PackageGraph {
         &self.external_dependency_index().identities
     }
 
+    /// Exact external identities attributed to the given packages by the
+    /// resolution generation. Used by prune lockfile-key unions so they no
+    /// longer read `PackageInfo::transitive_dependencies`.
+    pub fn external_package_identities_for_packages<'a, I>(
+        &self,
+        packages: I,
+    ) -> Vec<ExternalPackageIdentity>
+    where
+        I: IntoIterator<Item = &'a PackageName>,
+    {
+        let wanted: HashSet<&str> = packages.into_iter().map(PackageName::as_str).collect();
+        if wanted.is_empty() {
+            return Vec::new();
+        }
+        let Some(generation) = self.resolution_generation() else {
+            return Vec::new();
+        };
+
+        let mut seen = HashSet::new();
+        let mut identities = Vec::new();
+        for domain in generation.domains() {
+            let ExternalResolutionData::Resolved {
+                packages: resolved, ..
+            } = domain.data()
+            else {
+                continue;
+            };
+            for package in resolved {
+                if !wanted.contains(package.package()) {
+                    continue;
+                }
+                for identity in package.identities() {
+                    if seen.insert(identity.clone()) {
+                        identities.push(identity.clone());
+                    }
+                }
+            }
+        }
+        identities.sort();
+        identities
+    }
+
     /// Resolve a lockfile package to the generation identity that shares its
     /// exact `(key, version)`, retaining any stored human name.
     pub fn resolve_external_package_identity(
@@ -1952,8 +1994,25 @@ mod test {
                 "key:c", "1",
             ))
             .expect("c should have dependents");
-        assert!(c_dependents.contains(&PackageNode::Workspace(foo)));
-        assert!(c_dependents.contains(&PackageNode::Workspace(bar)));
+        assert!(c_dependents.contains(&PackageNode::Workspace(foo.clone())));
+        assert!(c_dependents.contains(&PackageNode::Workspace(bar.clone())));
+
+        let foo_identities = pkg_graph.external_package_identities_for_packages([&foo]);
+        assert_eq!(
+            foo_identities
+                .iter()
+                .map(|identity| (identity.key(), identity.version()))
+                .collect::<Vec<_>>(),
+            vec![("key:a", "1"), ("key:c", "1")]
+        );
+        let bar_identities = pkg_graph.external_package_identities_for_packages([&bar]);
+        assert_eq!(
+            bar_identities
+                .iter()
+                .map(|identity| identity.key())
+                .collect::<HashSet<_>>(),
+            HashSet::from(["key:b", "key:c"])
+        );
     }
 
     #[tokio::test]

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -149,6 +149,7 @@ pub(crate) struct DiscoveredPackageParts {
     pub scope_kind: DiscoveredScopeKind,
     pub descriptor: PackageJson,
     pub manifest_path: AbsoluteSystemPathBuf,
+    #[allow(dead_code)]
     pub external_dependencies: Option<std::collections::HashSet<turborepo_lockfiles::Package>>,
     pub native_relationships: Option<Vec<Relationship>>,
 }
@@ -1291,7 +1292,6 @@ mod tests {
                 "scripts": { "build": "next build", "empty": "" }
             }))
             .unwrap(),
-            ..Default::default()
         };
         let package_directory = turbopath::AnchoredSystemPath::new("apps/web").unwrap();
         let context = crate::package_graph::PackageTaskContext::new_for_test(

--- a/crates/turborepo-task-hash/src/global_hash.rs
+++ b/crates/turborepo-task-hash/src/global_hash.rs
@@ -11,7 +11,6 @@ use tracing::debug;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, RelativeUnixPathBuf};
 use turborepo_env::{DetailedMap, EnvironmentVariableMap, get_global_hashable_env_vars};
 use turborepo_hash::{GlobalHashable, TurboHash};
-use turborepo_lockfiles::Lockfile;
 use turborepo_repository::{
     package_graph::PackageInfo,
     package_manager::{self, PackageManager},
@@ -62,13 +61,13 @@ pub struct GlobalHashableInputs<'a> {
 }
 
 #[allow(clippy::too_many_arguments, clippy::result_large_err)]
-pub fn get_global_hash_inputs<'a, L: ?Sized + Lockfile>(
+pub fn get_global_hash_inputs<'a>(
     root_external_dependencies_hash: Option<&'a str>,
     root_internal_dependencies_hash: Option<&'a str>,
     root_package: &'a PackageInfo,
     root_path: &AbsoluteSystemPath,
     package_manager: Option<&PackageManager>,
-    lockfile: Option<&L>,
+    resolution_file_fallback: &[AbsoluteSystemPathBuf],
     global_file_dependencies: &'a [String],
     env_at_execution_start: &'a EnvironmentVariableMap,
     global_env: &'a [String],
@@ -86,7 +85,7 @@ pub fn get_global_hash_inputs<'a, L: ?Sized + Lockfile>(
         root_package,
         root_path,
         package_manager,
-        lockfile,
+        resolution_file_fallback,
         global_file_dependencies,
         env_at_execution_start,
         global_env,
@@ -129,15 +128,16 @@ pub struct GlobalFileHashInputs<'a> {
 /// can be run concurrently with package file hashing and internal deps
 /// hashing since it has no dependencies on those results.
 #[allow(clippy::too_many_arguments, clippy::result_large_err)]
-pub fn collect_global_file_hash_inputs<'a, L: ?Sized + Lockfile>(
+pub fn collect_global_file_hash_inputs<'a>(
     root_package: &'a PackageInfo,
     root_path: &AbsoluteSystemPath,
     // Absent for a pure Cargo workspace: there is no JavaScript package
-    // manager, root manifest, or lockfile to fold into the global hash. The
-    // Cargo lockfile and manifest are hashed per-task through the toolchain's
-    // derived inputs instead.
+    // manager to enumerate workspace exclusions for `globalDependencies`.
     package_manager: Option<&PackageManager>,
-    lockfile: Option<&L>,
+    // When JavaScript resolution is unavailable, hash the resolution
+    // definition sources (typically the lockfile path) and root package.json
+    // instead of folding lockfile contents into the external fingerprint.
+    resolution_file_fallback: &[AbsoluteSystemPathBuf],
     global_file_dependencies: &'a [String],
     env_at_execution_start: &'a EnvironmentVariableMap,
     global_env: &'a [String],
@@ -156,17 +156,8 @@ pub fn collect_global_file_hash_inputs<'a, L: ?Sized + Lockfile>(
     let mut global_deps =
         collect_global_deps(package_manager, root_path, global_file_dependencies)?;
 
-    // The root package.json and the JavaScript lockfile are global inputs
-    // only when there is a JavaScript project. A pure Cargo workspace has
-    // neither.
-    if let Some(package_manager) = package_manager
-        && lockfile.is_none()
-    {
-        global_deps.insert(root_path.join_component("package.json"));
-        let lockfile_path = package_manager.lockfile_path(root_path);
-        if lockfile_path.exists() {
-            global_deps.insert(lockfile_path);
-        }
+    for path in resolution_file_fallback {
+        global_deps.insert(path.clone());
     }
 
     // .gitattributes drives CRLF→LF normalization which affects file hashes.
@@ -395,7 +386,6 @@ impl<'a> GlobalHashInputsTrait for GlobalHashableInputs<'a> {
 mod tests {
     use turbopath::AbsoluteSystemPathBuf;
     use turborepo_env::EnvironmentVariableMap;
-    use turborepo_lockfiles::Lockfile;
     use turborepo_repository::{package_graph::PackageInfo, package_manager::PackageManager};
     use turborepo_scm::SCM;
     use turborepo_types::EnvMode;
@@ -419,7 +409,7 @@ mod tests {
 
         let env_var_map = EnvironmentVariableMap::default();
         let package_info = PackageInfo::default();
-        let lockfile: Option<&dyn Lockfile> = None;
+        let fallback = [root.join_component("package.json")];
         #[cfg(windows)]
         let file_deps = ["C:\\some\\path".to_string()];
         #[cfg(not(windows))]
@@ -430,7 +420,7 @@ mod tests {
             &package_info,
             &root,
             Some(&PackageManager::Pnpm),
-            lockfile,
+            &fallback,
             &file_deps,
             &env_var_map,
             &[],

--- a/crates/turborepo-task-hash/src/lib.rs
+++ b/crates/turborepo-task-hash/src/lib.rs
@@ -801,21 +801,6 @@ pub fn deferred_task_hash_message(inputs: &TaskInputs) -> &'static str {
     }
 }
 
-pub fn get_external_deps_hash(
-    transitive_dependencies: &Option<Vec<Arc<turborepo_lockfiles::Package>>>,
-) -> String {
-    let Some(transitive_dependencies) = transitive_dependencies else {
-        return "".into();
-    };
-
-    // The closure is already sorted by `Package`'s `(key, version)` ordering,
-    // so hashing is a single linear pass.
-    let transitive_deps: Vec<&turborepo_lockfiles::Package> =
-        transitive_dependencies.iter().map(|pkg| &**pkg).collect();
-
-    LockFilePackagesRef(transitive_deps).hash()
-}
-
 /// Produce byte-compatible fingerprints once from normalized resolution sets.
 pub fn hash_sorted_closures(
     closures: &HashMap<String, Vec<Arc<turborepo_lockfiles::Package>>>,
@@ -1856,91 +1841,9 @@ mod test {
         assert_eq!(result[3].1, "dddddddddddddddddddddddddddddddddddddddd");
     }
 
-    fn sorted_closure(
-        packages: Vec<turborepo_lockfiles::Package>,
-    ) -> Vec<Arc<turborepo_lockfiles::Package>> {
-        let mut closure: Vec<Arc<turborepo_lockfiles::Package>> =
-            packages.into_iter().map(Arc::new).collect();
-        closure.sort_unstable();
-        closure
-    }
-
-    #[test]
-    fn test_external_deps_hash_deterministic() {
-        use turborepo_lockfiles::Package;
-
-        let deps = sorted_closure(vec![
-            Package {
-                key: "react".to_string(),
-                version: "18.0.0".to_string(),
-            },
-            Package {
-                key: "lodash".to_string(),
-                version: "4.17.21".to_string(),
-            },
-            Package {
-                key: "typescript".to_string(),
-                version: "5.0.0".to_string(),
-            },
-        ]);
-
-        let hash1 = get_external_deps_hash(&Some(deps.clone()));
-        let hash2 = get_external_deps_hash(&Some(deps));
-        assert_eq!(hash1, hash2, "same deps should produce same hash");
-        assert!(!hash1.is_empty(), "hash should be non-empty");
-    }
-
-    #[test]
-    fn test_external_deps_hash_empty() {
-        let hash_none = get_external_deps_hash(&None);
-        assert_eq!(hash_none, "", "None deps should produce empty hash");
-
-        let hash_empty = get_external_deps_hash(&Some(Vec::new()));
-        assert_eq!(hash_empty, "459c029558afe716");
-    }
-
     /// The linear hash of a pre-sorted closure must be byte-identical to the
     /// legacy path, which collected a `HashSet` and sorted by
     /// `(key, version)` before hashing.
-    #[test]
-    fn test_external_deps_hash_matches_legacy_sort_then_hash() {
-        use turborepo_lockfiles::Package;
-
-        let packages = vec![
-            Package {
-                key: "b".to_string(),
-                version: "2.0".to_string(),
-            },
-            Package {
-                key: "a".to_string(),
-                version: "1.1".to_string(),
-            },
-            Package {
-                key: "a".to_string(),
-                version: "1.0".to_string(),
-            },
-            Package {
-                key: "c".to_string(),
-                version: "0.1".to_string(),
-            },
-        ];
-
-        let legacy_hash = {
-            let set: HashSet<Package> = packages.iter().cloned().collect();
-            let mut refs: Vec<&Package> = set.iter().collect();
-            refs.sort_unstable_by(|a, b| match a.key.cmp(&b.key) {
-                std::cmp::Ordering::Equal => a.version.cmp(&b.version),
-                other => other,
-            });
-            LockFilePackagesRef(refs).hash()
-        };
-
-        let sorted_hash = get_external_deps_hash(&Some(sorted_closure(packages)));
-        assert_eq!(
-            legacy_hash, sorted_hash,
-            "sorted-closure hash must match the legacy sort-then-hash path"
-        );
-    }
 
     #[test]
     fn test_tracker_pre_sized_hashmaps() {

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -162,13 +162,19 @@ Represents the workspace structure and package dependencies:
   single resolution owner tracks lifecycle status. Task hashing and run/task
   summaries (including OpenTelemetry external-input attributes) consume the
   same stored byte-compatible package resolution fingerprint and preserve
-  explicit unavailable states without closure fallback hashing. The JavaScript
+  explicit unavailable states without closure fallback hashing. Query external
+  package listing, human names, and internal-dependent reverse indexes read
+  the same resolution generation (including a lazy compact reverse index)
+  rather than `PackageInfo` closures or live lockfile human-name callbacks.
+  N-API JavaScript lockfile package listing uses the JavaScript domain of that
+  generation. The JavaScript
   adapter owns package-manager configuration, previous-lockfile parsing, and
   resolution through the same producer used at graph construction. Core
   compares the resulting normalized package identities without parser or
   ecosystem knowledge; unavailable, parse, and comparison failures retain the
   conservative all-packages fallback. The snapshot projects temporary
-  `PackageInfo` closure/hash fields for the remaining global-hash migration.
+  `PackageInfo` closure/hash fields for the remaining prune and global-hash
+  migrations.
   Framework inference and boundaries validation consume the package-scoped
   declaration projection directly;
   aliases, duplicate

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -175,8 +175,11 @@ Represents the workspace structure and package dependencies:
   conservative all-packages fallback. Prune lockfile-key unions also consume
   exact per-package resolution identities for retained JavaScript workspaces,
   while external-peer closure expansion still consults the lockfile directly.
-  The snapshot projects temporary `PackageInfo` closure/hash fields for the
-  remaining global-hash migration.
+  Global hashing consumes the same root resolution fingerprint as task hashing
+  and, when JavaScript resolution is unavailable, hashes resolution definition
+  sources plus the root package.json instead of reading the singleton lockfile
+  object. The snapshot projects temporary `PackageInfo` closure/hash fields only
+  until the Phase 3 deletion gate removes them.
   Framework inference and boundaries validation consume the package-scoped
   declaration projection directly;
   aliases, duplicate

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -178,9 +178,11 @@ Represents the workspace structure and package dependencies:
   Global hashing consumes the same root resolution fingerprint as task hashing
   and, when JavaScript resolution is unavailable, hashes resolution definition
   sources plus the root package.json instead of reading the singleton lockfile
-  object. Phase 3 deletion removed `PackageInfo` closure/hash compatibility
+  object.   Phase 3 deletion removed `PackageInfo` closure/hash compatibility
   fields and deferred resolution installation; readiness belongs to repository
-  construction.
+  construction. External declaration consumers (frameworks, boundaries, task
+  hashing) read the authoritative `ExternalDeclarations` projection built from
+  relationship knowledge rather than raw manifests or PackageInfo maps.
   Framework inference and boundaries validation consume the package-scoped
   declaration projection directly;
   aliases, duplicate

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -178,8 +178,9 @@ Represents the workspace structure and package dependencies:
   Global hashing consumes the same root resolution fingerprint as task hashing
   and, when JavaScript resolution is unavailable, hashes resolution definition
   sources plus the root package.json instead of reading the singleton lockfile
-  object. The snapshot projects temporary `PackageInfo` closure/hash fields only
-  until the Phase 3 deletion gate removes them.
+  object. Phase 3 deletion removed `PackageInfo` closure/hash compatibility
+  fields and deferred resolution installation; readiness belongs to repository
+  construction.
   Framework inference and boundaries validation consume the package-scoped
   declaration projection directly;
   aliases, duplicate
@@ -212,7 +213,7 @@ The remaining payload deletion phases are explicit:
 - **Phase 2:** Move script and version reads behind task queries; normalized
   relationship knowledge now owns graph assembly, while JavaScript declarations
   remain a temporary classification input.
-- **Phase 3:** Move unresolved dependency and lockfile-closure/hash state behind lockfile and hashing queries.
+- **Phase 3:** Complete. External resolution lives in the immutable generation; query, prune, hashing, and summaries consume it. `PackageInfo` no longer carries `unresolved_external_dependencies`, `transitive_dependencies`, or `external_deps_hash`, and deferred closure installation is gone.
 - **Phase 4:** Delete `PackageInfo`, its payload map, and optional-payload compatibility plumbing once all fail-closed consumers use those queries.
 
 Task hashing, run-cache path construction, and run-summary task directories use

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -172,9 +172,11 @@ Represents the workspace structure and package dependencies:
   resolution through the same producer used at graph construction. Core
   compares the resulting normalized package identities without parser or
   ecosystem knowledge; unavailable, parse, and comparison failures retain the
-  conservative all-packages fallback. The snapshot projects temporary
-  `PackageInfo` closure/hash fields for the remaining prune and global-hash
-  migrations.
+  conservative all-packages fallback. Prune lockfile-key unions also consume
+  exact per-package resolution identities for retained JavaScript workspaces,
+  while external-peer closure expansion still consults the lockfile directly.
+  The snapshot projects temporary `PackageInfo` closure/hash fields for the
+  remaining global-hash migration.
   Framework inference and boundaries validation consume the package-scoped
   declaration projection directly;
   aliases, duplicate

--- a/packages/turbo-repository/rust/src/lib.rs
+++ b/packages/turbo-repository/rust/src/lib.rs
@@ -177,32 +177,22 @@ impl Workspace {
         Ok(map)
     }
 
-    /// Returns all external packages from the lockfile as
-    /// `npm/<name>@<version>` strings. Collects the transitive external
-    /// dependencies of every workspace package and formats them using the
-    /// lockfile's human-readable name.
+    /// Returns all external packages from the JavaScript resolution domain as
+    /// `npm/<name>@<version>` strings. Names come from producer-supplied
+    /// human names on the resolution generation; Cargo identities are
+    /// excluded to preserve the historical lockfile-only listing.
     #[napi]
     pub async fn packages_from_lockfile(&self) -> Result<Vec<String>, napi::Error> {
-        let lockfile = self
-            .graph
-            .lockfile()
-            .ok_or_else(|| napi::Error::from_reason("No lockfile found"))?;
+        let identities = self.graph.javascript_external_package_identities();
+        if identities.is_empty() && self.graph.lockfile().is_none() {
+            return Err(napi::Error::from_reason("No lockfile found"));
+        }
 
-        let mut seen = HashSet::new();
-        let mut result: Vec<String> = self
-            .graph
-            .package_task_contexts()
-            .filter_map(|context| {
-                let info = context.package_info();
-                debug_assert!(
-                    info.is_some() || !context.requires_compatibility_payload(),
-                    "builder invariant: required package context has no payload"
-                );
-                info.and_then(|info| info.transitive_dependencies.as_ref())
-            })
-            .flatten()
-            .filter(|pkg| seen.insert(&pkg.key))
-            .filter_map(|pkg| lockfile.human_name(pkg).map(|name| format!("npm/{name}")))
+        let mut seen_keys = HashSet::new();
+        let mut result: Vec<String> = identities
+            .into_iter()
+            .filter(|identity| seen_keys.insert(identity.key().to_string()))
+            .filter_map(|identity| identity.human_name().map(|name| format!("npm/{name}")))
             .collect();
 
         result.sort();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Stack

This PR is the tip of the multi-language Phase 3 stack on `shew/multi-language-repo-architecture-0a20`.

| Layer | Issue | Named branch | Commit |
|---|---|---|---|
| 1 | TURBO-5811 | `shew/turbo-5811-migrate-external-package-queries` | `2b6d9869eb` |
| 2 | TURBO-5812 | `shew/turbo-5812-migrate-prune-external-closures` | `8331628e02` |
| 3 | TURBO-5813 | `shew/turbo-5813-migrate-global-external-hash-inputs` | `a4d776ad37` |
| 4 | TURBO-5814 | `shew/turbo-5814-delete-legacy-external-resolution-state` | `272ab47a7c` |
| 5 | TURBO-5825 | `shew/turbo-5825-remove-external-declaration-compatibility-paths` | `d436afe407` |

Layer compares:
- [5812](https://github.com/vercel/turborepo/compare/shew/turbo-5811-migrate-external-package-queries...shew/turbo-5812-migrate-prune-external-closures)
- [5813](https://github.com/vercel/turborepo/compare/shew/turbo-5812-migrate-prune-external-closures...shew/turbo-5813-migrate-global-external-hash-inputs)
- [5814](https://github.com/vercel/turborepo/compare/shew/turbo-5813-migrate-global-external-hash-inputs...shew/turbo-5814-delete-legacy-external-resolution-state)
- [5825](https://github.com/vercel/turborepo/compare/shew/turbo-5814-delete-legacy-external-resolution-state...shew/turbo-5825-remove-external-declaration-compatibility-paths)

## Summary

Completes JavaScript external-resolution knowledge migration (Phase 3):

1. Query/N-API consume resolution identities + human names + reverse index
2. Prune lockfile keys consume resolution identities
3. Global hash uses resolution fingerprints / definition-source fallback
4. Delete PackageInfo resolution fields, deferred closures, and rehash helpers
5. Declaration consumers use `ExternalDeclarations` only

Closes TURBO-5811.
Closes TURBO-5812.
Closes TURBO-5813.
Closes TURBO-5814.
Closes TURBO-5825.

## Testing

- `cargo test -p turborepo-repository --lib test_lockfile_traversal`
- `cargo test -p turborepo-repository --lib javascript_resolution_distinguishes_resolved_empty_from_unavailable`
- `cargo test -p turborepo-repository --lib external_dependency_reverse_index_is_lazy_and_cached`
- `cargo test -p turborepo-repository --lib declaration_view_preserves_effective_external_declarations`
- `cargo test -p turborepo-lib --lib prune` (17 passed)
- `cargo test -p turborepo-task-hash --lib` (18 passed)
- `cargo test -p turborepo-frameworks --lib` (21 passed)
- `cargo test -p turborepo-boundaries --lib` (63 passed)
- `cargo clippy -p turborepo-repository -p turborepo-lib -p turborepo-task-hash -p turborepo-frameworks -p turborepo-boundaries -p turborepo-hash --all-targets -- -D warnings`
- `cargo fmt --all`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df138d61-780e-4f39-ba9c-4fc14dc578a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df138d61-780e-4f39-ba9c-4fc14dc578a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

