### PR TITLE
refactor: Migrate external package queries to resolution knowledge

### DIFF
--- a/crates/turborepo-query/src/external_package.rs
+++ b/crates/turborepo-query/src/external_package.rs
@@ -1,40 +1,48 @@
 use std::sync::Arc;
 
 use async_graphql::Object;
+use turborepo_repository::external_resolution::ExternalPackageIdentity;
 
 use crate::{package::Package, Array, Error, QueryRun};
 
 #[derive(Clone)]
 pub struct ExternalPackage {
     run: Arc<dyn QueryRun>,
-    package: turborepo_lockfiles::Package,
+    identity: ExternalPackageIdentity,
 }
 
 impl ExternalPackage {
     pub fn new(run: Arc<dyn QueryRun>, package: turborepo_lockfiles::Package) -> Self {
-        Self { run, package }
+        let identity = run
+            .pkg_dep_graph()
+            .resolve_external_package_identity(&package)
+            .cloned()
+            .unwrap_or_else(|| {
+                ExternalPackageIdentity::new(package.key.clone(), package.version.clone())
+            });
+        Self { run, identity }
+    }
+
+    pub fn from_identity(run: Arc<dyn QueryRun>, identity: ExternalPackageIdentity) -> Self {
+        Self { run, identity }
     }
 
     pub fn human_name(&self) -> String {
-        self.run
-            .pkg_dep_graph()
-            .lockfile()
-            .and_then(|lockfile| lockfile.human_name(&self.package))
-            .unwrap_or_else(|| self.package.key.clone())
+        self.identity.display_name().to_string()
     }
 }
 
 #[Object]
 impl ExternalPackage {
     async fn name(&self) -> String {
-        self.human_name().to_string()
+        self.human_name()
     }
 
     async fn internal_dependents(&self) -> Result<Array<Package>, Error> {
         let Some(names) = self
             .run
             .pkg_dep_graph()
-            .internal_dependencies_for_external_dependency(&self.package)
+            .internal_dependencies_for_external_identity(&self.identity)
         else {
             return Ok(Array::from(Vec::new()));
         };

--- a/crates/turborepo-query/src/lib.rs
+++ b/crates/turborepo-query/src/lib.rs
@@ -772,15 +772,13 @@ impl RepositoryQuery {
     }
 
     async fn external_dependencies(&self) -> Result<Array<ExternalPackage>, Error> {
-        let pkg_dep_graph = self.run.pkg_dep_graph();
-        let all_package_names: Vec<_> = pkg_dep_graph
-            .package_scope_directories()
-            .map(|(name, _)| name)
-            .collect();
-        let mut packages = pkg_dep_graph
-            .transitive_external_dependencies(all_package_names.iter())
-            .into_iter()
-            .map(|pkg| ExternalPackage::new(self.run.clone(), pkg.clone()))
+        let mut packages = self
+            .run
+            .pkg_dep_graph()
+            .external_package_identities()
+            .iter()
+            .cloned()
+            .map(|identity| ExternalPackage::from_identity(self.run.clone(), identity))
             .collect::<Array<_>>();
         packages.sort_by_key(|pkg| pkg.human_name());
         Ok(packages)

--- a/crates/turborepo-repository/src/external_resolution.rs
+++ b/crates/turborepo-repository/src/external_resolution.rs
@@ -137,10 +137,42 @@ impl<'a> PackageExternalDeclarations<'a> {
 }
 
 /// An exact, opaque external package identity.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+///
+/// Equality, ordering, and hashing are defined by `(key, version)` only.
+/// `human_name` is display metadata captured at observation time so query
+/// consumers do not re-read native lockfiles.
+#[derive(Debug, Clone)]
 pub struct ExternalPackageIdentity {
     key: String,
     version: String,
+    human_name: Option<String>,
+}
+
+impl PartialEq for ExternalPackageIdentity {
+    fn eq(&self, other: &Self) -> bool {
+        self.key == other.key && self.version == other.version
+    }
+}
+
+impl Eq for ExternalPackageIdentity {}
+
+impl PartialOrd for ExternalPackageIdentity {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ExternalPackageIdentity {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        (&self.key, &self.version).cmp(&(&other.key, &other.version))
+    }
+}
+
+impl std::hash::Hash for ExternalPackageIdentity {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.key.hash(state);
+        self.version.hash(state);
+    }
 }
 
 impl ExternalPackageIdentity {
@@ -148,7 +180,13 @@ impl ExternalPackageIdentity {
         Self {
             key: key.into(),
             version: version.into(),
+            human_name: None,
         }
+    }
+
+    pub fn with_human_name(mut self, human_name: impl Into<String>) -> Self {
+        self.human_name = Some(human_name.into());
+        self
     }
 
     pub fn key(&self) -> &str {
@@ -157,6 +195,15 @@ impl ExternalPackageIdentity {
 
     pub fn version(&self) -> &str {
         &self.version
+    }
+
+    /// Prefer the producer-supplied display name; otherwise the opaque key.
+    pub fn display_name(&self) -> &str {
+        self.human_name.as_deref().unwrap_or(&self.key)
+    }
+
+    pub fn human_name(&self) -> Option<&str> {
+        self.human_name.as_deref()
     }
 }
 

--- a/crates/turborepo-repository/src/package_graph/javascript.rs
+++ b/crates/turborepo-repository/src/package_graph/javascript.rs
@@ -198,7 +198,12 @@ pub(super) fn resolve_dependencies(
                 .into_iter()
                 .flatten()
                 .map(|package| {
-                    ExternalPackageIdentity::new(package.key.clone(), package.version.clone())
+                    let mut identity =
+                        ExternalPackageIdentity::new(package.key.clone(), package.version.clone());
+                    if let Some(human_name) = lockfile.human_name(package) {
+                        identity = identity.with_human_name(human_name);
+                    }
+                    identity
                 });
             PackageResolution::new(identity, exact_identities)
         })

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -16,8 +16,9 @@ use turborepo_lockfiles::Lockfile;
 use crate::{
     discovery::LocalPackageDiscoveryBuilder,
     external_resolution::{
-        ExternalDeclarations, ExternalResolutionData, ExternalResolutionGeneration,
-        ExternalResolutionStatus, PackageExternalDeclarations, PackageResolutionState,
+        ExternalDeclarations, ExternalPackageIdentity, ExternalResolutionData,
+        ExternalResolutionGeneration, ExternalResolutionStatus, PackageExternalDeclarations,
+        PackageResolutionState,
     },
     knowledge::{RelationshipKnowledge, RepositoryKnowledge},
     package_json::PackageJson,
@@ -106,8 +107,10 @@ pub struct PackageGraph {
     /// across toolchains. Deferred JavaScript production is joined once by
     /// [`Self::ensure_transitive_closures`].
     external_resolution: Mutex<ExternalResolutionKnowledge>,
-    external_dep_to_internal_dependents:
-        OnceLock<HashMap<turborepo_lockfiles::Package, HashSet<PackageNode>>>,
+    /// Lazy reverse index from exact external identities to internal
+    /// dependents. Built once from the resolution generation, not from
+    /// `PackageInfo` compatibility payloads.
+    external_dep_to_internal_dependents: OnceLock<ExternalDependencyIndex>,
     /// Lazily computed internal dependencies of the root package. They are
     /// implied dependencies of every package, so per-package operations like
     /// `dependencies` and `ancestors` consult them on every call; the set is
@@ -330,6 +333,15 @@ pub struct ExternalDependencyChange {
     pub added: Vec<turborepo_lockfiles::Package>,
     /// Dependencies that were removed from the package
     pub removed: Vec<turborepo_lockfiles::Package>,
+}
+
+/// Lazy reverse index from exact external identities to internal dependents.
+#[derive(Debug, Default)]
+struct ExternalDependencyIndex {
+    /// Unique identities retaining producer-supplied display names.
+    identities: Vec<ExternalPackageIdentity>,
+    /// Exact identity -> internal workspace dependents (including transitive).
+    dependents: HashMap<ExternalPackageIdentity, HashSet<PackageNode>>,
 }
 
 impl PackageGraph {
@@ -1240,46 +1252,126 @@ impl PackageGraph {
             .collect()
     }
 
+    /// Unique external package identities from the resolution generation.
+    ///
+    /// Display names are the producer-supplied human names captured during
+    /// observation. This is the query authority for external package listing.
+    pub fn external_package_identities(&self) -> &[ExternalPackageIdentity] {
+        &self.external_dependency_index().identities
+    }
+
+    /// Resolve a lockfile package to the generation identity that shares its
+    /// exact `(key, version)`, retaining any stored human name.
+    pub fn resolve_external_package_identity(
+        &self,
+        package: &turborepo_lockfiles::Package,
+    ) -> Option<&ExternalPackageIdentity> {
+        let needle = ExternalPackageIdentity::new(package.key.clone(), package.version.clone());
+        self.external_dependency_index()
+            .identities
+            .iter()
+            .find(|identity| *identity == &needle)
+    }
+
+    /// JavaScript-domain external identities only. Used by N-API lockfile
+    /// listing which historically filtered through the JS lockfile human-name
+    /// path and therefore excluded Cargo identities.
+    pub fn javascript_external_package_identities(&self) -> Vec<ExternalPackageIdentity> {
+        let Some(generation) = self.resolution_generation() else {
+            return Vec::new();
+        };
+        let mut seen = HashSet::new();
+        let mut identities = Vec::new();
+        for domain in generation.domains() {
+            if domain.toolchain() != &crate::toolchain::ToolchainId::JAVASCRIPT {
+                continue;
+            }
+            let ExternalResolutionData::Resolved { packages, .. } = domain.data() else {
+                continue;
+            };
+            for package in packages {
+                for identity in package.identities() {
+                    if seen.insert(identity.clone()) {
+                        identities.push(identity.clone());
+                    }
+                }
+            }
+        }
+        identities.sort();
+        identities
+    }
+
     pub fn internal_dependencies_for_external_dependency(
         &self,
         external_package: &turborepo_lockfiles::Package,
     ) -> Option<&HashSet<PackageNode>> {
-        // In order to answer this once we have to calculate the info for every external
-        // package so we store the results
-        let map = self
-            .external_dep_to_internal_dependents
-            .get_or_init(|| self.build_external_dep_to_internal_dependents_map());
-        map.get(external_package)
+        let identity = ExternalPackageIdentity::new(
+            external_package.key.clone(),
+            external_package.version.clone(),
+        );
+        self.internal_dependencies_for_external_identity(&identity)
     }
 
-    /// Builds a map from external dependencies to the set of internal workspace
-    /// packages that depend on them (including transitive dependents).
-    fn build_external_dep_to_internal_dependents_map(
+    pub fn internal_dependencies_for_external_identity(
         &self,
-    ) -> HashMap<turborepo_lockfiles::Package, HashSet<PackageNode>> {
-        // TODO: provide size hint from Lockfile trait
-        let mut map: HashMap<turborepo_lockfiles::Package, HashSet<PackageNode>> = HashMap::new();
-        // First find which packages directly depend on each external package
-        for context in self.package_task_contexts() {
-            let Some(info) = context.package_info() else {
-                debug_assert!(
-                    !context.requires_compatibility_payload(),
-                    "builder invariant: required package context has no payload"
-                );
+        identity: &ExternalPackageIdentity,
+    ) -> Option<&HashSet<PackageNode>> {
+        self.external_dependency_index().dependents.get(identity)
+    }
+
+    fn external_dependency_index(&self) -> &ExternalDependencyIndex {
+        self.external_dep_to_internal_dependents
+            .get_or_init(|| self.build_external_dependency_index())
+    }
+
+    fn resolution_generation(&self) -> Option<Arc<ExternalResolutionGeneration>> {
+        self.external_resolution
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .generation
+            .clone()
+    }
+
+    /// Builds a compact reverse index from the resolution generation.
+    fn build_external_dependency_index(&self) -> ExternalDependencyIndex {
+        let Some(generation) = self.resolution_generation() else {
+            return ExternalDependencyIndex::default();
+        };
+
+        let mut dependents: HashMap<ExternalPackageIdentity, HashSet<PackageNode>> = HashMap::new();
+        let mut identity_order: Vec<ExternalPackageIdentity> = Vec::new();
+        let mut seen_identities = HashSet::new();
+        let mut root_external_dependencies = HashSet::new();
+
+        for domain in generation.domains() {
+            let ExternalResolutionData::Resolved { packages, .. } = domain.data() else {
                 continue;
             };
-            for dep in info.transitive_dependencies.iter().flatten() {
-                let rdeps = map.entry((**dep).clone()).or_default();
-                rdeps.insert(PackageNode::Workspace(context.package().clone()));
+            for package_resolution in packages {
+                let workspace = PackageNode::Workspace(PackageName::from(
+                    package_resolution.package().to_string(),
+                ));
+                let is_root = package_resolution.package() == ROOT_PKG_NAME
+                    || package_resolution.package() == "//";
+                for identity in package_resolution.identities() {
+                    if seen_identities.insert(identity.clone()) {
+                        identity_order.push(identity.clone());
+                    }
+                    if is_root {
+                        root_external_dependencies.insert(identity.clone());
+                    }
+                    dependents
+                        .entry(identity.clone())
+                        .or_default()
+                        .insert(workspace.clone());
+                }
             }
         }
-        // Now trace through all ancestors of the direct dependants
+
+        identity_order.sort();
+
         let root_internal_dependencies = self.root_internal_dependencies();
-        let root_external_dependencies =
-            self.transitive_external_dependencies(Some(&PackageName::Root));
-        for (external_pkg, rdeps) in map.iter_mut() {
-            // If one of the reverse dependencies of this external package is a root
-            // dependency, everything depends on this
+        for (external_pkg, rdeps) in dependents.iter_mut() {
             if root_external_dependencies.contains(external_pkg)
                 || !root_internal_dependencies.is_disjoint(rdeps)
             {
@@ -1295,7 +1387,11 @@ impl PackageGraph {
                 rdeps.extend(transitive_rdeps.into_iter().cloned());
             }
         }
-        map
+
+        ExternalDependencyIndex {
+            identities: identity_order,
+            dependents,
+        }
     }
 
     // Returns a map of package name and version for external dependencies
@@ -1835,6 +1931,93 @@ mod test {
             pkg_graph.transitive_external_dependencies([&foo, &bar].iter().copied()),
             HashSet::from_iter(vec![&a, &b, &c,])
         );
+
+        let identities = pkg_graph.external_package_identities();
+        assert_eq!(
+            identities
+                .iter()
+                .map(|identity| (identity.key(), identity.version()))
+                .collect::<HashSet<_>>(),
+            HashSet::from([("key:a", "1"), ("key:b", "1"), ("key:c", "1")])
+        );
+
+        let a_dependents = pkg_graph
+            .internal_dependencies_for_external_dependency(&a)
+            .expect("a should have dependents");
+        assert!(a_dependents.contains(&PackageNode::Workspace(foo.clone())));
+        assert!(!a_dependents.contains(&PackageNode::Workspace(bar.clone())));
+
+        let c_dependents = pkg_graph
+            .internal_dependencies_for_external_identity(&ExternalPackageIdentity::new(
+                "key:c", "1",
+            ))
+            .expect("c should have dependents");
+        assert!(c_dependents.contains(&PackageNode::Workspace(foo)));
+        assert!(c_dependents.contains(&PackageNode::Workspace(bar)));
+    }
+
+    #[tokio::test]
+    async fn external_dependency_reverse_index_is_lazy_and_cached() {
+        let root =
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+        let mut package_jsons = HashMap::new();
+        for index in 0..64 {
+            package_jsons.insert(
+                root.join_components(&[&format!("package_{index}"), "package.json"]),
+                PackageJson::from_value(json!({
+                    "name": format!("pkg-{index}"),
+                    "dependencies": { "a": "1" }
+                }))
+                .unwrap(),
+            );
+        }
+        let pkg_graph = PackageGraph::builder(
+            &root,
+            PackageJson::from_value(json!({ "name": "root" })).unwrap(),
+        )
+        .with_package_discovery(MockDiscovery)
+        .with_package_jsons(Some(package_jsons))
+        .with_lockfile(Some(Box::new(MockLockfile {})))
+        .build()
+        .await
+        .unwrap();
+
+        let start = std::time::Instant::now();
+        let first = pkg_graph
+            .internal_dependencies_for_external_dependency(&turborepo_lockfiles::Package::new(
+                "key:a", "1",
+            ))
+            .expect("reverse index should resolve key:a");
+        let first_elapsed = start.elapsed();
+        assert!(first.len() >= 64);
+
+        let start = std::time::Instant::now();
+        let second = pkg_graph
+            .internal_dependencies_for_external_dependency(&turborepo_lockfiles::Package::new(
+                "key:a", "1",
+            ))
+            .expect("cached reverse index should resolve key:a");
+        let second_elapsed = start.elapsed();
+
+        assert!(std::ptr::eq(first, second));
+        assert!(
+            second_elapsed * 10 < first_elapsed.max(std::time::Duration::from_micros(50)),
+            "cached reverse-index lookup should be much cheaper than the first build \
+             (first={first_elapsed:?}, second={second_elapsed:?})"
+        );
+        assert!(
+            first_elapsed < std::time::Duration::from_secs(2),
+            "reverse-index build took too long: {first_elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn external_package_identity_equality_ignores_human_name() {
+        let left = ExternalPackageIdentity::new("key:a", "1").with_human_name("a@1");
+        let right = ExternalPackageIdentity::new("key:a", "1");
+        assert_eq!(left, right);
+        assert_eq!(left.display_name(), "a@1");
+        assert_eq!(right.display_name(), "key:a");
     }
 
     #[tokio::test]

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -162,13 +162,19 @@ Represents the workspace structure and package dependencies:
   single resolution owner tracks lifecycle status. Task hashing and run/task
   summaries (including OpenTelemetry external-input attributes) consume the
   same stored byte-compatible package resolution fingerprint and preserve
-  explicit unavailable states without closure fallback hashing. The JavaScript
+  explicit unavailable states without closure fallback hashing. Query external
+  package listing, human names, and internal-dependent reverse indexes read
+  the same resolution generation (including a lazy compact reverse index)
+  rather than `PackageInfo` closures or live lockfile human-name callbacks.
+  N-API JavaScript lockfile package listing uses the JavaScript domain of that
+  generation. The JavaScript
   adapter owns package-manager configuration, previous-lockfile parsing, and
   resolution through the same producer used at graph construction. Core
   compares the resulting normalized package identities without parser or
   ecosystem knowledge; unavailable, parse, and comparison failures retain the
   conservative all-packages fallback. The snapshot projects temporary
-  `PackageInfo` closure/hash fields for the remaining global-hash migration.
+  `PackageInfo` closure/hash fields for the remaining prune and global-hash
+  migrations.
   Framework inference and boundaries validation consume the package-scoped
   declaration projection directly;
   aliases, duplicate

--- a/packages/turbo-repository/rust/src/lib.rs
+++ b/packages/turbo-repository/rust/src/lib.rs
@@ -177,32 +177,22 @@ impl Workspace {
         Ok(map)
     }
 
-    /// Returns all external packages from the lockfile as
-    /// `npm/<name>@<version>` strings. Collects the transitive external
-    /// dependencies of every workspace package and formats them using the
-    /// lockfile's human-readable name.
+    /// Returns all external packages from the JavaScript resolution domain as
+    /// `npm/<name>@<version>` strings. Names come from producer-supplied
+    /// human names on the resolution generation; Cargo identities are
+    /// excluded to preserve the historical lockfile-only listing.
     #[napi]
     pub async fn packages_from_lockfile(&self) -> Result<Vec<String>, napi::Error> {
-        let lockfile = self
-            .graph
-            .lockfile()
-            .ok_or_else(|| napi::Error::from_reason("No lockfile found"))?;
+        let identities = self.graph.javascript_external_package_identities();
+        if identities.is_empty() && self.graph.lockfile().is_none() {
+            return Err(napi::Error::from_reason("No lockfile found"));
+        }
 
-        let mut seen = HashSet::new();
-        let mut result: Vec<String> = self
-            .graph
-            .package_task_contexts()
-            .filter_map(|context| {
-                let info = context.package_info();
-                debug_assert!(
-                    info.is_some() || !context.requires_compatibility_payload(),
-                    "builder invariant: required package context has no payload"
-                );
-                info.and_then(|info| info.transitive_dependencies.as_ref())
-            })
-            .flatten()
-            .filter(|pkg| seen.insert(&pkg.key))
-            .filter_map(|pkg| lockfile.human_name(pkg).map(|name| format!("npm/{name}")))
+        let mut seen_keys = HashSet::new();
+        let mut result: Vec<String> = identities
+            .into_iter()
+            .filter(|identity| seen_keys.insert(identity.key().to_string()))
+            .filter_map(|identity| identity.human_name().map(|name| format!("npm/{name}")))
             .collect();
 
         result.sort();


### PR DESCRIPTION
## Intent

Turborepo is refactoring toward a multi-language repository architecture: ecosystem integrations contribute immutable repository knowledge, and core owns graph/task/hash/cache/watch/prune/query policy without ecosystem-specific branches.

This is **stack layer 1 / 5** of the JavaScript **external-resolution** migration. Earlier work already builds a shared resolution generation at graph construction and uses it for task hashing and lockfile affectedness. This layer migrates **query surfaces** onto that generation.

## Changes

- Store producer-supplied human names on `ExternalPackageIdentity`
- Lazy reverse index: external identity → internal dependents
- `turbo query` external packages / `internalDependents` read the catalog
- N-API `packages_from_lockfile` reads the JavaScript resolution domain

## Out of scope

Prune keys, global hash, deleting `PackageInfo` resolution fields (later layers).

## Testing

- `cargo test -p turborepo-repository --lib test_lockfile_traversal`
- `cargo test -p turborepo-repository --lib external_dependency_reverse_index_is_lazy_and_cached`
- `cargo clippy -p turborepo-repository -p turborepo-query --all-targets -- -D warnings`

Closes TURBO-5811.
