### PR TITLE
refactor: Migrate prune lockfile keys to resolution identities

### DIFF
--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -1284,9 +1284,9 @@ impl<'a> Prune<'a> {
     fn lockfile_keys(&self, workspaces: &[PackageName]) -> Result<Vec<String>, Error> {
         let mut keys = self
             .package_graph
-            .transitive_external_dependencies(workspaces.iter())
+            .external_package_identities_for_packages(workspaces.iter())
             .into_iter()
-            .map(|pkg| pkg.key.clone())
+            .map(|identity| identity.key().to_string())
             .collect::<HashSet<_>>();
 
         let lockfile = self

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -1260,6 +1260,48 @@ impl PackageGraph {
         &self.external_dependency_index().identities
     }
 
+    /// Exact external identities attributed to the given packages by the
+    /// resolution generation. Used by prune lockfile-key unions so they no
+    /// longer read `PackageInfo::transitive_dependencies`.
+    pub fn external_package_identities_for_packages<'a, I>(
+        &self,
+        packages: I,
+    ) -> Vec<ExternalPackageIdentity>
+    where
+        I: IntoIterator<Item = &'a PackageName>,
+    {
+        let wanted: HashSet<&str> = packages.into_iter().map(PackageName::as_str).collect();
+        if wanted.is_empty() {
+            return Vec::new();
+        }
+        let Some(generation) = self.resolution_generation() else {
+            return Vec::new();
+        };
+
+        let mut seen = HashSet::new();
+        let mut identities = Vec::new();
+        for domain in generation.domains() {
+            let ExternalResolutionData::Resolved {
+                packages: resolved, ..
+            } = domain.data()
+            else {
+                continue;
+            };
+            for package in resolved {
+                if !wanted.contains(package.package()) {
+                    continue;
+                }
+                for identity in package.identities() {
+                    if seen.insert(identity.clone()) {
+                        identities.push(identity.clone());
+                    }
+                }
+            }
+        }
+        identities.sort();
+        identities
+    }
+
     /// Resolve a lockfile package to the generation identity that shares its
     /// exact `(key, version)`, retaining any stored human name.
     pub fn resolve_external_package_identity(
@@ -1952,8 +1994,25 @@ mod test {
                 "key:c", "1",
             ))
             .expect("c should have dependents");
-        assert!(c_dependents.contains(&PackageNode::Workspace(foo)));
-        assert!(c_dependents.contains(&PackageNode::Workspace(bar)));
+        assert!(c_dependents.contains(&PackageNode::Workspace(foo.clone())));
+        assert!(c_dependents.contains(&PackageNode::Workspace(bar.clone())));
+
+        let foo_identities = pkg_graph.external_package_identities_for_packages([&foo]);
+        assert_eq!(
+            foo_identities
+                .iter()
+                .map(|identity| (identity.key(), identity.version()))
+                .collect::<Vec<_>>(),
+            vec![("key:a", "1"), ("key:c", "1")]
+        );
+        let bar_identities = pkg_graph.external_package_identities_for_packages([&bar]);
+        assert_eq!(
+            bar_identities
+                .iter()
+                .map(|identity| identity.key())
+                .collect::<HashSet<_>>(),
+            HashSet::from(["key:b", "key:c"])
+        );
     }
 
     #[tokio::test]

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -172,9 +172,11 @@ Represents the workspace structure and package dependencies:
   resolution through the same producer used at graph construction. Core
   compares the resulting normalized package identities without parser or
   ecosystem knowledge; unavailable, parse, and comparison failures retain the
-  conservative all-packages fallback. The snapshot projects temporary
-  `PackageInfo` closure/hash fields for the remaining prune and global-hash
-  migrations.
+  conservative all-packages fallback. Prune lockfile-key unions also consume
+  exact per-package resolution identities for retained JavaScript workspaces,
+  while external-peer closure expansion still consults the lockfile directly.
+  The snapshot projects temporary `PackageInfo` closure/hash fields for the
+  remaining global-hash migration.
   Framework inference and boundaries validation consume the package-scoped
   declaration projection directly;
   aliases, duplicate


### PR DESCRIPTION
## Intent

Continue the external-resolution migration: prune’s JS lockfile-key union must use the same exact per-package resolution identities as hashing/query, not legacy `PackageInfo::transitive_dependencies`.

## Changes

- `PackageGraph::external_package_identities_for_packages`
- Prune lockfile-key union consumes those identities for retained JS workspaces
- Preserve external-peer lockfile expansion and JS/Cargo separation

## Out of scope

Lockfile subgraph redesign, Cargo prune plans, global hash, field deletion.

## Testing

- `cargo test -p turborepo-repository --lib test_lockfile_traversal`
- `cargo test -p turborepo-lib --lib prune`
- `cargo clippy -p turborepo-repository -p turborepo-lib --all-targets -- -D warnings`

Closes TURBO-5812.