### PR TITLE
refactor: Migrate global hash inputs to resolution knowledge

### DIFF
--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -37,9 +37,8 @@ use turborepo_run_summary::{ObservabilityHandle, RunTracker};
 use turborepo_scm::{RepoGitIndex, SCM};
 use turborepo_signals::{ShutdownReason, SignalHandler};
 use turborepo_task_hash::{
-    collect_global_file_hash_inputs, compute_external_deps_hashes, get_external_deps_hash,
-    get_internal_deps_hash, global_hash::GLOBAL_CACHE_KEY, GlobalHashableInputs,
-    PackageInputsHashes,
+    collect_global_file_hash_inputs, compute_external_deps_hashes, get_internal_deps_hash,
+    global_hash::GLOBAL_CACHE_KEY, GlobalHashableInputs, PackageInputsHashes,
 };
 use turborepo_telemetry::events::generic::GenericEventBuilder;
 use turborepo_types::{EnvMode, UIMode};
@@ -1216,11 +1215,15 @@ impl Run {
                 s.spawn(|_| {
                     let _span =
                         tracing::info_span!("collect_global_file_hash_inputs_task").entered();
+                    let resolution_file_fallback = self
+                        .pkg_dep_graph
+                        .external_resolution_global_file_fallback()
+                        .unwrap_or_default();
                     global_file_result = Some(collect_global_file_hash_inputs(
                         root_workspace,
                         &self.repo_root,
                         self.pkg_dep_graph.package_manager(),
-                        self.pkg_dep_graph.lockfile(),
+                        &resolution_file_fallback,
                         self.root_turbo_json.global_deps_for_hash(),
                         &self.env_at_execution_start,
                         &self.root_turbo_json.global_env,
@@ -1249,12 +1252,21 @@ impl Run {
             global_file_result.ok_or(Error::GlobalFileHashTaskIncomplete)??;
         let external_deps_hashes = external_deps_hashes.transpose()?;
 
-        let root_external_dependencies_hash = is_monorepo.then(|| {
-            root_workspace
-                .external_deps_hash
-                .clone()
-                .unwrap_or_else(|| get_external_deps_hash(&root_workspace.transitive_dependencies))
-        });
+        let root_external_dependencies_hash = if is_monorepo {
+            let cache = external_deps_hashes.as_ref().ok_or_else(|| {
+                turborepo_task_hash::Error::MissingExternalDependencyHash(PackageName::Root)
+            })?;
+            Some(
+                cache
+                    .get(PackageName::Root.as_str())
+                    .cloned()
+                    .ok_or_else(|| {
+                        turborepo_task_hash::Error::MissingExternalDependencyHash(PackageName::Root)
+                    })?,
+            )
+        } else {
+            None
+        };
 
         let pass_through_env = match env_mode {
             EnvMode::Loose => {

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -1967,6 +1967,11 @@ mod test {
             Some("user-facing-root-name")
         );
         assert_eq!(retained_generation.packages().count(), 0);
+        assert_eq!(
+            graph.external_resolution_global_file_fallback(),
+            Some(vec![root.join_component("package.json")]),
+            "single-package mode must preserve package.json as a global hash input"
+        );
 
         let contexts = graph.package_task_contexts().collect::<Vec<_>>();
         assert_eq!(contexts.len(), 1);

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -10,7 +10,9 @@ use petgraph::{
     visit::EdgeRef,
 };
 use serde::Serialize;
-use turbopath::{AbsoluteSystemPath, AnchoredSystemPath, AnchoredSystemPathBuf};
+use turbopath::{
+    AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPath, AnchoredSystemPathBuf,
+};
 use turborepo_lockfiles::Lockfile;
 
 use crate::{
@@ -1302,6 +1304,33 @@ impl PackageGraph {
         identities
     }
 
+    /// Global-hash file fallback when JavaScript resolution is unavailable.
+    ///
+    /// Mirrors the historical behavior of hashing `package.json` plus the
+    /// package-manager lockfile path when a lockfile object was not loaded:
+    /// include the repository root `package.json` and any existing resolution
+    /// definition sources from the JavaScript domain.
+    pub fn external_resolution_global_file_fallback(&self) -> Option<Vec<AbsoluteSystemPathBuf>> {
+        let generation = self.resolution_generation()?;
+        let domain = generation
+            .domains()
+            .iter()
+            .find(|domain| domain.toolchain() == &crate::toolchain::ToolchainId::JAVASCRIPT)?;
+        match domain.data() {
+            ExternalResolutionData::Resolved { .. } => None,
+            ExternalResolutionData::Unavailable(_) => {
+                let mut paths = vec![self.repo_root().join_component("package.json")];
+                for source in domain.definition_sources() {
+                    let path = self.repo_root().resolve(source);
+                    if path.exists() {
+                        paths.push(path);
+                    }
+                }
+                Some(paths)
+            }
+        }
+    }
+
     /// Resolve a lockfile package to the generation identity that shares its
     /// exact `(key, version)`, retaining any stored human name.
     pub fn resolve_external_package_identity(
@@ -2142,6 +2171,21 @@ mod test {
                 .package_payloads
                 .get(&PackageName::Root)
                 .is_some_and(|info| info.transitive_dependencies.is_none())
+        );
+
+        let fallback = unavailable
+            .external_resolution_global_file_fallback()
+            .expect("unavailable JS resolution should expose a global file fallback");
+        assert!(
+            fallback
+                .iter()
+                .any(|path| path.file_name() == Some("package.json"))
+        );
+        assert!(
+            resolved
+                .external_resolution_global_file_fallback()
+                .is_none(),
+            "resolved domains must not use the global file fallback"
         );
     }
 

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -1309,9 +1309,18 @@ impl PackageGraph {
     /// Mirrors the historical behavior of hashing `package.json` plus the
     /// package-manager lockfile path when a lockfile object was not loaded:
     /// include the repository root `package.json` and any existing resolution
-    /// definition sources from the JavaScript domain.
+    /// definition sources from the JavaScript domain. Single-package mode has
+    /// no resolution generation, so it retains the package-manager fallback.
     pub fn external_resolution_global_file_fallback(&self) -> Option<Vec<AbsoluteSystemPathBuf>> {
-        let generation = self.resolution_generation()?;
+        let Some(generation) = self.resolution_generation() else {
+            let package_manager = self.package_manager()?;
+            let mut paths = vec![self.repo_root().join_component("package.json")];
+            let lockfile_path = package_manager.lockfile_path(self.repo_root());
+            if lockfile_path.exists() {
+                paths.push(lockfile_path);
+            }
+            return Some(paths);
+        };
         let domain = generation
             .domains()
             .iter()

--- a/crates/turborepo-task-hash/src/global_hash.rs
+++ b/crates/turborepo-task-hash/src/global_hash.rs
@@ -11,7 +11,6 @@ use tracing::debug;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, RelativeUnixPathBuf};
 use turborepo_env::{DetailedMap, EnvironmentVariableMap, get_global_hashable_env_vars};
 use turborepo_hash::{GlobalHashable, TurboHash};
-use turborepo_lockfiles::Lockfile;
 use turborepo_repository::{
     package_graph::PackageInfo,
     package_manager::{self, PackageManager},
@@ -62,13 +61,13 @@ pub struct GlobalHashableInputs<'a> {
 }
 
 #[allow(clippy::too_many_arguments, clippy::result_large_err)]
-pub fn get_global_hash_inputs<'a, L: ?Sized + Lockfile>(
+pub fn get_global_hash_inputs<'a>(
     root_external_dependencies_hash: Option<&'a str>,
     root_internal_dependencies_hash: Option<&'a str>,
     root_package: &'a PackageInfo,
     root_path: &AbsoluteSystemPath,
     package_manager: Option<&PackageManager>,
-    lockfile: Option<&L>,
+    resolution_file_fallback: &[AbsoluteSystemPathBuf],
     global_file_dependencies: &'a [String],
     env_at_execution_start: &'a EnvironmentVariableMap,
     global_env: &'a [String],
@@ -86,7 +85,7 @@ pub fn get_global_hash_inputs<'a, L: ?Sized + Lockfile>(
         root_package,
         root_path,
         package_manager,
-        lockfile,
+        resolution_file_fallback,
         global_file_dependencies,
         env_at_execution_start,
         global_env,
@@ -129,15 +128,16 @@ pub struct GlobalFileHashInputs<'a> {
 /// can be run concurrently with package file hashing and internal deps
 /// hashing since it has no dependencies on those results.
 #[allow(clippy::too_many_arguments, clippy::result_large_err)]
-pub fn collect_global_file_hash_inputs<'a, L: ?Sized + Lockfile>(
+pub fn collect_global_file_hash_inputs<'a>(
     root_package: &'a PackageInfo,
     root_path: &AbsoluteSystemPath,
     // Absent for a pure Cargo workspace: there is no JavaScript package
-    // manager, root manifest, or lockfile to fold into the global hash. The
-    // Cargo lockfile and manifest are hashed per-task through the toolchain's
-    // derived inputs instead.
+    // manager to enumerate workspace exclusions for `globalDependencies`.
     package_manager: Option<&PackageManager>,
-    lockfile: Option<&L>,
+    // When JavaScript resolution is unavailable, hash the resolution
+    // definition sources (typically the lockfile path) and root package.json
+    // instead of folding lockfile contents into the external fingerprint.
+    resolution_file_fallback: &[AbsoluteSystemPathBuf],
     global_file_dependencies: &'a [String],
     env_at_execution_start: &'a EnvironmentVariableMap,
     global_env: &'a [String],
@@ -156,17 +156,8 @@ pub fn collect_global_file_hash_inputs<'a, L: ?Sized + Lockfile>(
     let mut global_deps =
         collect_global_deps(package_manager, root_path, global_file_dependencies)?;
 
-    // The root package.json and the JavaScript lockfile are global inputs
-    // only when there is a JavaScript project. A pure Cargo workspace has
-    // neither.
-    if let Some(package_manager) = package_manager
-        && lockfile.is_none()
-    {
-        global_deps.insert(root_path.join_component("package.json"));
-        let lockfile_path = package_manager.lockfile_path(root_path);
-        if lockfile_path.exists() {
-            global_deps.insert(lockfile_path);
-        }
+    for path in resolution_file_fallback {
+        global_deps.insert(path.clone());
     }
 
     // .gitattributes drives CRLF→LF normalization which affects file hashes.
@@ -395,7 +386,6 @@ impl<'a> GlobalHashInputsTrait for GlobalHashableInputs<'a> {
 mod tests {
     use turbopath::AbsoluteSystemPathBuf;
     use turborepo_env::EnvironmentVariableMap;
-    use turborepo_lockfiles::Lockfile;
     use turborepo_repository::{package_graph::PackageInfo, package_manager::PackageManager};
     use turborepo_scm::SCM;
     use turborepo_types::EnvMode;
@@ -419,7 +409,7 @@ mod tests {
 
         let env_var_map = EnvironmentVariableMap::default();
         let package_info = PackageInfo::default();
-        let lockfile: Option<&dyn Lockfile> = None;
+        let fallback = [root.join_component("package.json")];
         #[cfg(windows)]
         let file_deps = ["C:\\some\\path".to_string()];
         #[cfg(not(windows))]
@@ -430,7 +420,7 @@ mod tests {
             &package_info,
             &root,
             Some(&PackageManager::Pnpm),
-            lockfile,
+            &fallback,
             &file_deps,
             &env_var_map,
             &[],

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -175,8 +175,11 @@ Represents the workspace structure and package dependencies:
   conservative all-packages fallback. Prune lockfile-key unions also consume
   exact per-package resolution identities for retained JavaScript workspaces,
   while external-peer closure expansion still consults the lockfile directly.
-  The snapshot projects temporary `PackageInfo` closure/hash fields for the
-  remaining global-hash migration.
+  Global hashing consumes the same root resolution fingerprint as task hashing
+  and, when JavaScript resolution is unavailable, hashes resolution definition
+  sources plus the root package.json instead of reading the singleton lockfile
+  object. The snapshot projects temporary `PackageInfo` closure/hash fields only
+  until the Phase 3 deletion gate removes them.
   Framework inference and boundaries validation consume the package-scoped
   declaration projection directly;
   aliases, duplicate


### PR DESCRIPTION
## Intent

Finish migrating resolution **consumers**: root/global external fingerprints and the missing-lockfile global-file fallback must come from resolution state / definition sources, matching task hashing—not `PackageInfo` closures or singleton lockfile object checks.

**Stack:** layer 3 / 5. Base = layer 2 (prune).

## Changes

- Root external hash from resolution fingerprint cache (`//`)
- Unavailable JS resolution → hash definition sources + root `package.json`
- Remove owned singleton lockfile reads from global-hash collection

## Out of scope

Task contracts (Phase 5), deleting legacy fields (next layer).

## Testing

- `cargo test -p turborepo-task-hash --lib`
- `cargo test -p turborepo-repository --lib javascript_resolution_distinguishes_resolved_empty_from_unavailable`
- `cargo clippy -p turborepo-repository -p turborepo-task-hash -p turborepo-lib --all-targets -- -D warnings`

Closes TURBO-5813.
