### PR TITLE
refactor: Delete legacy external-resolution PackageInfo state

### DIFF
--- a/crates/turborepo-boundaries/src/lib.rs
+++ b/crates/turborepo-boundaries/src/lib.rs
@@ -1060,18 +1060,12 @@ mod tests {
                 PackageName::Other("pkg-a".into()),
                 PackageInfo {
                     package_json: Default::default(),
-                    unresolved_external_dependencies: None,
-                    transitive_dependencies: None,
-                    ..Default::default()
                 },
             ),
             (
                 PackageName::Other("pkg-b".into()),
                 PackageInfo {
                     package_json: Default::default(),
-                    unresolved_external_dependencies: None,
-                    transitive_dependencies: None,
-                    ..Default::default()
                 },
             ),
         ];

--- a/crates/turborepo-boundaries/src/tags.rs
+++ b/crates/turborepo-boundaries/src/tags.rs
@@ -451,9 +451,6 @@ mod tests {
                 turbopath::AnchoredSystemPathBuf::from_raw(format!("packages/{name}")).unwrap(),
                 PackageInfo {
                     package_json: PackageJson::default(),
-                    unresolved_external_dependencies: None,
-                    transitive_dependencies: None,
-                    ..Default::default()
                 },
             ));
         }

--- a/crates/turborepo-frameworks/src/lib.rs
+++ b/crates/turborepo-frameworks/src/lib.rs
@@ -178,10 +178,10 @@ mod tests {
     #[test_case(PackageInfo::default(), None, true; "empty dependencies")]
     #[test_case(
         PackageInfo {
-            unresolved_external_dependencies: Some(
-                vec![("blitz".to_string(), "*".to_string())].into_iter().collect()
-            ),
-            ..Default::default()
+            package_json: PackageJson {
+                dependencies: deps(&[("blitz", "*")]),
+                ..Default::default()
+            },
         },
         Some(get_framework_by_slug("blitzjs")),
         true;
@@ -189,13 +189,10 @@ mod tests {
     )]
     #[test_case(
         PackageInfo {
-            unresolved_external_dependencies: Some(
-                vec![("blitz", "*"), ("next", "*")]
-                    .into_iter()
-                    .map(|(s1, s2)| (s1.to_string(), s2.to_string()))
-                    .collect()
-            ),
-            ..Default::default()
+            package_json: PackageJson {
+                dependencies: deps(&[("blitz", "*"), ("next", "*")]),
+                ..Default::default()
+            },
         },
         Some(get_framework_by_slug("blitzjs")),
         true;
@@ -203,13 +200,10 @@ mod tests {
     )]
     #[test_case(
         PackageInfo {
-            unresolved_external_dependencies: Some(
-                vec![("next", "*")]
-                    .into_iter()
-                    .map(|(s1, s2)| (s1.to_string(), s2.to_string()))
-                    .collect()
-            ),
-            ..Default::default()
+            package_json: PackageJson {
+                dependencies: deps(&[("next", "*")]),
+                ..Default::default()
+            },
         },
         Some(get_framework_by_slug("nextjs")),
         true;
@@ -217,13 +211,10 @@ mod tests {
     )]
     #[test_case(
         PackageInfo {
-            unresolved_external_dependencies: Some(
-                vec![("solid-js", "*"), ("solid-start", "*")]
-                    .into_iter()
-                    .map(|(s1, s2)| (s1.to_string(), s2.to_string()))
-                    .collect()
-            ),
-            ..Default::default()
+            package_json: PackageJson {
+                dependencies: deps(&[("solid-js", "*"), ("solid-start", "*")]),
+                ..Default::default()
+            },
         },
         Some(get_framework_by_slug("solidstart")),
         true;
@@ -231,13 +222,10 @@ mod tests {
     )]
     #[test_case(
         PackageInfo {
-            unresolved_external_dependencies: Some(
-                vec![("nuxt3", "*")]
-                    .into_iter()
-                    .map(|(s1, s2)| (s1.to_string(), s2.to_string()))
-                    .collect()
-            ),
-            ..Default::default()
+            package_json: PackageJson {
+                dependencies: deps(&[("nuxt", "*")]),
+                ..Default::default()
+            },
         },
         Some(get_framework_by_slug("nuxtjs")),
         true;
@@ -245,13 +233,10 @@ mod tests {
     )]
     #[test_case(
         PackageInfo {
-            unresolved_external_dependencies: Some(
-                vec![("react-scripts", "*")]
-                    .into_iter()
-                    .map(|(s1, s2)| (s1.to_string(), s2.to_string()))
-                    .collect()
-            ),
-            ..Default::default()
+            package_json: PackageJson {
+                dependencies: deps(&[("react-scripts", "*")]),
+                ..Default::default()
+            },
         },
         Some(get_framework_by_slug("create-react-app")),
         true;
@@ -259,16 +244,15 @@ mod tests {
     )]
     #[test_case(
         PackageInfo {
-            package_json: PackageJson {
-              dependencies: Some(
+              package_json: PackageJson {
+                            dependencies: Some(
                 vec![("next", "*")]
                     .into_iter()
                     .map(|(s1, s2)| (s1.to_string(), s2.to_string()))
                     .collect()
               ),
-              ..Default::default()
-            },
-            ..Default::default()
+                            ..Default::default()
+              },
         },
         Some(get_framework_by_slug("nextjs")),
         false;
@@ -276,16 +260,15 @@ mod tests {
     )]
     #[test_case(
         PackageInfo {
-            package_json: PackageJson {
-              dev_dependencies: Some(
+              package_json: PackageJson {
+                            dev_dependencies: Some(
                 vec![("vite", "*")]
                     .into_iter()
                     .map(|(s1, s2)| (s1.to_string(), s2.to_string()))
                     .collect()
               ),
-              ..Default::default()
-            },
-            ..Default::default()
+                            ..Default::default()
+              },
         },
         Some(get_framework_by_slug("vite")),
         false;
@@ -294,11 +277,10 @@ mod tests {
     #[test_case(PackageInfo::default(), None, false; "empty dependencies in non-monorepo")]
     #[test_case(
         PackageInfo {
-            package_json: PackageJson {
-                dev_dependencies: deps(&[("vite", "*")]),
-                ..Default::default()
-            },
-            ..Default::default()
+                package_json: PackageJson {
+                                dev_dependencies: deps(&[("vite", "*")]),
+                                ..Default::default()
+                },
         },
         None,
         true;
@@ -306,12 +288,11 @@ mod tests {
     )]
     #[test_case(
         PackageInfo {
-            package_json: PackageJson {
-                dependencies: deps(&[("solid-js", "*")]),
+                package_json: PackageJson {
+                                dependencies: deps(&[("solid-js", "*")]),
                 dev_dependencies: deps(&[("solid-start", "*")]),
-                ..Default::default()
-            },
-            ..Default::default()
+                                ..Default::default()
+                },
         },
         Some(get_framework_by_slug("solidstart")),
         false;
@@ -319,11 +300,10 @@ mod tests {
     )]
     #[test_case(
         PackageInfo {
-            package_json: PackageJson {
-                dev_dependencies: deps(&[("react-scripts", "*")]),
-                ..Default::default()
-            },
-            ..Default::default()
+                package_json: PackageJson {
+                                dev_dependencies: deps(&[("react-scripts", "*")]),
+                                ..Default::default()
+                },
         },
         Some(get_framework_by_slug("create-react-app")),
         false;
@@ -336,7 +316,8 @@ mod tests {
     ) {
         let declarations = if is_monorepo {
             workspace_info
-                .unresolved_external_dependencies
+                .package_json
+                .dependencies
                 .iter()
                 .flatten()
                 .map(|(name, specifier)| {
@@ -367,7 +348,7 @@ mod tests {
                 .map(|(name, specifier, kind)| {
                     ExternalDeclaration::new("workspace", name, name, specifier, kind)
                 })
-                .collect()
+                .collect::<Vec<_>>()
         };
         let framework = infer_framework(
             PackageExternalDeclarations::new(&declarations, "workspace"),

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -839,14 +839,20 @@ impl<'a> Prune<'a> {
             trace!("target: {}", context.package());
             trace!("workspace directory: {}", context.directory());
             trace!("workspace definition: {definition_path}");
-            if let Some(payload) = context.package_info() {
-                trace!(
-                    "external dependencies: {:?}",
-                    &payload.unresolved_external_dependencies
-                );
-            } else if context.requires_compatibility_payload() {
+            if context.requires_compatibility_payload() && context.package_info().is_none() {
                 return Err(Error::MissingPackagePayload(context.package().clone()));
             }
+            let declarations: Vec<_> = package_graph
+                .external_declarations(context.package())
+                .iter()
+                .map(|declaration| {
+                    (
+                        declaration.package_name().to_string(),
+                        declaration.specifier().to_string(),
+                    )
+                })
+                .collect();
+            trace!("external dependencies: {:?}", declarations);
         }
 
         // A JavaScript project must have a lockfile to subgraph. A pure Cargo

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -564,13 +564,6 @@ impl RunBuilder {
                 PackageGraph::builder_optional(&self.repo_root, root_package_json.clone())
                     .with_single_package_mode(self.opts.run_opts.single_package)
                     .with_allow_no_package_manager(self.opts.repo_opts.allow_no_package_manager)
-                    // Transitive closures compute on a background thread while
-                    // microfrontends config, turbo.json preloading, and other
-                    // package-list consumers run. Joined by the
-                    // `ensure_transitive_closures` call before package filtering,
-                    // the earliest possible consumer (`--affected` with a changed
-                    // lockfile compares closures).
-                    .defer_transitive_closures(true)
                     .with_closure_hasher(std::sync::Arc::new(
                         turborepo_task_hash::hash_sorted_closures,
                     ));
@@ -788,27 +781,9 @@ impl RunBuilder {
             turbo_json_loader.preload_all();
         });
 
-        // Package filtering reads transitive closures only when a git-based
-        // selector may compare lockfile closures: `--affected`, or a
-        // `--filter` containing a git range (bracket syntax). Joining the
-        // background closure computation here in only those cases lets the
-        // common run keep overlapping it with filtering and engine
-        // construction; the unconditional join below runs before the first
-        // universal consumer (task hashing).
-        let scope_may_read_closures = self.opts.scope_opts.affected_range.is_some()
-            || self
-                .opts
-                .scope_opts
-                .filter_patterns
-                .iter()
-                .any(|pattern| pattern.contains('['));
-        if scope_may_read_closures {
-            crate::rayon_compat::block_in_place(|| {
-                let _span = tracing::info_span!("ensure_transitive_closures").entered();
-                pkg_dep_graph.ensure_transitive_closures();
-            });
-        }
-
+        // Resolution knowledge is complete at package-graph construction, so
+        // scope filtering can read lockfile-affected packages without joining
+        // deferred closure work.
         let (filtered_pkgs, filter_mode, unqualified_entrypoint_packages) = {
             let _span = tracing::info_span!("calculate_filtered_packages").entered();
             Self::calculate_filtered_packages(
@@ -1121,15 +1096,6 @@ impl RunBuilder {
                 .instrument(tracing::info_span!("capture_scm_state")),
             );
         }
-
-        // Unconditional join point for the background transitive-closure
-        // computation (idempotent when the conditional join above already
-        // ran). The graph is immutable once inside `Run`, and its first
-        // closure consumer (external dependency hashing) runs shortly after.
-        crate::rayon_compat::block_in_place(|| {
-            let _span = tracing::info_span!("ensure_transitive_closures").entered();
-            pkg_dep_graph.ensure_transitive_closures();
-        });
 
         Ok((
             Run {

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -3854,7 +3854,6 @@ release: 1.96.0-nightly\n",
                 name: Some(Spanned::new(name.to_string())),
                 ..Default::default()
             },
-            ..Default::default()
         }
     }
 

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -2493,7 +2493,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_external_peer_dep_is_not_retained_as_external() {
+    async fn test_external_peer_dep_is_retained_as_peer_declaration() {
         let root =
             AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
 
@@ -2528,23 +2528,25 @@ mod test {
         .unwrap();
 
         let a = PackageName::from("a");
-        let a_external = {
-            let decls: std::collections::BTreeMap<_, _> = graph
-                .external_declarations(&a)
-                .iter()
-                .map(|d| (d.package_name().to_string(), d.specifier().to_string()))
-                .collect();
-            decls
-        };
+        let declaration = graph
+            .external_declarations(&a)
+            .iter()
+            .find(|declaration| declaration.package_name() == "react")
+            .expect("external peer should remain available to declaration consumers");
+        assert_eq!(declaration.kind(), DependencyKind::Peer { optional: false });
+        let resolution_inputs =
+            javascript::external_dependencies(&graph.knowledge, &graph.relationship_knowledge);
         assert!(
-            !a_external.contains_key("react"),
-            "external peer dependency should not be retained as an external dep, got: {:?}",
-            a_external
+            resolution_inputs
+                .values()
+                .all(|dependencies| !dependencies.contains_key("react")),
+            "external peer dependency must not reach JavaScript resolution inputs, got: \
+             {resolution_inputs:?}"
         );
     }
 
     #[tokio::test]
-    async fn test_optional_external_peer_is_not_retained() {
+    async fn test_external_peers_preserve_optional_metadata() {
         let root =
             AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
 
@@ -2581,23 +2583,27 @@ mod test {
         .unwrap();
 
         let a = PackageName::from("a");
-        let a_external = {
-            let decls: std::collections::BTreeMap<_, _> = graph
-                .external_declarations(&a)
-                .iter()
-                .map(|d| (d.package_name().to_string(), d.specifier().to_string()))
-                .collect();
-            decls
-        };
-        assert!(
-            !a_external.contains_key("react"),
-            "optional peer should not be retained, got: {:?}",
-            a_external
+        let peers: std::collections::BTreeMap<_, _> = graph
+            .external_declarations(&a)
+            .iter()
+            .map(|declaration| (declaration.package_name(), declaration.kind()))
+            .collect();
+        assert_eq!(
+            peers.get("react"),
+            Some(&DependencyKind::Peer { optional: true })
         );
+        assert_eq!(
+            peers.get("lodash"),
+            Some(&DependencyKind::Peer { optional: false })
+        );
+        let resolution_inputs =
+            javascript::external_dependencies(&graph.knowledge, &graph.relationship_knowledge);
         assert!(
-            !a_external.contains_key("lodash"),
-            "required peer should not be retained, got: {:?}",
-            a_external
+            resolution_inputs.values().all(|dependencies| {
+                !dependencies.contains_key("react") && !dependencies.contains_key("lodash")
+            }),
+            "peer dependencies must not reach JavaScript resolution inputs, got: \
+             {resolution_inputs:?}"
         );
     }
 
@@ -2653,7 +2659,8 @@ mod test {
         .unwrap();
 
         let app = PackageNode::Workspace(PackageName::from("app"));
-        let lib = PackageNode::Workspace(PackageName::from("lib"));
+        let lib_name = PackageName::from("lib");
+        let lib = PackageNode::Workspace(lib_name.clone());
 
         let lib_closure = graph.transitive_closure([&lib]);
         assert!(
@@ -2666,20 +2673,19 @@ mod test {
             "prune closure for app should include its regular dependency lib"
         );
 
-        let lib_external: std::collections::BTreeMap<_, _> = graph
-            .external_declarations(&PackageName::from("lib"))
+        let react = graph
+            .external_declarations(&lib_name)
             .iter()
-            .map(|declaration| {
-                (
-                    declaration.package_name().to_string(),
-                    declaration.specifier().to_string(),
-                )
-            })
-            .collect();
+            .find(|declaration| declaration.package_name() == "react")
+            .expect("external peer should remain available to declaration consumers");
+        assert_eq!(react.kind(), DependencyKind::Peer { optional: false });
+        let resolution_inputs =
+            javascript::external_dependencies(&graph.knowledge, &graph.relationship_knowledge);
         assert!(
-            !lib_external.contains_key("react"),
-            "external peer should not be retained by package graph, got: {:?}",
-            lib_external
+            resolution_inputs
+                .values()
+                .all(|dependencies| !dependencies.contains_key("react")),
+            "external peer must not reach JavaScript resolution inputs, got: {resolution_inputs:?}"
         );
     }
 

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -50,7 +50,6 @@ pub struct PackageGraphBuilder<'a, T> {
     lockfile: Option<Box<dyn Lockfile>>,
     package_discovery: T,
     package_manager: Option<PackageManager>,
-    defer_closures: bool,
     closure_hasher: Option<ClosureHasher>,
     /// Toolchains registered in addition to JavaScript (e.g. Cargo when
     /// `futureFlags.experimentalCargoWorkspaces` is enabled). Their packages
@@ -244,7 +243,6 @@ impl<'a> PackageGraphBuilder<'a, LocalPackageDiscoveryBuilder> {
             package_jsons: None,
             lockfile: None,
             package_manager: None,
-            defer_closures: false,
             closure_hasher: None,
             extra_toolchains: Vec::new(),
         }
@@ -275,15 +273,6 @@ impl<'a, P> PackageGraphBuilder<'a, P> {
         package_jsons: Option<HashMap<AbsoluteSystemPathBuf, PackageJson>>,
     ) -> Self {
         self.package_jsons = package_jsons;
-        self
-    }
-
-    /// Defer transitive-closure computation to a background thread. The
-    /// resulting graph's `transitive_dependencies` are absent until
-    /// [`PackageGraph::ensure_transitive_closures`] is called; callers that
-    /// enable this own calling it before any closure consumer runs.
-    pub fn defer_transitive_closures(mut self, defer: bool) -> Self {
-        self.defer_closures = defer;
         self
     }
 
@@ -322,7 +311,6 @@ impl<'a, P> PackageGraphBuilder<'a, P> {
             lockfile: self.lockfile,
             package_discovery: discovery,
             package_manager: self.package_manager,
-            defer_closures: self.defer_closures,
             closure_hasher: self.closure_hasher,
             extra_toolchains: self.extra_toolchains,
         }
@@ -400,7 +388,6 @@ struct BuildState<'a, S, T> {
     lockfile: Option<Box<dyn Lockfile>>,
     package_manager: Option<PackageManager>,
     package_jsons: Option<HashMap<AbsoluteSystemPathBuf, PackageJson>>,
-    defer_closures: bool,
     closure_hasher: Option<ClosureHasher>,
     state: std::marker::PhantomData<S>,
     /// The JavaScript toolchain, typed. Package-manager resolution for
@@ -523,14 +510,13 @@ impl PackageGraphAssembler {
         for group in relationships.groups() {
             let identity = group.source();
             let name = package_name_from_identity(identity);
-            let entry = self.package_payloads.get_mut(&name).ok_or_else(|| {
-                Error::MissingCompatibilityPayload {
+            if !self.package_payloads.contains_key(&name) {
+                return Err(Error::MissingCompatibilityPayload {
                     name: identity.to_string(),
-                }
-            })?;
+                });
+            }
             let mut seen = HashSet::new();
             let mut internal = HashMap::<&str, DependencyKind>::new();
-            let mut external = BTreeMap::new();
             for relationship in group.relationships() {
                 if !seen.insert(relationship.declaration_name()) {
                     continue;
@@ -553,12 +539,8 @@ impl PackageGraphAssembler {
                         DependencyKind::Production
                         | DependencyKind::Optional
                         | DependencyKind::Development,
-                        RelationshipTarget::UnresolvedExternal { name, specifier },
-                    ) => {
-                        external
-                            .entry(name.clone())
-                            .or_insert_with(|| specifier.clone());
-                    }
+                        RelationshipTarget::UnresolvedExternal { .. },
+                    ) => {}
                 }
             }
             let node_idx = self
@@ -588,7 +570,6 @@ impl PackageGraphAssembler {
                 self.workspace_graph
                     .add_edge(node_idx, dependency_idx, kind);
             }
-            entry.unresolved_external_dependencies = Some(external);
         }
         Ok(())
     }
@@ -626,7 +607,6 @@ where
         let PackageGraphBuilder {
             repo_root,
             root_package_json,
-            defer_closures,
             closure_hasher,
             is_single_package: single,
 
@@ -641,10 +621,9 @@ where
         // registered nor queried for a package manager. The graph is built
         // entirely from the extra toolchains (Cargo).
         let no_javascript = root_package_json.is_none();
-        let root_package_info = root_package_json.clone().map(|package_json| PackageInfo {
-            package_json,
-            ..Default::default()
-        });
+        let root_package_info = root_package_json
+            .clone()
+            .map(|package_json| PackageInfo { package_json });
         let assembler = PackageGraphAssembler::new(root_package_info);
 
         // The discovery strategy is shared (via the JavaScript toolchain)
@@ -684,7 +663,6 @@ where
             package_manager: None,
             package_jsons,
             root_package_json,
-            defer_closures,
             closure_hasher,
             state: std::marker::PhantomData,
             javascript,
@@ -704,25 +682,13 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             scope_kind,
             descriptor: json,
             manifest_path,
-            external_dependencies,
+            external_dependencies: _,
             native_relationships,
         } = package.into_parts();
-        // Toolchain-resolved external identities (e.g. Cargo's per-crate
-        // lockfile closures), in the sorted representation the JS lockfile
-        // phase produces. That phase later fills this for JavaScript
-        // packages and never touches non-JS ones; the external-dependency
-        // hash is computed on demand from the sorted closure.
-        let transitive_dependencies = external_dependencies.map(|externals| {
-            let mut sorted: Vec<std::sync::Arc<turborepo_lockfiles::Package>> =
-                externals.into_iter().map(std::sync::Arc::new).collect();
-            sorted.sort_by(|a, b| (&a.key, &a.version).cmp(&(&b.key, &b.version)));
-            sorted
-        });
-        let entry = PackageInfo {
-            package_json: json,
-            transitive_dependencies,
-            ..Default::default()
-        };
+        // Toolchain-resolved external identities are contributed to the
+        // resolution generation separately; PackageInfo no longer carries
+        // closure/hash compatibility projections.
+        let entry = PackageInfo { package_json: json };
         let observation = PackageScopeObservation {
             identity: name.clone(),
             definition_path: manifest_path.clone(),
@@ -841,7 +807,6 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             package_manager,
             javascript,
             toolchains,
-            defer_closures,
             closure_hasher,
             ..
         } = self;
@@ -858,7 +823,6 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             package_manager,
             javascript,
             toolchains,
-            defer_closures,
             closure_hasher,
             package_jsons: None,
             state: std::marker::PhantomData,
@@ -1129,7 +1093,6 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
             root_package_json,
             javascript,
             toolchains,
-            defer_closures,
             closure_hasher,
             ..
         } = self;
@@ -1145,7 +1108,6 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
             root_package_json,
             lockfile,
             package_manager,
-            defer_closures,
             closure_hasher,
             package_jsons: None,
             state: std::marker::PhantomData,
@@ -1231,12 +1193,8 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
 
     #[tracing::instrument(skip(self))]
     async fn build_inner(mut self) -> Result<PackageGraph, discovery::Error> {
-        // Transitive closures are only consumed by task hashing and
-        // change-detection, well after graph construction. When deferral is
-        // requested, compute them on a background thread so package-list
-        // consumers (microfrontends config, turbo.json preloading, engine
-        // construction) overlap with the closure work instead of waiting
-        // behind it. `PackageGraph::ensure_transitive_closures` joins.
+        // External resolution is produced during repository construction and
+        // retained as an immutable generation. Readiness belongs to build().
         let knowledge = self
             .knowledge
             .clone()
@@ -1258,61 +1216,6 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
         if let Some(definition_source) = definition_source {
             if let Some(lockfile) = arc_lockfile.clone() {
                 match self.all_external_dependencies() {
-                    Ok(external_dependencies) if self.defer_closures => {
-                        let (tx, rx) = std::sync::mpsc::sync_channel(1);
-                        let hasher = self.closure_hasher.clone();
-                        let resolution_knowledge = Arc::clone(&knowledge);
-                        let deferred_source = definition_source.clone();
-                        let deferred_native_resolutions = Arc::new(std::sync::Mutex::new(
-                            std::mem::take(&mut native_external_resolutions),
-                        ));
-                        let thread_native_resolutions = Arc::clone(&deferred_native_resolutions);
-                        let spawned = std::thread::Builder::new()
-                            .name("turbo-closures".into())
-                            .spawn(move || {
-                                let native_resolutions = std::mem::take(
-                                    &mut *thread_native_resolutions
-                                        .lock()
-                                        .unwrap_or_else(|poisoned| poisoned.into_inner()),
-                                );
-                                let result = javascript::resolve_dependencies(
-                                    &resolution_knowledge,
-                                    native_resolutions,
-                                    lockfile.as_ref(),
-                                    external_dependencies,
-                                    false,
-                                    deferred_source,
-                                    hasher.as_ref(),
-                                );
-                                let _ = tx.send(result);
-                            });
-                        match spawned {
-                            Ok(_) => {
-                                external_resolution = ExternalResolutionKnowledge::resolving(rx);
-                            }
-                            Err(error) => {
-                                warn!("Unable to spawn transitive closure thread: {}", error);
-                                let snapshot = javascript::unavailable_resolution(
-                                    &knowledge,
-                                    std::mem::take(
-                                        &mut *deferred_native_resolutions
-                                            .lock()
-                                            .unwrap_or_else(|poisoned| poisoned.into_inner()),
-                                    ),
-                                    definition_source,
-                                    "worker-unavailable",
-                                    error.to_string(),
-                                    None,
-                                    self.closure_hasher.as_ref(),
-                                )
-                                .map_err(|message| {
-                                    build_failure(Error::ExternalResolution(message))
-                                })?;
-                                external_resolution =
-                                    ExternalResolutionKnowledge::complete(snapshot.generation);
-                            }
-                        }
-                    }
                     Ok(external_dependencies) => {
                         let mut snapshot = turborepo_rayon_compat::block_in_place(|| {
                             javascript::resolve_dependencies(
@@ -1329,9 +1232,8 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
                         if let Some(warning) = snapshot.warning.take() {
                             warn!("Unable to calculate transitive closures: {}", warning);
                         }
-                        let generation = Arc::clone(&snapshot.generation);
-                        snapshot.project_legacy(&mut self.assembler.package_payloads, &knowledge);
-                        external_resolution = ExternalResolutionKnowledge::complete(generation);
+                        external_resolution =
+                            ExternalResolutionKnowledge::complete(snapshot.generation);
                     }
                     Err(error) => {
                         warn!("Unable to calculate transitive closures: {}", error);
@@ -2211,31 +2113,60 @@ mod test {
         );
 
         // Verify external deps are recorded correctly
-        let web_info = graph.package_info(&web_name).unwrap();
-        let web_ext = web_info.unresolved_external_dependencies.as_ref().unwrap();
+        let web_ext: std::collections::BTreeMap<_, _> = graph
+            .external_declarations(&web_name)
+            .iter()
+            .map(|declaration| {
+                (
+                    declaration.package_name().to_string(),
+                    declaration.specifier().to_string(),
+                )
+            })
+            .collect();
         assert_eq!(web_ext.get("react").map(|v| v.as_str()), Some("^18.0.0"));
         assert!(
             !web_ext.contains_key("ui"),
             "ui should be internal, not external"
         );
 
-        let api_info = graph.package_info(&api_name).unwrap();
-        let api_ext = api_info.unresolved_external_dependencies.as_ref().unwrap();
+        let api_ext: std::collections::BTreeMap<_, _> = graph
+            .external_declarations(&api_name)
+            .iter()
+            .map(|declaration| {
+                (
+                    declaration.package_name().to_string(),
+                    declaration.specifier().to_string(),
+                )
+            })
+            .collect();
         assert_eq!(api_ext.get("express").map(|v| v.as_str()), Some("^4.0.0"));
         assert!(
             !api_ext.contains_key("utils"),
             "utils should be internal, not external"
         );
 
-        let ui_info = graph.package_info(&ui_name).unwrap();
-        let ui_ext = ui_info.unresolved_external_dependencies.as_ref().unwrap();
+        let ui_ext: std::collections::BTreeMap<_, _> = graph
+            .external_declarations(&ui_name)
+            .iter()
+            .map(|declaration| {
+                (
+                    declaration.package_name().to_string(),
+                    declaration.specifier().to_string(),
+                )
+            })
+            .collect();
         assert_eq!(ui_ext.get("csstype").map(|v| v.as_str()), Some("^3.0.0"));
 
-        let utils_info = graph.package_info(&utils_name).unwrap();
-        let utils_ext = utils_info
-            .unresolved_external_dependencies
-            .as_ref()
-            .unwrap();
+        let utils_ext: std::collections::BTreeMap<_, _> = graph
+            .external_declarations(&utils_name)
+            .iter()
+            .map(|declaration| {
+                (
+                    declaration.package_name().to_string(),
+                    declaration.specifier().to_string(),
+                )
+            })
+            .collect();
         assert!(
             utils_ext.is_empty(),
             "utils should have no external deps, got: {:?}",
@@ -2472,12 +2403,14 @@ mod test {
             b_deps
         );
 
-        let b_external = graph
-            .package_info(&b)
-            .unwrap()
-            .unresolved_external_dependencies
-            .as_ref()
-            .unwrap();
+        let b_external = {
+            let decls: std::collections::BTreeMap<_, _> = graph
+                .external_declarations(&b)
+                .iter()
+                .map(|d| (d.package_name().to_string(), d.specifier().to_string()))
+                .collect();
+            decls
+        };
         assert_eq!(
             b_external.get("buffer").map(|v| v.as_str()),
             Some("npm:buffer@6.0.3")
@@ -2595,12 +2528,14 @@ mod test {
         .unwrap();
 
         let a = PackageName::from("a");
-        let a_external = graph
-            .package_info(&a)
-            .unwrap()
-            .unresolved_external_dependencies
-            .as_ref()
-            .unwrap();
+        let a_external = {
+            let decls: std::collections::BTreeMap<_, _> = graph
+                .external_declarations(&a)
+                .iter()
+                .map(|d| (d.package_name().to_string(), d.specifier().to_string()))
+                .collect();
+            decls
+        };
         assert!(
             !a_external.contains_key("react"),
             "external peer dependency should not be retained as an external dep, got: {:?}",
@@ -2646,12 +2581,14 @@ mod test {
         .unwrap();
 
         let a = PackageName::from("a");
-        let a_external = graph
-            .package_info(&a)
-            .unwrap()
-            .unresolved_external_dependencies
-            .as_ref()
-            .unwrap();
+        let a_external = {
+            let decls: std::collections::BTreeMap<_, _> = graph
+                .external_declarations(&a)
+                .iter()
+                .map(|d| (d.package_name().to_string(), d.specifier().to_string()))
+                .collect();
+            decls
+        };
         assert!(
             !a_external.contains_key("react"),
             "optional peer should not be retained, got: {:?}",
@@ -2729,12 +2666,16 @@ mod test {
             "prune closure for app should include its regular dependency lib"
         );
 
-        let lib_external = graph
-            .package_info(&PackageName::from("lib"))
-            .unwrap()
-            .unresolved_external_dependencies
-            .as_ref()
-            .unwrap();
+        let lib_external: std::collections::BTreeMap<_, _> = graph
+            .external_declarations(&PackageName::from("lib"))
+            .iter()
+            .map(|declaration| {
+                (
+                    declaration.package_name().to_string(),
+                    declaration.specifier().to_string(),
+                )
+            })
+            .collect();
         assert!(
             !lib_external.contains_key("react"),
             "external peer should not be retained by package graph, got: {:?}",

--- a/crates/turborepo-repository/src/package_graph/dep_splitter.rs
+++ b/crates/turborepo-repository/src/package_graph/dep_splitter.rs
@@ -371,9 +371,6 @@ mod test {
                         version: Some(package_version.to_string()),
                         ..Default::default()
                     },
-                    unresolved_external_dependencies: None,
-                    transitive_dependencies: None,
-                    ..Default::default()
                 },
             );
             map.insert(
@@ -383,9 +380,6 @@ mod test {
                         version: Some("1.0.0".to_string()),
                         ..Default::default()
                     },
-                    unresolved_external_dependencies: None,
-                    transitive_dependencies: None,
-                    ..Default::default()
                 },
             );
             map.insert(
@@ -395,9 +389,6 @@ mod test {
                         version: Some("1.0.0".to_string()),
                         ..Default::default()
                     },
-                    unresolved_external_dependencies: None,
-                    transitive_dependencies: None,
-                    ..Default::default()
                 },
             );
             map.insert(
@@ -407,9 +398,6 @@ mod test {
                         version: Some("6.0.3".to_string()),
                         ..Default::default()
                     },
-                    unresolved_external_dependencies: None,
-                    transitive_dependencies: None,
-                    ..Default::default()
                 },
             );
             map
@@ -495,9 +483,6 @@ mod test {
                         version: Some("1.0.0".to_string()),
                         ..Default::default()
                     },
-                    unresolved_external_dependencies: None,
-                    transitive_dependencies: None,
-                    ..Default::default()
                 },
             );
             map
@@ -536,9 +521,6 @@ mod test {
                         version: Some("1.0.0".to_string()),
                         ..Default::default()
                     },
-                    unresolved_external_dependencies: None,
-                    transitive_dependencies: None,
-                    ..Default::default()
                 },
             );
             map
@@ -577,9 +559,6 @@ mod test {
                         version: Some("1.2.3".to_string()),
                         ..Default::default()
                     },
-                    unresolved_external_dependencies: None,
-                    transitive_dependencies: None,
-                    ..Default::default()
                 },
             );
             map
@@ -643,9 +622,6 @@ mod test {
                         version: Some("1.0.0".to_string()),
                         ..Default::default()
                     },
-                    unresolved_external_dependencies: None,
-                    transitive_dependencies: None,
-                    ..Default::default()
                 },
             );
             map
@@ -681,9 +657,6 @@ mod test {
                         version: Some("1.0.0".to_string()),
                         ..Default::default()
                     },
-                    unresolved_external_dependencies: None,
-                    transitive_dependencies: None,
-                    ..Default::default()
                 },
             );
             map

--- a/crates/turborepo-repository/src/package_graph/javascript.rs
+++ b/crates/turborepo-repository/src/package_graph/javascript.rs
@@ -7,8 +7,7 @@ use turbopath::{AnchoredSystemPath, AnchoredSystemPathBuf};
 use turborepo_lockfiles::Lockfile;
 
 use super::{
-    ExternalDependencyChange, PackageGraph, PackageInfo, PackageName, ROOT_PKG_NAME,
-    WorkspacePackage,
+    ExternalDependencyChange, PackageGraph, PackageName, ROOT_PKG_NAME, WorkspacePackage,
     builder::{ClosureHasher, apply_resolution_fingerprints},
 };
 use crate::{
@@ -24,58 +23,13 @@ use crate::{
     toolchain::ToolchainId,
 };
 
-/// One JavaScript resolution snapshot and its temporary compatibility
-/// projection. Both inline and deferred production create this exact shape.
+/// One JavaScript resolution snapshot. Both production paths create this
+/// exact generation-backed shape; compatibility projections onto `PackageInfo`
+/// have been deleted.
 pub(super) struct ResolutionSnapshot {
     pub generation: Arc<ExternalResolutionGeneration>,
-    pub closures: HashMap<String, Vec<Arc<turborepo_lockfiles::Package>>>,
     pub warning: Option<String>,
 }
-
-impl ResolutionSnapshot {
-    pub(super) fn project_legacy(
-        &mut self,
-        package_payloads: &mut HashMap<PackageName, PackageInfo>,
-        knowledge: &RepositoryKnowledge,
-    ) {
-        let fingerprints = self
-            .generation
-            .domains()
-            .iter()
-            .find(|domain| domain.toolchain() == &ToolchainId::JAVASCRIPT)
-            .and_then(|domain| match domain.data() {
-                ExternalResolutionData::Resolved { packages, .. } => Some(
-                    packages
-                        .iter()
-                        .filter_map(|package| {
-                            package
-                                .fingerprint()
-                                .map(|fingerprint| (package.package(), fingerprint.as_str()))
-                        })
-                        .collect::<HashMap<_, _>>(),
-                ),
-                ExternalResolutionData::Unavailable(_) => None,
-            })
-            .unwrap_or_default();
-        for (name, info) in package_payloads {
-            let facts = scope_directory_and_toolchain(knowledge, name);
-            let Some((directory, toolchain)) = facts else {
-                continue;
-            };
-            if toolchain != &ToolchainId::JAVASCRIPT {
-                continue;
-            }
-            let directory = directory.to_unix();
-            info.transitive_dependencies = self.closures.remove(directory.as_str());
-            info.external_deps_hash = fingerprints
-                .get(name.as_str())
-                .map(|fingerprint| (*fingerprint).to_string());
-        }
-    }
-}
-
-pub(super) type DeferredResolutionReceiver =
-    std::sync::mpsc::Receiver<Result<ResolutionSnapshot, String>>;
 
 fn scope_directory_and_toolchain<'a>(
     knowledge: &'a RepositoryKnowledge,
@@ -157,7 +111,6 @@ pub(super) fn unavailable_resolution(
         .map_err(|error| error.to_string())?;
     Ok(ResolutionSnapshot {
         generation: Arc::new(generation),
-        closures: HashMap::new(),
         warning,
     })
 }
@@ -224,7 +177,6 @@ pub(super) fn resolve_dependencies(
         .map_err(|error| error.to_string())?;
     Ok(ResolutionSnapshot {
         generation: Arc::new(generation),
-        closures,
         warning: None,
     })
 }

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{HashMap, HashSet},
     fmt,
     sync::{Arc, Mutex, OnceLock},
 };
@@ -43,13 +43,10 @@ pub use crate::package_json::DependencyKind;
 
 pub const ROOT_PKG_NAME: &str = "//";
 
-type DeferredResolutionReceiver = javascript::DeferredResolutionReceiver;
-
 #[derive(Debug)]
 struct ExternalResolutionKnowledge {
     status: ExternalResolutionStatus,
     generation: Option<Arc<ExternalResolutionGeneration>>,
-    receiver: Option<DeferredResolutionReceiver>,
 }
 
 impl ExternalResolutionKnowledge {
@@ -57,7 +54,6 @@ impl ExternalResolutionKnowledge {
         Self {
             status: ExternalResolutionStatus::Complete,
             generation: None,
-            receiver: None,
         }
     }
 
@@ -65,25 +61,7 @@ impl ExternalResolutionKnowledge {
         Self {
             status: ExternalResolutionStatus::Complete,
             generation: Some(generation),
-            receiver: None,
         }
-    }
-
-    fn resolving(receiver: DeferredResolutionReceiver) -> Self {
-        Self {
-            status: ExternalResolutionStatus::Resolving,
-            generation: None,
-            receiver: Some(receiver),
-        }
-    }
-
-    fn take_receiver(&mut self) -> Option<DeferredResolutionReceiver> {
-        self.receiver.take()
-    }
-
-    fn finish(&mut self, generation: Option<Arc<ExternalResolutionGeneration>>) {
-        self.status = ExternalResolutionStatus::Complete;
-        self.generation = generation;
     }
 }
 
@@ -105,9 +83,9 @@ pub struct PackageGraph {
     relationship_knowledge: Arc<RelationshipKnowledge>,
     external_declarations: OnceLock<ExternalDeclarations>,
     relationship_projections: OnceLock<projections::RelationshipProjections>,
-    /// The sole owner of external-resolution lifecycle and terminal knowledge
-    /// across toolchains. Deferred JavaScript production is joined once by
-    /// [`Self::ensure_transitive_closures`].
+    /// The sole owner of external-resolution terminal knowledge across
+    /// toolchains. Resolution is complete when the package graph is returned
+    /// from construction.
     external_resolution: Mutex<ExternalResolutionKnowledge>,
     /// Lazy reverse index from exact external identities to internal
     /// dependents. Built once from the resolution generation, not from
@@ -146,11 +124,12 @@ impl WorkspacePackage {
     }
 }
 
-/// Compatibility data retained for descriptor relationship classification,
-/// JavaScript lockfile resolution/hash state, and task consumers.
+/// Compatibility data retained for descriptor relationship classification
+/// and task consumers.
 ///
-/// Package identity, directory ownership, definition source, and provenance
-/// are authoritative in [`RepositoryKnowledge`], not in this projection.
+/// Package identity, directory ownership, definition source, provenance, and
+/// external-resolution state are authoritative in repository knowledge, not in
+/// this projection.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct PackageInfo {
     /// A temporary compatibility descriptor for relationship classification
@@ -158,20 +137,7 @@ pub struct PackageInfo {
     /// Its native `name` may be retained for later payload semantics, but must
     /// never be used as package identity or to derive paths or provenance.
     pub package_json: PackageJson,
-    pub unresolved_external_dependencies: Option<BTreeMap<PackageKey, PackageVersion>>, /* name -> version */
-    /// The workspace's external dependency closure, sorted by `Package`'s
-    /// `(key, version)` ordering. Members are `Arc`-shared across workspaces.
-    pub transitive_dependencies: Option<Vec<Arc<turborepo_lockfiles::Package>>>,
-    /// Hash of `transitive_dependencies`, precomputed by the JavaScript
-    /// lockfile phase so task hashing and run summaries never re-sort or
-    /// re-hash closures. When `None` with a `Some` closure (toolchain-
-    /// resolved closures, e.g. Cargo's), consumers compute the hash from
-    /// the sorted closure on demand.
-    pub external_deps_hash: Option<String>,
 }
-
-type PackageKey = String;
-type PackageVersion = String;
 
 // PackageName refers to a real package's name or the root package.
 // It's not the best name, because root isn't a real package, but it's
@@ -843,48 +809,6 @@ impl PackageGraph {
         self.lockfile.as_deref()
     }
 
-    /// Join the background transitive-closure computation (if the graph was
-    /// built with deferred closures) and install the results. Idempotent and
-    /// cheap when there is nothing to join. Must be called before any
-    /// consumer of `PackageInfo::transitive_dependencies` runs.
-    pub fn ensure_transitive_closures(&mut self) {
-        let receiver = self
-            .external_resolution
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .take_receiver();
-        let Some(receiver) = receiver else {
-            return;
-        };
-        match receiver.recv() {
-            Ok(Ok(mut snapshot)) => {
-                if let Some(warning) = snapshot.warning.take() {
-                    tracing::warn!("Unable to calculate transitive closures: {}", warning);
-                }
-                let generation = Arc::clone(&snapshot.generation);
-                snapshot.project_legacy(&mut self.package_payloads, &self.knowledge);
-                self.external_resolution
-                    .lock()
-                    .unwrap_or_else(|poisoned| poisoned.into_inner())
-                    .finish(Some(generation));
-            }
-            Ok(Err(e)) => {
-                tracing::warn!("Unable to calculate transitive closures: {}", e);
-                self.external_resolution
-                    .lock()
-                    .unwrap_or_else(|poisoned| poisoned.into_inner())
-                    .finish(None);
-            }
-            Err(_) => {
-                tracing::warn!("transitive closure thread disappeared without a result");
-                self.external_resolution
-                    .lock()
-                    .unwrap_or_else(|poisoned| poisoned.into_inner())
-                    .finish(None);
-            }
-        }
-    }
-
     pub fn external_resolution_status(&self) -> ExternalResolutionStatus {
         self.external_resolution
             .lock()
@@ -1241,19 +1165,6 @@ impl PackageGraph {
         visited
     }
 
-    pub fn transitive_external_dependencies<'a, I: IntoIterator<Item = &'a PackageName>>(
-        &self,
-        packages: I,
-    ) -> HashSet<&turborepo_lockfiles::Package> {
-        packages
-            .into_iter()
-            .filter_map(|package| self.package_payloads.get(package))
-            .filter_map(|entry| entry.transitive_dependencies.as_ref())
-            .flatten()
-            .map(|pkg| &**pkg)
-            .collect()
-    }
-
     /// Unique external package identities from the resolution generation.
     ///
     /// Display names are the producer-supplied human names captured during
@@ -1264,7 +1175,7 @@ impl PackageGraph {
 
     /// Exact external identities attributed to the given packages by the
     /// resolution generation. Used by prune lockfile-key unions so they no
-    /// longer read `PackageInfo::transitive_dependencies`.
+    /// read resolution generation identities.
     pub fn external_package_identities_for_packages<'a, I>(
         &self,
         packages: I,
@@ -1473,16 +1384,6 @@ impl PackageGraph {
             dependents,
         }
     }
-
-    // Returns a map of package name and version for external dependencies
-    #[allow(dead_code)]
-    fn external_dependencies(
-        &self,
-        package: &PackageName,
-    ) -> Option<&BTreeMap<PackageKey, PackageVersion>> {
-        let entry = self.package_payloads.get(package)?;
-        entry.unresolved_external_dependencies.as_ref()
-    }
 }
 
 impl fmt::Display for PackageName {
@@ -1528,7 +1429,7 @@ impl AsRef<str> for PackageName {
 
 #[cfg(test)]
 mod test {
-    use std::{fs, path::Path, process::Command};
+    use std::{collections::BTreeMap, fs, path::Path, process::Command};
 
     use serde_json::json;
     use turbopath::AbsoluteSystemPathBuf;
@@ -1856,13 +1757,16 @@ mod test {
             .iter()
             .collect::<HashSet<_>>()
         );
-        let b_external = pkg_graph
-            .package_payloads
-            .get(&PackageName::from("b"))
-            .unwrap()
-            .unresolved_external_dependencies
-            .as_ref()
-            .unwrap();
+        let b_external: std::collections::BTreeMap<_, _> = pkg_graph
+            .external_declarations(&PackageName::from("b"))
+            .iter()
+            .map(|declaration| {
+                (
+                    declaration.package_name().to_string(),
+                    declaration.specifier().to_string(),
+                )
+            })
+            .collect();
 
         let pkg_version = b_external.get("c").unwrap();
         assert_eq!(pkg_version, "1.2.3");
@@ -1987,30 +1891,9 @@ mod test {
         let foo = PackageName::from("foo");
         let bar = PackageName::from("bar");
 
-        let foo_deps = pkg_graph
-            .package_payloads
-            .get(&foo)
-            .unwrap()
-            .transitive_dependencies
-            .as_ref()
-            .unwrap();
-        let bar_deps = pkg_graph
-            .package_payloads
-            .get(&bar)
-            .unwrap()
-            .transitive_dependencies
-            .as_ref()
-            .unwrap();
         let a = turborepo_lockfiles::Package::new("key:a", "1");
-        let b = turborepo_lockfiles::Package::new("key:b", "1");
-        let c = turborepo_lockfiles::Package::new("key:c", "1");
-        // Closures are sorted by (key, version).
-        assert_eq!(foo_deps, &vec![Arc::new(a.clone()), Arc::new(c.clone())]);
-        assert_eq!(bar_deps, &vec![Arc::new(b.clone()), Arc::new(c.clone())]);
-        assert_eq!(
-            pkg_graph.transitive_external_dependencies([&foo, &bar].iter().copied()),
-            HashSet::from_iter(vec![&a, &b, &c,])
-        );
+        let _b = turborepo_lockfiles::Package::new("key:b", "1");
+        let _c = turborepo_lockfiles::Package::new("key:c", "1");
 
         let identities = pkg_graph.external_package_identities();
         assert_eq!(
@@ -2153,12 +2036,10 @@ mod test {
         assert_eq!(packages.len(), 1);
         assert_eq!(packages[0].package(), ROOT_PKG_NAME);
         assert!(packages[0].identities().is_empty());
-        assert_eq!(
+        assert!(
             resolved
-                .package_payloads
-                .get(&PackageName::Root)
-                .and_then(|info| info.transitive_dependencies.as_deref()),
-            Some(&[][..])
+                .external_package_identities_for_packages([&PackageName::Root])
+                .is_empty()
         );
 
         let unavailable = PackageGraph::builder(&root, root_package())
@@ -2177,9 +2058,8 @@ mod test {
         assert_eq!(reason.code(), "lockfile-unavailable");
         assert!(
             unavailable
-                .package_payloads
-                .get(&PackageName::Root)
-                .is_some_and(|info| info.transitive_dependencies.is_none())
+                .external_resolution_global_file_fallback()
+                .is_some()
         );
 
         let fallback = unavailable
@@ -2196,127 +2076,6 @@ mod test {
                 .is_none(),
             "resolved domains must not use the global file fallback"
         );
-    }
-
-    /// A graph built with deferred closures must, after
-    /// `ensure_transitive_closures`, be indistinguishable from one built
-    /// inline.
-    #[tokio::test]
-    async fn test_deferred_closures_match_inline() {
-        let root =
-            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
-        let package_jsons = || {
-            let mut map = HashMap::new();
-            map.insert(
-                root.join_components(&["package_a", "package.json"]),
-                PackageJson::from_value(json!({
-                    "name": "foo",
-                    "dependencies": { "a": "1" }
-                }))
-                .unwrap(),
-            );
-            map.insert(
-                root.join_components(&["package_b", "package.json"]),
-                PackageJson::from_value(json!({
-                    "name": "bar",
-                    "dependencies": { "b": "1" }
-                }))
-                .unwrap(),
-            );
-            map
-        };
-        let hasher: crate::package_graph::builder::ClosureHasher = Arc::new(|closures| {
-            closures
-                .iter()
-                .map(|(package, identities)| {
-                    let fingerprint = identities
-                        .iter()
-                        .map(|identity| format!("{}@{}", identity.key, identity.version))
-                        .collect::<Vec<_>>()
-                        .join(",");
-                    (package.clone(), fingerprint)
-                })
-                .collect()
-        });
-
-        let inline = PackageGraph::builder(
-            &root,
-            PackageJson::from_value(json!({ "name": "root" })).unwrap(),
-        )
-        .with_package_discovery(MockDiscovery)
-        .with_package_jsons(Some(package_jsons()))
-        .with_lockfile(Some(Box::new(MockLockfile {})))
-        .with_closure_hasher(hasher.clone())
-        .build()
-        .await
-        .unwrap();
-
-        let mut deferred = PackageGraph::builder(
-            &root,
-            PackageJson::from_value(json!({ "name": "root" })).unwrap(),
-        )
-        .with_package_discovery(MockDiscovery)
-        .with_package_jsons(Some(package_jsons()))
-        .with_lockfile(Some(Box::new(MockLockfile {})))
-        .defer_transitive_closures(true)
-        .with_closure_hasher(hasher)
-        .build()
-        .await
-        .unwrap();
-
-        assert_eq!(
-            inline.external_resolution_status(),
-            ExternalResolutionStatus::Complete
-        );
-        assert_eq!(
-            deferred.external_resolution_status(),
-            ExternalResolutionStatus::Resolving
-        );
-        let inline_generation = inline
-            .external_resolution_generation()
-            .expect("inline resolution should be available");
-        assert_eq!(inline_generation.domains().len(), 1);
-
-        // Before the join, closures are absent.
-        assert!(
-            deferred
-                .package_payloads
-                .values()
-                .all(|info| info.transitive_dependencies.is_none()),
-            "deferred graph must not have closures before ensure"
-        );
-
-        deferred.ensure_transitive_closures();
-        // Idempotent.
-        deferred.ensure_transitive_closures();
-
-        assert_eq!(
-            deferred.external_resolution_status(),
-            ExternalResolutionStatus::Complete
-        );
-        assert_eq!(
-            inline_generation,
-            deferred
-                .external_resolution_generation()
-                .expect("deferred resolution should be available after joining")
-        );
-
-        for (name, info) in &inline.package_payloads {
-            let deferred_info = deferred.package_payloads.get(name).unwrap();
-            assert_eq!(
-                info.transitive_dependencies, deferred_info.transitive_dependencies,
-                "closures must match for {name}"
-            );
-            assert_eq!(
-                info.external_deps_hash, deferred_info.external_deps_hash,
-                "external deps hashes must match for {name}"
-            );
-            assert_eq!(
-                info.external_deps_hash.is_some(),
-                info.transitive_dependencies.is_some(),
-                "hash must be present exactly when the closure is, for {name}"
-            );
-        }
     }
 
     #[tokio::test]
@@ -2807,7 +2566,7 @@ version = "0.1.0"
         // process/build.
         let mut expected_cargo_fingerprint = None;
         for iteration in 0..8 {
-            let defer_resolution = iteration % 2 == 1;
+            let _defer_resolution = iteration % 2 == 1;
             let mut pkg_graph = PackageGraph::builder(
                 &root,
                 PackageJson::from_value(json!({ "name": "root", "dependencies": { "a": "1" } }))
@@ -2824,11 +2583,9 @@ version = "0.1.0"
             }))
             .with_lockfile(Some(Box::new(MockLockfile {})))
             .with_toolchain(crate::cargo::CargoToolchain::new(root.clone()))
-            .defer_transitive_closures(defer_resolution)
             .build()
             .await
             .unwrap();
-            pkg_graph.ensure_transitive_closures();
 
             assert!(pkg_graph.validate().is_ok());
             assert!(pkg_graph.package_task_contexts().all(|context| {
@@ -2859,7 +2616,7 @@ version = "0.1.0"
                 pkg_graph.package_toolchain(&PackageName::from("js-pkg")),
                 Some(&crate::toolchain::ToolchainId::JAVASCRIPT)
             );
-            let workspace_pkg = pkg_graph.package_info(&PackageName::from("acme")).unwrap();
+            let _workspace_pkg = pkg_graph.package_info(&PackageName::from("acme")).unwrap();
             assert_eq!(
                 pkg_graph.package_toolchain(&PackageName::from("acme")),
                 Some(&crate::toolchain::ToolchainId::RUST)
@@ -2955,34 +2712,20 @@ version = "0.1.0"
                 "workspace package should depend on every crate, got {workspace_deps:?}"
             );
 
-            // The root's JS lockfile closure is attributed to the root, not
-            // stolen by the cargo workspace package sharing its directory.
-            let root_closure = pkg_graph
-                .package_info(&PackageName::Root)
-                .unwrap()
-                .transitive_dependencies
-                .as_ref()
-                .expect("root should have a lockfile closure");
-            // Closures are sorted by (key, version).
+            // The root's JS resolution identities are attributed to the root
+            // package, not stolen by the Cargo workspace package sharing its
+            // directory.
+            let root_identities =
+                pkg_graph.external_package_identities_for_packages([&PackageName::Root]);
             assert_eq!(
-                root_closure,
-                &vec![
-                    Arc::new(turborepo_lockfiles::Package::new("key:a", "1")),
-                    Arc::new(turborepo_lockfiles::Package::new("key:c", "1")),
-                ],
-            );
-            // Cargo packages carry toolchain-resolved closures (here just
-            // the rustc stamp — the fixture has no external dependencies),
-            // never JS lockfile entries.
-            assert!(
-                workspace_pkg
-                    .transitive_dependencies
+                root_identities
                     .iter()
-                    .flatten()
-                    .all(|package| package.key == "rustc"),
-                "the cargo workspace package must not carry JS lockfile entries, got {:?}",
-                workspace_pkg.transitive_dependencies
+                    .map(|identity| (identity.key(), identity.version()))
+                    .collect::<Vec<_>>(),
+                vec![("key:a", "1"), ("key:c", "1")],
             );
+            // Cargo packages contribute identities through the Rust resolution
+            // domain, never JS lockfile entries.
 
             let resolution = pkg_graph
                 .external_resolution_generation()
@@ -3021,19 +2764,15 @@ version = "0.1.0"
                     "{} must include the compiler identity",
                     package.package()
                 );
-                let legacy: HashSet<_> = pkg_graph
-                    .package_info(&PackageName::from(package.package()))
-                    .and_then(|info| info.transitive_dependencies.as_ref())
-                    .into_iter()
-                    .flatten()
-                    .map(|identity| (identity.key.as_str(), identity.version.as_str()))
-                    .collect();
-                let normalized: HashSet<_> = package
-                    .identities()
-                    .iter()
-                    .map(|identity| (identity.key(), identity.version()))
-                    .collect();
-                assert_eq!(normalized, legacy);
+                assert!(
+                    package
+                        .identities()
+                        .iter()
+                        .all(|identity| identity.key() == "rustc"),
+                    "{} should only carry the compiler identity in this fixture, got {:?}",
+                    package.package(),
+                    package.identities()
+                );
             }
         }
     }

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -149,6 +149,7 @@ pub(crate) struct DiscoveredPackageParts {
     pub scope_kind: DiscoveredScopeKind,
     pub descriptor: PackageJson,
     pub manifest_path: AbsoluteSystemPathBuf,
+    #[allow(dead_code)]
     pub external_dependencies: Option<std::collections::HashSet<turborepo_lockfiles::Package>>,
     pub native_relationships: Option<Vec<Relationship>>,
 }
@@ -1291,7 +1292,6 @@ mod tests {
                 "scripts": { "build": "next build", "empty": "" }
             }))
             .unwrap(),
-            ..Default::default()
         };
         let package_directory = turbopath::AnchoredSystemPath::new("apps/web").unwrap();
         let context = crate::package_graph::PackageTaskContext::new_for_test(

--- a/crates/turborepo-task-hash/src/lib.rs
+++ b/crates/turborepo-task-hash/src/lib.rs
@@ -801,21 +801,6 @@ pub fn deferred_task_hash_message(inputs: &TaskInputs) -> &'static str {
     }
 }
 
-pub fn get_external_deps_hash(
-    transitive_dependencies: &Option<Vec<Arc<turborepo_lockfiles::Package>>>,
-) -> String {
-    let Some(transitive_dependencies) = transitive_dependencies else {
-        return "".into();
-    };
-
-    // The closure is already sorted by `Package`'s `(key, version)` ordering,
-    // so hashing is a single linear pass.
-    let transitive_deps: Vec<&turborepo_lockfiles::Package> =
-        transitive_dependencies.iter().map(|pkg| &**pkg).collect();
-
-    LockFilePackagesRef(transitive_deps).hash()
-}
-
 /// Produce byte-compatible fingerprints once from normalized resolution sets.
 pub fn hash_sorted_closures(
     closures: &HashMap<String, Vec<Arc<turborepo_lockfiles::Package>>>,
@@ -1856,91 +1841,9 @@ mod test {
         assert_eq!(result[3].1, "dddddddddddddddddddddddddddddddddddddddd");
     }
 
-    fn sorted_closure(
-        packages: Vec<turborepo_lockfiles::Package>,
-    ) -> Vec<Arc<turborepo_lockfiles::Package>> {
-        let mut closure: Vec<Arc<turborepo_lockfiles::Package>> =
-            packages.into_iter().map(Arc::new).collect();
-        closure.sort_unstable();
-        closure
-    }
-
-    #[test]
-    fn test_external_deps_hash_deterministic() {
-        use turborepo_lockfiles::Package;
-
-        let deps = sorted_closure(vec![
-            Package {
-                key: "react".to_string(),
-                version: "18.0.0".to_string(),
-            },
-            Package {
-                key: "lodash".to_string(),
-                version: "4.17.21".to_string(),
-            },
-            Package {
-                key: "typescript".to_string(),
-                version: "5.0.0".to_string(),
-            },
-        ]);
-
-        let hash1 = get_external_deps_hash(&Some(deps.clone()));
-        let hash2 = get_external_deps_hash(&Some(deps));
-        assert_eq!(hash1, hash2, "same deps should produce same hash");
-        assert!(!hash1.is_empty(), "hash should be non-empty");
-    }
-
-    #[test]
-    fn test_external_deps_hash_empty() {
-        let hash_none = get_external_deps_hash(&None);
-        assert_eq!(hash_none, "", "None deps should produce empty hash");
-
-        let hash_empty = get_external_deps_hash(&Some(Vec::new()));
-        assert_eq!(hash_empty, "459c029558afe716");
-    }
-
     /// The linear hash of a pre-sorted closure must be byte-identical to the
     /// legacy path, which collected a `HashSet` and sorted by
     /// `(key, version)` before hashing.
-    #[test]
-    fn test_external_deps_hash_matches_legacy_sort_then_hash() {
-        use turborepo_lockfiles::Package;
-
-        let packages = vec![
-            Package {
-                key: "b".to_string(),
-                version: "2.0".to_string(),
-            },
-            Package {
-                key: "a".to_string(),
-                version: "1.1".to_string(),
-            },
-            Package {
-                key: "a".to_string(),
-                version: "1.0".to_string(),
-            },
-            Package {
-                key: "c".to_string(),
-                version: "0.1".to_string(),
-            },
-        ];
-
-        let legacy_hash = {
-            let set: HashSet<Package> = packages.iter().cloned().collect();
-            let mut refs: Vec<&Package> = set.iter().collect();
-            refs.sort_unstable_by(|a, b| match a.key.cmp(&b.key) {
-                std::cmp::Ordering::Equal => a.version.cmp(&b.version),
-                other => other,
-            });
-            LockFilePackagesRef(refs).hash()
-        };
-
-        let sorted_hash = get_external_deps_hash(&Some(sorted_closure(packages)));
-        assert_eq!(
-            legacy_hash, sorted_hash,
-            "sorted-closure hash must match the legacy sort-then-hash path"
-        );
-    }
 
     #[test]
     fn test_tracker_pre_sized_hashmaps() {

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -178,8 +178,9 @@ Represents the workspace structure and package dependencies:
   Global hashing consumes the same root resolution fingerprint as task hashing
   and, when JavaScript resolution is unavailable, hashes resolution definition
   sources plus the root package.json instead of reading the singleton lockfile
-  object. The snapshot projects temporary `PackageInfo` closure/hash fields only
-  until the Phase 3 deletion gate removes them.
+  object. Phase 3 deletion removed `PackageInfo` closure/hash compatibility
+  fields and deferred resolution installation; readiness belongs to repository
+  construction.
   Framework inference and boundaries validation consume the package-scoped
   declaration projection directly;
   aliases, duplicate
@@ -212,7 +213,7 @@ The remaining payload deletion phases are explicit:
 - **Phase 2:** Move script and version reads behind task queries; normalized
   relationship knowledge now owns graph assembly, while JavaScript declarations
   remain a temporary classification input.
-- **Phase 3:** Move unresolved dependency and lockfile-closure/hash state behind lockfile and hashing queries.
+- **Phase 3:** Complete. External resolution lives in the immutable generation; query, prune, hashing, and summaries consume it. `PackageInfo` no longer carries `unresolved_external_dependencies`, `transitive_dependencies`, or `external_deps_hash`, and deferred closure installation is gone.
 - **Phase 4:** Delete `PackageInfo`, its payload map, and optional-payload compatibility plumbing once all fail-closed consumers use those queries.
 
 Task hashing, run-cache path construction, and run-summary task directories use


### PR DESCRIPTION
## Intent

**Deletion gate** for Phase 3: once every consumer reads resolution knowledge, remove legacy resolution state from `PackageInfo`, deferred closure installation, and fallback rehash helpers so readiness belongs to repository construction.

**Stack:** layer 4 / 5. Base = layer 3 (global hash).

## Changes

- Delete `PackageInfo::{unresolved_external_dependencies,transitive_dependencies,external_deps_hash}`
- Delete deferred closure workers / `ensure_transitive_closures`
- Delete `get_external_deps_hash` fallback rehash helper
- Mark Phase 3 complete in `ARCHITECTURE.md`

## Out of scope

Total `PackageInfo` deletion, script/version payload, declaration-path polish (layer 5).

## Testing

- `cargo test -p turborepo-repository --lib test_lockfile_traversal`
- `cargo test -p turborepo-lib --lib prune`
- `cargo test -p turborepo-task-hash --lib`
- `cargo test -p turborepo-frameworks --lib`
- `cargo clippy -p turborepo-repository -p turborepo-lib -p turborepo-task-hash -p turborepo-frameworks -p turborepo-boundaries -p turborepo-hash --all-targets -- -D warnings`

Closes TURBO-5814.
