### PR TITLE
refactor: Remove external declaration compatibility paths

### DIFF
--- a/crates/turborepo-repository/src/external_resolution.rs
+++ b/crates/turborepo-repository/src/external_resolution.rs
@@ -435,7 +435,6 @@ impl ExternalResolutionDomain {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExternalResolutionStatus {
     Pending,
-    Resolving,
     Complete,
 }
 

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -1905,11 +1905,10 @@ mod test {
         );
     }
 
-    // Regression test: connect_internal_dependencies must produce correct
-    // graph edges and external deps regardless of iteration order or
-    // parallelism. This captures the exact edges and
-    // unresolved_external_dependencies so any refactor of the collection phase
-    // (e.g. rayon parallelization) is safe.
+    // Regression test: relationship projection must produce correct graph
+    // edges and external declaration views regardless of iteration order or
+    // parallelism. This captures edges and declaration projections so any
+    // refactor of the collection phase (e.g. rayon parallelization) is safe.
     #[tokio::test]
     async fn test_connect_internal_dependencies_produces_correct_edges() {
         let root =

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -178,9 +178,11 @@ Represents the workspace structure and package dependencies:
   Global hashing consumes the same root resolution fingerprint as task hashing
   and, when JavaScript resolution is unavailable, hashes resolution definition
   sources plus the root package.json instead of reading the singleton lockfile
-  object. Phase 3 deletion removed `PackageInfo` closure/hash compatibility
+  object.   Phase 3 deletion removed `PackageInfo` closure/hash compatibility
   fields and deferred resolution installation; readiness belongs to repository
-  construction.
+  construction. External declaration consumers (frameworks, boundaries, task
+  hashing) read the authoritative `ExternalDeclarations` projection built from
+  relationship knowledge rather than raw manifests or PackageInfo maps.
   Framework inference and boundaries validation consume the package-scoped
   declaration projection directly;
   aliases, duplicate


### PR DESCRIPTION
## Intent

Final Phase 3 cleanup: ensure external **declaration** consumers only use the authoritative `ExternalDeclarations` projection (from relationship knowledge), and remove leftover resolution-lifecycle / compat commentary from the deleted PackageInfo declaration path.

**Stack:** layer 5 / 5. Base = layer 4 (deletion gate).

## Changes

- Remove unused `ExternalResolutionStatus::Resolving`
- Document that frameworks/boundaries/task hashing use `ExternalDeclarations`
- Clean stale unresolved-declaration compat comments

## Testing

- `cargo test -p turborepo-frameworks --lib`
- `cargo test -p turborepo-boundaries --lib`
- `cargo test -p turborepo-repository --lib declaration_view_preserves_effective_external_declarations`
- `cargo clippy -p turborepo-repository -p turborepo-frameworks -p turborepo-boundaries --all-targets -- -D warnings`

Closes TURBO-5825.
