### PR TITLE
refactor: Produce immutable native task and command knowledge

### DIFF
--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -1133,19 +1133,17 @@ impl Toolchain for CargoToolchain {
         override_command: Option<&[String]>,
     ) -> Result<Option<toolchain::TaskCommand>, toolchain::Error> {
         self.validate_context(context)?;
+        if let Some(override_command) = override_command {
+            let serial_group = (override_command.first().map(String::as_str) == Some("cargo"))
+                .then(|| "cargo".to_string());
+            return Ok(toolchain::override_task_command(
+                context,
+                override_command,
+                pass_through_args,
+                serial_group,
+            ));
+        }
         let Some(native_task) = context.native_tasks().get(task) else {
-            // Overrides still apply to scopes that own this toolchain even
-            // when the catalog has no verb for the task name.
-            if let Some(override_command) = override_command {
-                let serial_group = (override_command.first().map(String::as_str) == Some("cargo"))
-                    .then(|| "cargo".to_string());
-                return Ok(toolchain::override_task_command(
-                    context,
-                    override_command,
-                    pass_through_args,
-                    serial_group,
-                ));
-            }
             return Ok(None);
         };
         let cargo_binary = self
@@ -1160,7 +1158,7 @@ impl Toolchain for CargoToolchain {
             None,
             Some(cargo_binary),
             pass_through_args,
-            override_command,
+            None,
         )
         .map_err(|error| toolchain::Error::Failed(Box::new(error)))
     }
@@ -4102,7 +4100,12 @@ release: 1.96.0-nightly\n",
         assert_eq!(cmd.serial_group.as_deref(), Some("cargo"));
 
         // A non-cargo argv drops the group; pass-through args append
-        // verbatim (no separator injection).
+        // verbatim (no separator injection). Overrides must not require the
+        // cargo binary, even for tasks present in the native catalog.
+        toolchain
+            .cargo_binary
+            .set(Err(which::Error::CannotFindBinaryPath))
+            .unwrap();
         let override_argv = vec!["./scripts/test.sh".to_string()];
         let cmd = toolchain
             .task_command(

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -454,6 +454,36 @@ pub fn display_command(kind: CargoPackageKind, task: &str, package: &str) -> Opt
     })
 }
 
+/// Build native-task facts for a Cargo package from its verb tables.
+pub fn native_tasks_for_package(
+    details: &CargoPackageDetails,
+    package: &str,
+) -> Vec<crate::native_tasks::NativeTask> {
+    use crate::native_tasks::NativeTask;
+
+    let scope_arg = match details.kind {
+        CargoPackageKind::Workspace => "--workspace".to_string(),
+        CargoPackageKind::Entrypoint | CargoPackageKind::Library => {
+            format!("--package={package}")
+        }
+    };
+    registered_tasks(details)
+        .into_iter()
+        .filter_map(|task| {
+            let subcommand = task_subcommand(details.kind, task)?;
+            let display = display_command(details.kind, task, package)?;
+            Some(NativeTask::cargo(
+                task,
+                display,
+                subcommand,
+                scope_arg.clone(),
+                (subcommand != "run").then(|| "cargo".to_string()),
+                pass_through_uses_separator(subcommand),
+            ))
+        })
+        .collect()
+}
+
 /// Whether pass-through args for `subcommand` must follow a `--` separator.
 /// These subcommands forward everything after `--` to the underlying tool
 /// (the built binary for `run`, the test/bench harness, clippy's lint
@@ -1103,65 +1133,36 @@ impl Toolchain for CargoToolchain {
         override_command: Option<&[String]>,
     ) -> Result<Option<toolchain::TaskCommand>, toolchain::Error> {
         self.validate_context(context)?;
-        // An override replaces the verb-table resolution and applies to any
-        // crate, including tasks outside the built-in verb tables. The serial
-        // group survives when the override still invokes cargo: the
-        // group exists because of cargo's build-directory lock, a property
-        // of the binary, not of the verb table.
-        if let Some(override_command) = override_command {
-            let serial_group = (override_command.first().map(String::as_str) == Some("cargo"))
-                .then(|| "cargo".to_string());
-            return Ok(toolchain::override_task_command(
-                context,
-                override_command,
-                pass_through_args,
-                serial_group,
-            ));
-        }
-        let name = context.package().as_ref();
-        let Some(details) = self.package_details(name) else {
+        let Some(native_task) = context.native_tasks().get(task) else {
+            // Overrides still apply to scopes that own this toolchain even
+            // when the catalog has no verb for the task name.
+            if let Some(override_command) = override_command {
+                let serial_group = (override_command.first().map(String::as_str) == Some("cargo"))
+                    .then(|| "cargo".to_string());
+                return Ok(toolchain::override_task_command(
+                    context,
+                    override_command,
+                    pass_through_args,
+                    serial_group,
+                ));
+            }
             return Ok(None);
         };
-        let Some(subcommand) = task_subcommand(details.kind, task) else {
-            return Ok(None);
-        };
-
         let cargo_binary = self
             .cargo_binary
             .get_or_init(|| which::which("cargo"))
             .as_deref()
             .map_err(|err| toolchain::Error::Failed(Box::new(CargoCommandError::Which(*err))))?;
-
-        let scope = match context.kind() {
-            // `--package=<name>` as a single token so a hostile crate name can
-            // never be interpreted as a separate flag.
-            crate::package_graph::PackageTaskContextKind::Package => format!("--package={name}"),
-            crate::package_graph::PackageTaskContextKind::Aggregate => "--workspace".to_string(),
-            crate::package_graph::PackageTaskContextKind::Root => return Ok(None),
-        };
-        let mut args: Vec<std::ffi::OsString> =
-            vec![subcommand.into(), scope.into(), "--locked".into()];
-        if let Some(pass_through_args) = pass_through_args {
-            if pass_through_uses_separator(subcommand) {
-                args.push("--".into());
-            }
-            args.extend(pass_through_args.iter().map(std::ffi::OsString::from));
-        }
-
-        Ok(Some(toolchain::TaskCommand {
-            program: cargo_binary.as_os_str().to_owned(),
-            args,
-            // Scoping flags select the work, so we always run from the
-            // workspace root.
-            cwd: self.repo_root.clone(),
-            // Concurrent cargo processes serialize on Cargo's
-            // build-directory lock anyway (while emitting "Blocking waiting
-            // for file lock" noise), so run them one at a time and let each
-            // cargo use all cores internally. `cargo run` is exempt: the
-            // process outlives its build phase (dev servers etc.) and would
-            // starve the group.
-            serial_group: (subcommand != "run").then(|| "cargo".to_string()),
-        }))
+        crate::native_tasks::resolve_task_command(
+            context,
+            native_task,
+            None,
+            None,
+            Some(cargo_binary),
+            pass_through_args,
+            override_command,
+        )
+        .map_err(|error| toolchain::Error::Failed(Box::new(error)))
     }
 
     fn task_display_command(
@@ -1170,9 +1171,10 @@ impl Toolchain for CargoToolchain {
         task: &str,
     ) -> Option<String> {
         self.owns_context(context).then_some(())?;
-        let name = context.package().as_ref();
-        let details = self.package_details(name)?;
-        display_command(details.kind, task, name)
+        context
+            .native_tasks()
+            .get(task)
+            .and_then(|native_task| native_task.display().map(str::to_string))
     }
 
     fn task_defaults(
@@ -1198,16 +1200,11 @@ impl Toolchain for CargoToolchain {
         &self,
         context: &crate::package_graph::PackageTaskContext<'_>,
     ) -> Vec<String> {
-        self.owns_context(context)
-            .then(|| context.package().as_ref())
-            .and_then(|name| self.package_details(name))
-            .map(|details| {
-                registered_tasks(&details)
-                    .into_iter()
-                    .map(str::to_string)
-                    .collect()
-            })
-            .unwrap_or_default()
+        if self.owns_context(context) {
+            context.native_tasks().registered_names()
+        } else {
+            Vec::new()
+        }
     }
 
     fn registers_task(
@@ -1215,10 +1212,7 @@ impl Toolchain for CargoToolchain {
         context: &crate::package_graph::PackageTaskContext<'_>,
         task: &str,
     ) -> bool {
-        self.owns_context(context)
-            .then(|| context.package().as_ref())
-            .and_then(|name| self.package_details(name))
-            .is_some_and(|details| registered_tasks(&details).contains(&task))
+        self.owns_context(context) && context.native_tasks().registers(task)
     }
 
     /// Route rustc invocations through the embedded sccache, with the
@@ -1299,11 +1293,7 @@ impl Toolchain for CargoToolchain {
         context: &crate::package_graph::PackageTaskContext<'_>,
         task: &str,
     ) -> bool {
-        self.owns_context(context)
-            .then(|| context.package().as_ref())
-            .and_then(|name| self.package_details(name))
-            .and_then(|details| task_subcommand(details.kind, task))
-            .is_some()
+        self.owns_context(context) && context.native_tasks().defines(task)
     }
 
     fn derives_task_io(
@@ -1750,16 +1740,15 @@ impl Toolchain for CargoToolchain {
                     })
                     .map(|dir| dir.to_unix().to_string())
                     .unwrap_or_default();
-                self.record_details(
-                    cargo_crate.name.clone(),
-                    CargoPackageDetails {
-                        kind,
-                        deliverables: cargo_crate.deliverables,
-                        manifest_alters_output_layout: cargo_crate.manifest_alters_output_layout,
-                        dir,
-                        compilation_dependencies: cargo_crate.compilation_dependencies,
-                    },
-                );
+                let details = CargoPackageDetails {
+                    kind,
+                    deliverables: cargo_crate.deliverables,
+                    manifest_alters_output_layout: cargo_crate.manifest_alters_output_layout,
+                    dir,
+                    compilation_dependencies: cargo_crate.compilation_dependencies,
+                };
+                let native_tasks = native_tasks_for_package(&details, &cargo_crate.name);
+                self.record_details(cargo_crate.name.clone(), details);
                 let external_dependencies: HashSet<turborepo_lockfiles::Package> = closures
                     .remove(&cargo_crate.name)
                     .unwrap_or_default()
@@ -1778,7 +1767,8 @@ impl Toolchain for CargoToolchain {
                         cargo_crate.manifest_path,
                         Some(external_dependencies),
                     )
-                    .with_native_relationships(relationships),
+                    .with_native_relationships(relationships)
+                    .with_native_tasks(native_tasks),
                 );
             }
 
@@ -1787,16 +1777,16 @@ impl Toolchain for CargoToolchain {
             // name`. It depends on every crate so `--affected` and
             // dependent-filters propagate crate changes to it.
             if !crate_names.is_empty() {
-                self.record_details(
-                    workspace_name.clone(),
-                    CargoPackageDetails {
-                        kind: CargoPackageKind::Workspace,
-                        deliverables: Vec::new(),
-                        manifest_alters_output_layout: false,
-                        dir: String::new(),
-                        compilation_dependencies: Vec::new(),
-                    },
-                );
+                let workspace_details = CargoPackageDetails {
+                    kind: CargoPackageKind::Workspace,
+                    deliverables: Vec::new(),
+                    manifest_alters_output_layout: false,
+                    dir: String::new(),
+                    compilation_dependencies: Vec::new(),
+                };
+                let workspace_native_tasks =
+                    native_tasks_for_package(&workspace_details, &workspace_name);
+                self.record_details(workspace_name.clone(), workspace_details);
                 crate_names.sort();
                 let relationships = crate_names
                     .into_iter()
@@ -1815,7 +1805,8 @@ impl Toolchain for CargoToolchain {
                         // of all closures is this package's external surface.
                         Some(workspace_externals),
                     )
-                    .with_native_relationships(relationships),
+                    .with_native_relationships(relationships)
+                    .with_native_tasks(workspace_native_tasks),
                 );
             }
 
@@ -3858,13 +3849,30 @@ release: 1.96.0-nightly\n",
     }
 
     #[rustfmt::skip]
-    fn task_context<'a>(root: &'a AbsoluteSystemPath, name: &str, directory: &'a str, package: Option<&'a crate::package_graph::PackageInfo>) -> crate::package_graph::PackageTaskContext<'a> {
+    fn task_context<'a>(
+        toolchain: &CargoToolchain,
+        root: &'a AbsoluteSystemPath,
+        name: &str,
+        directory: &'a str,
+        package: Option<&'a crate::package_graph::PackageInfo>,
+    ) -> crate::package_graph::PackageTaskContext<'a> {
         let kind = if directory.is_empty() {
             crate::package_graph::PackageTaskContextKind::Aggregate
         } else {
             crate::package_graph::PackageTaskContextKind::Package
         };
-        crate::package_graph::PackageTaskContext::new_for_test(name.into(), root, turbopath::AnchoredSystemPath::new(directory).unwrap(), package, kind, Some(&ToolchainId::RUST))
+        let native_tasks = toolchain
+            .package_details(name)
+            .map(|details| native_tasks_for_package(&details, name));
+        crate::package_graph::PackageTaskContext::new_for_test_with_native_tasks(
+            name.into(),
+            root,
+            turbopath::AnchoredSystemPath::new(directory).unwrap(),
+            package,
+            kind,
+            Some(&ToolchainId::RUST),
+            native_tasks,
+        )
     }
 
     fn os_args(args: &[&str]) -> Vec<std::ffi::OsString> {
@@ -3882,12 +3890,12 @@ release: 1.96.0-nightly\n",
         toolchain.discover_packages().await.unwrap();
 
         let stale_package = package_info("stale-name");
-        let app_context = task_context(&root, "app", "crates/app", Some(&stale_package));
-        let lib_a_context = task_context(&root, "lib-a", "crates/lib-a", None);
-        let workspace_context = task_context(&root, "fixture-ws", "", Some(&stale_package));
+        let app_context = task_context(&toolchain, &root, "app", "crates/app", Some(&stale_package));
+        let lib_a_context = task_context(&toolchain, &root, "lib-a", "crates/lib-a", None);
+        let workspace_context = task_context(&toolchain, &root, "fixture-ws", "", Some(&stale_package));
 
         let foreign_root = root.join_component("foreign");
-        let foreign_context = task_context(&foreign_root, "app", "crates/app", None);
+        let foreign_context = task_context(&toolchain, &foreign_root, "app", "crates/app", None);
         assert!(toolchain.task_command(&foreign_context, "build", None, None).unwrap_err().to_string().contains("belongs to repository"));
 
         // Entrypoint build: scoped to the crate, serialized on the cargo
@@ -4069,8 +4077,15 @@ release: 1.96.0-nightly\n",
         toolchain.discover_packages().await.unwrap();
 
         let stale_package = package_info("stale-name");
-        let lib_a_context = task_context(&root, "lib-a", "crates/lib-a", Some(&stale_package));
-        let workspace_context = task_context(&root, "fixture-ws", "", Some(&stale_package));
+        let lib_a_context = task_context(
+            &toolchain,
+            &root,
+            "lib-a",
+            "crates/lib-a",
+            Some(&stale_package),
+        );
+        let workspace_context =
+            task_context(&toolchain, &root, "fixture-ws", "", Some(&stale_package));
 
         // An override applies to any crate and any task. cwd is the package's
         // directory, and an argv still invoking cargo keeps the serial group
@@ -4116,9 +4131,9 @@ release: 1.96.0-nightly\n",
         let app = package_info("app");
         let lib_a = package_info("lib-a");
         let workspace = package_info("fixture-ws");
-        let app_ctx = task_context(&root, "app", "crates/app", Some(&app));
-        let lib_ctx = task_context(&root, "lib-a", "crates/lib-a", Some(&lib_a));
-        let workspace_ctx = task_context(&root, "fixture-ws", "", Some(&workspace));
+        let app_ctx = task_context(&toolchain, &root, "app", "crates/app", Some(&app));
+        let lib_ctx = task_context(&toolchain, &root, "lib-a", "crates/lib-a", Some(&lib_a));
+        let workspace_ctx = task_context(&toolchain, &root, "fixture-ws", "", Some(&workspace));
         let environment = toolchain::TaskIOEnvironment::default();
         let context = toolchain::TaskIOContext {
             task_args: None,

--- a/crates/turborepo-repository/src/lib.rs
+++ b/crates/turborepo-repository/src/lib.rs
@@ -18,6 +18,7 @@ pub mod external_resolution;
 pub mod inference;
 mod knowledge;
 mod manifest_parser;
+pub mod native_tasks;
 pub mod package_graph;
 pub mod package_json;
 pub mod package_manager;

--- a/crates/turborepo-repository/src/native_tasks.rs
+++ b/crates/turborepo-repository/src/native_tasks.rs
@@ -1,0 +1,488 @@
+//! Parser-neutral native task and command knowledge.
+//!
+//! Ecosystems contribute observations once; core consumes an immutable catalog.
+//! Toolchain task callbacks are compatibility adapters over this catalog.
+
+use std::{
+    collections::{BTreeMap, HashMap},
+    ffi::OsString,
+};
+
+use turborepo_errors::Spanned;
+
+use crate::{
+    knowledge::RepositoryKnowledge,
+    package_graph::PackageTaskContext,
+    package_json::PackageJson,
+    package_manager::PackageManager,
+    toolchain::{TaskCommand, override_task_command, package_manager_command},
+};
+
+/// How a native command chooses its working directory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkingDirectoryPolicy {
+    /// Run in the package/aggregate source directory.
+    PackageDirectory,
+    /// Run at the repository root.
+    RepositoryRoot,
+}
+
+/// Declarative command template resolved into a [`TaskCommand`] at execution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NativeCommandTemplate {
+    /// `<package-manager> run <task>` with package-manager arg separators.
+    JavaScriptPackageManagerRun { task: String },
+    /// `cargo <subcommand> <scope> --locked` with Cargo serial grouping.
+    Cargo {
+        subcommand: String,
+        /// `--package=<name>` or `--workspace`.
+        scope_arg: String,
+        serial_group: Option<String>,
+        pass_through_uses_separator: bool,
+    },
+}
+
+/// One native task observed for an authoritative scope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NativeTask {
+    name: String,
+    /// Package-authored definition (e.g. package.json script).
+    authored: bool,
+    /// Appears in toolchain registered-task tables without turbo.json.
+    registered: bool,
+    /// Has a concrete executable command (non-empty script / known Cargo verb).
+    executable: bool,
+    display: Option<String>,
+    /// Source span for authored script text when available.
+    script: Option<Spanned<String>>,
+    command: Option<NativeCommandTemplate>,
+    cwd_policy: WorkingDirectoryPolicy,
+}
+
+impl NativeTask {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn authored(&self) -> bool {
+        self.authored
+    }
+
+    pub fn registered(&self) -> bool {
+        self.registered
+    }
+
+    pub fn executable(&self) -> bool {
+        self.executable
+    }
+
+    pub fn display(&self) -> Option<&str> {
+        self.display.as_deref()
+    }
+
+    pub fn script(&self) -> Option<&Spanned<String>> {
+        self.script.as_ref()
+    }
+
+    pub fn command(&self) -> Option<&NativeCommandTemplate> {
+        self.command.as_ref()
+    }
+
+    pub fn cwd_policy(&self) -> WorkingDirectoryPolicy {
+        self.cwd_policy
+    }
+
+    /// Construct a Cargo-synthesized native task (not package-authored).
+    pub fn cargo(
+        name: impl Into<String>,
+        display: String,
+        subcommand: impl Into<String>,
+        scope_arg: impl Into<String>,
+        serial_group: Option<String>,
+        pass_through_uses_separator: bool,
+    ) -> Self {
+        let name = name.into();
+        Self {
+            name: name.clone(),
+            authored: false,
+            registered: true,
+            executable: true,
+            display: Some(display),
+            script: None,
+            command: Some(NativeCommandTemplate::Cargo {
+                subcommand: subcommand.into(),
+                scope_arg: scope_arg.into(),
+                serial_group,
+                pass_through_uses_separator,
+            }),
+            cwd_policy: WorkingDirectoryPolicy::RepositoryRoot,
+        }
+    }
+}
+
+/// Observation state for one authoritative scope's native tasks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScopeNativeTasks {
+    /// Scope identity is not present in repository knowledge.
+    UnknownScope,
+    /// Scope exists but no native-task producer contributed observations.
+    Unobserved,
+    /// Producer observed the scope and found no tasks.
+    Empty,
+    /// Producer observed one or more tasks.
+    Available(Box<[NativeTask]>),
+}
+
+impl ScopeNativeTasks {
+    pub fn tasks(&self) -> &[NativeTask] {
+        match self {
+            Self::Available(tasks) => tasks,
+            Self::UnknownScope | Self::Unobserved | Self::Empty => &[],
+        }
+    }
+
+    pub fn get(&self, name: &str) -> Option<&NativeTask> {
+        self.tasks().iter().find(|task| task.name() == name)
+    }
+
+    pub fn defines(&self, name: &str) -> bool {
+        self.get(name).is_some_and(NativeTask::executable)
+    }
+
+    pub fn authors(&self, name: &str) -> bool {
+        self.get(name).is_some_and(NativeTask::authored)
+    }
+
+    pub fn registers(&self, name: &str) -> bool {
+        self.get(name).is_some_and(NativeTask::registered)
+    }
+
+    pub fn registered_names(&self) -> Vec<String> {
+        self.tasks()
+            .iter()
+            .filter(|task| task.registered())
+            .map(|task| task.name().to_string())
+            .collect()
+    }
+}
+
+/// Producer-supplied native task facts for one scope, before catalog
+/// validation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NativeTaskObservation {
+    pub scope: String,
+    pub tasks: Vec<NativeTask>,
+}
+
+/// Immutable native-task catalog for one repository generation.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct NativeTaskKnowledge {
+    by_scope: HashMap<String, ScopeNativeTasks>,
+}
+
+impl NativeTaskKnowledge {
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn build(
+        repository: &RepositoryKnowledge,
+        observations: Vec<NativeTaskObservation>,
+    ) -> Result<Self, NativeTaskError> {
+        let mut by_scope: HashMap<String, ScopeNativeTasks> = HashMap::new();
+
+        for scope in repository.scopes() {
+            by_scope.insert(scope.identity().to_string(), ScopeNativeTasks::Unobserved);
+        }
+        if repository.root_javascript_scope().is_some() {
+            by_scope
+                .entry("//".to_string())
+                .or_insert(ScopeNativeTasks::Unobserved);
+        }
+
+        for observation in observations {
+            let known = if observation.scope == "//" {
+                repository.root_javascript_scope().is_some()
+            } else {
+                repository.scope(&observation.scope).is_some()
+            };
+            if !known {
+                return Err(NativeTaskError::UnknownScope {
+                    identity: observation.scope,
+                });
+            }
+
+            let mut tasks = observation.tasks;
+            tasks.sort_by(|left, right| left.name.cmp(&right.name));
+            if let Some(duplicate) = tasks.windows(2).find(|pair| pair[0].name == pair[1].name) {
+                return Err(NativeTaskError::DuplicateTask {
+                    scope: observation.scope,
+                    task: duplicate[0].name.clone(),
+                });
+            }
+
+            let state = if tasks.is_empty() {
+                ScopeNativeTasks::Empty
+            } else {
+                ScopeNativeTasks::Available(tasks.into_boxed_slice())
+            };
+            by_scope.insert(observation.scope, state);
+        }
+
+        Ok(Self { by_scope })
+    }
+
+    pub fn for_scope(&self, scope: &str) -> &ScopeNativeTasks {
+        static UNKNOWN: ScopeNativeTasks = ScopeNativeTasks::UnknownScope;
+        self.by_scope.get(scope).unwrap_or(&UNKNOWN)
+    }
+
+    pub fn scopes(&self) -> impl Iterator<Item = (&str, &ScopeNativeTasks)> {
+        self.by_scope
+            .iter()
+            .map(|(scope, tasks)| (scope.as_str(), tasks))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum NativeTaskError {
+    #[error("native task observation for unknown scope {identity}")]
+    UnknownScope { identity: String },
+    #[error("scope {scope} contributed duplicate native task {task}")]
+    DuplicateTask { scope: String, task: String },
+}
+
+/// Convert package.json scripts into native-task observations.
+pub fn observation_from_scripts(
+    scope: impl Into<String>,
+    scripts: &BTreeMap<String, Spanned<String>>,
+) -> NativeTaskObservation {
+    let scope = scope.into();
+    let mut tasks = Vec::with_capacity(scripts.len());
+    for (name, script) in scripts {
+        let executable = !script.is_empty();
+        tasks.push(NativeTask {
+            name: name.clone(),
+            authored: executable,
+            registered: false,
+            executable,
+            display: executable.then(|| script.as_inner().clone()),
+            script: Some(script.clone()),
+            command: executable
+                .then(|| NativeCommandTemplate::JavaScriptPackageManagerRun { task: name.clone() }),
+            cwd_policy: WorkingDirectoryPolicy::PackageDirectory,
+        });
+    }
+    NativeTaskObservation { scope, tasks }
+}
+
+/// Convert a package.json descriptor into a native-task observation.
+pub fn observation_from_package_json(
+    scope: impl Into<String>,
+    package_json: &PackageJson,
+) -> NativeTaskObservation {
+    observation_from_scripts(scope, &package_json.scripts)
+}
+
+/// Resolve a catalog command template into an executable [`TaskCommand`].
+pub fn resolve_task_command(
+    context: &PackageTaskContext<'_>,
+    task: &NativeTask,
+    package_manager: Option<&PackageManager>,
+    package_manager_binary: Option<&std::path::Path>,
+    cargo_binary: Option<&std::path::Path>,
+    pass_through_args: Option<&[String]>,
+    override_command: Option<&[String]>,
+) -> Result<Option<TaskCommand>, ResolveNativeCommandError> {
+    if let Some(override_command) = override_command {
+        let serial_group = match task.command() {
+            Some(NativeCommandTemplate::Cargo { .. }) => {
+                (override_command.first().map(String::as_str) == Some("cargo"))
+                    .then(|| "cargo".to_string())
+            }
+            _ => None,
+        };
+        return Ok(override_task_command(
+            context,
+            override_command,
+            pass_through_args,
+            serial_group,
+        ));
+    }
+
+    let Some(template) = task.command() else {
+        return Ok(None);
+    };
+    if !task.executable() {
+        return Ok(None);
+    }
+
+    let cwd = match task.cwd_policy() {
+        WorkingDirectoryPolicy::PackageDirectory => {
+            context.repository_root().resolve(context.directory())
+        }
+        WorkingDirectoryPolicy::RepositoryRoot => context.repository_root().to_owned(),
+    };
+
+    match template {
+        NativeCommandTemplate::JavaScriptPackageManagerRun { task: task_name } => {
+            let package_manager =
+                package_manager.ok_or(ResolveNativeCommandError::MissingPackageManager)?;
+            let package_manager_binary = package_manager_binary
+                .ok_or(ResolveNativeCommandError::MissingPackageManagerBinary)?;
+            let (program, mut args) =
+                package_manager_command(package_manager, package_manager_binary);
+            args.extend([OsString::from("run"), OsString::from(task_name)]);
+            if let Some(pass_through_args) = pass_through_args {
+                args.extend(
+                    package_manager
+                        .arg_separator(pass_through_args)
+                        .map(OsString::from),
+                );
+                args.extend(pass_through_args.iter().map(OsString::from));
+            }
+            Ok(Some(TaskCommand {
+                program,
+                args,
+                cwd,
+                serial_group: None,
+            }))
+        }
+        NativeCommandTemplate::Cargo {
+            subcommand,
+            scope_arg,
+            serial_group,
+            pass_through_uses_separator,
+        } => {
+            let cargo_binary = cargo_binary.ok_or(ResolveNativeCommandError::MissingCargoBinary)?;
+            let mut args: Vec<OsString> =
+                vec![subcommand.into(), scope_arg.into(), "--locked".into()];
+            if let Some(pass_through_args) = pass_through_args {
+                if *pass_through_uses_separator {
+                    args.push("--".into());
+                }
+                args.extend(pass_through_args.iter().map(OsString::from));
+            }
+            Ok(Some(TaskCommand {
+                program: cargo_binary.as_os_str().to_owned(),
+                args,
+                cwd,
+                serial_group: serial_group.clone(),
+            }))
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ResolveNativeCommandError {
+    #[error("JavaScript package manager is not available for native task resolution")]
+    MissingPackageManager,
+    #[error("JavaScript package manager binary is not available for native task resolution")]
+    MissingPackageManagerBinary,
+    #[error("Cargo binary is not available for native task resolution")]
+    MissingCargoBinary,
+}
+
+#[cfg(test)]
+mod tests {
+    use turbopath::AbsoluteSystemPathBuf;
+
+    use super::*;
+    use crate::{
+        knowledge::{
+            PackageScopeObservation, RepositoryKnowledge, ScopeKind, WorkspaceRootObservation,
+        },
+        toolchain::{ToolchainId, WorkspaceRoot},
+    };
+
+    fn repository() -> RepositoryKnowledge {
+        let root =
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+        RepositoryKnowledge::build(
+            &root,
+            Some(Some("root".to_string())),
+            &[PackageScopeObservation {
+                identity: Some("web".to_string()),
+                definition_path: root.join_components(&["apps", "web", "package.json"]),
+                toolchain: ToolchainId::JAVASCRIPT,
+                scope_kind: ScopeKind::Package,
+            }],
+            &[WorkspaceRootObservation::new(
+                WorkspaceRoot::new("npm", root.clone()),
+                ToolchainId::JAVASCRIPT,
+            )],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn scripts_become_authored_executable_tasks() {
+        let mut scripts = BTreeMap::new();
+        scripts.insert("build".into(), Spanned::new("next build".into()));
+        scripts.insert("empty".into(), Spanned::new(String::new()));
+        let observation = observation_from_scripts("web", &scripts);
+        assert_eq!(observation.tasks.len(), 2);
+        let build = observation
+            .tasks
+            .iter()
+            .find(|task| task.name() == "build")
+            .unwrap();
+        assert!(build.authored());
+        assert!(build.executable());
+        assert!(!build.registered());
+        assert_eq!(build.display(), Some("next build"));
+        let empty = observation
+            .tasks
+            .iter()
+            .find(|task| task.name() == "empty")
+            .unwrap();
+        assert!(!empty.authored());
+        assert!(!empty.executable());
+    }
+
+    #[test]
+    fn catalog_validates_against_repository_knowledge() {
+        let repository = repository();
+        let observation = observation_from_scripts(
+            "web",
+            &BTreeMap::from([("build".into(), Spanned::new("tsc".into()))]),
+        );
+        let root_observation = observation_from_scripts("//", &BTreeMap::new());
+        let knowledge =
+            NativeTaskKnowledge::build(&repository, vec![observation, root_observation]).unwrap();
+        let scope = knowledge.for_scope("web");
+        assert!(matches!(scope, ScopeNativeTasks::Available(_)));
+        assert!(scope.defines("build"));
+        assert!(scope.authors("build"));
+        assert!(!scope.registers("build"));
+        assert!(matches!(
+            knowledge.for_scope("missing"),
+            ScopeNativeTasks::UnknownScope
+        ));
+        assert!(matches!(knowledge.for_scope("//"), ScopeNativeTasks::Empty));
+    }
+
+    #[test]
+    fn unknown_scope_observation_is_rejected() {
+        let repository = repository();
+        let observation = observation_from_scripts("other", &BTreeMap::new());
+        let error = NativeTaskKnowledge::build(&repository, vec![observation]).unwrap_err();
+        assert!(matches!(error, NativeTaskError::UnknownScope { .. }));
+    }
+
+    #[test]
+    fn cargo_tasks_are_registered_not_authored() {
+        let task = NativeTask::cargo(
+            "build",
+            "cargo build --package=app --locked".into(),
+            "build",
+            "--package=app",
+            Some("cargo".into()),
+            false,
+        );
+        assert!(!task.authored());
+        assert!(task.registered());
+        assert!(task.executable());
+        assert_eq!(task.cwd_policy(), WorkingDirectoryPolicy::RepositoryRoot);
+    }
+}

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -94,6 +94,8 @@ pub enum Error {
     MissingRelationshipKnowledge,
     #[error("external resolution generation failed: {0}")]
     ExternalResolution(String),
+    #[error("native task knowledge generation failed: {0}")]
+    NativeTasks(String),
     #[error("package or aggregate scope at {path} uses reserved root identity //")]
     ReservedRootIdentity { path: AnchoredSystemPathBuf },
     #[error("relationship source {identity} has no authoritative repository scope")]
@@ -382,6 +384,7 @@ struct BuildState<'a, S, T> {
     relationship_knowledge: Option<Arc<RelationshipKnowledge>>,
     native_relationships: HashMap<String, Vec<Relationship>>,
     native_external_resolutions: Vec<ExternalResolutionDomain>,
+    native_task_observations: Vec<crate::native_tasks::NativeTaskObservation>,
     /// The root `package.json`, absent for a pure Cargo workspace. See
     /// [`PackageGraphBuilder::root_package_json`].
     root_package_json: Option<PackageJson>,
@@ -421,6 +424,7 @@ struct ObservedPackage {
     scope: PackageScopeObservation,
     compatibility: Option<(String, PackageInfo)>,
     native_relationships: Option<(String, Vec<Relationship>)>,
+    native_tasks: Option<crate::native_tasks::NativeTaskObservation>,
 }
 
 impl PackageGraphAssembler {
@@ -659,6 +663,7 @@ where
             relationship_knowledge: None,
             native_relationships: HashMap::new(),
             native_external_resolutions: Vec::new(),
+            native_task_observations: Vec::new(),
             lockfile,
             package_manager: None,
             package_jsons,
@@ -684,10 +689,22 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             manifest_path,
             external_dependencies: _,
             native_relationships,
+            native_tasks,
         } = package.into_parts();
         // Toolchain-resolved external identities are contributed to the
         // resolution generation separately; PackageInfo no longer carries
         // closure/hash compatibility projections.
+        let native_task_observation = match (name.as_ref(), native_tasks) {
+            (Some(identity), Some(tasks)) => Some(crate::native_tasks::NativeTaskObservation {
+                scope: identity.clone(),
+                tasks,
+            }),
+            (Some(identity), None) => Some(crate::native_tasks::observation_from_package_json(
+                identity.clone(),
+                &json,
+            )),
+            (None, _) => None,
+        };
         let entry = PackageInfo { package_json: json };
         let observation = PackageScopeObservation {
             identity: name.clone(),
@@ -710,6 +727,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             scope: observation,
             compatibility,
             native_relationships,
+            native_tasks: native_task_observation,
         })
     }
 
@@ -770,6 +788,9 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             if let Some((source, relationships)) = observed.native_relationships {
                 self.native_relationships.insert(source, relationships);
             }
+            if let Some(tasks) = observed.native_tasks {
+                self.native_task_observations.push(tasks);
+            }
         }
         let root_name = self.root_package_json.as_ref().map(|package_json| {
             package_json
@@ -802,6 +823,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             relationship_knowledge,
             native_relationships,
             native_external_resolutions,
+            native_task_observations,
             root_package_json,
             lockfile,
             package_manager,
@@ -818,6 +840,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             relationship_knowledge,
             native_relationships,
             native_external_resolutions,
+            native_task_observations,
             root_package_json,
             lockfile,
             package_manager,
@@ -837,6 +860,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             relationship_knowledge: _,
             native_relationships: _,
             native_external_resolutions: _,
+            native_task_observations,
             root_package_json,
             lockfile,
             javascript,
@@ -918,6 +942,17 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
         };
 
         debug_assert!(single, "expected single package graph");
+        let mut native_task_observations = native_task_observations;
+        if let Some(root_package_json) = &root_package_json {
+            native_task_observations.push(crate::native_tasks::observation_from_package_json(
+                "//",
+                root_package_json,
+            ));
+        }
+        let native_task_knowledge = Arc::new(
+            crate::native_tasks::NativeTaskKnowledge::build(&knowledge, native_task_observations)
+                .map_err(|error| Error::NativeTasks(error.to_string()))?,
+        );
         Ok(PackageGraph {
             graph: workspace_graph,
             root_node_index,
@@ -935,6 +970,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             external_dep_to_internal_dependents: std::sync::OnceLock::new(),
             root_internal_dependencies: std::sync::OnceLock::new(),
             toolchains,
+            native_task_knowledge,
         })
     }
 }
@@ -1090,6 +1126,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
             knowledge,
             relationship_knowledge,
             native_external_resolutions,
+            native_task_observations,
             root_package_json,
             javascript,
             toolchains,
@@ -1105,6 +1142,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
             // Native contributions were consumed before lockfile setup.
             native_relationships: HashMap::new(),
             native_external_resolutions,
+            native_task_observations,
             root_package_json,
             lockfile,
             package_manager,
@@ -1278,6 +1316,7 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             assembler,
             knowledge,
             relationship_knowledge,
+            native_task_observations,
             root_package_json,
             toolchains,
             ..
@@ -1295,6 +1334,22 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             root_workspace_index,
             node_lookup,
         } = assembler.finish();
+
+        // Include root JavaScript scripts when a root package.json exists.
+        let mut native_task_observations = native_task_observations;
+        if let Some(root_package_json) = &root_package_json {
+            native_task_observations.push(crate::native_tasks::observation_from_package_json(
+                "//",
+                root_package_json,
+            ));
+        }
+        let native_task_knowledge = Arc::new(
+            crate::native_tasks::NativeTaskKnowledge::build(&knowledge, native_task_observations)
+                .map_err(|error| {
+                discovery::Error::Failed(Box::new(Error::NativeTasks(error.to_string())))
+            })?,
+        );
+
         Ok(PackageGraph {
             graph: workspace_graph,
             root_node_index,
@@ -1312,6 +1367,7 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             external_dep_to_internal_dependents: std::sync::OnceLock::new(),
             root_internal_dependencies: std::sync::OnceLock::new(),
             toolchains,
+            native_task_knowledge,
         })
     }
 }

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -99,6 +99,8 @@ pub struct PackageGraph {
     /// Toolchains registered during graph construction. Authoritative contexts
     /// determine which registrations were active for a particular concern.
     toolchains: crate::toolchain::ToolchainRegistry,
+    /// Immutable native-task catalog produced during repository construction.
+    native_task_knowledge: Arc<crate::native_tasks::NativeTaskKnowledge>,
 }
 
 /// The WorkspacePackage.
@@ -220,6 +222,7 @@ pub struct PackageTaskContext<'a> {
     directory: &'a AnchoredSystemPath,
     package_info: Option<&'a PackageInfo>,
     external_declarations: &'a ExternalDeclarations,
+    native_tasks: &'a crate::native_tasks::ScopeNativeTasks,
     kind: PackageTaskContextKind,
     toolchain: Option<&'a crate::toolchain::ToolchainId>,
     requires_compatibility_payload: bool,
@@ -236,10 +239,60 @@ impl<'a> PackageTaskContext<'a> {
     #[cfg(test)]
     #[rustfmt::skip]
     pub(crate) fn new_for_test(package: PackageName, repository_root: &'a AbsoluteSystemPath, directory: &'a AnchoredSystemPath, package_info: Option<&'a PackageInfo>, kind: PackageTaskContextKind, toolchain: Option<&'a crate::toolchain::ToolchainId>) -> Self {
+        Self::new_for_test_with_native_tasks(package, repository_root, directory, package_info, kind, toolchain, None)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_for_test_with_native_tasks(
+        package: PackageName,
+        repository_root: &'a AbsoluteSystemPath,
+        directory: &'a AnchoredSystemPath,
+        package_info: Option<&'a PackageInfo>,
+        kind: PackageTaskContextKind,
+        toolchain: Option<&'a crate::toolchain::ToolchainId>,
+        native_tasks: Option<Vec<crate::native_tasks::NativeTask>>,
+    ) -> Self {
         static EXTERNAL_DECLARATIONS: OnceLock<ExternalDeclarations> = OnceLock::new();
-        let external_declarations = EXTERNAL_DECLARATIONS.get_or_init(ExternalDeclarations::default);
-        let requires_compatibility_payload = package != PackageName::Root || toolchain == Some(&crate::toolchain::ToolchainId::JAVASCRIPT);
-        Self { package, repository_root, directory, package_info, external_declarations, kind, toolchain, requires_compatibility_payload }
+        static UNKNOWN_NATIVE_TASKS: crate::native_tasks::ScopeNativeTasks =
+            crate::native_tasks::ScopeNativeTasks::UnknownScope;
+        let external_declarations =
+            EXTERNAL_DECLARATIONS.get_or_init(ExternalDeclarations::default);
+        let native_tasks = if let Some(tasks) = native_tasks {
+            let scope = if tasks.is_empty() {
+                crate::native_tasks::ScopeNativeTasks::Empty
+            } else {
+                crate::native_tasks::ScopeNativeTasks::Available(tasks.into_boxed_slice())
+            };
+            Box::leak(Box::new(scope)) as &'static _
+        } else if let Some(info) = package_info {
+            let observation = crate::native_tasks::observation_from_package_json(
+                package.as_str(),
+                &info.package_json,
+            );
+            let scope = if observation.tasks.is_empty() {
+                crate::native_tasks::ScopeNativeTasks::Empty
+            } else {
+                crate::native_tasks::ScopeNativeTasks::Available(
+                    observation.tasks.into_boxed_slice(),
+                )
+            };
+            Box::leak(Box::new(scope)) as &'static _
+        } else {
+            &UNKNOWN_NATIVE_TASKS
+        };
+        let requires_compatibility_payload = package != PackageName::Root
+            || toolchain == Some(&crate::toolchain::ToolchainId::JAVASCRIPT);
+        Self {
+            package,
+            repository_root,
+            directory,
+            package_info,
+            external_declarations,
+            native_tasks,
+            kind,
+            toolchain,
+            requires_compatibility_payload,
+        }
     }
 
     pub fn package(&self) -> &PackageName {
@@ -261,6 +314,10 @@ impl<'a> PackageTaskContext<'a> {
     pub fn external_declarations(&self) -> PackageExternalDeclarations<'_> {
         self.external_declarations
             .for_package(self.package.as_str())
+    }
+
+    pub fn native_tasks(&self) -> &'a crate::native_tasks::ScopeNativeTasks {
+        self.native_tasks
     }
 
     pub fn kind(&self) -> PackageTaskContextKind {
@@ -674,6 +731,7 @@ impl PackageGraph {
             }
         };
         let package_info = self.package_payloads.get(&package);
+        let native_tasks = self.native_task_knowledge.for_scope(package.as_str());
 
         Some(PackageTaskContext {
             package,
@@ -681,6 +739,7 @@ impl PackageGraph {
             directory,
             package_info,
             external_declarations: self.external_declaration_view(),
+            native_tasks,
             kind,
             toolchain,
             requires_compatibility_payload,

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -969,23 +969,23 @@ impl<P: PackageDiscovery + Send + Sync> Toolchain for JavaScriptToolchain<P> {
         let Some(native_task) = context.native_tasks().get(task) else {
             return Ok(None);
         };
-        let package_manager = self.resolved_package_manager.get();
-        let package_manager_binary = package_manager.map(|package_manager| {
-            self.package_manager_binary
-                .get_or_init(|| which::which(package_manager.command()))
-        });
-        let package_manager_binary = match package_manager_binary {
-            Some(Ok(path)) => Some(path.as_path()),
-            Some(Err(err)) => {
+        let Some(package_manager) = self.resolved_package_manager.get() else {
+            return Ok(None);
+        };
+        let package_manager_binary = match self
+            .package_manager_binary
+            .get_or_init(|| which::which(package_manager.command()))
+        {
+            Ok(path) => path.as_path(),
+            Err(err) => {
                 return Err(Error::Failed(Box::new(JavaScriptCommandError::Which(*err))));
             }
-            None => None,
         };
         crate::native_tasks::resolve_task_command(
             context,
             native_task,
-            package_manager,
-            package_manager_binary,
+            Some(package_manager),
+            Some(package_manager_binary),
             None,
             pass_through_args,
             None,
@@ -1290,6 +1290,19 @@ mod tests {
             Some(&package),
             crate::package_graph::PackageTaskContextKind::Package,
             Some(&ToolchainId::JAVASCRIPT),
+        );
+
+        let unresolved_toolchain = JavaScriptToolchain::new(
+            StubDiscovery,
+            repo_root_buf.clone(),
+            Some(PackageManager::Npm),
+        );
+        assert!(
+            unresolved_toolchain
+                .task_command(&context, "build", None, None)
+                .unwrap()
+                .is_none(),
+            "an unresolved package manager must preserve the no-op fallback"
         );
 
         let command = toolchain

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -136,6 +136,10 @@ pub struct DiscoveredPackage {
     /// preserves compatibility by asking core to classify `descriptor`,
     /// regardless of the producer's toolchain id.
     native_relationships: Option<Vec<Relationship>>,
+    /// Native task facts contributed at discovery time. `None` means the
+    /// graph builder should derive tasks from `descriptor.scripts` when
+    /// present (JavaScript). Cargo fills this with verb-table facts.
+    native_tasks: Option<Vec<crate::native_tasks::NativeTask>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -152,6 +156,7 @@ pub(crate) struct DiscoveredPackageParts {
     #[allow(dead_code)]
     pub external_dependencies: Option<std::collections::HashSet<turborepo_lockfiles::Package>>,
     pub native_relationships: Option<Vec<Relationship>>,
+    pub native_tasks: Option<Vec<crate::native_tasks::NativeTask>>,
 }
 
 /// Parser-neutral observation of one contributed native workspace root.
@@ -242,6 +247,7 @@ impl DiscoveredPackage {
             manifest_path,
             external_dependencies,
             native_relationships: None,
+            native_tasks: None,
         }
     }
 
@@ -261,6 +267,7 @@ impl DiscoveredPackage {
             manifest_path,
             external_dependencies,
             native_relationships: None,
+            native_tasks: None,
         }
     }
 
@@ -272,6 +279,12 @@ impl DiscoveredPackage {
         self
     }
 
+    /// Supply native task facts observed at discovery time.
+    pub fn with_native_tasks(mut self, tasks: Vec<crate::native_tasks::NativeTask>) -> Self {
+        self.native_tasks = Some(tasks);
+        self
+    }
+
     pub(crate) fn into_parts(self) -> DiscoveredPackageParts {
         let Self {
             name,
@@ -280,6 +293,7 @@ impl DiscoveredPackage {
             manifest_path,
             external_dependencies,
             native_relationships,
+            native_tasks,
         } = self;
         DiscoveredPackageParts {
             name,
@@ -288,6 +302,7 @@ impl DiscoveredPackage {
             manifest_path,
             external_dependencies,
             native_relationships,
+            native_tasks,
         }
     }
 }
@@ -908,7 +923,7 @@ fn npm_direct_command(
 }
 
 #[cfg(windows)]
-fn package_manager_command(
+pub(crate) fn package_manager_command(
     package_manager: &PackageManager,
     package_manager_binary: &std::path::Path,
 ) -> (OsString, Vec<OsString>) {
@@ -922,7 +937,7 @@ fn package_manager_command(
 }
 
 #[cfg(not(windows))]
-fn package_manager_command(
+pub(crate) fn package_manager_command(
     _package_manager: &PackageManager,
     package_manager_binary: &std::path::Path,
 ) -> (OsString, Vec<OsString>) {
@@ -941,9 +956,8 @@ impl<P: PackageDiscovery + Send + Sync> Toolchain for JavaScriptToolchain<P> {
         pass_through_args: Option<&[String]>,
         override_command: Option<&[String]>,
     ) -> Result<Option<TaskCommand>, Error> {
-        // An override replaces the whole package-manager indirection: the
-        // argv is executed directly from the package directory. Note this
-        // bypasses `<pm> run`, so `node_modules/.bin` is not added to PATH.
+        // An override replaces the whole package-manager indirection even when
+        // the catalog has no authored script for this task name.
         if let Some(override_command) = override_command {
             return Ok(override_task_command(
                 context,
@@ -952,46 +966,31 @@ impl<P: PackageDiscovery + Send + Sync> Toolchain for JavaScriptToolchain<P> {
                 None,
             ));
         }
-        // No script (or an empty one) means the task is a no-op.
-        let Some(package) = context.package_info() else {
+        let Some(native_task) = context.native_tasks().get(task) else {
             return Ok(None);
         };
-        if package
-            .package_json
-            .scripts
-            .get(task)
-            .is_none_or(|script| script.is_empty())
-        {
-            return Ok(None);
-        }
-        let Some(package_manager) = self.resolved_package_manager.get() else {
-            // The graph was not built through this toolchain instance;
-            // without a package manager there is no way to run a script.
-            return Ok(None);
+        let package_manager = self.resolved_package_manager.get();
+        let package_manager_binary = package_manager.map(|package_manager| {
+            self.package_manager_binary
+                .get_or_init(|| which::which(package_manager.command()))
+        });
+        let package_manager_binary = match package_manager_binary {
+            Some(Ok(path)) => Some(path.as_path()),
+            Some(Err(err)) => {
+                return Err(Error::Failed(Box::new(JavaScriptCommandError::Which(*err))));
+            }
+            None => None,
         };
-
-        let package_manager_binary = self
-            .package_manager_binary
-            .get_or_init(|| which::which(package_manager.command()))
-            .as_deref()
-            .map_err(|err| Error::Failed(Box::new(JavaScriptCommandError::Which(*err))))?;
-        let (program, mut args) = package_manager_command(package_manager, package_manager_binary);
-        args.extend([OsString::from("run"), OsString::from(task)]);
-        if let Some(pass_through_args) = pass_through_args {
-            args.extend(
-                package_manager
-                    .arg_separator(pass_through_args)
-                    .map(OsString::from),
-            );
-            args.extend(pass_through_args.iter().map(OsString::from));
-        }
-
-        Ok(Some(TaskCommand {
-            program,
-            args,
-            cwd: context.repository_root().resolve(context.directory()),
-            serial_group: None,
-        }))
+        crate::native_tasks::resolve_task_command(
+            context,
+            native_task,
+            package_manager,
+            package_manager_binary,
+            None,
+            pass_through_args,
+            None,
+        )
+        .map_err(|error| Error::Failed(Box::new(error)))
     }
 
     fn task_display_command(
@@ -999,14 +998,10 @@ impl<P: PackageDiscovery + Send + Sync> Toolchain for JavaScriptToolchain<P> {
         context: &crate::package_graph::PackageTaskContext<'_>,
         task: &str,
     ) -> Option<String> {
-        // Summaries show the script text itself, matching historical
-        // behavior.
         context
-            .package_info()?
-            .package_json
-            .scripts
+            .native_tasks()
             .get(task)
-            .map(|script| script.as_inner().clone())
+            .and_then(|native_task| native_task.display().map(str::to_string))
     }
 
     fn defines_task(
@@ -1014,13 +1009,7 @@ impl<P: PackageDiscovery + Send + Sync> Toolchain for JavaScriptToolchain<P> {
         context: &crate::package_graph::PackageTaskContext<'_>,
         task: &str,
     ) -> bool {
-        context.package_info().is_some_and(|package| {
-            package
-                .package_json
-                .scripts
-                .get(task)
-                .is_some_and(|script| !script.is_empty())
-        })
+        context.native_tasks().defines(task)
     }
 
     /// package.json scripts are authored by the package: they shadow
@@ -1030,7 +1019,7 @@ impl<P: PackageDiscovery + Send + Sync> Toolchain for JavaScriptToolchain<P> {
         context: &crate::package_graph::PackageTaskContext<'_>,
         task: &str,
     ) -> bool {
-        self.defines_task(context, task)
+        context.native_tasks().authors(task)
     }
 
     fn derived_task_io(

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -216,7 +216,8 @@ The remaining payload deletion phases are explicit:
   relationship knowledge now owns graph assembly, while JavaScript declarations
   remain a temporary classification input.
 - **Phase 3:** Complete. External resolution lives in the immutable generation; query, prune, hashing, and summaries consume it. `PackageInfo` no longer carries `unresolved_external_dependencies`, `transitive_dependencies`, or `external_deps_hash`, and deferred closure installation is gone.
-- **Phase 4:** Delete `PackageInfo`, its payload map, and optional-payload compatibility plumbing once all fail-closed consumers use those queries.
+- **Phase 4 (in progress):** Native task/command knowledge is produced into an immutable catalog at repository construction. JavaScript scripts and Cargo verb tables contribute observations; `Toolchain` task callbacks are adapters over that catalog. Remaining work migrates engine/turbo-json/executor/query/summary consumers and deletes legacy script reads.
+- **Phase 5:** Delete `PackageInfo`, its payload map, and optional-payload compatibility plumbing once all fail-closed consumers use those queries.
 
 Task hashing, run-cache path construction, and run-summary task directories use
 a graph-created `PackageTaskContext` that binds identity, repository root,


### PR DESCRIPTION
## Intent

Turborepo’s multi-language architecture treats ecosystem integrations as sources of immutable repository knowledge. After Phase 3 moved external-resolution facts into a shared generation, this PR starts **Phase 4 (native tasks and commands)**.

Today JavaScript script execution and Cargo verb tables live behind behavioral `Toolchain` callbacks (and some direct `PackageJson::scripts` reads). This layer introduces a **parser-neutral native-task catalog** produced once during repository construction, validates it against `RepositoryKnowledge`, and turns JS/Cargo `Toolchain` task methods into **adapters over that catalog** (catalog is the sole authority for availability/authorship/registration/command templates).

Later stack layers migrate engine/turbo-json/executor/query/summary consumers and eventually delete the callbacks.

## Changes

- Add `native_tasks` module: observations, scope states (unknown/unobserved/empty/available), command templates, resolve helpers
- Produce JS tasks from package.json scripts (preserving spans) and Cargo tasks from verb tables at discovery
- Retain `NativeTaskKnowledge` on `PackageGraph` / `PackageTaskContext`
- Adapt `JavaScriptToolchain` and `CargoToolchain` `task_command` / display / defines / authors / registered APIs to the catalog

## Out of scope

- Migrating engine / turbo-json / executor / query / summary consumers (TURBO-5817+)
- Deleting Toolchain task callbacks or direct script reads outside adapters
- Task contracts / hashing / cache (Phase 5)

## Testing

- `cargo test -p turborepo-repository --lib native_tasks`
- `cargo test -p turborepo-repository --lib test_javascript_task_command`
- `cargo test -p turborepo-repository --lib cargo::test::test_cargo_task_commands`
- `cargo test -p turborepo-repository --lib cargo::test::test_cargo_derived_task_io`
- `cargo clippy -p turborepo-repository --all-targets -- -D warnings`

Closes TURBO-5816.
