### PR TITLE
refactor: Migrate native task registration and suggestions

### DIFF
--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -162,13 +162,15 @@ impl EngineExt for Engine<Built> {
                                 package_name: dep_id.package().to_string(),
                             })?;
 
-                    let package_json = package_graph
-                        .package_json(&PackageName::from(dep_id.package()))
-                        .ok_or_else(|| ValidateError::MissingPackageJson {
+                    let package_name = PackageName::from(dep_id.package());
+                    let Some(dep_context) = package_graph.package_task_context(&package_name)
+                    else {
+                        return Err(ValidateError::MissingPackageJson {
                             package: dep_id.package().to_string(),
-                        })?;
+                        });
+                    };
                     if task_definition.persistent
-                        && package_json.scripts.contains_key(dep_id.task())
+                        && dep_context.native_tasks().defines(dep_id.task())
                     {
                         let (span, text) = self
                             .task_locations()
@@ -185,20 +187,15 @@ impl EngineExt for Engine<Built> {
                     }
                 }
 
-                // check if the package for the task has that task in its package.json
+                // check if the package for the task defines an executable native task
                 let package_name = PackageName::from(task_id.package().to_string());
-                let info = package_graph.package_info(&package_name).ok_or_else(|| {
-                    ValidateError::MissingPackageJson {
+                let Some(context) = package_graph.package_task_context(&package_name) else {
+                    return Err(ValidateError::MissingPackageJson {
                         package: task_id.package().to_string(),
-                    }
-                })?;
+                    });
+                };
 
-                let package_has_task = info
-                    .package_json
-                    .scripts
-                    .get(task_id.task())
-                    // handle legacy behaviour from go where an empty string may appear
-                    .is_some_and(|script| !script.is_empty());
+                let package_has_task = context.native_tasks().defines(task_id.task());
 
                 let task_is_persistent = self
                     .task_definition(task_id)

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -520,29 +520,16 @@ impl Run {
             if !self.filtered_pkgs.contains(name) {
                 continue;
             }
-            let package_info = context.package_info();
-            if context.requires_compatibility_payload() && package_info.is_none() {
-                return Err(Error::MissingPackagePayload(name.clone()));
-            }
-            for task_name in package_info
-                .into_iter()
-                .flat_map(|info| info.package_json.scripts.keys())
-            {
-                tasks
-                    .entry(task_name.clone())
-                    .or_insert_with(Vec::new)
-                    .push(name.to_string())
-            }
-            if let Some(toolchain) = context
-                .toolchain()
-                .and_then(|id| self.pkg_dep_graph.toolchains().get(id))
-            {
-                for task_name in toolchain.registered_tasks(&context) {
-                    tasks
-                        .entry(task_name)
-                        .or_insert_with(Vec::new)
-                        .push(name.to_string());
+            // Authored scripts and registered native tasks both come from the
+            // native-task catalog produced at repository construction.
+            for native_task in context.native_tasks().tasks() {
+                if !native_task.executable() && !native_task.registered() {
+                    continue;
                 }
+                tasks
+                    .entry(native_task.name().to_string())
+                    .or_insert_with(Vec::new)
+                    .push(name.to_string());
             }
         }
 


### PR DESCRIPTION
## Intent

Continue Phase 4 of the multi-language repository architecture: after the native-task catalog exists, migrate **registration / availability / suggestion** consumers onto it so engine missing-task accounting and CLI potential-task listing no longer read `PackageJson::scripts` directly.

**Stack:** Phase 4 layer 2. Base = `shew/turbo-5816-produce-immutable-native-task-and-command-knowledge`.

## Changes

- `Run::get_potential_tasks` enumerates authored+registered catalog tasks
- Engine persistent-task validation / concurrency accounting uses catalog `defines`
- Engine add-all already used `registered_tasks` (now catalog-backed via adapters)

## Out of scope

- turbo.json no-config synthesis (TURBO-5818)
- Task-definition precedence, command planning/execution

## Testing

- `cargo test -p turborepo-engine --lib` (127 passed)
- `cargo clippy -p turborepo-lib -p turborepo-engine --all-targets -- -D warnings`

Closes TURBO-5817.
