### PR TITLE
refactor: Migrate turbo-json native task synthesis

### DIFF
--- a/crates/turborepo-lib/src/devtools.rs
+++ b/crates/turborepo-lib/src/devtools.rs
@@ -87,16 +87,27 @@ impl ProperTaskGraphBuilder {
         // Create turbo json loader
         let reader =
             TurboJsonReader::new(self.repo_root.clone()).with_future_flags(opts.future_flags);
-        let loader = match (
-            opts.run_opts.single_package,
-            pkg_graph.package_json(&PackageName::Root).cloned(),
-        ) {
-            (true, Some(root_package_json)) => UnifiedTurboJsonLoader::single_package(
-                reader,
-                opts.repo_opts.root_turbo_json_path.clone(),
-                root_package_json,
-            ),
-            _ => UnifiedTurboJsonLoader::workspace(
+        let loader = match opts.run_opts.single_package {
+            true => {
+                let root_scripts = pkg_graph
+                    .package_task_context(&PackageName::Root)
+                    .map(|context| {
+                        context
+                            .native_tasks()
+                            .tasks()
+                            .iter()
+                            .filter(|task| task.executable() || task.authored())
+                            .map(|task| task.name().to_string())
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                UnifiedTurboJsonLoader::single_package(
+                    reader,
+                    opts.repo_opts.root_turbo_json_path.clone(),
+                    root_scripts,
+                )
+            }
+            false => UnifiedTurboJsonLoader::workspace(
                 reader,
                 opts.repo_opts.root_turbo_json_path.clone(),
                 pkg_graph.package_scope_directories(),

--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -474,18 +474,29 @@ impl Subscriber {
         };
 
         let reader = TurboJsonReader::new(self.repo_root.clone());
-        let root_turbo_json = match (self.single_package, root_package_json) {
-            (true, Some(root_package_json)) => {
-                UnifiedTurboJsonLoader::single_package(reader, config_path, root_package_json)
-            }
+        let root_turbo_json = if self.single_package {
+            let root_scripts = pkg_dep_graph
+                .package_task_context(&PackageName::Root)
+                .map(|context| {
+                    context
+                        .native_tasks()
+                        .tasks()
+                        .iter()
+                        .filter(|task| task.executable() || task.authored())
+                        .map(|task| task.name().to_string())
+                        .collect()
+                })
+                .unwrap_or_default();
+            UnifiedTurboJsonLoader::single_package(reader, config_path, root_scripts)
+        } else {
             // A native-only graph still has Turbo's root task namespace, but
             // it does not have a root JavaScript scope to synthesize config
             // from. Workspace loading preserves that distinction.
-            _ => UnifiedTurboJsonLoader::workspace(
+            UnifiedTurboJsonLoader::workspace(
                 reader,
                 config_path,
                 pkg_dep_graph.package_scope_directories(),
-            ),
+            )
         }
         .load(&PackageName::Root)
         .ok()

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -712,13 +712,23 @@ impl RunBuilder {
                     root_turbo_json_path.clone(),
                     root_package_json.clone(),
                 )
-            } else if let (Some(root_package_json), true) =
-                (root_package_json.as_ref(), is_single_package)
-            {
+            } else if is_single_package {
+                let root_scripts = pkg_dep_graph
+                    .package_task_context(&PackageName::Root)
+                    .map(|context| {
+                        context
+                            .native_tasks()
+                            .tasks()
+                            .iter()
+                            .filter(|task| task.executable() || task.authored())
+                            .map(|task| task.name().to_string())
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
                 UnifiedTurboJsonLoader::single_package(
                     reader,
                     root_turbo_json_path.clone(),
-                    root_package_json.clone(),
+                    root_scripts,
                 )
             } else if !root_turbo_json_path.exists() &&
             // Infer a turbo.json if allowing no turbo.json is explicitly allowed or if MFE configs are discovered
@@ -728,16 +738,14 @@ impl RunBuilder {
                     .package_task_contexts()
                     .map(|context| {
                         let package = context.package().clone();
-                        let info = context.package_info();
-                        if context.requires_compatibility_payload() && info.is_none() {
-                            return Err(Error::MissingPackagePayload(package));
-                        }
-                        Ok((
-                            package,
-                            info.into_iter()
-                                .flat_map(|info| info.package_json.scripts.keys().cloned())
-                                .collect(),
-                        ))
+                        let scripts = context
+                            .native_tasks()
+                            .tasks()
+                            .iter()
+                            .filter(|task| task.executable() || task.authored())
+                            .map(|task| task.name().to_string())
+                            .collect();
+                        Ok((package, scripts))
                     })
                     .collect::<Result<_, Error>>()?;
                 UnifiedTurboJsonLoader::workspace_no_turbo_json(

--- a/crates/turborepo-lib/src/turbo_json/loader.rs
+++ b/crates/turborepo-lib/src/turbo_json/loader.rs
@@ -112,12 +112,12 @@ impl UnifiedTurboJsonLoader {
     pub fn single_package(
         reader: TurboJsonReader,
         root_turbo_json: AbsoluteSystemPathBuf,
-        package_json: PackageJson,
+        root_scripts: Vec<String>,
     ) -> Self {
         Self::Standard(TurboJsonLoader::single_package(
             reader,
             root_turbo_json,
-            package_json,
+            root_scripts,
         ))
     }
 

--- a/crates/turborepo-turbo-json/src/loader.rs
+++ b/crates/turborepo-turbo-json/src/loader.rs
@@ -253,10 +253,11 @@ pub struct TurboJsonLoader<U: TurboJsonUpdater = NoOpUpdater> {
 }
 
 #[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
 enum Strategy<U: TurboJsonUpdater> {
     SinglePackage {
         root_turbo_json: AbsoluteSystemPathBuf,
-        package_json: PackageJson,
+        root_scripts: Vec<String>,
     },
     Workspace {
         // Map of package names to their package specific turbo.json
@@ -318,14 +319,14 @@ impl TurboJsonLoader<NoOpUpdater> {
     pub fn single_package(
         reader: TurboJsonReader,
         root_turbo_json: AbsoluteSystemPathBuf,
-        package_json: PackageJson,
+        root_scripts: Vec<String>,
     ) -> Self {
         Self {
             reader,
             cache: FixedMap::new(Some(PackageName::Root).into_iter()),
             strategy: Strategy::SinglePackage {
                 root_turbo_json,
-                package_json,
+                root_scripts,
             },
         }
     }
@@ -449,13 +450,13 @@ impl<U: TurboJsonUpdater> TurboJsonLoader<U> {
         let reader = &self.reader;
         match &self.strategy {
             Strategy::SinglePackage {
-                package_json,
+                root_scripts,
                 root_turbo_json,
             } => {
                 if !matches!(package, PackageName::Root) {
                     Err(LoaderError::InvalidTurboJsonLoad(package.clone()).into())
                 } else {
-                    load_from_root_package_json(reader, root_turbo_json, package_json)
+                    load_from_root_scripts(reader, root_turbo_json, root_scripts)
                         .map_err(|e| e.into())
                 }
             }
@@ -643,23 +644,68 @@ fn load_from_root_package_json(
 
     // TODO: Add location info from package.json
     for script_name in root_package_json.scripts.keys() {
-        let task_name = TaskName::from(script_name.as_str());
-        if !turbo_json.has_task(&task_name) {
-            let task_name = task_name.into_root_task();
-            // Explicitly set cache to Some(false) in this definition
-            // so we can pretend it was set on purpose. That way it
-            // won't get clobbered by the merge function.
-            turbo_json.tasks.insert(
-                task_name,
-                Spanned::new(RawTaskDefinition {
-                    cache: Some(Spanned::new(false)),
-                    ..RawTaskDefinition::default()
-                }),
-            );
-        }
+        insert_synthesized_root_task(&mut turbo_json, script_name);
     }
 
     Ok(turbo_json)
+}
+
+fn load_from_root_scripts(
+    reader: &TurboJsonReader,
+    turbo_json_path: &AbsoluteSystemPath,
+    root_scripts: &[String],
+) -> Result<TurboJson, LoaderError> {
+    let mut turbo_json = match reader.read(turbo_json_path, true) {
+        Ok(Some(mut turbo_json)) => {
+            let mut pipeline = Pipeline::default();
+            for (task_name, task_definition) in turbo_json.tasks {
+                if task_name.is_package_task() {
+                    let (span, text) = task_definition.span_and_text("turbo.json");
+
+                    return Err(LoaderError::TurboJson(
+                        Error::PackageTaskInSinglePackageMode {
+                            task_id: task_name.to_string(),
+                            span,
+                            text,
+                        },
+                    ));
+                }
+
+                pipeline.insert(task_name.into_root_task(), task_definition);
+            }
+
+            turbo_json.tasks = pipeline;
+
+            turbo_json
+        }
+        Ok(None) => TurboJson::default(),
+        Err(e) => {
+            return Err(LoaderError::TurboJson(e));
+        }
+    };
+
+    for script_name in root_scripts {
+        insert_synthesized_root_task(&mut turbo_json, script_name);
+    }
+
+    Ok(turbo_json)
+}
+
+fn insert_synthesized_root_task(turbo_json: &mut TurboJson, script_name: &str) {
+    let task_name = TaskName::from(script_name);
+    if !turbo_json.has_task(&task_name) {
+        let task_name = task_name.into_root_task();
+        // Explicitly set cache to Some(false) in this definition
+        // so we can pretend it was set on purpose. That way it
+        // won't get clobbered by the merge function.
+        turbo_json.tasks.insert(
+            task_name,
+            Spanned::new(RawTaskDefinition {
+                cache: Some(Spanned::new(false)),
+                ..RawTaskDefinition::default()
+            }),
+        );
+    }
 }
 
 fn root_turbo_json_from_scripts(scripts: &[String]) -> Result<TurboJson, LoaderError> {
@@ -921,11 +967,9 @@ mod tests {
         }
 
         let reader = TurboJsonReader::new(repo_root.to_owned());
-        let loader = TurboJsonLoader::<NoOpUpdater>::single_package(
-            reader,
-            root_turbo_json,
-            root_package_json,
-        );
+        let root_scripts: Vec<_> = root_package_json.scripts.keys().cloned().collect();
+        let loader =
+            TurboJsonLoader::<NoOpUpdater>::single_package(reader, root_turbo_json, root_scripts);
         let mut turbo_json = loader.load(&PackageName::Root).unwrap().clone();
         turbo_json.clear_metadata();
         for task_definition in turbo_json.tasks.values_mut() {
@@ -948,7 +992,7 @@ mod tests {
         let single_loader = TurboJsonLoader::<NoOpUpdater>::single_package(
             reader.clone(),
             junk_path.to_owned(),
-            PackageJson::default(),
+            Vec::new(),
         );
         let task_access_loader = TurboJsonLoader::<NoOpUpdater>::task_access(
             reader,


### PR DESCRIPTION
## Intent

Continue Phase 4: when Turborepo synthesizes task definitions without an authored turbo.json (or in single-package mode), enumerate native tasks from the **native-task catalog** instead of reading `PackageJson::scripts` directly.

**Stack:** Phase 4 layer 3. Base = `shew/turbo-5817-migrate-native-task-registration-and-suggestions`.

## Changes

- Workspace no-turbo.json synthesis collects catalog executable/authored task names
- Single-package synthesis takes root script names from the catalog (`single_package(root_scripts)`)
- Devtools / package-changes watcher updated to the same API

## Out of scope

Task-definition precedence, executor command planning, persistent validation overhaul (later layers).

## Testing

- `cargo test -p turborepo-turbo-json --lib` (178 passed)
- `cargo clippy -p turborepo-turbo-json -p turborepo-lib --all-targets -- -D warnings`

Closes TURBO-5818.
