### PR TITLE
refactor: Migrate persistent and recursive task validation

### DIFF
--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -90,10 +90,7 @@ pub(crate) fn task_has_command(
     {
         Some(turborepo_types::TaskCommandOverride::Argv(_)) => true,
         Some(turborepo_types::TaskCommandOverride::OptOut) => false,
-        None => context
-            .toolchain()
-            .and_then(|id| package_graph.toolchains().get(id))
-            .is_some_and(|toolchain| toolchain.defines_task(&context, task.task())),
+        None => context.native_tasks().defines(task.task()),
     }
 }
 
@@ -105,14 +102,11 @@ impl EngineExt for Engine<Built> {
                 TaskNode::Task(task) => Some(task),
             })
             .filter(|task| {
-                // Ask the package's toolchain whether the task resolves to a
-                // runnable command — the same authority execution uses. For
-                // JS packages this is the package.json scripts lookup; for
-                // Cargo packages it consults the verb tables, so toolchain
-                // tasks appear in the TUI task list. A resolved `command`
-                // override is authoritative in both directions: an argv
-                // executes even where the toolchain defines nothing, and an
-                // opt-out never executes even where it does.
+                // Ask the native-task catalog whether the task resolves to a
+                // runnable command — the same authority execution uses. A
+                // resolved `command` override is authoritative in both
+                // directions: an argv executes even where the catalog defines
+                // nothing, and an opt-out never executes even where it does.
                 task_has_command(self, pkg_graph, task)
             })
             .map(ToString::to_string)

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -1256,14 +1256,13 @@ impl RunBuilder {
                 continue;
             }
 
-            let has_command = pkg_dep_graph.package_task_contexts().any(|context| {
-                context
-                    .toolchain()
-                    .and_then(|id| pkg_dep_graph.toolchains().get(id))
-                    .is_some_and(|toolchain| toolchain.defines_task(&context, task.task()))
-            }) || engine.task_ids().any(|task_id| {
-                task_id.task() == task.task() && task_has_command(engine, pkg_dep_graph, task_id)
-            });
+            let has_command = pkg_dep_graph
+                .package_task_contexts()
+                .any(|context| context.native_tasks().defines(task.task()))
+                || engine.task_ids().any(|task_id| {
+                    task_id.task() == task.task()
+                        && task_has_command(engine, pkg_dep_graph, task_id)
+                });
 
             for package in candidate_packages {
                 let task_id = TaskId::new(package.as_ref(), task.task()).into_owned();

--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -710,29 +710,36 @@ impl<'a> Visitor<'a> {
                 });
                 break;
             };
-            let command = package_context
-                .package_info()
-                .and_then(|workspace| workspace.package_json.scripts.get(info.task()));
+            // Recursive turbo detection uses catalog authored display/source
+            // facts, not a live PackageJson::scripts read.
+            if info.package() == ROOT_PKG_NAME {
+                if let Some(native_task) = package_context.native_tasks().get(info.task()) {
+                    if let Some(cmd) = native_task.display().or_else(|| {
+                        native_task
+                            .script()
+                            .map(|script| script.as_inner().as_str())
+                    }) {
+                        if command_invokes_turbo(cmd) {
+                            let package_task_event =
+                                PackageTaskEventBuilder::new(info.package(), info.task())
+                                    .with_parent(telemetry);
+                            package_task_event.track_error(TrackedErrors::RecursiveError);
+                            let (span, text) = native_task
+                                .script()
+                                .map(|script| script.span_and_text("package.json"))
+                                .unwrap_or((None, NamedSource::new("", String::new())));
 
-            match command {
-                Some(cmd)
-                    if info.package() == ROOT_PKG_NAME && command_invokes_turbo(cmd.as_str()) =>
-                {
-                    let package_task_event =
-                        PackageTaskEventBuilder::new(info.package(), info.task())
-                            .with_parent(telemetry);
-                    package_task_event.track_error(TrackedErrors::RecursiveError);
-                    let (span, text) = cmd.span_and_text("package.json");
-
-                    dispatch_error = Some(Error::RecursiveTurbo(Box::new(RecursiveTurboError {
-                        task_name: info.to_string(),
-                        command: cmd.to_string(),
-                        span,
-                        text,
-                    })));
-                    break;
+                            dispatch_error =
+                                Some(Error::RecursiveTurbo(Box::new(RecursiveTurboError {
+                                    task_name: info.to_string(),
+                                    command: cmd.to_string(),
+                                    span,
+                                    text,
+                                })));
+                            break;
+                        }
+                    }
                 }
-                _ => (),
             }
 
             let Some(task_definition) = engine.task_definition(&info) else {


### PR DESCRIPTION
## Intent

Continue Phase 4 of the multi-language repository architecture: persistent-task validation and recursive-turbo detection must use **effective executability / authored display facts from the native-task catalog**, not live `PackageJson::scripts` reads.

**Stack:** Phase 4 layer 4. Base = `shew/turbo-5818-migrate-turbo-json-native-task-synthesis`.

## Changes

- `task_has_command` / entrypoint selection use catalog `defines`
- Visitor recursive-turbo check uses catalog display/script spans (root-only)
- Persistent dependency/concurrency paths already catalog-backed (refined comments/usage)

## Out of scope

Persistent/interactive semantics, stdin lifecycle, cache contracts.

## Testing

- `cargo test -p turborepo-lib --lib engine::` (10 passed)
- `cargo clippy -p turborepo-lib --all-targets -- -D warnings`

Closes TURBO-5819.
