### PR TITLE
refactor: Migrate engine native command planning

### DIFF
--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -939,6 +939,50 @@ impl PackageGraph {
             .generation = None;
     }
 
+    /// Resolve a native or override command plan from the catalog.
+    ///
+    /// Binary lookup (`which`) is performed here so callers receive a concrete
+    /// [`TaskCommand`]. Package-manager / cargo framing comes from the
+    /// catalog templates, not from `Toolchain::task_command`.
+    pub fn resolve_native_task_command(
+        &self,
+        context: &PackageTaskContext<'_>,
+        task: &str,
+        pass_through_args: Option<&[String]>,
+        override_command: Option<&[String]>,
+    ) -> Result<Option<crate::toolchain::TaskCommand>, crate::native_tasks::ResolveNativeCommandError>
+    {
+        let package_manager = self.package_manager();
+        let package_manager_binary = package_manager
+            .and_then(|package_manager| which::which(package_manager.command()).ok());
+        let cargo_binary = which::which("cargo").ok();
+
+        if let Some(native_task) = context.native_tasks().get(task) {
+            return crate::native_tasks::resolve_task_command(
+                context,
+                native_task,
+                package_manager,
+                package_manager_binary.as_deref(),
+                cargo_binary.as_deref(),
+                pass_through_args,
+                override_command,
+            );
+        }
+
+        let Some(override_command) = override_command else {
+            return Ok(None);
+        };
+        let serial_group = (context.toolchain() == Some(&crate::toolchain::ToolchainId::RUST)
+            && override_command.first().map(String::as_str) == Some("cargo"))
+        .then(|| "cargo".to_string());
+        Ok(crate::toolchain::override_task_command(
+            context,
+            override_command,
+            pass_through_args,
+            serial_group,
+        ))
+    }
+
     pub fn package_json(&self, package: &PackageName) -> Option<&PackageJson> {
         let entry = self.package_payloads.get(package)?;
         Some(&entry.package_json)

--- a/crates/turborepo-task-executor/src/command.rs
+++ b/crates/turborepo-task-executor/src/command.rs
@@ -154,14 +154,13 @@ pub enum CommandProviderError {
     Toolchain(#[from] turborepo_repository::toolchain::Error),
 }
 
-/// Command provider that resolves commands through the package's toolchain.
+/// Command provider that resolves commands through the native-task catalog.
 ///
-/// The toolchain owns command construction (JavaScript: run the package.json
-/// script via the package manager; Cargo: `cargo <verb>` scoped to the
-/// crate or workspace). This provider adapts the resolved [`TaskCommand`]
-/// data into a process command and applies concerns that are not
-/// toolchain-specific: the task environment, stdin policy, and
-/// microfrontends proxy decorations.
+/// The catalog owns native command templates (JavaScript: package-manager
+/// `run <script>`; Cargo: `cargo <verb>` scoped to crate/workspace). This
+/// provider adapts the resolved [`TaskCommand`] data into a process command
+/// and applies concerns that are not native-task-specific: the task
+/// environment, stdin policy, and microfrontends proxy decorations.
 #[derive(Debug)]
 pub struct ToolchainCommandProvider<'a, M = crate::NoMfeConfig> {
     package_graph: &'a PackageGraph,
@@ -172,7 +171,7 @@ pub struct ToolchainCommandProvider<'a, M = crate::NoMfeConfig> {
     /// one is running for this run.
     compile_cache: Option<&'a CompileCacheEndpoint>,
     /// Resolved `command` overrides by task, from the engine's task
-    /// definitions. An argv replaces the toolchain's own resolution; an
+    /// definitions. An argv replaces the native catalog resolution; an
     /// opt-out makes the task an explicit no-op.
     command_overrides: HashMap<TaskId<'static>, TaskCommandOverride>,
 }
@@ -253,23 +252,20 @@ impl<'a, M: MfeConfigProvider, E: From<CommandProviderError>> CommandProvider<E>
             cmd.open_stdin();
             return Ok(Some(cmd));
         };
-        let toolchain = self
-            .package_graph
-            .toolchains()
-            .get(toolchain_id)
-            .ok_or_else(|| CommandProviderError::MissingToolchain {
-                toolchain: toolchain_id.clone(),
-                package_name: package_context.package().clone(),
-            })?;
 
-        let spec = toolchain
-            .task_command(
+        let spec = self
+            .package_graph
+            .resolve_native_task_command(
                 &package_context,
                 task_id.task(),
                 self.task_args.args_for_task(task_id),
                 override_command,
             )
-            .map_err(CommandProviderError::from)?;
+            .map_err(|error| {
+                CommandProviderError::Toolchain(turborepo_repository::toolchain::Error::Failed(
+                    Box::new(error),
+                ))
+            })?;
         let Some(spec) = spec else {
             return Ok(None);
         };
@@ -308,12 +304,11 @@ impl<'a, M: MfeConfigProvider, E: From<CommandProviderError>> CommandProvider<E>
             cmd.env("TURBO_MFE_PORT", port.to_string());
         }
 
-        // The toolchain decides how the injection composes with the task's
-        // environment (competing configuration suppresses it, ambient
-        // settings are tolerated) and returns exactly what to inject; see
-        // `Toolchain::compile_cache_env`.
+        // Compile-cache injection remains toolchain-owned until environment
+        // contracts move; look up the toolchain only for that decoration.
         if should_inject_toolchain_compile_cache(command_override)
             && let Some(endpoint) = self.compile_cache
+            && let Some(toolchain) = self.package_graph.toolchains().get(toolchain_id)
         {
             let vars = toolchain.compile_cache_env(endpoint, environment);
             if vars.is_empty() {


### PR DESCRIPTION
## Intent

Continue Phase 4: engine/run execution should plan native commands from the **native-task catalog + TaskArgs**, producing an ecosystem-neutral `TaskCommand` without calling `Toolchain::task_command`.

**Stack:** Phase 4 layer 6. Base = `shew/turbo-5820-migrate-native-task-definition-precedence`.

## Changes

- Add `PackageGraph::resolve_native_task_command` (catalog templates + which + overrides)
- `ToolchainCommandProvider` plans via that API instead of `toolchain.task_command`
- Preserve override / pure-native-root / MFE / compile-cache decoration behavior

## Out of scope

Lazy binary cache polish (TURBO-5822), env/hash contract changes.

## Testing

- `cargo test -p turborepo-task-executor --lib` (18 passed)
- `cargo clippy -p turborepo-repository -p turborepo-task-executor --all-targets -- -D warnings`

Closes TURBO-5821.
