### PR TITLE
refactor: Migrate native task query, devtools, and LSP views

### DIFF
--- a/crates/turborepo-lib/src/devtools.rs
+++ b/crates/turborepo-lib/src/devtools.rs
@@ -138,7 +138,7 @@ impl ProperTaskGraphBuilder {
         // when not listed in turbo.json.
         if let Some(context) = pkg_graph.package_task_context(&PackageName::Root) {
             for native_task in context.native_tasks().tasks() {
-                if !(native_task.executable() || native_task.authored()) {
+                if native_task.script().is_none() {
                     continue;
                 }
                 let task_name = TaskName::from(format!("//#{}", native_task.name())).into_owned();
@@ -182,11 +182,7 @@ impl ProperTaskGraphBuilder {
                     let script = pkg_graph
                         .package_task_context(&PackageName::from(task_id.package()))
                         .and_then(|context| context.native_tasks().get(task_id.task()))
-                        .and_then(|task| {
-                            task.script()
-                                .map(|script| script.as_inner().clone())
-                                .or_else(|| task.display().map(str::to_string))
-                        })
+                        .and_then(|task| task.script().map(|script| script.as_inner().clone()))
                         .unwrap_or_default();
 
                     nodes.push(TaskNode {

--- a/crates/turborepo-lib/src/devtools.rs
+++ b/crates/turborepo-lib/src/devtools.rs
@@ -134,11 +134,14 @@ impl ProperTaskGraphBuilder {
             })
             .unwrap_or_default();
 
-        // Also add all scripts from root package.json as potential root tasks
-        // This ensures tasks like //#build:ts are allowed even if not in turbo.json
-        if let Some(root_pkg_json) = pkg_graph.package_json(&PackageName::Root) {
-            for script_name in root_pkg_json.scripts.keys() {
-                let task_name = TaskName::from(format!("//#{}", script_name)).into_owned();
+        // Also add catalog-backed root tasks so //#script tasks appear even
+        // when not listed in turbo.json.
+        if let Some(context) = pkg_graph.package_task_context(&PackageName::Root) {
+            for native_task in context.native_tasks().tasks() {
+                if !(native_task.executable() || native_task.authored()) {
+                    continue;
+                }
+                let task_name = TaskName::from(format!("//#{}", native_task.name())).into_owned();
                 if !root_tasks.contains(&task_name) {
                     root_tasks.push(task_name);
                 }
@@ -175,11 +178,15 @@ impl ProperTaskGraphBuilder {
                     let task = task_id.task().to_string();
                     let id = task_id.to_string();
 
-                    // Get script from package.json
+                    // Get display/script text from the native-task catalog.
                     let script = pkg_graph
-                        .package_json(&PackageName::from(task_id.package()))
-                        .and_then(|pj| pj.scripts.get(task_id.task()))
-                        .map(|s| s.value.clone())
+                        .package_task_context(&PackageName::from(task_id.package()))
+                        .and_then(|context| context.native_tasks().get(task_id.task()))
+                        .and_then(|task| {
+                            task.script()
+                                .map(|script| script.as_inner().clone())
+                                .or_else(|| task.display().map(str::to_string))
+                        })
                         .unwrap_or_default();
 
                     nodes.push(TaskNode {

--- a/crates/turborepo-lsp/src/lib.rs
+++ b/crates/turborepo-lsp/src/lib.rs
@@ -38,6 +38,7 @@ use turborepo_lib::{
 use turborepo_repository::{
     discovery::{self, PackageDiscovery},
     inference::RepoState,
+    native_tasks::observation_from_package_json,
     package_graph::{self, PackageGraph, PackageName},
     package_json::PackageJson,
     toolchain::ToolchainId,
@@ -154,6 +155,22 @@ impl LspPackages {
         Self { packages }
     }
 
+    /// Map an unsaved/in-memory package.json payload to the same native-task
+    /// observation vocabulary used by the repository catalog.
+    fn observed_task_names(package: &LspPackage) -> Vec<String> {
+        let scope = package
+            .identity
+            .as_ref()
+            .map(|identity| identity.as_str())
+            .unwrap_or("//");
+        observation_from_package_json(scope, &package.package_json)
+            .tasks
+            .into_iter()
+            .filter(|task| task.authored() || task.executable())
+            .map(|task| task.name().to_string())
+            .collect()
+    }
+
     fn task_index(&self) -> HashMap<String, Vec<Option<String>>> {
         let mut tasks = HashMap::<String, Vec<Option<String>>>::new();
         for package in &self.packages {
@@ -161,8 +178,8 @@ impl LspPackages {
                 .identity
                 .as_ref()
                 .map(|identity| identity.as_str().to_string());
-            for script in package.package_json.scripts.keys() {
-                let identities = tasks.entry(script.clone()).or_default();
+            for script in Self::observed_task_names(package) {
+                let identities = tasks.entry(script).or_default();
                 if !identities.contains(&identity) {
                     identities.push(identity.clone());
                 }
@@ -174,17 +191,12 @@ impl LspPackages {
     fn completion_labels(&self) -> Vec<String> {
         let qualified = self.packages.iter().flat_map(|package| {
             package.identity.iter().flat_map(|identity| {
-                package
-                    .package_json
-                    .scripts
-                    .keys()
+                Self::observed_task_names(package)
+                    .into_iter()
                     .map(move |script| format!("{}#{script}", identity.as_str()))
             })
         });
-        let tasks = self
-            .packages
-            .iter()
-            .flat_map(|package| package.package_json.scripts.keys().cloned());
+        let tasks = self.packages.iter().flat_map(Self::observed_task_names);
 
         qualified.chain(tasks).unique().collect()
     }
@@ -203,7 +215,9 @@ impl LspPackages {
                         .identity
                         .as_ref()
                         .is_some_and(|identity| requested == identity.as_str())
-                }) && package.package_json.scripts.contains_key(task)
+                }) && Self::observed_task_names(package)
+                    .iter()
+                    .any(|name| name == task)
             })
             .filter_map(|package| {
                 // TODO: use jsonc_ast instead of text search.

--- a/crates/turborepo-lsp/src/lib.rs
+++ b/crates/turborepo-lsp/src/lib.rs
@@ -166,7 +166,7 @@ impl LspPackages {
         observation_from_package_json(scope, &package.package_json)
             .tasks
             .into_iter()
-            .filter(|task| task.authored() || task.executable())
+            .filter(|task| task.script().is_some())
             .map(|task| task.name().to_string())
             .collect()
     }

--- a/crates/turborepo-query/src/package.rs
+++ b/crates/turborepo-query/src/package.rs
@@ -70,11 +70,21 @@ impl Package {
     pub fn get_tasks(&self) -> HashMap<String, Spanned<String>> {
         self.run
             .pkg_dep_graph()
-            .package_json(&self.name)
-            .map(|json| {
-                json.scripts
+            .package_task_context(&self.name)
+            .map(|context| {
+                context
+                    .native_tasks()
+                    .tasks()
                     .iter()
-                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .filter_map(|task| {
+                        task.script()
+                            .cloned()
+                            .or_else(|| {
+                                task.display()
+                                    .map(|display| Spanned::new(display.to_string()))
+                            })
+                            .map(|script| (task.name().to_string(), script))
+                    })
                     .collect()
             })
             .unwrap_or_default()
@@ -82,29 +92,28 @@ impl Package {
 
     pub fn get_task_names(&self) -> BTreeSet<String> {
         let packages = HashSet::from([self.name.clone()]);
-        let registered_tasks: HashSet<_> = self
+        let catalog_tasks: HashSet<_> = self
             .run
             .pkg_dep_graph()
             .package_task_context(&self.name)
-            .and_then(|context| {
-                self.run
-                    .pkg_dep_graph()
-                    .toolchains()
-                    .get(context.toolchain()?)
-                    .map(|toolchain| toolchain.registered_tasks(&context))
+            .map(|context| {
+                context
+                    .native_tasks()
+                    .tasks()
+                    .iter()
+                    .filter(|task| task.executable() || task.registered() || task.authored())
+                    .map(|task| task.name().to_string())
+                    .collect()
             })
-            .unwrap_or_default()
+            .unwrap_or_default();
+        catalog_tasks
             .into_iter()
-            .collect();
-        self.get_tasks()
-            .into_keys()
             .chain(
                 self.run
                     .engine()
                     .task_ids_for_packages(&packages)
                     .into_iter()
-                    .map(|task| task.task().to_string())
-                    .filter(|task| registered_tasks.contains(task)),
+                    .map(|task| task.task().to_string()),
             )
             .collect()
     }

--- a/crates/turborepo-query/src/package.rs
+++ b/crates/turborepo-query/src/package.rs
@@ -88,28 +88,27 @@ impl Package {
 
     pub fn get_task_names(&self) -> BTreeSet<String> {
         let packages = HashSet::from([self.name.clone()]);
-        let catalog_tasks: HashSet<_> = self
+        let registered_tasks: HashSet<_> = self
             .run
             .pkg_dep_graph()
             .package_task_context(&self.name)
             .map(|context| {
                 context
                     .native_tasks()
-                    .tasks()
-                    .iter()
-                    .filter(|task| task.script().is_some())
-                    .map(|task| task.name().to_string())
+                    .registered_names()
+                    .into_iter()
                     .collect()
             })
             .unwrap_or_default();
-        catalog_tasks
-            .into_iter()
+        self.get_tasks()
+            .into_keys()
             .chain(
                 self.run
                     .engine()
                     .task_ids_for_packages(&packages)
                     .into_iter()
-                    .map(|task| task.task().to_string()),
+                    .map(|task| task.task().to_string())
+                    .filter(|task| registered_tasks.contains(task)),
             )
             .collect()
     }

--- a/crates/turborepo-query/src/package.rs
+++ b/crates/turborepo-query/src/package.rs
@@ -79,10 +79,6 @@ impl Package {
                     .filter_map(|task| {
                         task.script()
                             .cloned()
-                            .or_else(|| {
-                                task.display()
-                                    .map(|display| Spanned::new(display.to_string()))
-                            })
                             .map(|script| (task.name().to_string(), script))
                     })
                     .collect()
@@ -101,7 +97,7 @@ impl Package {
                     .native_tasks()
                     .tasks()
                     .iter()
-                    .filter(|task| task.executable() || task.registered() || task.authored())
+                    .filter(|task| task.script().is_some())
                     .map(|task| task.name().to_string())
                     .collect()
             })

--- a/crates/turborepo-query/src/task.rs
+++ b/crates/turborepo-query/src/task.rs
@@ -42,15 +42,7 @@ impl RepositoryTask {
                 .run()
                 .pkg_dep_graph()
                 .package_task_context(self.package.get_name())
-                .and_then(|context| {
-                    self.package
-                        .run()
-                        .pkg_dep_graph()
-                        .toolchains()
-                        .get(context.toolchain()?)
-                        .map(|toolchain| (context, toolchain))
-                })
-                .is_some_and(|(context, toolchain)| toolchain.defines_task(&context, &self.name)),
+                .is_some_and(|context| context.native_tasks().defines(&self.name)),
         }
     }
 

--- a/crates/turborepo-task-executor/src/command.rs
+++ b/crates/turborepo-task-executor/src/command.rs
@@ -491,7 +491,7 @@ impl<'a, M: MfeConfigProvider, E: From<CommandProviderError>> CommandProvider<E>
                 package_name: package_context.package().clone(),
             }
         })?;
-        let has_custom_proxy = package_info.package_json.scripts.contains_key("proxy");
+        let has_custom_proxy = package_context.native_tasks().defines("proxy");
 
         // Check if package depends on @vercel/microfrontends
         const MICROFRONTENDS_PACKAGE: &str = "@vercel/microfrontends";


### PR DESCRIPTION
## Intent

Continue Phase 4: query, devtools, and LSP task views must consume the **native-task catalog / observation vocabulary** instead of direct `PackageJson::scripts` reads—while LSP still maps unsaved package.json buffers through the same observation helper so editor features stay source-accurate.

**Stack:** Phase 4 layer 8. Base = `shew/turbo-5822-migrate-executor-native-command-resolution`.

## Changes

- Query package tasks/script/executes use catalog facts
- Devtools root-task enumeration and task-graph script text use catalog
- LSP completions/index/references use `observation_from_package_json` on buffer payloads
- MFE custom `proxy` detection uses catalog `defines`

## Out of scope

GraphQL schema changes, run-summary command display (TURBO-5824).

## Testing

- `cargo test -p turborepo-query --lib` (9 passed)
- `cargo test -p turborepo-task-executor --lib command::tests` (10 passed)
- `cargo clippy -p turborepo-query -p turborepo-lib -p turborepo-lsp -p turborepo-task-executor --all-targets -- -D warnings`

Closes TURBO-5823.
