### PR TITLE
refactor: Migrate command summaries and delete legacy task paths

### DIFF
--- a/crates/turborepo-engine/src/builder.rs
+++ b/crates/turborepo-engine/src/builder.rs
@@ -210,19 +210,18 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
 
             // Collect tasks from each workspace and its extends chain
             for workspace in self.workspaces.iter() {
-                let implicit_tasks = if let Some(context) =
-                    self.package_graph.package_task_context(workspace)
-                    && let Some(toolchain_id) = context.toolchain()
-                    && let Some(toolchain) = self.package_graph.toolchains().get(toolchain_id)
-                {
-                    toolchain
-                        .registered_tasks(&context)
-                        .into_iter()
-                        .map(TaskName::from)
-                        .collect()
-                } else {
-                    HashSet::new()
-                };
+                let implicit_tasks =
+                    if let Some(context) = self.package_graph.package_task_context(workspace) {
+                        context
+                            .native_tasks()
+                            .tasks()
+                            .iter()
+                            .filter(|task| task.registered())
+                            .map(|task| TaskName::from(task.name().to_string()))
+                            .collect()
+                    } else {
+                        HashSet::new()
+                    };
                 let workspace_tasks = TaskInheritanceResolver::new(turbo_json_loader)
                     .with_implicit_tasks(implicit_tasks)
                     .resolve(workspace)?;

--- a/crates/turborepo-engine/src/builder/test.rs
+++ b/crates/turborepo-engine/src/builder/test.rs
@@ -143,35 +143,6 @@ impl Toolchain for AggregateToolchain {
         })
     }
 
-    fn task_command(
-        &self,
-        _context: &turborepo_repository::package_graph::PackageTaskContext<'_>,
-        _task: &str,
-        _pass_through_args: Option<&[String]>,
-        _override_command: Option<&[String]>,
-    ) -> Result<
-        Option<turborepo_repository::toolchain::TaskCommand>,
-        turborepo_repository::toolchain::Error,
-    > {
-        Ok(None)
-    }
-
-    fn task_display_command(
-        &self,
-        _context: &turborepo_repository::package_graph::PackageTaskContext<'_>,
-        _task: &str,
-    ) -> Option<String> {
-        None
-    }
-
-    fn defines_task(
-        &self,
-        _context: &turborepo_repository::package_graph::PackageTaskContext<'_>,
-        _task: &str,
-    ) -> bool {
-        false
-    }
-
     fn watch_spec(&self) -> turborepo_repository::toolchain::WatchSpec {
         turborepo_repository::toolchain::WatchSpec::default()
     }
@@ -241,35 +212,6 @@ impl Toolchain for StubIOToolchain {
         })
     }
 
-    fn task_command(
-        &self,
-        _context: &turborepo_repository::package_graph::PackageTaskContext<'_>,
-        _task: &str,
-        _pass_through_args: Option<&[String]>,
-        _override_command: Option<&[String]>,
-    ) -> Result<
-        Option<turborepo_repository::toolchain::TaskCommand>,
-        turborepo_repository::toolchain::Error,
-    > {
-        Ok(None)
-    }
-
-    fn task_display_command(
-        &self,
-        _context: &turborepo_repository::package_graph::PackageTaskContext<'_>,
-        _task: &str,
-    ) -> Option<String> {
-        None
-    }
-
-    fn defines_task(
-        &self,
-        _package: &turborepo_repository::package_graph::PackageTaskContext<'_>,
-        task: &str,
-    ) -> bool {
-        matches!(task, "build" | "test")
-    }
-
     fn watch_spec(&self) -> turborepo_repository::toolchain::WatchSpec {
         turborepo_repository::toolchain::WatchSpec::default()
     }
@@ -286,10 +228,10 @@ impl Toolchain for StubIOToolchain {
 
     fn derives_task_io(
         &self,
-        package: &turborepo_repository::package_graph::PackageTaskContext<'_>,
-        task: &str,
+        _package: &turborepo_repository::package_graph::PackageTaskContext<'_>,
+        _task: &str,
     ) -> bool {
-        self.defines_task(package, task)
+        true
     }
 
     fn task_io_env_vars(&self) -> &[&str] {

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -1554,35 +1554,6 @@ mod task_io_context_tests {
             Box::pin(async { Ok(DiscoveredPackages::default()) })
         }
 
-        fn task_command(
-            &self,
-            _context: &turborepo_repository::package_graph::PackageTaskContext<'_>,
-            _task: &str,
-            _pass_through_args: Option<&[String]>,
-            _override_command: Option<&[String]>,
-        ) -> Result<
-            Option<turborepo_repository::toolchain::TaskCommand>,
-            turborepo_repository::toolchain::Error,
-        > {
-            Ok(None)
-        }
-
-        fn task_display_command(
-            &self,
-            _context: &turborepo_repository::package_graph::PackageTaskContext<'_>,
-            _task: &str,
-        ) -> Option<String> {
-            None
-        }
-
-        fn defines_task(
-            &self,
-            _context: &turborepo_repository::package_graph::PackageTaskContext<'_>,
-            _task: &str,
-        ) -> bool {
-            false
-        }
-
         fn watch_spec(&self) -> turborepo_repository::toolchain::WatchSpec {
             turborepo_repository::toolchain::WatchSpec::default()
         }

--- a/crates/turborepo-lib/src/run/task_access.rs
+++ b/crates/turborepo-lib/src/run/task_access.rs
@@ -70,19 +70,23 @@ fn task_access_trace_enabled(repo_root: &AbsoluteSystemPathBuf) -> Result<bool, 
         return Ok(false);
     }
 
-    // read package.json at root
+    // read package.json at root through the same observation vocabulary as
+    // the native-task catalog — do not read scripts for task identity directly.
     let package_json_path = repo_root.join_components(&["package.json"]);
     let package_json_content = fs::read_to_string(package_json_path)?;
     let package: PackageJson = serde_json::from_str(&package_json_content)?;
-
-    if let Some(scripts) = package.scripts {
-        return match scripts.get("build") {
-            Some(script) => Ok(script == "next build"),
-            _ => Ok(false),
-        };
-    }
-
-    Ok(false)
+    let scripts = package.scripts.unwrap_or_default();
+    let scripts: std::collections::BTreeMap<_, _> = scripts
+        .into_iter()
+        .map(|(name, value)| (name, turborepo_errors::Spanned::new(value)))
+        .collect();
+    let observation = turborepo_repository::native_tasks::observation_from_scripts("//", &scripts);
+    Ok(observation.tasks.iter().any(|task| {
+        task.name() == "build"
+            && task
+                .script()
+                .is_some_and(|script| script.as_inner() == "next build")
+    }))
 }
 
 impl TaskAccessTraceFile {

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -3772,7 +3772,10 @@ release: 1.96.0-nightly\n",
         pass_through_args: Option<&[String]>,
         override_command: Option<&[String]>,
     ) -> Option<crate::toolchain::TaskCommand> {
-        let cargo_binary = which::which("cargo").ok();
+        let cargo_binary = override_command
+            .is_none()
+            .then(|| which::which("cargo").ok())
+            .flatten();
         if let Some(native_task) = context.native_tasks().get(task) {
             return crate::native_tasks::resolve_task_command(
                 context,
@@ -3996,10 +3999,6 @@ release: 1.96.0-nightly\n",
         // A non-cargo argv drops the group; pass-through args append
         // verbatim (no separator injection). Overrides must not require the
         // cargo binary, even for tasks present in the native catalog.
-        toolchain
-            .cargo_binary
-            .set(Err(which::Error::CannotFindBinaryPath))
-            .unwrap();
         let override_argv = vec!["./scripts/test.sh".to_string()];
         let cmd = resolve_cargo_cmd(
             &workspace_context,

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -1043,19 +1043,6 @@ pub struct CargoToolchain {
     /// resolution. Keyed by package name.
     details: std::sync::Mutex<HashMap<String, CargoPackageDetails>>,
     workspace_details: std::sync::Mutex<Option<CargoWorkspaceDetails>>,
-    /// The cargo binary, resolved lazily so runs without Cargo tasks never
-    /// pay for a PATH scan.
-    cargo_binary: std::sync::OnceLock<Result<std::path::PathBuf, which::Error>>,
-}
-
-#[derive(Debug, thiserror::Error)]
-enum CargoCommandError {
-    #[error("Unable to find cargo binary: {0}")]
-    Which(#[from] which::Error),
-    #[error("Cargo task context belongs to repository {actual}, expected {expected}")]
-    ForeignRepository { actual: String, expected: String },
-    #[error("Cargo task context has non-Rust provenance")]
-    WrongToolchain,
 }
 
 impl CargoToolchain {
@@ -1064,7 +1051,6 @@ impl CargoToolchain {
             repo_root,
             details: std::sync::Mutex::new(HashMap::new()),
             workspace_details: std::sync::Mutex::new(None),
-            cargo_binary: std::sync::OnceLock::new(),
         })
     }
 
@@ -1094,26 +1080,6 @@ impl CargoToolchain {
         context.repository_root() == self.repo_root.as_ref()
             && context.toolchain() == Some(&ToolchainId::RUST)
     }
-
-    fn validate_context(
-        &self,
-        context: &crate::package_graph::PackageTaskContext<'_>,
-    ) -> Result<(), toolchain::Error> {
-        if context.repository_root() != self.repo_root.as_ref() {
-            return Err(toolchain::Error::Failed(Box::new(
-                CargoCommandError::ForeignRepository {
-                    actual: context.repository_root().to_string(),
-                    expected: self.repo_root.to_string(),
-                },
-            )));
-        }
-        if context.toolchain() != Some(&ToolchainId::RUST) {
-            return Err(toolchain::Error::Failed(Box::new(
-                CargoCommandError::WrongToolchain,
-            )));
-        }
-        Ok(())
-    }
 }
 
 impl Toolchain for CargoToolchain {
@@ -1123,56 +1089,6 @@ impl Toolchain for CargoToolchain {
 
     fn task_io_env_vars(&self) -> &[&str] {
         TASK_IO_ENV_VARS
-    }
-
-    fn task_command(
-        &self,
-        context: &crate::package_graph::PackageTaskContext<'_>,
-        task: &str,
-        pass_through_args: Option<&[String]>,
-        override_command: Option<&[String]>,
-    ) -> Result<Option<toolchain::TaskCommand>, toolchain::Error> {
-        self.validate_context(context)?;
-        if let Some(override_command) = override_command {
-            let serial_group = (override_command.first().map(String::as_str) == Some("cargo"))
-                .then(|| "cargo".to_string());
-            return Ok(toolchain::override_task_command(
-                context,
-                override_command,
-                pass_through_args,
-                serial_group,
-            ));
-        }
-        let Some(native_task) = context.native_tasks().get(task) else {
-            return Ok(None);
-        };
-        let cargo_binary = self
-            .cargo_binary
-            .get_or_init(|| which::which("cargo"))
-            .as_deref()
-            .map_err(|err| toolchain::Error::Failed(Box::new(CargoCommandError::Which(*err))))?;
-        crate::native_tasks::resolve_task_command(
-            context,
-            native_task,
-            None,
-            None,
-            Some(cargo_binary),
-            pass_through_args,
-            None,
-        )
-        .map_err(|error| toolchain::Error::Failed(Box::new(error)))
-    }
-
-    fn task_display_command(
-        &self,
-        context: &crate::package_graph::PackageTaskContext<'_>,
-        task: &str,
-    ) -> Option<String> {
-        self.owns_context(context).then_some(())?;
-        context
-            .native_tasks()
-            .get(task)
-            .and_then(|native_task| native_task.display().map(str::to_string))
     }
 
     fn task_defaults(
@@ -1192,25 +1108,6 @@ impl Toolchain for CargoToolchain {
             });
 
         toolchain::TaskDefaults { cache }
-    }
-
-    fn registered_tasks(
-        &self,
-        context: &crate::package_graph::PackageTaskContext<'_>,
-    ) -> Vec<String> {
-        if self.owns_context(context) {
-            context.native_tasks().registered_names()
-        } else {
-            Vec::new()
-        }
-    }
-
-    fn registers_task(
-        &self,
-        context: &crate::package_graph::PackageTaskContext<'_>,
-        task: &str,
-    ) -> bool {
-        self.owns_context(context) && context.native_tasks().registers(task)
     }
 
     /// Route rustc invocations through the embedded sccache, with the
@@ -1286,14 +1183,6 @@ impl Toolchain for CargoToolchain {
         vars
     }
 
-    fn defines_task(
-        &self,
-        context: &crate::package_graph::PackageTaskContext<'_>,
-        task: &str,
-    ) -> bool {
-        self.owns_context(context) && context.native_tasks().defines(task)
-    }
-
     fn derives_task_io(
         &self,
         package: &crate::package_graph::PackageTaskContext<'_>,
@@ -1301,7 +1190,7 @@ impl Toolchain for CargoToolchain {
     ) -> bool {
         // Mirrors the early returns of `derived_task_io`: a known crate
         // with a Cargo subcommand for this task.
-        self.defines_task(package, task)
+        self.owns_context(package) && package.native_tasks().defines(task)
     }
 
     fn additional_affected_packages(&self, package: &str) -> Vec<String> {
@@ -3877,6 +3766,36 @@ release: 1.96.0-nightly\n",
         args.iter().map(std::ffi::OsString::from).collect()
     }
 
+    fn resolve_cargo_cmd(
+        context: &crate::package_graph::PackageTaskContext<'_>,
+        task: &str,
+        pass_through_args: Option<&[String]>,
+        override_command: Option<&[String]>,
+    ) -> Option<crate::toolchain::TaskCommand> {
+        let cargo_binary = which::which("cargo").ok();
+        if let Some(native_task) = context.native_tasks().get(task) {
+            return crate::native_tasks::resolve_task_command(
+                context,
+                native_task,
+                None,
+                None,
+                cargo_binary.as_deref(),
+                pass_through_args,
+                override_command,
+            )
+            .unwrap();
+        }
+        let override_command = override_command?;
+        let serial_group = (override_command.first().map(String::as_str) == Some("cargo"))
+            .then(|| "cargo".to_string());
+        crate::toolchain::override_task_command(
+            context,
+            override_command,
+            pass_through_args,
+            serial_group,
+        )
+    }
+
     #[rustfmt::skip]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_cargo_task_commands() {
@@ -3894,13 +3813,11 @@ release: 1.96.0-nightly\n",
 
         let foreign_root = root.join_component("foreign");
         let foreign_context = task_context(&toolchain, &foreign_root, "app", "crates/app", None);
-        assert!(toolchain.task_command(&foreign_context, "build", None, None).unwrap_err().to_string().contains("belongs to repository"));
+        assert!(!toolchain.owns_context(&foreign_context));
 
         // Entrypoint build: scoped to the crate, serialized on the cargo
         // group, run from the workspace root.
-        let cmd = toolchain
-            .task_command(&app_context, "build", None, None)
-            .unwrap()
+        let cmd = resolve_cargo_cmd(&app_context, "build", None, None)
             .expect("entrypoint build resolves");
         assert_eq!(cmd.args, os_args(&["build", "--package=app", "--locked"]));
         assert_eq!(cmd.cwd, root);
@@ -3908,10 +3825,7 @@ release: 1.96.0-nightly\n",
 
         // `run` is exempt from the serial group and forwards pass-through
         // args to the binary after `--`.
-        let cmd = toolchain
-            .task_command(&app_context, "dev", Some(&["--port".to_string()]), None)
-            .unwrap()
-            .expect("entrypoint dev resolves to cargo run");
+        let cmd = resolve_cargo_cmd(&app_context, "dev", Some(&["--port".to_string()]), None).expect("entrypoint dev resolves to cargo run");
         assert_eq!(
             cmd.args,
             os_args(&["run", "--package=app", "--locked", "--", "--port"])
@@ -3920,76 +3834,58 @@ release: 1.96.0-nightly\n",
 
         // Other subcommands attach pass-through args as cargo flags, no
         // separator.
-        let cmd = toolchain
-            .task_command(
+        let cmd = resolve_cargo_cmd(
                 &app_context,
                 "build",
                 Some(&["--release".to_string()]),
                 None,
-            )
-            .unwrap()
-            .expect("entrypoint build resolves");
+            ).expect("entrypoint build resolves");
         assert_eq!(
             cmd.args,
             os_args(&["build", "--package=app", "--locked", "--release"])
         );
 
         // A filtered library build resolves directly to that package.
-        let cmd = toolchain
-            .task_command(&lib_a_context, "build", None, None)
-            .unwrap()
+        let cmd = resolve_cargo_cmd(&lib_a_context, "build", None, None)
             .expect("library build resolves");
         assert_eq!(cmd.args, os_args(&["build", "--package=lib-a", "--locked"]));
-        let cmd = toolchain
-            .task_command(&lib_a_context, "test", None, None)
-            .unwrap()
+        let cmd = resolve_cargo_cmd(&lib_a_context, "test", None, None)
             .expect("library test resolves");
         assert_eq!(cmd.args, os_args(&["test", "--package=lib-a", "--locked"]));
-        let cmd = toolchain
-            .task_command(&app_context, "check", None, None)
-            .unwrap()
+        let cmd = resolve_cargo_cmd(&app_context, "check", None, None)
             .expect("entrypoint check resolves");
         assert_eq!(cmd.args, os_args(&["check", "--package=app", "--locked"]));
 
         // The workspace package runs verification verbs at workspace scope.
-        let cmd = toolchain
-            .task_command(&workspace_context, "lint", None, None)
-            .unwrap()
+        let cmd = resolve_cargo_cmd(&workspace_context, "lint", None, None)
             .expect("workspace lint resolves to clippy");
         assert_eq!(cmd.args, os_args(&["clippy", "--workspace", "--locked"]));
         assert_eq!(cmd.serial_group.as_deref(), Some("cargo"));
 
         // Harness-forwarding subcommands separate pass-through args with
         // `--`; e.g. `turbo test -- --nocapture` reaches the test harness.
-        let cmd = toolchain
-            .task_command(
+        let cmd = resolve_cargo_cmd(
                 &workspace_context,
                 "test",
                 Some(&["--nocapture".to_string()]),
                 None,
-            )
-            .unwrap()
-            .expect("workspace test resolves");
+            ).expect("workspace test resolves");
         assert_eq!(
             cmd.args,
             os_args(&["test", "--workspace", "--locked", "--", "--nocapture"])
         );
         assert!(
-            toolchain
-                .task_command(&workspace_context, "build", None, None)
-                .unwrap()
+            resolve_cargo_cmd(&workspace_context, "build", None, None)
                 .is_none(),
             "workspace-wide build would duplicate entrypoint builds"
         );
 
         // Display strings derive from the same tables.
-        assert_eq!(toolchain.task_display_command(&app_context, "build").as_deref(), Some("cargo build --package=app --locked"));
-        assert_eq!(toolchain.task_display_command(&workspace_context, "test").as_deref(), Some("cargo test --workspace --locked"));
-        assert_eq!(toolchain.task_display_command(&lib_a_context, "test").as_deref(), Some("cargo test --package=lib-a --locked"));
+        assert_eq!(app_context.native_tasks().get("build").and_then(|t| t.display()), Some("cargo build --package=app --locked"));
+        assert_eq!(workspace_context.native_tasks().get("test").and_then(|t| t.display()), Some("cargo test --workspace --locked"));
+        assert_eq!(lib_a_context.native_tasks().get("test").and_then(|t| t.display()), Some("cargo test --package=lib-a --locked"));
         assert_eq!(
-            toolchain
-                .task_display_command(&lib_a_context, "build")
-                .as_deref(),
+            lib_a_context.native_tasks().get("build").and_then(|t| t.display()),
             Some("cargo build --package=lib-a --locked")
         );
 
@@ -4090,9 +3986,7 @@ release: 1.96.0-nightly\n",
         // (the group
         // exists because of cargo's build-directory lock).
         let override_argv = vec!["cargo".to_string(), "fuzz".to_string(), "run".to_string()];
-        let cmd = toolchain
-            .task_command(&lib_a_context, "fuzz", None, Some(&override_argv))
-            .unwrap()
+        let cmd = resolve_cargo_cmd(&lib_a_context, "fuzz", None, Some(&override_argv))
             .expect("override defines the task for a library crate");
         assert_eq!(cmd.program, std::ffi::OsString::from("cargo"));
         assert_eq!(cmd.args, os_args(&["fuzz", "run"]));
@@ -4107,15 +4001,13 @@ release: 1.96.0-nightly\n",
             .set(Err(which::Error::CannotFindBinaryPath))
             .unwrap();
         let override_argv = vec!["./scripts/test.sh".to_string()];
-        let cmd = toolchain
-            .task_command(
-                &workspace_context,
-                "test",
-                Some(&["--fast".to_string()]),
-                Some(&override_argv),
-            )
-            .unwrap()
-            .expect("override resolves");
+        let cmd = resolve_cargo_cmd(
+            &workspace_context,
+            "test",
+            Some(&["--fast".to_string()]),
+            Some(&override_argv),
+        )
+        .expect("override resolves");
         assert_eq!(cmd.program, std::ffi::OsString::from("./scripts/test.sh"));
         assert_eq!(cmd.args, os_args(&["--fast"]));
         // The workspace package's directory is the repo root.
@@ -4144,11 +4036,11 @@ release: 1.96.0-nightly\n",
         };
 
         // defines_task mirrors the verb tables.
-        assert!(toolchain.defines_task(&app_ctx, "build"));
-        assert!(toolchain.defines_task(&app_ctx, "test"));
-        assert!(toolchain.defines_task(&lib_ctx, "test"));
-        assert!(toolchain.defines_task(&lib_ctx, "build"));
-        assert!(toolchain.defines_task(&workspace_ctx, "test"));
+        assert!(app_ctx.native_tasks().defines("build"));
+        assert!(app_ctx.native_tasks().defines("test"));
+        assert!(lib_ctx.native_tasks().defines("test"));
+        assert!(lib_ctx.native_tasks().defines("build"));
+        assert!(workspace_ctx.native_tasks().defines("test"));
 
         // Entrypoint build with automatic inputs: workspace files + the
         // dependency crate closure as inputs (own sources via default

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -1481,32 +1481,6 @@ mod test {
             Box::pin(async move { Ok(DiscoveredPackages::new(Vec::new(), self.roots.clone())) })
         }
 
-        fn task_command(
-            &self,
-            _context: &crate::package_graph::PackageTaskContext<'_>,
-            _task: &str,
-            _pass_through_args: Option<&[String]>,
-            _override_command: Option<&[String]>,
-        ) -> Result<Option<crate::toolchain::TaskCommand>, crate::toolchain::Error> {
-            Ok(None)
-        }
-
-        fn task_display_command(
-            &self,
-            _context: &crate::package_graph::PackageTaskContext<'_>,
-            _task: &str,
-        ) -> Option<String> {
-            None
-        }
-
-        fn defines_task(
-            &self,
-            _context: &crate::package_graph::PackageTaskContext<'_>,
-            _task: &str,
-        ) -> bool {
-            false
-        }
-
         fn watch_spec(&self) -> crate::toolchain::WatchSpec {
             crate::toolchain::WatchSpec::default()
         }
@@ -1542,32 +1516,6 @@ mod test {
             })
         }
 
-        fn task_command(
-            &self,
-            _context: &crate::package_graph::PackageTaskContext<'_>,
-            _task: &str,
-            _pass_through_args: Option<&[String]>,
-            _override_command: Option<&[String]>,
-        ) -> Result<Option<crate::toolchain::TaskCommand>, crate::toolchain::Error> {
-            Ok(None)
-        }
-
-        fn task_display_command(
-            &self,
-            _context: &crate::package_graph::PackageTaskContext<'_>,
-            _task: &str,
-        ) -> Option<String> {
-            None
-        }
-
-        fn defines_task(
-            &self,
-            _context: &crate::package_graph::PackageTaskContext<'_>,
-            _task: &str,
-        ) -> bool {
-            false
-        }
-
         fn watch_spec(&self) -> crate::toolchain::WatchSpec {
             crate::toolchain::WatchSpec::default()
         }
@@ -1598,32 +1546,6 @@ mod test {
                     vec![WorkspaceRoot::new("custom", self.root.clone())],
                 ))
             })
-        }
-
-        fn task_command(
-            &self,
-            _context: &crate::package_graph::PackageTaskContext<'_>,
-            _task: &str,
-            _pass_through_args: Option<&[String]>,
-            _override_command: Option<&[String]>,
-        ) -> Result<Option<crate::toolchain::TaskCommand>, crate::toolchain::Error> {
-            Ok(None)
-        }
-
-        fn task_display_command(
-            &self,
-            _context: &crate::package_graph::PackageTaskContext<'_>,
-            _task: &str,
-        ) -> Option<String> {
-            None
-        }
-
-        fn defines_task(
-            &self,
-            _context: &crate::package_graph::PackageTaskContext<'_>,
-            _task: &str,
-        ) -> bool {
-            false
         }
 
         fn watch_spec(&self) -> crate::toolchain::WatchSpec {

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -3047,10 +3047,7 @@ version = "0.1.0"
             Some(&crate::toolchain::ToolchainId::RUST)
         );
         let command = pkg_graph
-            .toolchains()
-            .get(app_context.toolchain().unwrap())
-            .unwrap()
-            .task_command(&app_context, "build", None, None)
+            .resolve_native_task_command(&app_context, "build", None, None)
             .unwrap()
             .unwrap();
         assert_eq!(

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -380,86 +380,6 @@ pub trait Toolchain: Send + Sync {
     /// one observation envelope.
     fn discover_packages(&self) -> DiscoverPackagesFuture<'_>;
 
-    /// Resolve the command that implements `task` for `package`, or `None`
-    /// when the toolchain defines no command for it — the task is then a
-    /// no-op, like a missing package.json script.
-    ///
-    /// `pass_through_args` are user-supplied arguments (`turbo run task --
-    /// <args>`); the toolchain owns how they are attached, since separator
-    /// conventions differ per tool.
-    ///
-    /// `override_command`, when present, replaces the argv the toolchain
-    /// would have constructed — element 0 is the program, nothing is
-    /// prepended. The toolchain still owns the frame (working directory,
-    /// serial grouping); the shared placement lives in
-    /// [`override_task_command`]. Pass-through args append verbatim: turbo
-    /// cannot know an arbitrary command's separator convention.
-    fn task_command(
-        &self,
-        context: &crate::package_graph::PackageTaskContext<'_>,
-        task: &str,
-        pass_through_args: Option<&[String]>,
-        override_command: Option<&[String]>,
-    ) -> Result<Option<TaskCommand>, Error>;
-
-    /// A one-line description of what `task` runs for `package`, for
-    /// dry-run output and run summaries. Derived from the same tables as
-    /// [`Toolchain::task_command`] so display cannot drift from execution.
-    fn task_display_command(
-        &self,
-        context: &crate::package_graph::PackageTaskContext<'_>,
-        task: &str,
-    ) -> Option<String>;
-
-    /// Whether the package itself *authors* a definition for `task` — a
-    /// package.json script, written by the package's owner. Distinct from
-    /// [`Toolchain::defines_task`]: toolchain-synthesized fallbacks (Cargo's
-    /// verb tables) define tasks without the package authoring anything.
-    ///
-    /// Authored definitions shadow unscoped `command` defaults from the
-    /// root turbo.json; synthesized ones sit below them.
-    fn authors_task(
-        &self,
-        context: &crate::package_graph::PackageTaskContext<'_>,
-        task: &str,
-    ) -> bool {
-        let _ = (context, task);
-        false
-    }
-
-    /// Task names this toolchain makes available without an explicit
-    /// turbo.json definition. These act as lowest-precedence empty task
-    /// definitions; normal task configuration still overrides them.
-    fn registered_tasks(
-        &self,
-        context: &crate::package_graph::PackageTaskContext<'_>,
-    ) -> Vec<String> {
-        let _ = context;
-        Vec::new()
-    }
-
-    /// Whether [`Toolchain::registered_tasks`] contains `task`.
-    fn registers_task(
-        &self,
-        context: &crate::package_graph::PackageTaskContext<'_>,
-        task: &str,
-    ) -> bool {
-        self.registered_tasks(context)
-            .iter()
-            .any(|registered| registered == task)
-    }
-
-    /// Whether this toolchain defines an executable command for `task` in
-    /// `package`. Tasks without one are phantom/transit tasks (they exist
-    /// solely for dependency ordering via `dependsOn: ["^task"]`): they do
-    /// not execute, so hashing concerns like global input files must not
-    /// apply to them.
-    fn defines_task(
-        &self,
-        context: &crate::package_graph::PackageTaskContext<'_>,
-        task: &str,
-    ) -> bool;
-
     /// Defaults this toolchain supplies for `task` when turbo.json does not
     /// configure the corresponding field. Explicit user configuration always
     /// wins.
@@ -847,16 +767,6 @@ pub struct JavaScriptToolchain<P> {
     /// by the builder so synchronous concerns (command resolution) can use
     /// it without re-running discovery.
     resolved_package_manager: std::sync::OnceLock<PackageManager>,
-    /// The package manager binary, resolved lazily on first command.
-    package_manager_binary: std::sync::OnceLock<Result<std::path::PathBuf, which::Error>>,
-}
-
-#[derive(Debug, thiserror::Error)]
-enum JavaScriptCommandError {
-    // Message kept identical to the pre-toolchain provider error for
-    // output compatibility.
-    #[error("Unable to find package manager binary: {0}")]
-    Which(#[from] which::Error),
 }
 
 impl<P: PackageDiscovery + Send + Sync> JavaScriptToolchain<P> {
@@ -870,7 +780,6 @@ impl<P: PackageDiscovery + Send + Sync> JavaScriptToolchain<P> {
             repo_root,
             known_package_manager,
             resolved_package_manager: std::sync::OnceLock::new(),
-            package_manager_binary: std::sync::OnceLock::new(),
         }
     }
 
@@ -947,79 +856,6 @@ pub(crate) fn package_manager_command(
 impl<P: PackageDiscovery + Send + Sync> Toolchain for JavaScriptToolchain<P> {
     fn id(&self) -> ToolchainId {
         ToolchainId::JAVASCRIPT
-    }
-
-    fn task_command(
-        &self,
-        context: &crate::package_graph::PackageTaskContext<'_>,
-        task: &str,
-        pass_through_args: Option<&[String]>,
-        override_command: Option<&[String]>,
-    ) -> Result<Option<TaskCommand>, Error> {
-        // An override replaces the whole package-manager indirection even when
-        // the catalog has no authored script for this task name.
-        if let Some(override_command) = override_command {
-            return Ok(override_task_command(
-                context,
-                override_command,
-                pass_through_args,
-                None,
-            ));
-        }
-        let Some(native_task) = context.native_tasks().get(task) else {
-            return Ok(None);
-        };
-        let Some(package_manager) = self.resolved_package_manager.get() else {
-            return Ok(None);
-        };
-        let package_manager_binary = match self
-            .package_manager_binary
-            .get_or_init(|| which::which(package_manager.command()))
-        {
-            Ok(path) => path.as_path(),
-            Err(err) => {
-                return Err(Error::Failed(Box::new(JavaScriptCommandError::Which(*err))));
-            }
-        };
-        crate::native_tasks::resolve_task_command(
-            context,
-            native_task,
-            Some(package_manager),
-            Some(package_manager_binary),
-            None,
-            pass_through_args,
-            None,
-        )
-        .map_err(|error| Error::Failed(Box::new(error)))
-    }
-
-    fn task_display_command(
-        &self,
-        context: &crate::package_graph::PackageTaskContext<'_>,
-        task: &str,
-    ) -> Option<String> {
-        context
-            .native_tasks()
-            .get(task)
-            .and_then(|native_task| native_task.display().map(str::to_string))
-    }
-
-    fn defines_task(
-        &self,
-        context: &crate::package_graph::PackageTaskContext<'_>,
-        task: &str,
-    ) -> bool {
-        context.native_tasks().defines(task)
-    }
-
-    /// package.json scripts are authored by the package: they shadow
-    /// unscoped `command` defaults.
-    fn authors_task(
-        &self,
-        context: &crate::package_graph::PackageTaskContext<'_>,
-        task: &str,
-    ) -> bool {
-        context.native_tasks().authors(task)
     }
 
     fn derived_task_io(
@@ -1292,23 +1128,17 @@ mod tests {
             Some(&ToolchainId::JAVASCRIPT),
         );
 
-        let unresolved_toolchain = JavaScriptToolchain::new(
-            StubDiscovery,
-            repo_root_buf.clone(),
-            Some(PackageManager::Npm),
-        );
-        assert!(
-            unresolved_toolchain
-                .task_command(&context, "build", None, None)
-                .unwrap()
-                .is_none(),
-            "an unresolved package manager must preserve the no-op fallback"
-        );
-
-        let command = toolchain
-            .task_command(&context, "build", None, None)
-            .unwrap()
-            .expect("script exists, command resolves");
+        let command = crate::native_tasks::resolve_task_command(
+            &context,
+            context.native_tasks().get("build").expect("build task"),
+            Some(&PackageManager::Npm),
+            which::which("npm").ok().as_deref(),
+            None,
+            None,
+            None,
+        )
+        .unwrap()
+        .expect("script exists, command resolves");
         // The program is the resolved npm binary (or node.exe on Windows);
         // the invocation shape is what matters.
         assert!(
@@ -1326,40 +1156,37 @@ mod tests {
         assert_eq!(command.serial_group, None);
 
         // Missing and empty scripts are no-ops.
-        assert!(
-            toolchain
-                .task_command(&context, "lint", None, None)
-                .unwrap()
-                .is_none()
-        );
-        assert!(
-            toolchain
-                .task_command(&context, "empty", None, None)
-                .unwrap()
-                .is_none()
-        );
+        assert!(!context.native_tasks().defines("lint"));
+        assert!(!context.native_tasks().defines("empty"));
 
         // Display shows the script text itself.
         assert_eq!(
-            toolchain.task_display_command(&context, "build").as_deref(),
+            context
+                .native_tasks()
+                .get("build")
+                .and_then(|task| task.display()),
             Some("next build")
         );
-        assert_eq!(toolchain.task_display_command(&context, "lint"), None);
+        assert_eq!(
+            context
+                .native_tasks()
+                .get("lint")
+                .and_then(|task| task.display()),
+            None
+        );
 
         // A `command` override replaces the whole package-manager
         // indirection: argv[0] is the program, nothing is prepended, cwd is
         // the package directory. It also defines tasks no script does, and
         // pass-through args append verbatim.
         let override_argv = vec!["vitest".to_string(), "run".to_string()];
-        let cmd = toolchain
-            .task_command(
-                &context,
-                "lint",
-                Some(&["--bail".to_string()]),
-                Some(&override_argv),
-            )
-            .unwrap()
-            .expect("override defines the task");
+        let cmd = override_task_command(
+            &context,
+            &override_argv,
+            Some(&["--bail".to_string()]),
+            None,
+        )
+        .expect("override defines the task");
         assert_eq!(cmd.program, OsString::from("vitest"));
         assert_eq!(
             cmd.args,
@@ -1427,32 +1254,6 @@ mod tests {
             }
             fn discover_packages(&self) -> DiscoverPackagesFuture<'_> {
                 Box::pin(async { Ok(DiscoveredPackages::default()) })
-            }
-
-            fn task_command(
-                &self,
-                _context: &crate::package_graph::PackageTaskContext<'_>,
-                _task: &str,
-                _pass_through_args: Option<&[String]>,
-                _override_command: Option<&[String]>,
-            ) -> Result<Option<TaskCommand>, Error> {
-                Ok(None)
-            }
-
-            fn task_display_command(
-                &self,
-                _context: &crate::package_graph::PackageTaskContext<'_>,
-                _task: &str,
-            ) -> Option<String> {
-                None
-            }
-
-            fn defines_task(
-                &self,
-                _context: &crate::package_graph::PackageTaskContext<'_>,
-                _task: &str,
-            ) -> bool {
-                false
             }
 
             fn watch_spec(&self) -> WatchSpec {

--- a/crates/turborepo-run-summary/src/task_factory.rs
+++ b/crates/turborepo-run-summary/src/task_factory.rs
@@ -278,13 +278,14 @@ fn summary_command(
     task_definition: &TaskDefinition,
     task: &str,
 ) -> String {
+    let _ = package_graph;
     match &task_definition.command {
         Some(turborepo_types::TaskCommandOverride::Argv(argv)) => argv.join(" "),
         Some(turborepo_types::TaskCommandOverride::OptOut) => "<OPT OUT>".to_string(),
         None => package_context
-            .toolchain()
-            .and_then(|id| package_graph.toolchains().get(id))
-            .and_then(|toolchain| toolchain.task_display_command(package_context, task))
+            .native_tasks()
+            .get(task)
+            .and_then(|native_task| native_task.display().map(str::to_string))
             .unwrap_or_else(|| "<NONEXISTENT>".to_string()),
     }
 }

--- a/crates/turborepo-scope/src/filter.rs
+++ b/crates/turborepo-scope/src/filter.rs
@@ -1004,35 +1004,6 @@ mod test {
             })
         }
 
-        fn task_command(
-            &self,
-            _context: &turborepo_repository::package_graph::PackageTaskContext<'_>,
-            _task: &str,
-            _pass_through_args: Option<&[String]>,
-            _override_command: Option<&[String]>,
-        ) -> Result<
-            Option<turborepo_repository::toolchain::TaskCommand>,
-            turborepo_repository::toolchain::Error,
-        > {
-            Ok(None)
-        }
-
-        fn task_display_command(
-            &self,
-            _context: &turborepo_repository::package_graph::PackageTaskContext<'_>,
-            _task: &str,
-        ) -> Option<String> {
-            None
-        }
-
-        fn defines_task(
-            &self,
-            _context: &turborepo_repository::package_graph::PackageTaskContext<'_>,
-            _task: &str,
-        ) -> bool {
-            false
-        }
-
         fn watch_spec(&self) -> turborepo_repository::toolchain::WatchSpec {
             turborepo_repository::toolchain::WatchSpec::default()
         }

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -216,7 +216,7 @@ The remaining payload deletion phases are explicit:
   relationship knowledge now owns graph assembly, while JavaScript declarations
   remain a temporary classification input.
 - **Phase 3:** Complete. External resolution lives in the immutable generation; query, prune, hashing, and summaries consume it. `PackageInfo` no longer carries `unresolved_external_dependencies`, `transitive_dependencies`, or `external_deps_hash`, and deferred closure installation is gone.
-- **Phase 4 (in progress):** Native task/command knowledge is produced into an immutable catalog at repository construction. JavaScript scripts and Cargo verb tables contribute observations; `Toolchain` task callbacks are adapters over that catalog. Remaining work migrates engine/turbo-json/executor/query/summary consumers and deletes legacy script reads.
+- **Phase 4 (complete):** Native task/command knowledge is an immutable catalog produced at repository construction. JavaScript scripts and Cargo verb tables contribute observations; engine, turbo-json, executor, query, devtools, LSP, and summary consumers read the catalog. `Toolchain::task_command` / `task_display_command` / `authors_task` / `registered_tasks` / `registers_task` / `defines_task` have been deleted — only the JavaScript producer and the LSP unsaved-source adapter parse scripts.
 - **Phase 5:** Delete `PackageInfo`, its payload map, and optional-payload compatibility plumbing once all fail-closed consumers use those queries.
 
 Task hashing, run-cache path construction, and run-summary task directories use


### PR DESCRIPTION
## Intent

Final Phase 4 gate: dry-run/run summaries must use the same catalog display facts as execution, and production code must no longer call `Toolchain` task-command callbacks. Those callbacks and their JavaScript/Cargo adapters are deleted.

**Stack:** Phase 4 layer 9. Base = `shew/turbo-5823-migrate-native-task-query-devtools-and-lsp-views`.

## Changes

- Summary `command` text uses catalog `display`
- Engine implicit registration uses catalog `registered`
- Task-access Next.js detection uses observation vocabulary
- Delete `Toolchain::{task_command,task_display_command,authors_task,registered_tasks,registers_task,defines_task}` and JS/Cargo impls
- `ARCHITECTURE.md` marks Phase 4 complete

## Out of scope

`task_defaults` / derived I/O / cache contracts (TURBO-5789), total `PackageInfo` deletion.

## Testing

- `cargo test -p turborepo-engine --lib` (127 passed)
- `cargo test -p turborepo-run-summary --lib` (43 passed)
- `cargo test -p turborepo-repository --lib test_javascript_task_command`
- `cargo test -p turborepo-repository --lib test_cargo_task_commands`
- `cargo clippy … -- -D warnings`

Closes TURBO-5824.
