### PR TITLE
refactor: Produce immutable task-contract knowledge

### DIFF
--- a/crates/turborepo-repository/src/lib.rs
+++ b/crates/turborepo-repository/src/lib.rs
@@ -23,5 +23,6 @@ pub mod package_graph;
 pub mod package_json;
 pub mod package_manager;
 pub mod relationships;
+pub mod task_contracts;
 pub mod toolchain;
 pub mod workspaces;

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -96,6 +96,8 @@ pub enum Error {
     ExternalResolution(String),
     #[error("native task knowledge generation failed: {0}")]
     NativeTasks(String),
+    #[error("Task contract knowledge error: {0}")]
+    TaskContracts(String),
     #[error("package or aggregate scope at {path} uses reserved root identity //")]
     ReservedRootIdentity { path: AnchoredSystemPathBuf },
     #[error("relationship source {identity} has no authoritative repository scope")]
@@ -953,6 +955,27 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             crate::native_tasks::NativeTaskKnowledge::build(&knowledge, native_task_observations)
                 .map_err(|error| Error::NativeTasks(error.to_string()))?,
         );
+
+        let task_contract_knowledge = Arc::new({
+            let observations = knowledge.scopes().map(|scope| {
+                let contract = if scope.toolchain() == &crate::toolchain::ToolchainId::JAVASCRIPT {
+                    crate::task_contracts::ScopeTaskContract::javascript()
+                } else {
+                    crate::task_contracts::ScopeTaskContract::empty()
+                };
+                (scope.identity().to_owned(), contract)
+            });
+            let mut observations: Vec<_> = observations.collect();
+            if knowledge.root_javascript_scope().is_some() {
+                observations.push((
+                    "//".to_string(),
+                    crate::task_contracts::ScopeTaskContract::javascript(),
+                ));
+            }
+            crate::task_contracts::TaskContractKnowledge::build(observations)
+                .map_err(|error| Error::TaskContracts(error.to_string()))?
+        });
+
         Ok(PackageGraph {
             graph: workspace_graph,
             root_node_index,
@@ -971,6 +994,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             root_internal_dependencies: std::sync::OnceLock::new(),
             toolchains,
             native_task_knowledge,
+            task_contract_knowledge,
         })
     }
 }
@@ -1349,6 +1373,26 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
                 discovery::Error::Failed(Box::new(Error::NativeTasks(error.to_string())))
             })?,
         );
+        let task_contract_knowledge = Arc::new({
+            let observations = knowledge.scopes().map(|scope| {
+                let contract = if scope.toolchain() == &crate::toolchain::ToolchainId::JAVASCRIPT {
+                    crate::task_contracts::ScopeTaskContract::javascript()
+                } else {
+                    crate::task_contracts::ScopeTaskContract::empty()
+                };
+                (scope.identity().to_owned(), contract)
+            });
+            let mut observations: Vec<_> = observations.collect();
+            if knowledge.root_javascript_scope().is_some() {
+                observations.push((
+                    "//".to_string(),
+                    crate::task_contracts::ScopeTaskContract::javascript(),
+                ));
+            }
+            crate::task_contracts::TaskContractKnowledge::build(observations).map_err(|error| {
+                discovery::Error::Failed(Box::new(Error::TaskContracts(error.to_string())))
+            })?
+        });
 
         Ok(PackageGraph {
             graph: workspace_graph,
@@ -1368,6 +1412,7 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             root_internal_dependencies: std::sync::OnceLock::new(),
             toolchains,
             native_task_knowledge,
+            task_contract_knowledge,
         })
     }
 }

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -101,6 +101,8 @@ pub struct PackageGraph {
     toolchains: crate::toolchain::ToolchainRegistry,
     /// Immutable native-task catalog produced during repository construction.
     native_task_knowledge: Arc<crate::native_tasks::NativeTaskKnowledge>,
+    /// Immutable task-contract catalog produced during repository construction.
+    task_contract_knowledge: Arc<crate::task_contracts::TaskContractKnowledge>,
 }
 
 /// The WorkspacePackage.
@@ -223,6 +225,7 @@ pub struct PackageTaskContext<'a> {
     package_info: Option<&'a PackageInfo>,
     external_declarations: &'a ExternalDeclarations,
     native_tasks: &'a crate::native_tasks::ScopeNativeTasks,
+    task_contract: crate::task_contracts::ScopeTaskContract,
     kind: PackageTaskContextKind,
     toolchain: Option<&'a crate::toolchain::ToolchainId>,
     requires_compatibility_payload: bool,
@@ -282,6 +285,11 @@ impl<'a> PackageTaskContext<'a> {
         };
         let requires_compatibility_payload = package != PackageName::Root
             || toolchain == Some(&crate::toolchain::ToolchainId::JAVASCRIPT);
+        let task_contract = if toolchain == Some(&crate::toolchain::ToolchainId::JAVASCRIPT) {
+            crate::task_contracts::ScopeTaskContract::javascript()
+        } else {
+            crate::task_contracts::ScopeTaskContract::empty()
+        };
         Self {
             package,
             repository_root,
@@ -289,6 +297,7 @@ impl<'a> PackageTaskContext<'a> {
             package_info,
             external_declarations,
             native_tasks,
+            task_contract,
             kind,
             toolchain,
             requires_compatibility_payload,
@@ -318,6 +327,10 @@ impl<'a> PackageTaskContext<'a> {
 
     pub fn native_tasks(&self) -> &'a crate::native_tasks::ScopeNativeTasks {
         self.native_tasks
+    }
+
+    pub fn task_contract(&self) -> &crate::task_contracts::ScopeTaskContract {
+        &self.task_contract
     }
 
     pub fn kind(&self) -> PackageTaskContextKind {
@@ -732,6 +745,7 @@ impl PackageGraph {
         };
         let package_info = self.package_payloads.get(&package);
         let native_tasks = self.native_task_knowledge.for_scope(package.as_str());
+        let task_contract = self.task_contract_knowledge.for_scope(package.as_str());
 
         Some(PackageTaskContext {
             package,
@@ -740,6 +754,7 @@ impl PackageGraph {
             package_info,
             external_declarations: self.external_declaration_view(),
             native_tasks,
+            task_contract,
             kind,
             toolchain,
             requires_compatibility_payload,

--- a/crates/turborepo-repository/src/task_contracts.rs
+++ b/crates/turborepo-repository/src/task_contracts.rs
@@ -1,0 +1,131 @@
+//! Foundational task-contract knowledge.
+//!
+//! Ecosystems contribute immutable observations about derived I/O defaults,
+//! environment patterns, and whether a scope participates in toolchain-derived
+//! hash wiring. Core composes these with turbo.json into effective contracts.
+//!
+//! JavaScript packages contribute empty contract observations: turbo.json is
+//! the whole story. Cargo temporarily retains `Toolchain` derived-I/O
+//! callbacks until its Rust port.
+
+use std::collections::BTreeMap;
+
+use crate::toolchain::{TaskDefaults, ToolchainId};
+
+/// Per-scope task-contract observation produced at repository construction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScopeTaskContract {
+    /// Whether this scope participates in derived task I/O composition.
+    ///
+    /// JavaScript is always `false`. Cargo remains on toolchain callbacks
+    /// until its port and is not recorded here yet.
+    derives_io: bool,
+    defaults: TaskDefaults,
+    /// Startup environment patterns this scope needs for derived I/O.
+    env_vars: Vec<&'static str>,
+    /// Toolchain provenance when the observation came from a known ecosystem.
+    toolchain: Option<ToolchainId>,
+}
+
+impl ScopeTaskContract {
+    /// JavaScript packages: no derived I/O, no env patterns, no defaults.
+    pub fn javascript() -> Self {
+        Self {
+            derives_io: false,
+            defaults: TaskDefaults::default(),
+            env_vars: Vec::new(),
+            toolchain: Some(ToolchainId::JAVASCRIPT),
+        }
+    }
+
+    /// Scope with no toolchain-derived contract (pure-native root, etc.).
+    pub fn empty() -> Self {
+        Self {
+            derives_io: false,
+            defaults: TaskDefaults::default(),
+            env_vars: Vec::new(),
+            toolchain: None,
+        }
+    }
+
+    pub fn derives_io(&self) -> bool {
+        self.derives_io
+    }
+
+    pub fn defaults(&self) -> &TaskDefaults {
+        &self.defaults
+    }
+
+    pub fn env_vars(&self) -> &[&'static str] {
+        &self.env_vars
+    }
+
+    pub fn toolchain(&self) -> Option<&ToolchainId> {
+        self.toolchain.as_ref()
+    }
+}
+
+/// Immutable catalog of per-scope task-contract observations.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TaskContractKnowledge {
+    by_scope: BTreeMap<String, ScopeTaskContract>,
+}
+
+impl TaskContractKnowledge {
+    pub fn build(
+        observations: impl IntoIterator<Item = (String, ScopeTaskContract)>,
+    ) -> Result<Self, TaskContractError> {
+        let mut by_scope = BTreeMap::new();
+        for (scope, contract) in observations {
+            if by_scope.insert(scope.clone(), contract).is_some() {
+                return Err(TaskContractError::DuplicateScope { scope });
+            }
+        }
+        Ok(Self { by_scope })
+    }
+
+    pub fn for_scope(&self, scope: &str) -> ScopeTaskContract {
+        self.by_scope
+            .get(scope)
+            .cloned()
+            .unwrap_or_else(ScopeTaskContract::empty)
+    }
+
+    pub fn scopes(&self) -> impl Iterator<Item = (&str, &ScopeTaskContract)> {
+        self.by_scope
+            .iter()
+            .map(|(scope, contract)| (scope.as_str(), contract))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum TaskContractError {
+    #[error("duplicate task-contract observation for scope {scope}")]
+    DuplicateScope { scope: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn javascript_contract_is_empty() {
+        let contract = ScopeTaskContract::javascript();
+        assert!(!contract.derives_io());
+        assert_eq!(contract.defaults().cache, None);
+        assert!(contract.env_vars().is_empty());
+        assert_eq!(contract.toolchain(), Some(&ToolchainId::JAVASCRIPT));
+    }
+
+    #[test]
+    fn knowledge_indexes_by_scope() {
+        let knowledge = TaskContractKnowledge::build([
+            ("web".into(), ScopeTaskContract::javascript()),
+            ("//".into(), ScopeTaskContract::javascript()),
+        ])
+        .unwrap();
+        assert!(!knowledge.for_scope("web").derives_io());
+        assert!(!knowledge.for_scope("missing").derives_io());
+        assert_eq!(knowledge.scopes().count(), 2);
+    }
+}

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -217,7 +217,7 @@ The remaining payload deletion phases are explicit:
   remain a temporary classification input.
 - **Phase 3:** Complete. External resolution lives in the immutable generation; query, prune, hashing, and summaries consume it. `PackageInfo` no longer carries `unresolved_external_dependencies`, `transitive_dependencies`, or `external_deps_hash`, and deferred closure installation is gone.
 - **Phase 4 (complete):** Native task/command knowledge is an immutable catalog produced at repository construction. JavaScript scripts and Cargo verb tables contribute observations; engine, turbo-json, executor, query, devtools, LSP, and summary consumers read the catalog. `Toolchain::task_command` / `task_display_command` / `authors_task` / `registered_tasks` / `registers_task` / `defines_task` have been deleted — only the JavaScript producer and the LSP unsaved-source adapter parse scripts.
-- **Phase 5:** Delete `PackageInfo`, its payload map, and optional-payload compatibility plumbing once all fail-closed consumers use those queries.
+- **Phase 5 (in progress):** Task-contract knowledge catalog is produced for JavaScript scopes (empty derived I/O). Remaining work migrates engine/hash/cache consumers and deletes JS toolchain I/O callbacks. Later: Delete `PackageInfo`, its payload map, and optional-payload compatibility plumbing once all fail-closed consumers use those queries.
 
 Task hashing, run-cache path construction, and run-summary task directories use
 a graph-created `PackageTaskContext` that binds identity, repository root,


### PR DESCRIPTION
## Intent

Start Phase 5 (task contracts): produce an immutable **task-contract knowledge** catalog for JavaScript scopes. JS packages observe empty derived-I/O contracts (turbo.json is the whole story). Cargo remains on temporary toolchain callbacks until its Rust port.

**Stack:** Phase 5 layer 1. Base = `shew/turbo-5824-migrate-command-summaries-and-delete-legacy-task-paths`.

## Changes

- New `task_contracts` module (`ScopeTaskContract`, `TaskContractKnowledge`)
- Package graph construction indexes JS scopes (including root `//`) with empty contracts
- `PackageTaskContext::task_contract()` exposes the observation

## Out of scope

Engine composition (TURBO-5827), hashing/cache (TURBO-5828), deleting JS I/O callbacks (TURBO-5829).

## Testing

- `cargo test -p turborepo-repository --lib task_contracts` (2 passed)
- `cargo clippy -p turborepo-repository --all-targets -- -D warnings`

Closes TURBO-5826.
