### PR TITLE
refactor: Produce immutable change knowledge

### DIFF
--- a/crates/turborepo-repository/src/change_knowledge.rs
+++ b/crates/turborepo-repository/src/change_knowledge.rs
@@ -1,0 +1,180 @@
+//! Foundational change knowledge for watch and affectedness.
+//!
+//! Ecosystems contribute immutable observations about package ownership,
+//! membership/resolution triggers, and ignored byproduct prefixes. Core owns
+//! subscriptions, coalescing, and generation publication.
+//!
+//! JavaScript observations are produced from repository knowledge plus the
+//! active package manager. Cargo temporarily retains `Toolchain::watch_spec`
+//! until its Rust port.
+
+use std::collections::BTreeMap;
+
+use crate::{
+    knowledge::RepositoryKnowledge,
+    package_manager::PackageManager,
+    toolchain::{ToolchainId, WatchSpec},
+};
+
+/// Immutable change facts for the repository.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ChangeKnowledge {
+    /// Manifest file names that can change package membership wherever they
+    /// appear (e.g. `package.json` for JavaScript).
+    membership_file_names: Vec<String>,
+    /// Repo-root-relative unix paths that can change package membership
+    /// (e.g. workspace configuration files).
+    membership_paths: Vec<String>,
+    /// Repo-root-relative unix paths that can change external resolution
+    /// (e.g. lockfiles).
+    resolution_paths: Vec<String>,
+    /// Repo-root-relative directory prefixes containing ecosystem byproducts
+    /// that must not feed watch loops.
+    ignore_prefixes: Vec<String>,
+    /// Package identity → repo-relative unix directory for ownership.
+    package_directories: BTreeMap<String, String>,
+}
+
+impl ChangeKnowledge {
+    /// Produce JavaScript change observations from repository knowledge.
+    pub(crate) fn javascript(
+        knowledge: &RepositoryKnowledge,
+        package_manager: Option<&PackageManager>,
+    ) -> Self {
+        let mut membership_file_names = Vec::new();
+        let mut membership_paths = Vec::new();
+        let mut resolution_paths = Vec::new();
+
+        let has_js = knowledge.root_javascript_scope().is_some()
+            || knowledge
+                .scopes()
+                .any(|scope| scope.toolchain() == &ToolchainId::JAVASCRIPT);
+
+        if has_js {
+            membership_file_names.push("package.json".to_string());
+            if let Some(package_manager) = package_manager {
+                resolution_paths.push(package_manager.lockfile_name().to_string());
+                if let Some(workspace_config) = package_manager.workspace_configuration_path() {
+                    membership_paths.push(workspace_config.to_string());
+                }
+            }
+        }
+
+        let package_directories = knowledge
+            .scopes()
+            .filter(|scope| scope.toolchain() == &ToolchainId::JAVASCRIPT)
+            .map(|scope| {
+                (
+                    scope.identity().to_owned(),
+                    scope.directory().to_unix().to_string(),
+                )
+            })
+            .collect();
+
+        Self {
+            membership_file_names,
+            membership_paths,
+            resolution_paths,
+            ignore_prefixes: Vec::new(),
+            package_directories,
+        }
+    }
+
+    pub fn membership_file_names(&self) -> &[String] {
+        &self.membership_file_names
+    }
+
+    pub fn membership_paths(&self) -> &[String] {
+        &self.membership_paths
+    }
+
+    pub fn resolution_paths(&self) -> &[String] {
+        &self.resolution_paths
+    }
+
+    pub fn ignore_prefixes(&self) -> &[String] {
+        &self.ignore_prefixes
+    }
+
+    pub fn package_directories(&self) -> &BTreeMap<String, String> {
+        &self.package_directories
+    }
+
+    /// Project change knowledge into the watcher `WatchSpec` shape, then merge
+    /// temporary toolchain specs (e.g. Cargo) on top.
+    pub fn to_watch_spec(&self) -> WatchSpec {
+        let mut definition_paths = self.membership_paths.clone();
+        definition_paths.extend(self.resolution_paths.iter().cloned());
+        WatchSpec {
+            definition_file_names: self.membership_file_names.clone(),
+            definition_paths,
+            ignore_prefixes: self.ignore_prefixes.clone(),
+        }
+    }
+
+    /// Combine foundational change knowledge with toolchain WatchSpecs.
+    pub fn combined_watch_spec(&self, toolchain_spec: WatchSpec) -> WatchSpec {
+        let mut combined = self.to_watch_spec();
+        combined.extend(toolchain_spec);
+        combined
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use turbopath::AbsoluteSystemPathBuf;
+
+    use super::*;
+    use crate::{
+        knowledge::{PackageScopeObservation, ScopeKind, WorkspaceRootObservation},
+        package_manager::PackageManager,
+        toolchain::WorkspaceRoot,
+    };
+
+    fn empty_repository() -> RepositoryKnowledge {
+        let root =
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+        RepositoryKnowledge::build(&root, None, &[], &[]).unwrap()
+    }
+
+    fn javascript_repository() -> RepositoryKnowledge {
+        let root =
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+        RepositoryKnowledge::build(
+            &root,
+            Some(Some("root".to_string())),
+            &[PackageScopeObservation {
+                identity: Some("web".to_string()),
+                definition_path: root.join_components(&["apps", "web", "package.json"]),
+                toolchain: ToolchainId::JAVASCRIPT,
+                scope_kind: ScopeKind::Package,
+            }],
+            &[WorkspaceRootObservation::new(
+                WorkspaceRoot::new("npm", root.clone()),
+                ToolchainId::JAVASCRIPT,
+            )],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn empty_repository_has_no_js_triggers() {
+        let knowledge = empty_repository();
+        let change = ChangeKnowledge::javascript(&knowledge, None);
+        assert!(change.membership_file_names().is_empty());
+        assert!(change.resolution_paths().is_empty());
+        assert!(change.package_directories().is_empty());
+    }
+
+    #[test]
+    fn javascript_includes_package_json_and_lockfile() {
+        let knowledge = javascript_repository();
+        let change = ChangeKnowledge::javascript(&knowledge, Some(&PackageManager::Npm));
+        assert_eq!(change.membership_file_names(), ["package.json"]);
+        assert_eq!(change.resolution_paths(), ["package-lock.json"]);
+        assert!(change.package_directories().contains_key("web"));
+        let watch = change.to_watch_spec();
+        assert!(watch.definition_file_names.contains(&"package.json".into()));
+        assert!(watch.definition_paths.contains(&"package-lock.json".into()));
+    }
+}

--- a/crates/turborepo-repository/src/lib.rs
+++ b/crates/turborepo-repository/src/lib.rs
@@ -12,6 +12,7 @@
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 pub mod cargo;
+pub mod change_knowledge;
 pub mod change_mapper;
 pub mod discovery;
 pub mod external_resolution;

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -988,6 +988,10 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             )
             .map_err(|error| Error::TaskContracts(error.to_string()))?
         });
+        let change_knowledge = Arc::new(crate::change_knowledge::ChangeKnowledge::javascript(
+            &knowledge,
+            package_manager.as_ref(),
+        ));
 
         Ok(PackageGraph {
             graph: workspace_graph,
@@ -1008,6 +1012,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             toolchains,
             native_task_knowledge,
             task_contract_knowledge,
+            change_knowledge,
         })
     }
 }
@@ -1420,6 +1425,10 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
                 discovery::Error::Failed(Box::new(Error::TaskContracts(error.to_string())))
             })?
         });
+        let change_knowledge = Arc::new(crate::change_knowledge::ChangeKnowledge::javascript(
+            &knowledge,
+            package_manager.as_ref(),
+        ));
 
         Ok(PackageGraph {
             graph: workspace_graph,
@@ -1440,6 +1449,7 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             toolchains,
             native_task_knowledge,
             task_contract_knowledge,
+            change_knowledge,
         })
     }
 }

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -103,6 +103,8 @@ pub struct PackageGraph {
     native_task_knowledge: Arc<crate::native_tasks::NativeTaskKnowledge>,
     /// Immutable task-contract catalog produced during repository construction.
     task_contract_knowledge: Arc<crate::task_contracts::TaskContractKnowledge>,
+    /// Immutable change knowledge for watch/affectedness classification.
+    change_knowledge: Arc<crate::change_knowledge::ChangeKnowledge>,
 }
 
 /// The WorkspacePackage.
@@ -623,6 +625,11 @@ impl PackageGraph {
     /// Root `engines` captured into task-contract knowledge at construction.
     pub fn root_engines(&self) -> &std::collections::BTreeMap<String, String> {
         self.task_contract_knowledge.root_engines()
+    }
+
+    /// Foundational change knowledge for watch classification.
+    pub fn change_knowledge(&self) -> &crate::change_knowledge::ChangeKnowledge {
+        &self.change_knowledge
     }
 
     /// Toolchains registered during graph construction.


### PR DESCRIPTION
## Intent

Start Phase 6 (change/watch): produce an immutable **change knowledge** catalog for JavaScript — package ownership, membership triggers (`package.json` / workspace config), and resolution triggers (lockfile) — from repository knowledge + the active package manager.

**Stack:** Phase 6 layer 1. Base = `shew/turbo-5829-migrate-dry-run-summary-contracts-and-delete-js-io-callbacks`.

## Changes

- New `change_knowledge` module (`ChangeKnowledge`)
- Package graph construction produces JS change observations
- `PackageGraph::change_knowledge()` + `to_watch_spec` / `combined_watch_spec` helpers for watcher migration

## Out of scope

Watcher consumer migration (TURBO-5832), deleting JS-only reconstruction paths (TURBO-5831).

## Testing

- `cargo test -p turborepo-repository --lib change_knowledge` (2 passed)
- `cargo clippy -p turborepo-repository --all-targets -- -D warnings`

Closes TURBO-5830.
