### PR TITLE
refactor: Migrate watcher classification to change knowledge

### DIFF
--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -771,7 +771,9 @@ impl Subscriber {
                     continue;
                 };
 
-                let watch_spec = repo_state.pkg_dep_graph.toolchains().watch_spec();
+                // Classify using foundational change knowledge + active
+                // toolchain WatchSpecs (same source as rediscovery reinit).
+                let watch_spec = repo_state.pkg_dep_graph.active_watch_spec();
                 let action = classify_changed_files(
                     &trie,
                     &self.repo_root,

--- a/crates/turborepo-repository/src/change_knowledge.rs
+++ b/crates/turborepo-repository/src/change_knowledge.rs
@@ -100,14 +100,18 @@ impl ChangeKnowledge {
         &self.package_directories
     }
 
-    /// Project change knowledge into the watcher `WatchSpec` shape, then merge
-    /// temporary toolchain specs (e.g. Cargo) on top.
+    /// Project change knowledge into the watcher `WatchSpec` shape.
+    ///
+    /// Only workspace-configuration paths and ignore prefixes are projected
+    /// into rediscovery triggers. Per-package `package.json` and lockfile
+    /// changes continue to flow through `ChangeMapper` / lockfile content
+    /// analysis so we preserve today's affectedness granularity; those facts
+    /// remain available via [`Self::membership_file_names`] and
+    /// [`Self::resolution_paths`].
     pub fn to_watch_spec(&self) -> WatchSpec {
-        let mut definition_paths = self.membership_paths.clone();
-        definition_paths.extend(self.resolution_paths.iter().cloned());
         WatchSpec {
-            definition_file_names: self.membership_file_names.clone(),
-            definition_paths,
+            definition_file_names: Vec::new(),
+            definition_paths: self.membership_paths.clone(),
             ignore_prefixes: self.ignore_prefixes.clone(),
         }
     }
@@ -174,7 +178,21 @@ mod tests {
         assert_eq!(change.resolution_paths(), ["package-lock.json"]);
         assert!(change.package_directories().contains_key("web"));
         let watch = change.to_watch_spec();
-        assert!(watch.definition_file_names.contains(&"package.json".into()));
-        assert!(watch.definition_paths.contains(&"package-lock.json".into()));
+        assert!(watch.definition_file_names.is_empty());
+        assert!(watch.definition_paths.is_empty()); // npm has no workspace config path
+    }
+
+    #[test]
+    fn pnpm_workspace_config_projects_into_watch_spec() {
+        let knowledge = javascript_repository();
+        let change = ChangeKnowledge::javascript(&knowledge, Some(&PackageManager::Pnpm));
+        assert_eq!(change.resolution_paths(), ["pnpm-lock.yaml"]);
+        let watch = change.to_watch_spec();
+        assert!(
+            watch
+                .definition_paths
+                .iter()
+                .any(|path| path.contains("pnpm-workspace"))
+        );
     }
 }

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -637,21 +637,24 @@ impl PackageGraph {
         &self.toolchains
     }
 
-    /// The watch behavior of toolchains that contributed at least one
-    /// authoritative execution scope to this graph. Registered toolchains
-    /// that were inactive (notably extras in single-package mode) are omitted.
+    /// Watch classification facts for this graph: foundational change knowledge
+    /// (JavaScript membership/workspace triggers and ignore prefixes) combined
+    /// with active toolchain `WatchSpec`s (Cargo until its Rust port).
+    ///
+    /// Registered toolchains that were inactive (notably extras in
+    /// single-package mode) are omitted from the toolchain contribution.
     pub fn active_watch_spec(&self) -> crate::toolchain::WatchSpec {
         let active: HashSet<_> = self
             .package_task_contexts()
             .filter_map(|context| context.toolchain().cloned())
             .collect();
-        let mut watch_spec = crate::toolchain::WatchSpec::default();
+        let mut toolchain_spec = crate::toolchain::WatchSpec::default();
         for toolchain in self.toolchains.iter() {
             if active.contains(&toolchain.id()) {
-                watch_spec.extend(toolchain.watch_spec());
+                toolchain_spec.extend(toolchain.watch_spec());
             }
         }
-        watch_spec
+        self.change_knowledge.combined_watch_spec(toolchain_spec)
     }
 
     pub fn repo_root(&self) -> &AbsoluteSystemPath {


### PR DESCRIPTION
## Intent

Continue Phase 6: the package-changes watcher must classify filesystem events using **`PackageGraph::active_watch_spec()`**, which combines foundational change knowledge with active toolchain WatchSpecs — not a raw `toolchains().watch_spec()` merge that ignores JS change knowledge.

**Stack:** Phase 6 layer 2. Base = `shew/turbo-5830-produce-immutable-change-knowledge`.

## Changes

- `active_watch_spec` merges `ChangeKnowledge::to_watch_spec()` with active toolchain specs
- Watcher poll loop uses `active_watch_spec()` for classification (same as rediscovery reinit)
- JS workspace-config paths project into rediscovery triggers; per-package/lockfile facts stay on change knowledge for ChangeMapper granularity

## Testing

- `cargo test -p turborepo-repository --lib change_knowledge` (3 passed)
- `cargo test -p turborepo-lib --lib package_changes_watcher` (43 passed)
- `cargo clippy -p turborepo-repository -p turborepo-lib --all-targets -- -D warnings`

Closes TURBO-5832.
