### PR TITLE
refactor: Migrate change classification to immutable knowledge

### DIFF
--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -771,7 +771,9 @@ impl Subscriber {
                     continue;
                 };
 
-                let watch_spec = repo_state.pkg_dep_graph.toolchains().watch_spec();
+                // Classify using foundational change knowledge + active
+                // toolchain WatchSpecs (same source as rediscovery reinit).
+                let watch_spec = repo_state.pkg_dep_graph.active_watch_spec();
                 let action = classify_changed_files(
                     &trie,
                     &self.repo_root,

--- a/crates/turborepo-repository/src/change_knowledge.rs
+++ b/crates/turborepo-repository/src/change_knowledge.rs
@@ -1,0 +1,180 @@
+//! Foundational change knowledge for watch and affectedness.
+//!
+//! Ecosystems contribute immutable observations about package ownership,
+//! membership/resolution triggers, and ignored byproduct prefixes. Core owns
+//! subscriptions, coalescing, and generation publication.
+//!
+//! JavaScript observations are produced from repository knowledge plus the
+//! active package manager. Cargo temporarily retains `Toolchain::watch_spec`
+//! until its Rust port.
+
+use std::collections::BTreeMap;
+
+use crate::{
+    knowledge::RepositoryKnowledge,
+    package_manager::PackageManager,
+    toolchain::{ToolchainId, WatchSpec},
+};
+
+/// Immutable change facts for the repository.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ChangeKnowledge {
+    /// Manifest file names that can change package membership wherever they
+    /// appear (e.g. `package.json` for JavaScript).
+    membership_file_names: Vec<String>,
+    /// Repo-root-relative unix paths that can change package membership
+    /// (e.g. workspace configuration files).
+    membership_paths: Vec<String>,
+    /// Repo-root-relative unix paths that can change external resolution
+    /// (e.g. lockfiles).
+    resolution_paths: Vec<String>,
+    /// Repo-root-relative directory prefixes containing ecosystem byproducts
+    /// that must not feed watch loops.
+    ignore_prefixes: Vec<String>,
+    /// Package identity → repo-relative unix directory for ownership.
+    package_directories: BTreeMap<String, String>,
+}
+
+impl ChangeKnowledge {
+    /// Produce JavaScript change observations from repository knowledge.
+    pub(crate) fn javascript(
+        knowledge: &RepositoryKnowledge,
+        package_manager: Option<&PackageManager>,
+    ) -> Self {
+        let mut membership_file_names = Vec::new();
+        let mut membership_paths = Vec::new();
+        let mut resolution_paths = Vec::new();
+
+        let has_js = knowledge.root_javascript_scope().is_some()
+            || knowledge
+                .scopes()
+                .any(|scope| scope.toolchain() == &ToolchainId::JAVASCRIPT);
+
+        if has_js {
+            membership_file_names.push("package.json".to_string());
+            if let Some(package_manager) = package_manager {
+                resolution_paths.push(package_manager.lockfile_name().to_string());
+                if let Some(workspace_config) = package_manager.workspace_configuration_path() {
+                    membership_paths.push(workspace_config.to_string());
+                }
+            }
+        }
+
+        let package_directories = knowledge
+            .scopes()
+            .filter(|scope| scope.toolchain() == &ToolchainId::JAVASCRIPT)
+            .map(|scope| {
+                (
+                    scope.identity().to_owned(),
+                    scope.directory().to_unix().to_string(),
+                )
+            })
+            .collect();
+
+        Self {
+            membership_file_names,
+            membership_paths,
+            resolution_paths,
+            ignore_prefixes: Vec::new(),
+            package_directories,
+        }
+    }
+
+    pub fn membership_file_names(&self) -> &[String] {
+        &self.membership_file_names
+    }
+
+    pub fn membership_paths(&self) -> &[String] {
+        &self.membership_paths
+    }
+
+    pub fn resolution_paths(&self) -> &[String] {
+        &self.resolution_paths
+    }
+
+    pub fn ignore_prefixes(&self) -> &[String] {
+        &self.ignore_prefixes
+    }
+
+    pub fn package_directories(&self) -> &BTreeMap<String, String> {
+        &self.package_directories
+    }
+
+    /// Project change knowledge into the watcher `WatchSpec` shape, then merge
+    /// temporary toolchain specs (e.g. Cargo) on top.
+    pub fn to_watch_spec(&self) -> WatchSpec {
+        let mut definition_paths = self.membership_paths.clone();
+        definition_paths.extend(self.resolution_paths.iter().cloned());
+        WatchSpec {
+            definition_file_names: self.membership_file_names.clone(),
+            definition_paths,
+            ignore_prefixes: self.ignore_prefixes.clone(),
+        }
+    }
+
+    /// Combine foundational change knowledge with toolchain WatchSpecs.
+    pub fn combined_watch_spec(&self, toolchain_spec: WatchSpec) -> WatchSpec {
+        let mut combined = self.to_watch_spec();
+        combined.extend(toolchain_spec);
+        combined
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use turbopath::AbsoluteSystemPathBuf;
+
+    use super::*;
+    use crate::{
+        knowledge::{PackageScopeObservation, ScopeKind, WorkspaceRootObservation},
+        package_manager::PackageManager,
+        toolchain::WorkspaceRoot,
+    };
+
+    fn empty_repository() -> RepositoryKnowledge {
+        let root =
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+        RepositoryKnowledge::build(&root, None, &[], &[]).unwrap()
+    }
+
+    fn javascript_repository() -> RepositoryKnowledge {
+        let root =
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+        RepositoryKnowledge::build(
+            &root,
+            Some(Some("root".to_string())),
+            &[PackageScopeObservation {
+                identity: Some("web".to_string()),
+                definition_path: root.join_components(&["apps", "web", "package.json"]),
+                toolchain: ToolchainId::JAVASCRIPT,
+                scope_kind: ScopeKind::Package,
+            }],
+            &[WorkspaceRootObservation::new(
+                WorkspaceRoot::new("npm", root.clone()),
+                ToolchainId::JAVASCRIPT,
+            )],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn empty_repository_has_no_js_triggers() {
+        let knowledge = empty_repository();
+        let change = ChangeKnowledge::javascript(&knowledge, None);
+        assert!(change.membership_file_names().is_empty());
+        assert!(change.resolution_paths().is_empty());
+        assert!(change.package_directories().is_empty());
+    }
+
+    #[test]
+    fn javascript_includes_package_json_and_lockfile() {
+        let knowledge = javascript_repository();
+        let change = ChangeKnowledge::javascript(&knowledge, Some(&PackageManager::Npm));
+        assert_eq!(change.membership_file_names(), ["package.json"]);
+        assert_eq!(change.resolution_paths(), ["package-lock.json"]);
+        assert!(change.package_directories().contains_key("web"));
+        let watch = change.to_watch_spec();
+        assert!(watch.definition_file_names.contains(&"package.json".into()));
+        assert!(watch.definition_paths.contains(&"package-lock.json".into()));
+    }
+}

--- a/crates/turborepo-repository/src/change_knowledge.rs
+++ b/crates/turborepo-repository/src/change_knowledge.rs
@@ -100,14 +100,18 @@ impl ChangeKnowledge {
         &self.package_directories
     }
 
-    /// Project change knowledge into the watcher `WatchSpec` shape, then merge
-    /// temporary toolchain specs (e.g. Cargo) on top.
+    /// Project change knowledge into the watcher `WatchSpec` shape.
+    ///
+    /// Only workspace-configuration paths and ignore prefixes are projected
+    /// into rediscovery triggers. Per-package `package.json` and lockfile
+    /// changes continue to flow through `ChangeMapper` / lockfile content
+    /// analysis so we preserve today's affectedness granularity; those facts
+    /// remain available via [`Self::membership_file_names`] and
+    /// [`Self::resolution_paths`].
     pub fn to_watch_spec(&self) -> WatchSpec {
-        let mut definition_paths = self.membership_paths.clone();
-        definition_paths.extend(self.resolution_paths.iter().cloned());
         WatchSpec {
-            definition_file_names: self.membership_file_names.clone(),
-            definition_paths,
+            definition_file_names: Vec::new(),
+            definition_paths: self.membership_paths.clone(),
             ignore_prefixes: self.ignore_prefixes.clone(),
         }
     }
@@ -174,7 +178,21 @@ mod tests {
         assert_eq!(change.resolution_paths(), ["package-lock.json"]);
         assert!(change.package_directories().contains_key("web"));
         let watch = change.to_watch_spec();
-        assert!(watch.definition_file_names.contains(&"package.json".into()));
-        assert!(watch.definition_paths.contains(&"package-lock.json".into()));
+        assert!(watch.definition_file_names.is_empty());
+        assert!(watch.definition_paths.is_empty()); // npm has no workspace config path
+    }
+
+    #[test]
+    fn pnpm_workspace_config_projects_into_watch_spec() {
+        let knowledge = javascript_repository();
+        let change = ChangeKnowledge::javascript(&knowledge, Some(&PackageManager::Pnpm));
+        assert_eq!(change.resolution_paths(), ["pnpm-lock.yaml"]);
+        let watch = change.to_watch_spec();
+        assert!(
+            watch
+                .definition_paths
+                .iter()
+                .any(|path| path.contains("pnpm-workspace"))
+        );
     }
 }

--- a/crates/turborepo-repository/src/lib.rs
+++ b/crates/turborepo-repository/src/lib.rs
@@ -12,6 +12,7 @@
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 pub mod cargo;
+pub mod change_knowledge;
 pub mod change_mapper;
 pub mod discovery;
 pub mod external_resolution;

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -988,6 +988,10 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             )
             .map_err(|error| Error::TaskContracts(error.to_string()))?
         });
+        let change_knowledge = Arc::new(crate::change_knowledge::ChangeKnowledge::javascript(
+            &knowledge,
+            package_manager.as_ref(),
+        ));
 
         Ok(PackageGraph {
             graph: workspace_graph,
@@ -1008,6 +1012,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             toolchains,
             native_task_knowledge,
             task_contract_knowledge,
+            change_knowledge,
         })
     }
 }
@@ -1420,6 +1425,10 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
                 discovery::Error::Failed(Box::new(Error::TaskContracts(error.to_string())))
             })?
         });
+        let change_knowledge = Arc::new(crate::change_knowledge::ChangeKnowledge::javascript(
+            &knowledge,
+            package_manager.as_ref(),
+        ));
 
         Ok(PackageGraph {
             graph: workspace_graph,
@@ -1440,6 +1449,7 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             toolchains,
             native_task_knowledge,
             task_contract_knowledge,
+            change_knowledge,
         })
     }
 }

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -103,6 +103,8 @@ pub struct PackageGraph {
     native_task_knowledge: Arc<crate::native_tasks::NativeTaskKnowledge>,
     /// Immutable task-contract catalog produced during repository construction.
     task_contract_knowledge: Arc<crate::task_contracts::TaskContractKnowledge>,
+    /// Immutable change knowledge for watch/affectedness classification.
+    change_knowledge: Arc<crate::change_knowledge::ChangeKnowledge>,
 }
 
 /// The WorkspacePackage.
@@ -623,6 +625,11 @@ impl PackageGraph {
     /// Root `engines` captured into task-contract knowledge at construction.
     pub fn root_engines(&self) -> &std::collections::BTreeMap<String, String> {
         self.task_contract_knowledge.root_engines()
+    }
+
+    /// Foundational change knowledge for watch classification.
+    pub fn change_knowledge(&self) -> &crate::change_knowledge::ChangeKnowledge {
+        &self.change_knowledge
     }
 
     /// Toolchains registered during graph construction.

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -637,21 +637,24 @@ impl PackageGraph {
         &self.toolchains
     }
 
-    /// The watch behavior of toolchains that contributed at least one
-    /// authoritative execution scope to this graph. Registered toolchains
-    /// that were inactive (notably extras in single-package mode) are omitted.
+    /// Watch classification facts for this graph: foundational change knowledge
+    /// (JavaScript membership/workspace triggers and ignore prefixes) combined
+    /// with active toolchain `WatchSpec`s (Cargo until its Rust port).
+    ///
+    /// Registered toolchains that were inactive (notably extras in
+    /// single-package mode) are omitted from the toolchain contribution.
     pub fn active_watch_spec(&self) -> crate::toolchain::WatchSpec {
         let active: HashSet<_> = self
             .package_task_contexts()
             .filter_map(|context| context.toolchain().cloned())
             .collect();
-        let mut watch_spec = crate::toolchain::WatchSpec::default();
+        let mut toolchain_spec = crate::toolchain::WatchSpec::default();
         for toolchain in self.toolchains.iter() {
             if active.contains(&toolchain.id()) {
-                watch_spec.extend(toolchain.watch_spec());
+                toolchain_spec.extend(toolchain.watch_spec());
             }
         }
-        watch_spec
+        self.change_knowledge.combined_watch_spec(toolchain_spec)
     }
 
     pub fn repo_root(&self) -> &AbsoluteSystemPath {

--- a/crates/turborepo-scope/src/change_detector.rs
+++ b/crates/turborepo-scope/src/change_detector.rs
@@ -90,24 +90,32 @@ impl<'a> ScopeChangeDetector<'a> {
 
     /// Gets the lockfile content from SCM if it has changed.
     /// Does *not* error if cannot get content.
+    ///
+    /// Resolution definition paths come from foundational change knowledge
+    /// rather than probing the package manager at classification time.
     pub fn get_lockfile_contents(
         &self,
         from_ref: Option<&str>,
         changed_files: &HashSet<AnchoredSystemPathBuf>,
     ) -> LockfileContents {
-        let Some(package_manager) = self.pkg_graph.package_manager() else {
-            return LockfileContents::Unchanged;
-        };
-        let lockfile_path = package_manager.lockfile_path(self.turbo_root);
-
-        if !ChangeMapper::<DefaultPackageChangeMapper>::lockfile_changed(
-            self.turbo_root,
-            changed_files,
-            &lockfile_path,
-        ) {
-            debug!("lockfile did not change");
+        let resolution_paths = self.pkg_graph.change_knowledge().resolution_paths();
+        if resolution_paths.is_empty() {
             return LockfileContents::Unchanged;
         }
+
+        let Some(lockfile_path) = resolution_paths.iter().find_map(|path| {
+            let relative = turbopath::RelativeUnixPath::new(path).ok()?;
+            let absolute = self.turbo_root.join_unix_path(relative);
+            ChangeMapper::<DefaultPackageChangeMapper>::lockfile_changed(
+                self.turbo_root,
+                changed_files,
+                &absolute,
+            )
+            .then_some(absolute)
+        }) else {
+            debug!("lockfile did not change");
+            return LockfileContents::Unchanged;
+        };
 
         let Ok(content) = self.scm.previous_content(from_ref, &lockfile_path) else {
             debug!("lockfile did change but could not get previous content");

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -218,6 +218,7 @@ The remaining payload deletion phases are explicit:
 - **Phase 3:** Complete. External resolution lives in the immutable generation; query, prune, hashing, and summaries consume it. `PackageInfo` no longer carries `unresolved_external_dependencies`, `transitive_dependencies`, or `external_deps_hash`, and deferred closure installation is gone.
 - **Phase 4 (complete):** Native task/command knowledge is an immutable catalog produced at repository construction. JavaScript scripts and Cargo verb tables contribute observations; engine, turbo-json, executor, query, devtools, LSP, and summary consumers read the catalog. `Toolchain::task_command` / `task_display_command` / `authors_task` / `registered_tasks` / `registers_task` / `defines_task` have been deleted — only the JavaScript producer and the LSP unsaved-source adapter parse scripts.
 - **Phase 5 (in progress):** Task-contract knowledge catalog is produced for JavaScript scopes; engine composition and global `engines` hashing consume it; JS packages are excluded from Toolchain task-I/O environment dispatch. Remaining: fuller hash/framework contract production and final Phase 5 gate. Later: Delete `PackageInfo`, its payload map, and optional-payload compatibility plumbing once all fail-closed consumers use those queries.
+- **Phase 6 (complete for JS change knowledge first wave):** Change knowledge is produced at repository construction; watcher classification and scope lockfile probes consume it via `active_watch_spec` / `resolution_paths` rather than ad-hoc package-manager probes.
 
 Task hashing, run-cache path construction, and run-summary task directories use
 a graph-created `PackageTaskContext` that binds identity, repository root,
@@ -279,8 +280,9 @@ topological (`^`) dependencies.
 The package graph is generic over language toolchains. The existing discovery
 method returns one envelope containing packages/scopes and workspace-root
 observations. Core validates the combined contributed roots
-without adding another behavioral toolchain method. Watching native marker-only
-changes that are not observed by today's package watcher remains Phase 6 work.
+without adding another behavioral toolchain method. Watch classification consumes foundational change knowledge (JavaScript
+membership/workspace/resolution triggers) combined with active toolchain
+`WatchSpec`s; remaining marker-only edge cases stay follow-up work.
 Native discovery output contributes package/scope observations to repository
 knowledge, while a
 `Toolchain` continues to answer ecosystem-specific behavioral questions such as


### PR DESCRIPTION
## Intent

Complete the first Phase 6 change/watch cutover as one unit: produce immutable JavaScript change knowledge, migrate watcher classification to it, and remove direct package-manager lockfile probes.

**Base:** `main`.

## Changes

- Add package ownership, membership triggers, and resolution paths to `ChangeKnowledge`
- Build the active watcher specification from foundational change knowledge plus active toolchain specifications
- Route package-change lockfile reads through change-knowledge resolution paths
- Remove JavaScript-only lockfile probes from change classification

## Testing

- `cargo test -p turborepo-repository --lib change_knowledge`
- `cargo test -p turborepo-lib --lib package_changes_watcher`
- `cargo test -p turborepo-scope --lib`
- `cargo clippy -p turborepo-repository -p turborepo-lib -p turborepo-scope --all-targets -- -D warnings`

Closes TURBO-5830.
Closes TURBO-5832.
Closes TURBO-5831.