### PR TITLE
fix: Serialize macOS Homebrew setup

### DIFF
--- a/.github/actions/setup-capnproto/action.yml
+++ b/.github/actions/setup-capnproto/action.yml
@@ -44,20 +44,7 @@ runs:
     - name: "Setup capnproto for macos"
       if: runner.os == 'macOS'
       shell: bash
-      run: |
-        for attempt in 1 2 3 4 5; do
-          if brew install capnp; then
-            exit 0
-          fi
-
-          if [[ "$attempt" -eq 5 ]]; then
-            exit 1
-          fi
-
-          delay=$((attempt * 5))
-          echo "Homebrew install failed, retrying in ${delay} seconds..."
-          sleep "$delay"
-        done
+      run: brew install capnp
 
     - name: "Cache capnproto (Windows)"
       if: runner.os == 'Windows' && inputs.use-cache == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)

--- a/.github/actions/setup-capnproto/action.yml
+++ b/.github/actions/setup-capnproto/action.yml
@@ -44,7 +44,20 @@ runs:
     - name: "Setup capnproto for macos"
       if: runner.os == 'macOS'
       shell: bash
-      run: brew install capnp
+      run: |
+        for attempt in 1 2 3 4 5; do
+          if brew install capnp; then
+            exit 0
+          fi
+
+          if [[ "$attempt" -eq 5 ]]; then
+            exit 1
+          fi
+
+          delay=$((attempt * 5))
+          echo "Homebrew install failed, retrying in ${delay} seconds..."
+          sleep "$delay"
+        done
 
     - name: "Cache capnproto (Windows)"
       if: runner.os == 'Windows' && inputs.use-cache == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)

--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -81,8 +81,13 @@ jobs:
         if: ${{ matrix.settings.prepare }}
         run: ${{ matrix.settings.prepare }}
 
+      - name: Setup Homebrew dependencies
+        if: runner.os == 'macOS'
+        run: brew install bash capnp
+
       - parallel:
           - name: Setup capnproto
+            if: runner.os != 'macOS'
             uses: ./.github/actions/setup-capnproto
 
           - name: Rust Setup

--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -128,6 +128,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Setup Homebrew dependencies
+        if: runner.os == 'macOS'
+        run: brew install bash capnp
+
       - parallel:
           - name: Setup Rust
             uses: ./.github/actions/setup-rust
@@ -143,6 +147,7 @@ jobs:
             if: ${{ !matrix.settings.install }}
 
           - name: Setup capnproto
+            if: runner.os != 'macOS'
             uses: ./.github/actions/setup-capnproto
             with:
               use-cache: ${{ !matrix.settings.install }}

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -393,6 +393,10 @@ jobs:
           filter: blob:none
           persist-credentials: false
 
+      - name: Setup Homebrew dependencies
+        if: runner.os == 'macOS'
+        run: brew install bash capnp
+
       - parallel:
           - name: Setup Protoc
             uses: ./.github/actions/setup-protoc
@@ -401,6 +405,7 @@ jobs:
               github-token: ${{ secrets.GITHUB_TOKEN }}
 
           - name: Setup capnproto
+            if: runner.os != 'macOS'
             uses: ./.github/actions/setup-capnproto
 
           - name: Rust Setup

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -197,6 +197,10 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Setup Homebrew dependencies
+        if: runner.os == 'macOS'
+        run: brew install bash capnp
+
       - parallel:
           # Exchanges a GitHub OIDC token for a short-lived Remote Cache access
           # token, exported as TURBO_TOKEN/TURBO_TEAM for subsequent steps.
@@ -229,6 +233,7 @@ jobs:
             uses: ./.github/actions/setup-zig
 
           - name: Setup capnproto
+            if: runner.os != 'macOS'
             uses: ./.github/actions/setup-capnproto
 
           - name: Restore Cargo target
@@ -419,6 +424,10 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Setup Homebrew dependencies
+        if: runner.os == 'macOS'
+        run: brew install bash capnp
+
       - parallel:
           # Exchanges a GitHub OIDC token for a short-lived Remote Cache access
           # token, exported as TURBO_TOKEN/TURBO_TEAM for subsequent steps.
@@ -448,6 +457,7 @@ jobs:
             uses: ./.github/actions/setup-zig
 
           - name: Setup capnproto
+            if: runner.os != 'macOS'
             uses: ./.github/actions/setup-capnproto
 
       - name: Install Global Turbo


### PR DESCRIPTION
## Summary

- Install macOS Homebrew dependencies together before parallel environment setup.
- Skip the parallel capnproto installer on macOS to prevent competing Homebrew processes.
- Preserve parallel capnproto setup on Linux and Windows.

Failure: https://github.com/vercel/turborepo/actions/runs/30475729604/job/90657097622

## Testing

- `oxfmt --check` on the changed action and workflow files
- YAML syntax validation with Ruby Psych
- DevOps review of all macOS-capable capnproto setup groups
- Pre-push formatting, TOML, and Rust formatting checks