### PR TITLE
refactor: Migrate MFE dependency detection off PackageInfo

### DIFF
--- a/crates/turborepo-lib/src/microfrontends.rs
+++ b/crates/turborepo-lib/src/microfrontends.rs
@@ -5,7 +5,7 @@ use tracing::warn;
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPath, RelativeUnixPath, RelativeUnixPathBuf};
 use turborepo_microfrontends::{Error, TurborepoMfeConfig as MfeConfig, MICROFRONTENDS_PACKAGE};
 use turborepo_repository::{
-    package_graph::{PackageGraph, PackageGraphNodeKind, PackageInfo, PackageName},
+    package_graph::{PackageGraph, PackageGraphNodeKind, PackageName},
     toolchain::ToolchainId,
 };
 use turborepo_task_executor::MfeConfigProvider;
@@ -48,13 +48,9 @@ impl MicrofrontendsConfigs {
 
         let packages = javascript_packages(package_graph).collect::<Vec<_>>();
 
-        // Dependency tables intentionally remain a Phase 2 PackageJson
-        // compatibility read. Package identity and source roots above are
-        // authoritative repository-knowledge views.
         let any_has_mfe_dep = packages
             .iter()
-            .filter_map(|(_, info, _)| *info)
-            .any(has_mfe_dependency);
+            .any(|(_, package_name, _)| has_mfe_dependency(package_graph, package_name));
         tracing::debug!(
             "from_disk - any package has @vercel/microfrontends dep: {}",
             any_has_mfe_dep
@@ -62,7 +58,7 @@ impl MicrofrontendsConfigs {
 
         type LoadedConfig<'a> = (
             &'a str,
-            Option<&'a PackageInfo>,
+            PackageName,
             &'a AnchoredSystemPath,
             Result<Option<MfeConfig>, Error>,
         );
@@ -73,13 +69,13 @@ impl MicrofrontendsConfigs {
             use rayon::prelude::*;
             packages
                 .into_par_iter()
-                .map(|(name, info, directory)| {
+                .map(|(name, package_name, directory)| {
                     let config_result = MfeConfig::load_from_dir_with_mfe_dep(
                         repo_root,
                         directory,
                         any_has_mfe_dep,
                     );
-                    (name, info, directory, config_result)
+                    (name, package_name, directory, config_result)
                 })
                 .collect()
         });
@@ -90,10 +86,10 @@ impl MicrofrontendsConfigs {
                 has_mfe_dep: HashMap::new(),
                 configs: Vec::new(),
             },
-            |mut acc, (name, info, directory, config_result)| {
+            |mut acc, (name, package_name, directory, config_result)| {
                 let name_str = name;
                 acc.names.insert(name_str);
-                let has_dep = info.is_some_and(has_mfe_dependency);
+                let has_dep = has_mfe_dependency(package_graph, &package_name);
                 tracing::debug!(
                     "from_disk - package: {}, has @vercel/microfrontends dep: {}",
                     name_str,
@@ -357,7 +353,7 @@ impl MicrofrontendsConfigs {
 /// scopes are not package directories and must not be interpreted as such.
 fn javascript_packages(
     package_graph: &PackageGraph,
-) -> impl Iterator<Item = (&str, Option<&PackageInfo>, &turbopath::AnchoredSystemPath)> {
+) -> impl Iterator<Item = (&str, PackageName, &turbopath::AnchoredSystemPath)> {
     package_graph.node_views().filter_map(|(node, view)| {
         let is_historical_js_scope = matches!(
             view.kind(),
@@ -375,22 +371,25 @@ fn javascript_packages(
                 .real_package_names()
                 .find(|candidate| **candidate == name)?,
         };
-        let compatibility_name = match name {
+        let package_name = match name {
             "//" => PackageName::Root,
             name => PackageName::Other(name.to_owned()),
         };
-        Some((
-            name,
-            package_graph.package_info(&compatibility_name),
-            view.directory()?,
-        ))
+        Some((name, package_name, view.directory()?))
     })
 }
 
-fn has_mfe_dependency(info: &PackageInfo) -> bool {
-    info.package_json
-        .all_dependencies()
-        .any(|(dep, _)| dep.as_str() == MICROFRONTENDS_PACKAGE)
+/// Whether a package declares a dependency on `@vercel/microfrontends`, using
+/// external-declaration knowledge rather than `PackageInfo` / PackageJson.
+fn has_mfe_dependency(package_graph: &PackageGraph, package: &PackageName) -> bool {
+    package_graph
+        .package_task_context(package)
+        .is_some_and(|context| {
+            context
+                .external_declarations()
+                .iter()
+                .any(|declaration| declaration.package_name() == MICROFRONTENDS_PACKAGE)
+        })
 }
 
 impl MfeConfigProvider for MicrofrontendsConfigs {

--- a/crates/turborepo-lib/src/microfrontends.rs
+++ b/crates/turborepo-lib/src/microfrontends.rs
@@ -380,16 +380,9 @@ fn javascript_packages(
 }
 
 /// Whether a package declares a dependency on `@vercel/microfrontends`, using
-/// external-declaration knowledge rather than `PackageInfo` / PackageJson.
+/// relationship knowledge rather than `PackageInfo` / PackageJson.
 fn has_mfe_dependency(package_graph: &PackageGraph, package: &PackageName) -> bool {
-    package_graph
-        .package_task_context(package)
-        .is_some_and(|context| {
-            context
-                .external_declarations()
-                .iter()
-                .any(|declaration| declaration.package_name() == MICROFRONTENDS_PACKAGE)
-        })
+    package_graph.has_dependency_declaration(package, MICROFRONTENDS_PACKAGE)
 }
 
 impl MfeConfigProvider for MicrofrontendsConfigs {
@@ -583,12 +576,15 @@ impl ConfigInfo {
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashMap;
+
     use serde_json::json;
     use tempfile::TempDir;
     use turbopath::AbsoluteSystemPathBuf;
     use turborepo_microfrontends::MICROFRONTENDS_PACKAGE;
     use turborepo_repository::{
         cargo::CargoToolchain, package_graph::PackageGraph, package_json::PackageJson,
+        package_manager::PackageManager,
     };
 
     use super::*;
@@ -669,6 +665,85 @@ mod test {
         assert!(MicrofrontendsConfigs::from_disk(&root, &graph)
             .unwrap()
             .is_none());
+    }
+
+    #[tokio::test]
+    async fn mfe_dependency_detection_uses_declaration_names() {
+        for (manifest, expected) in [
+            (
+                json!({ "dependencies": { (MICROFRONTENDS_PACKAGE): "1.0.0" } }),
+                true,
+            ),
+            (
+                json!({ "devDependencies": { (MICROFRONTENDS_PACKAGE): "1.0.0" } }),
+                true,
+            ),
+            (
+                json!({ "optionalDependencies": { (MICROFRONTENDS_PACKAGE): "1.0.0" } }),
+                true,
+            ),
+            (
+                json!({ "peerDependencies": { (MICROFRONTENDS_PACKAGE): "1.0.0" } }),
+                true,
+            ),
+            (
+                json!({
+                    "dependencies": {
+                        "mfe-alias": "npm:@vercel/microfrontends@1.0.0"
+                    }
+                }),
+                false,
+            ),
+            (json!({}), false),
+        ] {
+            let tmp = TempDir::new().unwrap();
+            let root = temp_root(&tmp);
+            let mut root_manifest = json!({
+                "name": "root-app",
+                "packageManager": "npm@10.0.0",
+            });
+            root_manifest
+                .as_object_mut()
+                .unwrap()
+                .extend(manifest.as_object().unwrap().clone());
+            let root_package_json = PackageJson::from_value(root_manifest).unwrap();
+            let graph = PackageGraph::builder(&root, root_package_json)
+                .with_single_package_mode(true)
+                .build()
+                .await
+                .unwrap();
+
+            assert_eq!(has_mfe_dependency(&graph, &PackageName::Root), expected);
+            assert!(!graph
+                .has_dependency_declaration(&PackageName::from("missing"), MICROFRONTENDS_PACKAGE));
+        }
+    }
+
+    #[tokio::test]
+    async fn mfe_dependency_detection_includes_internal_workspaces() {
+        let tmp = TempDir::new().unwrap();
+        let root = temp_root(&tmp);
+        let root_package_json = PackageJson::from_value(json!({
+            "name": "root-app",
+            "packageManager": "npm@10.0.0",
+            "workspaces": ["packages/*"],
+            "dependencies": { (MICROFRONTENDS_PACKAGE): "workspace:*" },
+        }))
+        .unwrap();
+        let mfe_package_json = PackageJson::from_value(json!({
+            "name": MICROFRONTENDS_PACKAGE,
+            "version": "1.0.0",
+        }))
+        .unwrap();
+        let package_path = root.join_components(&["packages", "mfe", "package.json"]);
+        let graph = PackageGraph::builder(&root, root_package_json)
+            .with_package_manager(PackageManager::Npm)
+            .with_package_jsons(Some(HashMap::from([(package_path, mfe_package_json)])))
+            .build()
+            .await
+            .unwrap();
+
+        assert!(has_mfe_dependency(&graph, &PackageName::Root));
     }
 
     struct PackageUpdateTest {

--- a/crates/turborepo-repository/src/knowledge.rs
+++ b/crates/turborepo-repository/src/knowledge.rs
@@ -81,6 +81,14 @@ impl RelationshipKnowledge {
     pub(crate) fn groups(&self) -> &[RelationshipGroup] {
         &self.groups
     }
+
+    pub(crate) fn relationships_for_source(&self, source: &str) -> &[Relationship] {
+        self.groups
+            .binary_search_by(|group| group.source().cmp(source))
+            .ok()
+            .map(|index| self.groups[index].relationships())
+            .unwrap_or_default()
+    }
 }
 
 /// A workspace root paired by core with the registry entry that produced its

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -398,6 +398,20 @@ impl PackageGraph {
             .for_package(package.as_str())
     }
 
+    /// Whether a package declared a dependency under this exact manifest key.
+    /// This includes internal and unresolved-external relationships and does
+    /// not treat an alias target as a declaration under the target's name.
+    pub fn has_dependency_declaration(
+        &self,
+        package: &PackageName,
+        declaration_name: &str,
+    ) -> bool {
+        self.relationship_knowledge
+            .relationships_for_source(package.as_str())
+            .iter()
+            .any(|relationship| relationship.declaration_name() == declaration_name)
+    }
+
     fn relationship_projections(&self) -> &projections::RelationshipProjections {
         self.relationship_projections.get_or_init(|| {
             projections::RelationshipProjections::build(

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -182,7 +182,9 @@ Represents the workspace structure and package dependencies:
   fields and deferred resolution installation; readiness belongs to repository
   construction. External declaration consumers (frameworks, boundaries, task
   hashing) read the authoritative `ExternalDeclarations` projection built from
-  relationship knowledge rather than raw manifests or PackageInfo maps.
+  relationship knowledge rather than raw manifests or PackageInfo maps. MFE
+  enablement checks exact declaration names in the same relationship generation
+  so internal workspace declarations and alias-key behavior remain unchanged.
   Framework inference and boundaries validation consume the package-scoped
   declaration projection directly;
   aliases, duplicate
@@ -220,7 +222,7 @@ The remaining payload deletion phases are explicit:
 - **Phase 5 (in progress):** Task-contract knowledge catalog is produced for JavaScript scopes; engine composition and global `engines` hashing consume it; JS packages are excluded from Toolchain task-I/O environment dispatch. Remaining: fuller hash/framework contract production and final Phase 5 gate. Later: Delete `PackageInfo`, its payload map, and optional-payload compatibility plumbing once all fail-closed consumers use those queries.
 - **Phase 6 (complete for JS change knowledge first wave):** Change knowledge is produced at repository construction; watcher classification and scope lockfile probes consume it via `active_watch_spec` / `resolution_paths` rather than ad-hoc package-manager probes.
 - **Phase 7 (complete):** JavaScript prune rendering is a distinct pure step (`render_javascript_prune`) producing typed artifacts; `commands/prune.rs` selects closures, performs path-safe layout, and materializes those artifacts without inline lockfile/manifest/patch format interpretation. Golden inventories cover standard and Docker layouts.
-- **Phase 8 (audit complete for owned consumers):** Query/devtools/summary/run/engine/watch/prune task and resolution views consume knowledge catalogs. Remaining `PackageJson` / `PackageInfo` reads are construction entry points, LSP unsaved-buffer adapters, prune relationship/peer helpers, compatibility-payload guards in run and summaries, MFE dependency detection, manifest-backed boundary tags, and package-manager detection — tracked for deletion under TURBO-5787 (`PackageInfo` / `JavaScriptToolchain` removal), not deferred silently.
+- **Phase 8 (audit complete for owned consumers):** Query/devtools/summary/run/engine/watch/prune task and resolution views consume knowledge catalogs. Remaining `PackageJson` / `PackageInfo` reads are construction entry points, LSP unsaved-buffer adapters, prune relationship/peer helpers, compatibility-payload guards in run and summaries, manifest-backed boundary tags, and package-manager detection — tracked for deletion under TURBO-5787 (`PackageInfo` / `JavaScriptToolchain` removal), not deferred silently.
 
 Task hashing, run-cache path construction, and run-summary task directories use
 a graph-created `PackageTaskContext` that binds identity, repository root,


### PR DESCRIPTION
## Intent

Move `@vercel/microfrontends` dependency detection from compatibility `PackageInfo` manifests to immutable relationship knowledge without changing enablement behavior.

**Base:** `main`.

## Changes

- Enumerate JavaScript package identities without carrying `PackageInfo`.
- Query exact relationship declaration names for MFE detection.
- Preserve all dependency-table, internal-workspace, and npm-alias semantics.
- Add direct, alias, peer, optional, development, unknown-scope, and internal-workspace coverage.
- Update `ARCHITECTURE.md` to remove MFE detection from the compatibility-read inventory.

## Testing

- `cargo test -p turborepo-lib microfrontends` (26 passed)
- `cargo test -p turborepo-repository package_graph` (94 passed)
- `cargo clippy -p turborepo-repository -p turborepo-lib --all-targets -- -D warnings`
- `cargo fmt --check`

Closes TURBO-5838.