### PR TITLE
refactor: Remove prune PackageInfo dependencies

### DIFF
--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -15,9 +15,7 @@ use turbopath::{
     RelativeUnixPath, RelativeUnixPathBuf,
 };
 use turborepo_repository::{
-    package_graph::{
-        self, PackageGraph, PackageName, PackageTaskContext, PackageTaskContextKind,
-    },
+    package_graph::{self, PackageGraph, PackageName, PackageTaskContext, PackageTaskContextKind},
     package_json::PackageJson,
     package_manager::{npmrc::NpmRc, PackageManager},
     toolchain::ToolchainId,
@@ -1065,28 +1063,10 @@ impl<'a> Prune<'a> {
             let context = self.package_context(workspace)?;
             // Required external peers (not same-workspace packages) from
             // declaration knowledge — not PackageJson peer tables.
-            let peer_dependencies = context
-                .external_declarations()
-                .iter()
-                .filter(|declaration| {
-                    matches!(
-                        declaration.kind(),
-                        turborepo_repository::relationships::DependencyKind::Peer {
-                            optional: false
-                        }
-                    )
-                })
-                .filter(|declaration| {
-                    self.package_graph
-                        .package_task_context(&PackageName::from(declaration.package_name()))
-                        .is_none()
-                })
-                .map(|declaration| {
-                    (
-                        declaration.package_name().to_string(),
-                        declaration.specifier().to_string(),
-                    )
-                })
+            let peer_dependencies = self
+                .package_graph
+                .required_external_peer_declarations(workspace)
+                .map(|(name, specifier)| (name.to_string(), specifier.to_string()))
                 .collect::<BTreeMap<_, _>>();
 
             if peer_dependencies.is_empty() {

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -51,6 +51,10 @@ pub enum Error {
     #[error(transparent)]
     PackageGraph(#[from] package_graph::Error),
     #[error(transparent)]
+    RelationshipProjection(
+        #[from] turborepo_repository::package_graph::RelationshipProjectionError,
+    ),
+    #[error(transparent)]
     Lockfile(#[from] turborepo_lockfiles::Error),
     #[error("`turbo` does not support workspaces at file system root.")]
     WorkspaceAtFilesystemRoot,
@@ -1037,69 +1041,22 @@ impl<'a> Prune<'a> {
     }
 
     fn internal_dependencies(&self) -> Result<Vec<PackageName>, Error> {
-        let workspaces = std::iter::once(PackageNode::Workspace(PackageName::Root))
-            .chain(
-                self.scope
-                    .iter()
-                    .map(|workspace| PackageNode::Workspace(PackageName::Other(workspace.clone()))),
-            )
-            .collect::<Vec<_>>();
-        let mut names = self
-            .workspace_transitive_closure(workspaces.iter())
-            .into_iter()
-            .filter_map(|node| match node {
-                PackageNode::Root => None,
-                PackageNode::Workspace(workspace) => Some(workspace.clone()),
-            })
-            .collect::<HashSet<_>>();
-
-        loop {
-            let mut changed = false;
-            for workspace in names.clone() {
-                let context = self.package_context(&workspace)?;
-                let payload = match context.package_info() {
-                    Some(payload) => payload,
-                    None if context.requires_compatibility_payload() => {
-                        return Err(Error::MissingPackagePayload(context.package().clone()));
-                    }
-                    None => continue,
-                };
-                for (peer_name, _) in payload.package_json.peer_dependencies.iter().flatten() {
-                    if payload.package_json.is_optional_peer_dependency(peer_name) {
-                        continue;
-                    }
-
-                    let peer = PackageName::from(peer_name.as_str());
-                    if self.package_graph.package_task_context(&peer).is_some()
-                        && names.insert(peer)
-                    {
-                        changed = true;
-                    }
-                }
-            }
-
-            if !changed {
-                break;
-            }
-
-            let workspace_nodes = names
-                .iter()
-                .cloned()
-                .map(PackageNode::Workspace)
-                .collect::<Vec<_>>();
-            names.extend(
-                self.workspace_transitive_closure(workspace_nodes.iter())
-                    .into_iter()
-                    .filter_map(|node| match node {
-                        PackageNode::Root => None,
-                        PackageNode::Workspace(workspace) => Some(workspace.clone()),
-                    }),
-            );
-        }
-
-        let mut names = names.into_iter().collect::<Vec<_>>();
-        names.sort();
-        Ok(names)
+        // Install-oriented package closure including required same-name peer
+        // workspaces — from relationship knowledge, not PackageJson peer tables.
+        let seeds: Vec<PackageName> = self
+            .scope
+            .iter()
+            .map(|workspace| PackageName::Other(workspace.clone()))
+            .collect();
+        let mode = if self.production {
+            turborepo_repository::package_graph::PruneDependencyMode::ProductionOnly
+        } else {
+            turborepo_repository::package_graph::PruneDependencyMode::IncludeDevDependencies
+        };
+        Ok(self
+            .package_graph
+            .prune_relationships()
+            .package_closure(&seeds, mode)?)
     }
 
     fn lockfile_keys(&self, workspaces: &[PackageName]) -> Result<Vec<String>, Error> {
@@ -1117,20 +1074,30 @@ impl<'a> Prune<'a> {
 
         for workspace in workspaces {
             let context = self.package_context(workspace)?;
-            let payload = self.required_package_payload(&context)?;
-
-            let peer_dependencies = payload
-                .package_json
-                .peer_dependencies
+            // Required external peers (not same-workspace packages) from
+            // declaration knowledge — not PackageJson peer tables.
+            let peer_dependencies = context
+                .external_declarations()
                 .iter()
-                .flatten()
-                .filter(|(name, _)| !payload.package_json.is_optional_peer_dependency(name))
-                .filter(|(name, _)| {
+                .filter(|declaration| {
+                    matches!(
+                        declaration.kind(),
+                        turborepo_repository::relationships::DependencyKind::Peer {
+                            optional: false
+                        }
+                    )
+                })
+                .filter(|declaration| {
                     self.package_graph
-                        .package_task_context(&PackageName::from(name.as_str()))
+                        .package_task_context(&PackageName::from(declaration.package_name()))
                         .is_none()
                 })
-                .map(|(name, version)| (name.clone(), version.clone()))
+                .map(|declaration| {
+                    (
+                        declaration.package_name().to_string(),
+                        declaration.specifier().to_string(),
+                    )
+                })
                 .collect::<BTreeMap<_, _>>();
 
             if peer_dependencies.is_empty() {
@@ -1632,8 +1599,12 @@ mod tests {
             .package_graph
             .remove_package_info_for_test(&web)
             .is_some());
+        // Closure selection uses relationship knowledge and no longer requires
+        // PackageInfo; fail-closed payload checks happen at copy/render time.
+        assert!(prune.internal_dependencies().is_ok());
+        let context = prune.package_context(&web).unwrap();
         assert!(matches!(
-            prune.internal_dependencies(),
+            prune.required_package_payload(&context),
             Err(Error::MissingPackagePayload(package)) if package == web
         ));
     }

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -16,7 +16,7 @@ use turbopath::{
 };
 use turborepo_repository::{
     package_graph::{
-        self, PackageGraph, PackageName, PackageNode, PackageTaskContext, PackageTaskContextKind,
+        self, PackageGraph, PackageName, PackageTaskContext, PackageTaskContextKind,
     },
     package_json::PackageJson,
     package_manager::{npmrc::NpmRc, PackageManager},

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -1029,17 +1029,6 @@ impl<'a> Prune<'a> {
         Ok(())
     }
 
-    fn workspace_transitive_closure<'graph, 'node, I: IntoIterator<Item = &'node PackageNode>>(
-        &'graph self,
-        nodes: I,
-    ) -> HashSet<&'graph PackageNode> {
-        if self.production {
-            self.package_graph.production_transitive_closure(nodes)
-        } else {
-            self.package_graph.transitive_closure(nodes)
-        }
-    }
-
     fn internal_dependencies(&self) -> Result<Vec<PackageName>, Error> {
         // Install-oriented package closure including required same-name peer
         // workspaces — from relationship knowledge, not PackageJson peer tables.

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -60,8 +60,6 @@ pub enum Error {
     NoWorkspaceSpecified,
     #[error("Invalid scope. Package with name {0} in `package.json` not found.")]
     MissingWorkspace(PackageName),
-    #[error("Missing compatibility package payload for {0}")]
-    MissingPackagePayload(PackageName),
     #[error("Missing native package definition for {0}")]
     MissingPackageDefinition(PackageName),
     #[error("Missing toolchain provenance for {0}")]
@@ -279,6 +277,7 @@ pub async fn prune(
                 continue;
             }
             prune.copy_workspace(
+                context.package(),
                 context.directory(),
                 definition_path,
                 &excluded_dev_workspaces,
@@ -843,6 +842,7 @@ impl<'a> Prune<'a> {
 
     fn copy_workspace(
         &self,
+        workspace: &PackageName,
         workspace_directory: &AnchoredSystemPath,
         definition_path: &AnchoredSystemPath,
         excluded_dev_workspaces: &HashSet<String>,
@@ -850,9 +850,7 @@ impl<'a> Prune<'a> {
         let package_json_path = self.root.resolve(definition_path);
         let original_dir = self.root.resolve(workspace_directory);
         if !original_dir.contains(&package_json_path) {
-            return Err(Error::MissingPackageDefinition(PackageName::Other(
-                workspace_directory.to_string(),
-            )));
+            return Err(Error::MissingPackageDefinition(workspace.clone()));
         }
         let definition_name = package_json_path
             .file_name()
@@ -863,9 +861,7 @@ impl<'a> Prune<'a> {
                 turborepo_repository::package_json::Error::Io(io)
                     if io.kind() == ErrorKind::NotFound =>
                 {
-                    Error::MissingPackageDefinition(PackageName::Other(
-                        workspace_directory.to_string(),
-                    ))
+                    Error::MissingPackageDefinition(workspace.clone())
                 }
                 other => Error::PackageJson(other),
             })?;
@@ -1198,7 +1194,7 @@ mod tests {
     use super::{
         bin_paths, finalized_path_is_contained,
         prune_js::{merge_preserving_key_order, prune_package_json_workspaces},
-        sync_prune_finalize_files, Prune, ADDITIONAL_FILES,
+        sync_prune_finalize_files, Error, Prune, ADDITIONAL_FILES,
     };
 
     struct MockDiscovery;
@@ -1476,7 +1472,7 @@ mod tests {
         workspace_dir.create_dir_all().unwrap();
         workspace_dir
             .join_component("package.json")
-            .create_with_contents("{\n  \"name\": \"web\"\n}\n")
+            .create_with_contents("{\n  \"name\": \"web\",\n  \"bin\": \"bin/cli.js\"\n}\n")
             .unwrap();
         workspace_dir
             .join_component("index.js")
@@ -1527,7 +1523,7 @@ mod tests {
             "packages/web/package.json"
         );
         prune
-            .copy_workspace(context.directory(), definition_path, &HashSet::new())
+            .copy_workspace(&web, context.directory(), definition_path, &HashSet::new())
             .unwrap();
 
         assert_eq!(
@@ -1544,8 +1540,12 @@ mod tests {
                 .join_components(&["packages", "web", "package.json"])
                 .read_to_string()
                 .unwrap(),
-            "{\n  \"name\": \"web\"\n}\n"
+            "{\n  \"name\": \"web\",\n  \"bin\": \"bin/cli.js\"\n}\n"
         );
+        assert!(prune
+            .docker_directory()
+            .join_components(&["packages", "web", "bin", "cli.js"])
+            .exists());
         assert!(!prune.full_directory.join_component("stale").exists());
 
         // Closure/copy no longer require PackageInfo; definition-path IO is
@@ -1558,8 +1558,27 @@ mod tests {
         let context = prune.package_context(&web).unwrap();
         let definition_path = prune.package_definition_path(&context).unwrap();
         assert!(prune
-            .copy_workspace(context.directory(), definition_path, &HashSet::new())
+            .copy_workspace(&web, context.directory(), definition_path, &HashSet::new())
             .is_ok());
+
+        let package_json_path = root.resolve(definition_path);
+        package_json_path.create_with_contents("not json").unwrap();
+        assert!(matches!(
+            prune.copy_workspace(&web, context.directory(), definition_path, &HashSet::new()),
+            Err(Error::PackageJson(_))
+        ));
+
+        std::fs::remove_file(package_json_path.as_std_path()).unwrap();
+        assert!(matches!(
+            prune.copy_workspace(&web, context.directory(), definition_path, &HashSet::new()),
+            Err(Error::MissingPackageDefinition(package)) if package == web
+        ));
+
+        package_json_path.create_dir_all().unwrap();
+        let result =
+            prune.copy_workspace(&web, context.directory(), definition_path, &HashSet::new());
+        std::fs::remove_dir(package_json_path.as_std_path()).unwrap();
+        assert!(matches!(result, Err(Error::PackageJson(_))));
     }
 
     #[tokio::test]

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -278,11 +278,9 @@ pub async fn prune(
                 workspace_names.push(workspace);
                 continue;
             }
-            let payload = prune.required_package_payload(&context)?;
             prune.copy_workspace(
                 context.directory(),
                 definition_path,
-                &payload.package_json,
                 &excluded_dev_workspaces,
             )?;
             workspace_paths.push(context.directory().to_unix().to_string());
@@ -488,15 +486,6 @@ impl<'a> Prune<'a> {
             .ok_or_else(|| Error::MissingWorkspace(package.clone()))
     }
 
-    fn required_package_payload<'graph>(
-        &self,
-        context: &PackageTaskContext<'graph>,
-    ) -> Result<&'graph package_graph::PackageInfo, Error> {
-        context
-            .package_info()
-            .ok_or_else(|| Error::MissingPackagePayload(context.package().clone()))
-    }
-
     fn package_definition_path<'graph>(
         &'graph self,
         context: &PackageTaskContext<'graph>,
@@ -582,9 +571,6 @@ impl<'a> Prune<'a> {
             trace!("target: {}", context.package());
             trace!("workspace directory: {}", context.directory());
             trace!("workspace definition: {definition_path}");
-            if context.requires_compatibility_payload() && context.package_info().is_none() {
-                return Err(Error::MissingPackagePayload(context.package().clone()));
-            }
             let declarations: Vec<_> = package_graph
                 .external_declarations(context.package())
                 .iter()
@@ -859,7 +845,6 @@ impl<'a> Prune<'a> {
         &self,
         workspace_directory: &AnchoredSystemPath,
         definition_path: &AnchoredSystemPath,
-        workspace_package_json: &PackageJson,
         excluded_dev_workspaces: &HashSet<String>,
     ) -> Result<(), Error> {
         let package_json_path = self.root.resolve(definition_path);
@@ -872,6 +857,18 @@ impl<'a> Prune<'a> {
         let definition_name = package_json_path
             .file_name()
             .ok_or(Error::WorkspaceAtFilesystemRoot)?;
+        // Load from the authoritative definition path — not PackageInfo.
+        let workspace_package_json =
+            PackageJson::load(&package_json_path).map_err(|error| match error {
+                turborepo_repository::package_json::Error::Io(io)
+                    if io.kind() == ErrorKind::NotFound =>
+                {
+                    Error::MissingPackageDefinition(PackageName::Other(
+                        workspace_directory.to_string(),
+                    ))
+                }
+                other => Error::PackageJson(other),
+            })?;
         let pruned_package_json = if excluded_dev_workspaces.is_empty() {
             None
         } else {
@@ -912,7 +909,7 @@ impl<'a> Prune<'a> {
                 turborepo_fs::copy_file(&package_json_path, docker_package_json)?;
             }
             self.create_docker_bin_stubs(
-                workspace_package_json,
+                &workspace_package_json,
                 &original_dir,
                 &docker_workspace_dir,
             )?;
@@ -978,18 +975,11 @@ impl<'a> Prune<'a> {
 
         for workspace in all_workspaces {
             let context = self.package_context(&workspace)?;
-            let payload = if context.requires_compatibility_payload() {
-                Some(self.required_package_payload(&context)?)
-            } else {
-                context.package_info()
-            };
             let workspace_abs_dir = self.root.resolve(context.directory());
 
-            for (_dep_name, dep_version) in payload
-                .into_iter()
-                .flat_map(|payload| payload.package_json.all_dependencies())
-            {
-                let Some(path_str) = dep_version.strip_prefix("file:") else {
+            // `file:` dependencies from declaration knowledge.
+            for declaration in context.external_declarations().iter() {
+                let Some(path_str) = declaration.specifier().strip_prefix("file:") else {
                     continue;
                 };
 
@@ -1208,7 +1198,7 @@ mod tests {
     use super::{
         bin_paths, finalized_path_is_contained,
         prune_js::{merge_preserving_key_order, prune_package_json_workspaces},
-        sync_prune_finalize_files, Error, Prune, ADDITIONAL_FILES,
+        sync_prune_finalize_files, Prune, ADDITIONAL_FILES,
     };
 
     struct MockDiscovery;
@@ -1536,14 +1526,8 @@ mod tests {
             definition_path.to_unix().as_str(),
             "packages/web/package.json"
         );
-        let payload = prune.required_package_payload(&context).unwrap();
         prune
-            .copy_workspace(
-                context.directory(),
-                definition_path,
-                &payload.package_json,
-                &HashSet::new(),
-            )
+            .copy_workspace(context.directory(), definition_path, &HashSet::new())
             .unwrap();
 
         assert_eq!(
@@ -1564,18 +1548,18 @@ mod tests {
         );
         assert!(!prune.full_directory.join_component("stale").exists());
 
+        // Closure/copy no longer require PackageInfo; definition-path IO is
+        // the fail-closed source for package.json during workspace copy.
         assert!(prune
             .package_graph
             .remove_package_info_for_test(&web)
             .is_some());
-        // Closure selection uses relationship knowledge and no longer requires
-        // PackageInfo; fail-closed payload checks happen at copy/render time.
         assert!(prune.internal_dependencies().is_ok());
         let context = prune.package_context(&web).unwrap();
-        assert!(matches!(
-            prune.required_package_payload(&context),
-            Err(Error::MissingPackagePayload(package)) if package == web
-        ));
+        let definition_path = prune.package_definition_path(&context).unwrap();
+        assert!(prune
+            .copy_workspace(context.directory(), definition_path, &HashSet::new())
+            .is_ok());
     }
 
     #[tokio::test]

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -25,6 +25,7 @@ use crate::{
     knowledge::{RelationshipKnowledge, RepositoryKnowledge},
     package_json::PackageJson,
     package_manager::PackageManager,
+    relationships::RelationshipTarget,
 };
 
 pub mod builder;
@@ -410,6 +411,37 @@ impl PackageGraph {
             .relationships_for_source(package.as_str())
             .iter()
             .any(|relationship| relationship.declaration_name() == declaration_name)
+    }
+
+    /// Required peer declarations that remain external after relationship
+    /// classification. Declaration keys are preserved for lockfile traversal,
+    /// including npm aliases and peers shadowed in other dependency tables.
+    pub fn required_external_peer_declarations(
+        &self,
+        package: &PackageName,
+    ) -> impl Iterator<Item = (&str, &str)> {
+        self.relationship_knowledge
+            .relationships_for_source(package.as_str())
+            .iter()
+            .filter_map(|relationship| {
+                if relationship.kind()
+                    != (crate::relationships::DependencyKind::Peer { optional: false })
+                {
+                    return None;
+                }
+                let RelationshipTarget::UnresolvedExternal { specifier, .. } =
+                    relationship.target()
+                else {
+                    return None;
+                };
+                if self
+                    .package_task_context(&PackageName::from(relationship.declaration_name()))
+                    .is_some()
+                {
+                    return None;
+                }
+                Some((relationship.declaration_name(), specifier.as_str()))
+            })
     }
 
     fn relationship_projections(&self) -> &projections::RelationshipProjections {
@@ -2080,6 +2112,63 @@ mod test {
                 .map(|identity| identity.key())
                 .collect::<HashSet<_>>(),
             HashSet::from(["key:b", "key:c"])
+        );
+    }
+
+    #[tokio::test]
+    async fn required_external_peer_declarations_preserve_required_external_manifest_entries() {
+        let root =
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+        let pkg_graph = PackageGraph::builder(
+            &root,
+            PackageJson::from_value(json!({ "name": "root" })).unwrap(),
+        )
+        .with_package_discovery(MockDiscovery)
+        .with_package_jsons(Some(HashMap::from([
+            (
+                root.join_components(&["packages", "app", "package.json"]),
+                PackageJson::from_value(json!({
+                    "name": "app",
+                    "dependencies": {
+                        "declared-twice": "1.0.0"
+                    },
+                    "peerDependencies": {
+                        "external-peer": "^1.0.0",
+                        "react-legacy": "npm:react@^18.0.0",
+                        "optional-peer": "^2.0.0",
+                        "declared-twice": "^2.0.0",
+                        "workspace-peer": "^2.0.0"
+                    },
+                    "peerDependenciesMeta": {
+                        "optional-peer": { "optional": true }
+                    }
+                }))
+                .unwrap(),
+            ),
+            (
+                root.join_components(&["packages", "workspace-peer", "package.json"]),
+                PackageJson::from_value(json!({
+                    "name": "workspace-peer",
+                    "version": "1.0.0"
+                }))
+                .unwrap(),
+            ),
+        ])))
+        .build()
+        .await
+        .unwrap();
+
+        let declarations = pkg_graph
+            .required_external_peer_declarations(&PackageName::from("app"))
+            .collect::<BTreeMap<_, _>>();
+
+        assert_eq!(
+            declarations,
+            BTreeMap::from([
+                ("declared-twice", "^2.0.0"),
+                ("external-peer", "^1.0.0"),
+                ("react-legacy", "npm:react@^18.0.0"),
+            ])
         );
     }
 

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -173,8 +173,9 @@ Represents the workspace structure and package dependencies:
   compares the resulting normalized package identities without parser or
   ecosystem knowledge; unavailable, parse, and comparison failures retain the
   conservative all-packages fallback. Prune lockfile-key unions also consume
-  exact per-package resolution identities for retained JavaScript workspaces,
-  while external-peer closure expansion still consults the lockfile directly.
+  exact per-package resolution identities for retained JavaScript workspaces;
+  required external peer declarations come from relationship knowledge before
+  closure expansion consults the lockfile.
   Global hashing consumes the same root resolution fingerprint as task hashing
   and, when JavaScript resolution is unavailable, hashes resolution definition
   sources plus the root package.json instead of reading the singleton lockfile
@@ -222,7 +223,7 @@ The remaining payload deletion phases are explicit:
 - **Phase 5 (in progress):** Task-contract knowledge catalog is produced for JavaScript scopes; engine composition and global `engines` hashing consume it; JS packages are excluded from Toolchain task-I/O environment dispatch. Remaining: fuller hash/framework contract production and final Phase 5 gate. Later: Delete `PackageInfo`, its payload map, and optional-payload compatibility plumbing once all fail-closed consumers use those queries.
 - **Phase 6 (complete for JS change knowledge first wave):** Change knowledge is produced at repository construction; watcher classification and scope lockfile probes consume it via `active_watch_spec` / `resolution_paths` rather than ad-hoc package-manager probes.
 - **Phase 7 (complete):** JavaScript prune rendering is a distinct pure step (`render_javascript_prune`) producing typed artifacts; `commands/prune.rs` selects closures, performs path-safe layout, and materializes those artifacts without inline lockfile/manifest/patch format interpretation. Golden inventories cover standard and Docker layouts.
-- **Phase 8 (audit complete for owned consumers):** Query/devtools/summary/run/engine/watch/prune task and resolution views consume knowledge catalogs. Remaining `PackageJson` / `PackageInfo` reads are construction entry points, LSP unsaved-buffer adapters, prune relationship/peer helpers, compatibility-payload guards in run and summaries, manifest-backed boundary tags, and package-manager detection — tracked for deletion under TURBO-5787 (`PackageInfo` / `JavaScriptToolchain` removal), not deferred silently.
+- **Phase 8 (audit complete for owned consumers):** Query/devtools/summary/run/engine/watch/prune task and resolution views consume knowledge catalogs. Remaining `PackageJson` / `PackageInfo` reads are construction entry points, LSP unsaved-buffer adapters, compatibility-payload guards in run and summaries, manifest-backed boundary tags, and package-manager detection — tracked for deletion under TURBO-5787 (`PackageInfo` / `JavaScriptToolchain` removal), not deferred silently.
 
 Task hashing, run-cache path construction, and run-summary task directories use
 a graph-created `PackageTaskContext` that binds identity, repository root,


### PR DESCRIPTION
## Intent

Remove prune's remaining compatibility reads as one unit: resolve peer relationships from authoritative relationship knowledge and copy workspaces from authoritative definition paths instead of `PackageJson`/`PackageInfo` payloads.

**Base:** `main`.

## Changes

- Resolve prune peer relationships from authoritative declarations and package identities
- Load workspace manifests from authoritative definition paths
- Use relationship declarations for local `file:` dependencies
- Preserve fail-closed malformed, missing, and unreadable manifest behavior
- Remove obsolete compatibility-payload checks and errors

## Testing

- `cargo test -p turborepo-repository --lib required_external_peer_declarations`
- `cargo test -p turborepo-lib --lib commands::prune`
- `cargo test -p turbo --test prune_test`
- `cargo clippy -p turborepo-repository -p turborepo-lib --all-targets -- -D warnings`

Closes TURBO-5839.
Closes TURBO-5840.