### PR TITLE
refactor: Stop requiring PackageInfo for MFE proxy commands

### DIFF
--- a/crates/turborepo-task-executor/src/command.rs
+++ b/crates/turborepo-task-executor/src/command.rs
@@ -441,11 +441,6 @@ impl<'a, M: MfeConfigProvider> MicroFrontendProxyProvider<'a, M> {
                 package_name: context.package().clone(),
             });
         }
-        if context.package_info().is_none() {
-            return Err(CommandProviderError::MissingPackagePayload {
-                package_name: context.package().clone(),
-            });
-        }
         Ok(context)
     }
 }
@@ -478,19 +473,14 @@ impl<'a, M: MfeConfigProvider, E: From<CommandProviderError>> CommandProvider<E>
         );
 
         let package_context = self.validated_package_context(task_id)?;
-        let package_info = package_context.package_info().ok_or_else(|| {
-            CommandProviderError::MissingPackagePayload {
-                package_name: package_context.package().clone(),
-            }
-        })?;
         let has_custom_proxy = package_context.native_tasks().defines("proxy");
 
-        // Check if package depends on @vercel/microfrontends
+        // Check if package depends on @vercel/microfrontends via declarations.
         const MICROFRONTENDS_PACKAGE: &str = "@vercel/microfrontends";
-        let has_mfe_dependency = package_info
-            .package_json
-            .all_dependencies()
-            .any(|(package, _version)| package.as_str() == MICROFRONTENDS_PACKAGE);
+        let has_mfe_dependency = package_context
+            .external_declarations()
+            .iter()
+            .any(|declaration| declaration.package_name() == MICROFRONTENDS_PACKAGE);
 
         debug!(
             "MicroFrontendProxyProvider::command - has_custom_proxy: {}, has_mfe_dependency: {}",
@@ -985,7 +975,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_microfrontend_proxy_requires_compatibility_payload() {
+    async fn test_microfrontend_proxy_does_not_require_package_info_payload() {
         let (_tempdir, repo_root, package_dir) = create_test_repo();
         let mut graph = package_graph(&repo_root, &package_dir, PackageJson::default()).await;
         graph.remove_package_info_for_test(&PackageName::from("web"));
@@ -993,17 +983,14 @@ mod tests {
         let tasks = [TaskId::new("docs", "dev"), TaskId::new("web", "proxy")];
         let command_provider = MicroFrontendProxyProvider::new(&graph, tasks.iter(), &mfe_config);
 
-        let error = CommandProvider::<CommandProviderError>::command(
+        // Proxy framing uses native tasks + external declarations; PackageInfo
+        // is no longer required.
+        let result = CommandProvider::<CommandProviderError>::command(
             &command_provider,
             &TaskId::new("web", "proxy"),
             &EnvironmentVariableMap::default(),
-        )
-        .unwrap_err();
-
-        assert!(matches!(
-            error,
-            CommandProviderError::MissingPackagePayload { .. }
-        ));
+        );
+        assert!(result.is_ok());
     }
 
     #[tokio::test]

--- a/crates/turborepo-task-executor/src/command.rs
+++ b/crates/turborepo-task-executor/src/command.rs
@@ -113,8 +113,6 @@ pub enum CommandProviderError {
         package_name: PackageName,
         task_id: TaskId<'static>,
     },
-    #[error("Missing compatibility payload for package {package_name}.")]
-    MissingPackagePayload { package_name: PackageName },
     #[error("Package {package_name} is not a JavaScript package execution scope.")]
     InvalidMfePackageContext { package_name: PackageName },
     #[error("Package directory {directory} is outside repository root {repository_root}.")]
@@ -477,10 +475,9 @@ impl<'a, M: MfeConfigProvider, E: From<CommandProviderError>> CommandProvider<E>
 
         // Check if package depends on @vercel/microfrontends via declarations.
         const MICROFRONTENDS_PACKAGE: &str = "@vercel/microfrontends";
-        let has_mfe_dependency = package_context
-            .external_declarations()
-            .iter()
-            .any(|declaration| declaration.package_name() == MICROFRONTENDS_PACKAGE);
+        let has_mfe_dependency = self
+            .package_graph
+            .has_dependency_declaration(package_context.package(), MICROFRONTENDS_PACKAGE);
 
         debug!(
             "MicroFrontendProxyProvider::command - has_custom_proxy: {}, has_mfe_dependency: {}",
@@ -901,7 +898,7 @@ mod tests {
         let (_tempdir, repo_root, package_dir) = create_test_repo();
         let inherited_env = inherited_env_name();
         write_custom_proxy_package(&package_dir, inherited_env);
-        let package_graph = package_graph(
+        let mut package_graph = package_graph(
             &repo_root,
             &package_dir,
             PackageJson {
@@ -913,6 +910,7 @@ mod tests {
             },
         )
         .await;
+        package_graph.remove_package_info_for_test(&PackageName::from("web"));
         let cmd = proxy_command(&package_graph, &filtered_environment());
         assert!(
             cmd.label()
@@ -977,20 +975,37 @@ mod tests {
     #[tokio::test]
     async fn test_microfrontend_proxy_does_not_require_package_info_payload() {
         let (_tempdir, repo_root, package_dir) = create_test_repo();
-        let mut graph = package_graph(&repo_root, &package_dir, PackageJson::default()).await;
+        write_microfrontends_binary(&package_dir, inherited_env_name());
+        let mut graph = package_graph(
+            &repo_root,
+            &package_dir,
+            PackageJson {
+                dependencies: Some(BTreeMap::from([(
+                    "@vercel/microfrontends".to_owned(),
+                    "1.0.0".to_owned(),
+                )])),
+                ..Default::default()
+            },
+        )
+        .await;
         graph.remove_package_info_for_test(&PackageName::from("web"));
         let mfe_config = MockMfeConfig("configs/microfrontends.json");
         let tasks = [TaskId::new("docs", "dev"), TaskId::new("web", "proxy")];
         let command_provider = MicroFrontendProxyProvider::new(&graph, tasks.iter(), &mfe_config);
 
-        // Proxy framing uses native tasks + external declarations; PackageInfo
-        // is no longer required.
-        let result = CommandProvider::<CommandProviderError>::command(
+        let command = CommandProvider::<CommandProviderError>::command(
             &command_provider,
             &TaskId::new("web", "proxy"),
             &EnvironmentVariableMap::default(),
+        )
+        .unwrap()
+        .expect("declaration knowledge should select the package binary");
+        assert!(
+            command
+                .program()
+                .to_string_lossy()
+                .contains("microfrontends")
         );
-        assert!(result.is_ok());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Intent

Remove `MicroFrontendProxyProvider`'s dependency on compatibility `PackageInfo` payloads without changing proxy selection or framing.

**Stack:** JavaScript compatibility removal layer 4. Base = `shew/turbo-5840-stop-requiring-packageinfo-for-prune-workspace-copy-v2`.

## Changes

- Select custom proxy commands from native-task knowledge.
- Detect `@vercel/microfrontends` through exact relationship declaration keys.
- Preserve internal-workspace and npm-alias semantics.
- Remove the obsolete missing-payload error.
- Exercise custom and package-binary framing after removing `PackageInfo`.

## Testing

- `USER=reviewer cargo test -p turborepo-task-executor command` (11 passed)
- `cargo clippy -p turborepo-task-executor --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

Closes TURBO-5841.