### PR TITLE
refactor: Migrate boundary diagnostics off PackageInfo

### DIFF
--- a/crates/turborepo-boundaries/src/lib.rs
+++ b/crates/turborepo-boundaries/src/lib.rs
@@ -29,7 +29,7 @@ use turborepo_errors::Spanned;
 use turborepo_log::Subsystem;
 use turborepo_repository::{
     external_resolution::PackageExternalDeclarations,
-    package_graph::{PackageGraph, PackageGraphNodeKind, PackageInfo, PackageName, PackageNode},
+    package_graph::{PackageGraph, PackageGraphNodeKind, PackageName, PackageNode},
     toolchain::ToolchainId,
 };
 use turborepo_ui::{BOLD_GREEN, BOLD_RED, ColorConfig, color};
@@ -40,6 +40,7 @@ use crate::imports::DependencyLocations;
 #[derive(Clone)]
 pub struct PackageScope<'a> {
     pub name: PackageName,
+    pub name_source: Option<&'a Spanned<()>>,
     pub directory: &'a turbopath::AnchoredSystemPath,
     pub kind: PackageGraphNodeKind,
     pub toolchain: &'a ToolchainId,
@@ -49,8 +50,6 @@ pub trait PackageGraphProvider: Send + Sync {
     /// Authoritative scopes. Implementations must not derive these facts from
     /// compatibility manifests.
     fn package_scopes(&self) -> Box<dyn Iterator<Item = PackageScope<'_>> + '_>;
-    /// Phase 2 compatibility payload used only for dependency information.
-    fn package_info(&self, name: &PackageName) -> Option<&PackageInfo>;
     fn external_declarations<'a>(
         &'a self,
         name: &'a PackageName,
@@ -71,16 +70,13 @@ impl PackageGraphProvider for PackageGraph {
         Box::new(self.node_views().filter_map(|(node, view)| match node {
             PackageNode::Workspace(name) => Some(PackageScope {
                 name,
+                name_source: view.name_source(),
                 directory: view.directory()?,
                 kind: view.kind(),
                 toolchain: view.toolchain()?,
             }),
             PackageNode::Root => None,
         }))
-    }
-
-    fn package_info(&self, name: &PackageName) -> Option<&PackageInfo> {
-        PackageGraph::package_info(self, name)
     }
 
     fn external_declarations<'a>(
@@ -248,8 +244,6 @@ pub enum BoundariesDiagnostic {
 
 #[derive(Debug, Error, Diagnostic)]
 pub enum Error {
-    #[error("missing Phase 2 compatibility payload for package `{0}`")]
-    MissingCompatibilityPayload(PackageName),
     #[error("file `{0}` does not have a parent directory")]
     NoParentDir(AbsoluteSystemPathBuf),
     #[error(transparent)]
@@ -551,14 +545,8 @@ impl BoundariesChecker {
                     && scope.kind == PackageGraphNodeKind::Package
                     && scope.toolchain == &ToolchainId::JAVASCRIPT
             })
-            .map(|scope| {
-                let info = ctx
-                    .pkg_dep_graph
-                    .package_info(&scope.name)
-                    .ok_or_else(|| Error::MissingCompatibilityPayload(scope.name.clone()))?;
-                Ok((scope.name, info, scope.directory))
-            })
-            .collect::<Result<_, Error>>()?;
+            .map(|scope| (scope.name, scope.name_source, scope.directory))
+            .collect();
 
         let progress = if show_progress {
             println!("Checking packages...");
@@ -572,11 +560,11 @@ impl BoundariesChecker {
             turborepo_rayon_compat::block_in_place(|| {
                 packages_to_check
                     .par_iter()
-                    .map(|(package_name, package_info, package_directory)| {
+                    .map(|(package_name, package_name_source, package_directory)| {
                         let pkg_result = Self::check_package(
                             ctx,
                             package_name,
-                            package_info,
+                            *package_name_source,
                             package_directory,
                             &rules_map,
                             &global_implicit_dependencies,
@@ -611,7 +599,7 @@ impl BoundariesChecker {
     fn check_package<G, T>(
         ctx: &BoundariesContext<'_, G, T>,
         package_name: &PackageName,
-        package_info: &PackageInfo,
+        package_name_source: Option<&Spanned<()>>,
         package_directory: &turbopath::AnchoredSystemPath,
         tag_rules: &Option<ProcessedRulesMap>,
         global_implicit_dependencies: &HashMap<String, Spanned<()>>,
@@ -640,7 +628,7 @@ impl BoundariesChecker {
             result.diagnostics.extend(tags::check_package_tags(
                 ctx,
                 PackageNode::Workspace(package_name.clone()),
-                &package_info.package_json,
+                package_name_source,
                 package_tags,
                 tag_rules.as_ref(),
             )?);
@@ -907,17 +895,16 @@ mod tests {
 
     // Minimal mock providers for integration tests
     struct MockGraph {
-        packages: Vec<(PackageName, PackageInfo)>,
+        packages: Vec<PackageName>,
         aggregates: HashSet<PackageName>,
         authoritative_directories: HashMap<PackageName, turbopath::AnchoredSystemPathBuf>,
-        missing_payloads: HashSet<PackageName>,
     }
 
     impl MockGraph {
-        fn new(packages: Vec<(PackageName, PackageInfo)>) -> Self {
+        fn new(packages: Vec<PackageName>) -> Self {
             let authoritative_directories = packages
                 .iter()
-                .map(|(name, _)| {
+                .map(|name| {
                     (
                         name.clone(),
                         turbopath::AnchoredSystemPathBuf::from_raw(format!(
@@ -932,7 +919,6 @@ mod tests {
                 packages,
                 aggregates: HashSet::new(),
                 authoritative_directories,
-                missing_payloads: HashSet::new(),
             }
         }
 
@@ -948,18 +934,14 @@ mod tests {
             );
             self
         }
-
-        fn without_payload(mut self, name: PackageName) -> Self {
-            self.missing_payloads.insert(name);
-            self
-        }
     }
 
     impl PackageGraphProvider for MockGraph {
         fn package_scopes(&self) -> Box<dyn Iterator<Item = PackageScope<'_>> + '_> {
-            Box::new(self.packages.iter().map(|(name, _)| {
+            Box::new(self.packages.iter().map(|name| {
                 PackageScope {
                     name: name.clone(),
+                    name_source: None,
                     directory: self
                         .authoritative_directories
                         .get(name)
@@ -973,15 +955,6 @@ mod tests {
                     toolchain: &ToolchainId::JAVASCRIPT,
                 }
             }))
-        }
-
-        fn package_info(&self, name: &PackageName) -> Option<&PackageInfo> {
-            if self.missing_payloads.contains(name) {
-                return None;
-            }
-            self.packages
-                .iter()
-                .find_map(|(candidate, info)| (candidate == name).then_some(info))
         }
 
         fn immediate_dependencies(&self, _: &PackageNode) -> Option<HashSet<&PackageNode>> {
@@ -1056,18 +1029,8 @@ mod tests {
         }
 
         let packages = vec![
-            (
-                PackageName::Other("pkg-a".into()),
-                PackageInfo {
-                    package_json: Default::default(),
-                },
-            ),
-            (
-                PackageName::Other("pkg-b".into()),
-                PackageInfo {
-                    package_json: Default::default(),
-                },
-            ),
+            PackageName::Other("pkg-a".into()),
+            PackageName::Other("pkg-b".into()),
         ];
 
         let graph = MockGraph::new(packages);
@@ -1102,13 +1065,8 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let repo_root = AbsoluteSystemPath::new(tmp.path().to_str().unwrap()).unwrap();
         let aggregate_name = PackageName::Other("cargo-workspace".into());
-        let graph = MockGraph::new(vec![(
-            aggregate_name.clone(),
-            PackageInfo {
-                ..Default::default()
-            },
-        )])
-        .with_aggregate(aggregate_name.clone());
+        let graph =
+            MockGraph::new(vec![aggregate_name.clone()]).with_aggregate(aggregate_name.clone());
         let filtered = HashSet::from([aggregate_name]);
         let result = BoundariesChecker::check_boundaries(
             &BoundariesContext {
@@ -1127,17 +1085,11 @@ mod tests {
     }
 
     #[test]
-    fn authoritative_package_missing_compatibility_payload_fails_closed() {
+    fn authoritative_package_does_not_require_compatibility_payload() {
         let tmp = tempfile::tempdir().unwrap();
         let repo_root = AbsoluteSystemPath::new(tmp.path().to_str().unwrap()).unwrap();
         let package_name = PackageName::Other("authoritative-web".into());
-        let graph = MockGraph::new(vec![(
-            package_name.clone(),
-            PackageInfo {
-                ..Default::default()
-            },
-        )])
-        .without_payload(package_name.clone());
+        let graph = MockGraph::new(vec![package_name.clone()]);
         let filtered = HashSet::from([package_name.clone()]);
 
         let result = BoundariesChecker::check_boundaries(
@@ -1149,15 +1101,10 @@ mod tests {
                 filtered_pkgs: &filtered,
             },
             false,
-        );
-        let Err(error) = result else {
-            panic!("missing compatibility payload must fail closed");
-        };
+        )
+        .unwrap();
 
-        assert!(matches!(
-            error,
-            Error::MissingCompatibilityPayload(name) if name == package_name
-        ));
+        assert_eq!(result.packages_checked, 1);
     }
 
     #[test]
@@ -1173,13 +1120,8 @@ mod tests {
             .join_components(&["actual", "web", "index.ts"])
             .create_with_contents("export {};\n")
             .unwrap();
-        let graph = MockGraph::new(vec![(
-            package_name.clone(),
-            PackageInfo {
-                ..Default::default()
-            },
-        )])
-        .with_directory(package_name.clone(), "actual/web");
+        let graph = MockGraph::new(vec![package_name.clone()])
+            .with_directory(package_name.clone(), "actual/web");
         let filtered = HashSet::from([package_name]);
 
         let result = BoundariesChecker::check_boundaries(

--- a/crates/turborepo-boundaries/src/tags.rs
+++ b/crates/turborepo-boundaries/src/tags.rs
@@ -3,10 +3,7 @@ use std::collections::{HashMap, HashSet};
 use miette::NamedSource;
 use tracing::info_span;
 use turborepo_errors::Spanned;
-use turborepo_repository::{
-    package_graph::{PackageName, PackageNode},
-    package_json::PackageJson,
-};
+use turborepo_repository::package_graph::{PackageName, PackageNode};
 
 use crate::{
     BoundariesContext, BoundariesDiagnostic, Error, PackageGraphProvider, SecondaryDiagnostic,
@@ -61,7 +58,7 @@ impl From<Permissions> for ProcessedPermissions {
 fn validate_relation<G, T>(
     _ctx: &BoundariesContext<'_, G, T>,
     package_name: &PackageName,
-    package_json: &PackageJson,
+    package_name_source: Option<&Spanned<()>>,
     relation_package_name: &PackageName,
     tags: Option<&Spanned<Vec<Spanned<String>>>>,
     allow_list: Option<&Spanned<HashSet<String>>>,
@@ -81,10 +78,8 @@ where
     if let Some(deny_list) = deny_list
         && deny_list.contains(relation_package_name.as_str())
     {
-        let (span, text) = package_json
-            .name
-            .as_ref()
-            .map(|name| name.span_and_text("turbo.json"))
+        let (span, text) = package_name_source
+            .map(|name| name.span_and_text("package.json"))
             .unwrap_or_else(|| (None, NamedSource::new("package.json", String::new())));
         let deny_list_spanned = deny_list.to(());
         let (deny_list_span, deny_list_text) = deny_list_spanned.span_and_text("turbo.json");
@@ -169,7 +164,7 @@ pub(crate) fn check_tag_with_cache<G, T>(
     dependencies: Option<&ProcessedPermissions>,
     dependents: Option<&ProcessedPermissions>,
     pkg: &PackageNode,
-    package_json: &PackageJson,
+    package_name_source: Option<&Spanned<()>>,
     cached_deps: &[&PackageNode],
     cached_ancestors: &[&PackageNode],
 ) -> Result<(), Error>
@@ -190,7 +185,7 @@ where
             diagnostics.extend(validate_relation(
                 ctx,
                 pkg.as_package_name(),
-                package_json,
+                package_name_source,
                 dependency.as_package_name(),
                 dependency_tags,
                 dependency_permissions.allow.as_ref(),
@@ -210,7 +205,7 @@ where
             diagnostics.extend(validate_relation(
                 ctx,
                 pkg.as_package_name(),
-                package_json,
+                package_name_source,
                 dependent.as_package_name(),
                 dependent_tags,
                 dependent_permissions.allow.as_ref(),
@@ -225,13 +220,11 @@ where
 fn check_if_package_name_is_tag(
     tags_rules: &ProcessedRulesMap,
     pkg: &PackageNode,
-    package_json: &PackageJson,
+    package_name_source: Option<&Spanned<()>>,
 ) -> Option<BoundariesDiagnostic> {
     let rule = tags_rules.get(pkg.as_package_name().as_str())?;
     let (tag_span, tag_text) = rule.span.span_and_text("turbo.json");
-    let (package_span, package_text) = package_json
-        .name
-        .as_ref()
+    let (package_span, package_text) = package_name_source
         .map(|name| name.span_and_text("package.json"))
         .unwrap_or_else(|| (None, NamedSource::new("package.json", "".into())));
     Some(BoundariesDiagnostic::TagSharesPackageName {
@@ -330,7 +323,7 @@ where
 pub(crate) fn check_package_tags<G, T>(
     ctx: &BoundariesContext<'_, G, T>,
     pkg: PackageNode,
-    package_json: &PackageJson,
+    package_name_source: Option<&Spanned<()>>,
     current_package_tags: Option<&Spanned<Vec<Spanned<String>>>>,
     tags_rules: Option<&ProcessedRulesMap>,
 ) -> Result<Vec<BoundariesDiagnostic>, Error>
@@ -387,7 +380,7 @@ where
             dependencies.as_ref(),
             dependents.as_ref(),
             &pkg,
-            package_json,
+            package_name_source,
             &cached_deps,
             &cached_ancestors,
         )?;
@@ -396,7 +389,11 @@ where
     if let Some(tags_rules) = tags_rules {
         // We don't allow tags to share the same name as the package
         // because we allow package names to be used as a tag
-        diagnostics.extend(check_if_package_name_is_tag(tags_rules, &pkg, package_json));
+        diagnostics.extend(check_if_package_name_is_tag(
+            tags_rules,
+            &pkg,
+            package_name_source,
+        ));
 
         for tag in current_package_tags.into_iter().flatten().flatten() {
             if let Some(rule) = tags_rules.get(tag.as_inner()) {
@@ -406,7 +403,7 @@ where
                     rule.dependencies.as_ref(),
                     rule.dependents.as_ref(),
                     &pkg,
-                    package_json,
+                    package_name_source,
                     &cached_deps,
                     &cached_ancestors,
                 )?;
@@ -420,8 +417,7 @@ where
 #[cfg(test)]
 mod tests {
     use turborepo_repository::{
-        package_graph::{PackageGraphNodeKind, PackageInfo, PackageName, PackageNode},
-        package_json::PackageJson,
+        package_graph::{PackageGraphNodeKind, PackageName, PackageNode},
         toolchain::ToolchainId,
     };
 
@@ -430,7 +426,7 @@ mod tests {
 
     // Minimal mock graph that tracks packages, dependencies, and ancestors.
     struct MockGraph {
-        packages: Vec<(PackageName, turbopath::AnchoredSystemPathBuf, PackageInfo)>,
+        packages: Vec<(PackageName, turbopath::AnchoredSystemPathBuf)>,
         deps: HashMap<PackageNode, Vec<PackageNode>>,
         ancestors: HashMap<PackageNode, Vec<PackageNode>>,
     }
@@ -449,9 +445,6 @@ mod tests {
             self.packages.push((
                 pkg_name,
                 turbopath::AnchoredSystemPathBuf::from_raw(format!("packages/{name}")).unwrap(),
-                PackageInfo {
-                    package_json: PackageJson::default(),
-                },
             ));
         }
 
@@ -471,19 +464,14 @@ mod tests {
             Box::new(
                 self.packages
                     .iter()
-                    .map(|(name, directory, _)| crate::PackageScope {
+                    .map(|(name, directory)| crate::PackageScope {
                         name: name.clone(),
+                        name_source: None,
                         directory,
                         kind: PackageGraphNodeKind::Package,
                         toolchain: &ToolchainId::JAVASCRIPT,
                     }),
             )
-        }
-
-        fn package_info(&self, name: &PackageName) -> Option<&PackageInfo> {
-            self.packages
-                .iter()
-                .find_map(|(candidate, _, info)| (candidate == name).then_some(info))
         }
 
         fn immediate_dependencies(&self, _node: &PackageNode) -> Option<HashSet<&PackageNode>> {
@@ -572,6 +560,81 @@ mod tests {
         {
             turbopath::AbsoluteSystemPathBuf::new("C:\\tmp\\test-repo").unwrap()
         }
+    }
+
+    fn package_name_source() -> Spanned<()> {
+        Spanned::new(())
+            .with_range(9..16)
+            .with_text(r#"{"name": "pkg-a"}"#)
+            .with_path("packages/pkg-a/package.json".into())
+    }
+
+    #[test]
+    fn package_name_collision_uses_authoritative_provenance() {
+        let rules = [(
+            "pkg-a".to_string(),
+            ProcessedRule {
+                span: Spanned::new(()),
+                dependencies: None,
+                dependents: None,
+            },
+        )]
+        .into();
+        let pkg = PackageNode::Workspace(PackageName::Other("pkg-a".into()));
+        let source = package_name_source();
+
+        let diagnostic = check_if_package_name_is_tag(&rules, &pkg, Some(&source)).unwrap();
+        let BoundariesDiagnostic::TagSharesPackageName { secondary, .. } = diagnostic else {
+            panic!("expected package-name collision diagnostic");
+        };
+        let SecondaryDiagnostic::PackageDefinedHere {
+            package_span,
+            package_text,
+            ..
+        } = &secondary[0]
+        else {
+            panic!("expected package definition provenance");
+        };
+
+        assert_eq!(package_span.unwrap().offset(), 9);
+        assert_eq!(package_span.unwrap().len(), 7);
+        assert_eq!(package_text.name(), "packages/pkg-a/package.json");
+    }
+
+    #[test]
+    fn denied_package_name_uses_authoritative_provenance() {
+        let graph = MockGraph::new();
+        let turbo_json = MockTurboJson::new();
+        let repo_root = make_repo_root();
+        let filtered = HashSet::new();
+        let ctx = BoundariesContext {
+            repo_root: &repo_root,
+            pkg_dep_graph: &graph,
+            turbo_json_provider: &turbo_json,
+            root_boundaries_config: None,
+            filtered_pkgs: &filtered,
+        };
+        let source = package_name_source();
+        let deny = Spanned::new(HashSet::from(["pkg-b".to_string()]));
+
+        let diagnostic = validate_relation(
+            &ctx,
+            &PackageName::Other("pkg-a".into()),
+            Some(&source),
+            &PackageName::Other("pkg-b".into()),
+            None,
+            None,
+            Some(&deny),
+        )
+        .unwrap()
+        .unwrap();
+        let BoundariesDiagnostic::DeniedTag { span, text, .. } = diagnostic else {
+            panic!("expected denied-tag diagnostic");
+        };
+
+        assert_eq!(span.unwrap().offset(), 9);
+        assert_eq!(span.unwrap().len(), 7);
+        assert_eq!(text.name(), "packages/pkg-a/package.json");
     }
 
     // -- needs_dependencies / needs_ancestors tests --
@@ -763,10 +826,9 @@ mod tests {
         .into();
 
         let pkg = PackageNode::Workspace(PackageName::Other("pkg-a".into()));
-        let pkg_json = PackageJson::default();
         let tags = turbo_json.package_tags(&PackageName::Other("pkg-a".into()));
 
-        let diagnostics = check_package_tags(&ctx, pkg, &pkg_json, tags, Some(&tag_rules)).unwrap();
+        let diagnostics = check_package_tags(&ctx, pkg, None, tags, Some(&tag_rules)).unwrap();
 
         // tag1 allows "lib": pkg-b has "lib" (ok), pkg-c has "util" (violation)
         // tag2 allows "util": pkg-c has "util" (ok), pkg-b has "lib" (violation)
@@ -818,10 +880,9 @@ mod tests {
         .into();
 
         let pkg = PackageNode::Workspace(PackageName::Other("pkg-a".into()));
-        let pkg_json = PackageJson::default();
         let tags = turbo_json.package_tags(&PackageName::Other("pkg-a".into()));
 
-        let diagnostics = check_package_tags(&ctx, pkg, &pkg_json, tags, Some(&tag_rules)).unwrap();
+        let diagnostics = check_package_tags(&ctx, pkg, None, tags, Some(&tag_rules)).unwrap();
 
         // No dependency/dependent rules → no violations possible from tag checking
         let tag_violations: Vec<_> = diagnostics
@@ -855,8 +916,6 @@ mod tests {
         };
 
         let pkg = PackageNode::Workspace(PackageName::Other("pkg-a".into()));
-        let pkg_json = PackageJson::default();
-
         let perms = ProcessedPermissions {
             allow: Some(Spanned::new(["allowed-tag".into()].into())),
             deny: None,
@@ -873,7 +932,7 @@ mod tests {
             Some(&perms),
             None,
             &pkg,
-            &pkg_json,
+            None,
             &cached_deps,
             &[],
         )

--- a/crates/turborepo-repository/src/change_knowledge.rs
+++ b/crates/turborepo-repository/src/change_knowledge.rs
@@ -149,6 +149,7 @@ mod tests {
             Some(Some("root".to_string())),
             &[PackageScopeObservation {
                 identity: Some("web".to_string()),
+                name_source: None,
                 definition_path: root.join_components(&["apps", "web", "package.json"]),
                 toolchain: ToolchainId::JAVASCRIPT,
                 scope_kind: ScopeKind::Package,

--- a/crates/turborepo-repository/src/external_resolution.rs
+++ b/crates/turborepo-repository/src/external_resolution.rs
@@ -648,12 +648,14 @@ mod tests {
             &[
                 PackageScopeObservation {
                     identity: Some("app".to_string()),
+                    name_source: None,
                     definition_path: root.join_components(&["apps", "app", "package.json"]),
                     toolchain: ToolchainId::JAVASCRIPT,
                     scope_kind: ScopeKind::Package,
                 },
                 PackageScopeObservation {
                     identity: Some("crate".to_string()),
+                    name_source: None,
                     definition_path: root.join_components(&["crates", "crate", "Cargo.toml"]),
                     toolchain: ToolchainId::RUST,
                     scope_kind: ScopeKind::Package,

--- a/crates/turborepo-repository/src/knowledge.rs
+++ b/crates/turborepo-repository/src/knowledge.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 use turbopath::{
     AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPath, AnchoredSystemPathBuf,
 };
+use turborepo_errors::Spanned;
 
 use crate::{
     relationships::{Relationship, RelationshipTarget},
@@ -122,6 +123,7 @@ pub(crate) enum ScopeKind {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ScopeKnowledge {
     identity: String,
+    name_source: Option<Spanned<()>>,
     directory: AnchoredSystemPathBuf,
     definition_path: AnchoredSystemPathBuf,
     toolchain: ToolchainId,
@@ -135,6 +137,10 @@ impl ScopeKnowledge {
 
     pub(crate) fn user_facing_name(&self) -> &str {
         &self.identity
+    }
+
+    pub(crate) fn name_source(&self) -> Option<&Spanned<()>> {
+        self.name_source.as_ref()
     }
 
     pub(crate) fn directory(&self) -> &AnchoredSystemPath {
@@ -317,6 +323,7 @@ impl RepositoryKnowledge {
             scope_lookup.insert(identity.clone(), scopes.len());
             scopes.push(ScopeKnowledge {
                 identity: identity.clone(),
+                name_source: observation.name_source.clone(),
                 directory,
                 definition_path,
                 toolchain: observation.toolchain.clone(),
@@ -427,6 +434,7 @@ fn canonical_physical_path(path: &std::path::Path) -> Option<std::path::PathBuf>
 
 pub(crate) struct PackageScopeObservation {
     pub identity: Option<String>,
+    pub name_source: Option<Spanned<()>>,
     pub definition_path: AbsoluteSystemPathBuf,
     pub toolchain: ToolchainId,
     pub scope_kind: ScopeKind,
@@ -488,12 +496,14 @@ mod tests {
             &[
                 PackageScopeObservation {
                     identity: Some("app".to_string()),
+                    name_source: None,
                     definition_path: root.join_components(&["apps", "app", "package.json"]),
                     toolchain: ToolchainId::JAVASCRIPT,
                     scope_kind: ScopeKind::Package,
                 },
                 PackageScopeObservation {
                     identity: Some("lib".to_string()),
+                    name_source: None,
                     definition_path: root.join_components(&["packages", "lib", "package.json"]),
                     toolchain: ToolchainId::JAVASCRIPT,
                     scope_kind: ScopeKind::Package,
@@ -538,6 +548,7 @@ mod tests {
             None,
             &[PackageScopeObservation {
                 identity: Some("//".to_string()),
+                name_source: None,
                 definition_path: root.join_components(&["native", "manifest"]),
                 toolchain: ToolchainId::new("native"),
                 scope_kind: ScopeKind::Aggregate,
@@ -549,6 +560,37 @@ mod tests {
         );
 
         assert!(matches!(result, Err(Error::ReservedRootIdentity { .. })));
+    }
+
+    #[test]
+    fn repository_knowledge_preserves_package_name_provenance() {
+        let root =
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+        let source = Spanned::new(())
+            .with_range(9..14)
+            .with_text(r#"{"name": "app"}"#)
+            .with_path("apps/app/package.json".into());
+        let repository = RepositoryKnowledge::build(
+            &root,
+            None,
+            &[PackageScopeObservation {
+                identity: Some("app".to_string()),
+                name_source: Some(source.clone()),
+                definition_path: root.join_components(&["apps", "app", "package.json"]),
+                toolchain: ToolchainId::JAVASCRIPT,
+                scope_kind: ScopeKind::Package,
+            }],
+            &[WorkspaceRootObservation::new(
+                WorkspaceRoot::new("npm", root.clone()),
+                ToolchainId::JAVASCRIPT,
+            )],
+        )
+        .unwrap();
+
+        assert_eq!(
+            repository.scope("app").unwrap().name_source(),
+            Some(&source)
+        );
     }
 
     #[test]

--- a/crates/turborepo-repository/src/manifest_parser.rs
+++ b/crates/turborepo-repository/src/manifest_parser.rs
@@ -63,6 +63,10 @@ impl Manifest {
     fn finish(mut self, contents: &str, path: &str) -> PackageJson {
         let text: Arc<str> = contents.into();
         let path: Arc<str> = path.into();
+        if let Some(name) = self.package_json.name.as_mut() {
+            name.add_text(text.clone());
+            name.add_path(path.clone());
+        }
         if let Some(package_manager) = self.package_json.package_manager.as_mut() {
             package_manager.add_text(text.clone());
             package_manager.add_path(path.clone());
@@ -639,6 +643,11 @@ mod test {
         let pkg = parse_ok(contents);
         for (label, text, path) in [
             (
+                "name",
+                pkg.name.as_ref().unwrap().text.as_deref(),
+                pkg.name.as_ref().unwrap().path.as_deref(),
+            ),
+            (
                 "packageManager",
                 pkg.package_manager.as_ref().unwrap().text.as_deref(),
                 pkg.package_manager.as_ref().unwrap().path.as_deref(),
@@ -657,6 +666,7 @@ mod test {
             assert_eq!(text, Some(contents), "{label} text");
             assert_eq!(path, Some("pkg/package.json"), "{label} path");
         }
+        assert_eq!(pkg.name.as_ref().unwrap().range, Some(9..12));
     }
 
     #[test]

--- a/crates/turborepo-repository/src/native_tasks.rs
+++ b/crates/turborepo-repository/src/native_tasks.rs
@@ -412,6 +412,7 @@ mod tests {
             Some(Some("root".to_string())),
             &[PackageScopeObservation {
                 identity: Some("web".to_string()),
+                name_source: None,
                 definition_path: root.join_components(&["apps", "web", "package.json"]),
                 toolchain: ToolchainId::JAVASCRIPT,
                 scope_kind: ScopeKind::Package,

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -686,6 +686,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
     ) -> Result<ObservedPackage, Error> {
         let DiscoveredPackageParts {
             name,
+            name_source,
             scope_kind,
             descriptor: json,
             manifest_path,
@@ -710,6 +711,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
         let entry = PackageInfo { package_json: json };
         let observation = PackageScopeObservation {
             identity: name.clone(),
+            name_source,
             definition_path: manifest_path.clone(),
             toolchain,
             scope_kind: match scope_kind {
@@ -1743,7 +1745,12 @@ mod test {
                 (
                     root.join_components(&["apps", "app", "package.json"]),
                     PackageJson {
-                        name: Some(Spanned::new("app".into())),
+                        name: Some(
+                            Spanned::new("app".to_string())
+                                .with_range(9..14)
+                                .with_text(r#"{"name": "app"}"#)
+                                .with_path("apps/app/package.json".into()),
+                        ),
                         ..Default::default()
                     },
                 ),
@@ -1844,6 +1851,15 @@ mod test {
                 Some("apps/app/package.json".to_string())
             );
             assert_eq!(app_view.toolchain(), Some(&ToolchainId::JAVASCRIPT));
+            let app_name_source = app_view
+                .name_source()
+                .expect("the authored JavaScript name retains diagnostic provenance");
+            assert_eq!(app_name_source.range, Some(9..14));
+            assert_eq!(app_name_source.text.as_deref(), Some(r#"{"name": "app"}"#));
+            assert_eq!(
+                app_name_source.path.as_deref(),
+                Some("apps/app/package.json")
+            );
             assert_eq!(graph.node_views().count(), 4);
 
             let mut packages = graph

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -200,7 +200,7 @@ pub enum PackageGraphNodeKind {
     GraphSentinel,
 }
 
-/// Manifest-independent facts about a package graph node.
+/// Compatibility-payload-independent facts about a package graph node.
 ///
 /// Paths and provenance come from the graph's immutable repository knowledge,
 /// not from the [`PackageInfo`] compatibility projection. The graph sentinel
@@ -208,6 +208,7 @@ pub enum PackageGraphNodeKind {
 #[derive(Debug, Clone, Copy)]
 pub struct PackageGraphNodeView<'a> {
     kind: PackageGraphNodeKind,
+    name_source: Option<&'a turborepo_errors::Spanned<()>>,
     directory: Option<&'a AnchoredSystemPath>,
     definition_path: Option<&'a AnchoredSystemPath>,
     toolchain: Option<&'a crate::toolchain::ToolchainId>,
@@ -352,6 +353,10 @@ impl<'a> PackageTaskContext<'a> {
 impl<'a> PackageGraphNodeView<'a> {
     pub fn kind(&self) -> PackageGraphNodeKind {
         self.kind
+    }
+
+    pub fn name_source(&self) -> Option<&'a turborepo_errors::Spanned<()>> {
+        self.name_source
     }
 
     pub fn directory(&self) -> Option<&'a AnchoredSystemPath> {
@@ -734,6 +739,7 @@ impl PackageGraph {
         match node {
             PackageNode::Root => Some(PackageGraphNodeView {
                 kind: PackageGraphNodeKind::GraphSentinel,
+                name_source: None,
                 directory: None,
                 definition_path: None,
                 toolchain: None,
@@ -751,6 +757,7 @@ impl PackageGraph {
                 let scope = self.knowledge.root_javascript_scope()?;
                 Some(PackageGraphNodeView {
                     kind: PackageGraphNodeKind::RootJavaScript,
+                    name_source: None,
                     directory: Some(self.knowledge.repository_directory()),
                     definition_path: Some(scope.definition_path()),
                     toolchain: Some(scope.toolchain()),
@@ -764,6 +771,7 @@ impl PackageGraph {
                 };
                 Some(PackageGraphNodeView {
                     kind,
+                    name_source: scope.name_source(),
                     directory: Some(scope.directory()),
                     definition_path: Some(scope.definition_path()),
                     toolchain: Some(scope.toolchain()),
@@ -877,6 +885,7 @@ impl PackageGraph {
                         crate::knowledge::ScopeKind::Package => PackageGraphNodeKind::Package,
                         crate::knowledge::ScopeKind::Aggregate => PackageGraphNodeKind::Aggregate,
                     },
+                    name_source: scope.name_source(),
                     directory: Some(scope.directory()),
                     definition_path: Some(scope.definition_path()),
                     toolchain: Some(scope.toolchain()),

--- a/crates/turborepo-repository/src/package_graph/projections.rs
+++ b/crates/turborepo-repository/src/package_graph/projections.rs
@@ -526,6 +526,7 @@ mod tests {
             .iter()
             .map(|identity| PackageScopeObservation {
                 identity: Some((*identity).to_string()),
+                name_source: None,
                 definition_path: root.join_components(&[identity, "package.json"]),
                 toolchain: toolchain.clone(),
                 scope_kind: ScopeKind::Package,

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -111,6 +111,9 @@ pub struct DiscoveredPackage {
     /// Real user-facing identity, extracted by the native producer. `None`
     /// preserves JavaScript's historical unnamed-package suppression.
     name: Option<String>,
+    /// Source provenance for the authored package name when it agrees with the
+    /// authoritative identity.
+    name_source: Option<Spanned<()>>,
     /// Whether this is a real package or an execution-only aggregate scope.
     scope_kind: DiscoveredScopeKind,
     /// Temporary relationship/task compatibility data; never identity or path
@@ -150,6 +153,7 @@ pub(crate) enum DiscoveredScopeKind {
 
 pub(crate) struct DiscoveredPackageParts {
     pub name: Option<String>,
+    pub name_source: Option<Spanned<()>>,
     pub scope_kind: DiscoveredScopeKind,
     pub descriptor: PackageJson,
     pub manifest_path: AbsoluteSystemPathBuf,
@@ -239,9 +243,15 @@ impl DiscoveredPackage {
         manifest_path: AbsoluteSystemPathBuf,
         external_dependencies: Option<std::collections::HashSet<turborepo_lockfiles::Package>>,
     ) -> Self {
+        let name_source = descriptor
+            .name
+            .as_ref()
+            .filter(|source| name.as_deref() == Some(source.as_str()))
+            .map(|source| source.to(()));
         descriptor.name = name.clone().map(Spanned::new);
         Self {
             name,
+            name_source,
             scope_kind: DiscoveredScopeKind::Package,
             descriptor,
             manifest_path,
@@ -262,6 +272,7 @@ impl DiscoveredPackage {
         descriptor.name = Some(Spanned::new(name.clone()));
         Self {
             name: Some(name),
+            name_source: None,
             scope_kind: DiscoveredScopeKind::Aggregate,
             descriptor,
             manifest_path,
@@ -288,6 +299,7 @@ impl DiscoveredPackage {
     pub(crate) fn into_parts(self) -> DiscoveredPackageParts {
         let Self {
             name,
+            name_source,
             scope_kind,
             descriptor,
             manifest_path,
@@ -297,6 +309,7 @@ impl DiscoveredPackage {
         } = self;
         DiscoveredPackageParts {
             name,
+            name_source,
             scope_kind,
             descriptor,
             manifest_path,
@@ -986,7 +999,12 @@ mod tests {
         })
         .unwrap();
         let mismatched = PackageJson {
-            name: Some(Spanned::new("payload-name".to_string())),
+            name: Some(
+                Spanned::new("payload-name".to_string())
+                    .with_range(9..23)
+                    .with_text(r#"{"name": "payload-name"}"#)
+                    .with_path("package.json".into()),
+            ),
             ..Default::default()
         };
 
@@ -998,6 +1016,7 @@ mod tests {
         )
         .into_parts();
         assert_eq!(package.name.as_deref(), Some("authoritative-name"));
+        assert_eq!(package.name_source, None);
         assert_eq!(
             package.descriptor.name.as_ref().map(|name| name.as_str()),
             Some("authoritative-name")
@@ -1005,7 +1024,24 @@ mod tests {
 
         let unnamed = DiscoveredPackage::package(None, mismatched, path.clone(), None).into_parts();
         assert_eq!(unnamed.name, None);
+        assert_eq!(unnamed.name_source, None);
         assert_eq!(unnamed.descriptor.name, None);
+
+        let authored_name = Spanned::new("authoritative-name".to_string())
+            .with_range(9..29)
+            .with_text(r#"{"name": "authoritative-name"}"#)
+            .with_path("package.json".into());
+        let matching = DiscoveredPackage::package(
+            Some("authoritative-name".to_string()),
+            PackageJson {
+                name: Some(authored_name.clone()),
+                ..Default::default()
+            },
+            path.clone(),
+            None,
+        )
+        .into_parts();
+        assert_eq!(matching.name_source, Some(authored_name.to(())));
 
         let aggregate = DiscoveredPackage::aggregate(
             "workspace".to_string(),
@@ -1015,6 +1051,7 @@ mod tests {
         )
         .into_parts();
         assert_eq!(aggregate.name.as_deref(), Some("workspace"));
+        assert_eq!(aggregate.name_source, None);
         assert_eq!(aggregate.scope_kind, DiscoveredScopeKind::Aggregate);
         assert_eq!(
             aggregate.descriptor.name.as_ref().map(|name| name.as_str()),

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -209,9 +209,10 @@ Compatibility payloads still provide JavaScript relationship-classification
 inputs, lockfile resolution and hash state, and task construction data. Cargo
 no longer synthesizes JavaScript dependency maps, but retains empty
 `PackageJson` descriptors until task compatibility payloads are removed.
-Native manifests and metadata do not enter repository knowledge. Native
-definition paths must remain within the repository, including after resolving
-existing symlinks.
+Native manifest objects do not enter repository knowledge. Repository knowledge
+may retain bounded diagnostic provenance for an authoritative fact, such as an
+authored JavaScript package name's source text and span. Native definition paths
+must remain within the repository, including after resolving existing symlinks.
 
 The remaining payload deletion phases are explicit:
 
@@ -223,7 +224,7 @@ The remaining payload deletion phases are explicit:
 - **Phase 5 (in progress):** Task-contract knowledge catalog is produced for JavaScript scopes; engine composition and global `engines` hashing consume it; JS packages are excluded from Toolchain task-I/O environment dispatch. Remaining: fuller hash/framework contract production and final Phase 5 gate. Later: Delete `PackageInfo`, its payload map, and optional-payload compatibility plumbing once all fail-closed consumers use those queries.
 - **Phase 6 (complete for JS change knowledge first wave):** Change knowledge is produced at repository construction; watcher classification and scope lockfile probes consume it via `active_watch_spec` / `resolution_paths` rather than ad-hoc package-manager probes.
 - **Phase 7 (complete):** JavaScript prune rendering is a distinct pure step (`render_javascript_prune`) producing typed artifacts; `commands/prune.rs` selects closures, performs path-safe layout, and materializes those artifacts without inline lockfile/manifest/patch format interpretation. Golden inventories cover standard and Docker layouts.
-- **Phase 8 (audit complete for owned consumers):** Query/devtools/summary/run/engine/watch/prune task and resolution views consume knowledge catalogs. Remaining `PackageJson` / `PackageInfo` reads are construction entry points, LSP unsaved-buffer adapters, manifest-backed boundary tags, and package-manager detection — tracked for deletion under TURBO-5787 (`PackageInfo` / `JavaScriptToolchain` removal), not deferred silently.
+- **Phase 8 (audit complete for owned consumers):** Query/devtools/summary/run/engine/watch/prune task and resolution views consume knowledge catalogs. Remaining `PackageJson` / `PackageInfo` reads are construction entry points, LSP unsaved-buffer adapters, and package-manager detection — tracked for deletion under TURBO-5787 (`PackageInfo` / `JavaScriptToolchain` removal), not deferred silently. Boundary tag diagnostics consume optional authored-name provenance from repository knowledge only when the authored name matches the authoritative identity.
 
 Task hashing, run-cache path construction, and run-summary task directories use
 a graph-created `PackageTaskContext` that binds identity, repository root,


### PR DESCRIPTION
## Intent

Remove boundaries' final dependency on compatibility `PackageInfo` while preserving package-name diagnostic provenance.

**Base:** `main`.

## Changes

- Preserve authored JavaScript package-name source text, path, and span in immutable repository knowledge.
- Expose optional name provenance through package graph node views and boundary package scopes.
- Generate package-name tag diagnostics without reading compatibility manifests.
- Remove the boundaries compatibility-payload fail-closed gate.
- Update architecture documentation and add provenance regression coverage.

## Testing

- `cargo test -p turborepo-boundaries` (65 passed)
- `cargo test -p turborepo-repository --lib` (379 passed)
- `cargo clippy -p turborepo-repository -p turborepo-boundaries --all-targets -- -D warnings`
- `cargo fmt --check`

Closes TURBO-5843.