### PR TITLE
refactor: Complete Cargo relationship and resolution knowledge

### DIFF
--- a/crates/turborepo-engine/src/builder/definitions.rs
+++ b/crates/turborepo-engine/src/builder/definitions.rs
@@ -412,16 +412,14 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
             // `dependencies` walks the package's full transitive closure,
             // which is far too expensive to compute per task just to hand
             // to a toolchain that derives nothing (JavaScript).
+            let package = PackageName::from(task_id.as_inner().package());
             let dependencies: Vec<_> = self
                 .package_graph
-                .dependencies(&PackageNode::Workspace(PackageName::from(
-                    task_id.as_inner().package(),
-                )))
-                .into_iter()
-                .filter_map(|dep| match dep {
-                    PackageNode::Workspace(name) => self.package_graph.package_task_context(name),
-                    _ => None,
-                })
+                .hash_relationships()
+                .dependency_inputs(&package)
+                .unwrap_or_default()
+                .iter()
+                .filter_map(|dependency| self.package_graph.package_task_context(dependency))
                 .collect();
             let task_args = TaskArgs::new(&self.pass_through_args, &self.requested_tasks);
             let empty_environment = turborepo_repository::toolchain::TaskIOEnvironment::default();

--- a/crates/turborepo-engine/src/builder/test.rs
+++ b/crates/turborepo-engine/src/builder/test.rs
@@ -136,7 +136,6 @@ impl Toolchain for AggregateToolchain {
                     "cargo-workspace".to_owned(),
                     PackageJson::default(),
                     self.repo_root.join_component("Cargo.toml"),
-                    Some(HashSet::new()),
                 )],
                 vec![WorkspaceRoot::new("aggregate-test", self.repo_root.clone())],
             ))
@@ -199,7 +198,6 @@ impl Toolchain for StubIOToolchain {
                     },
                     self.repo_root
                         .join_components(&["packages", name, "stub.json"]),
-                    Some(HashSet::new()),
                 )
             };
             Ok(DiscoveredPackages::new(

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -364,10 +364,6 @@ pub struct CargoPackageDetails {
     /// The crate's directory, repo-root-relative in unix form (empty for
     /// the workspace aggregate).
     pub dir: String,
-    /// A conservative transitive closure of declared local dependencies. This
-    /// is separate from the package graph because Cargo permits dev-dependency
-    /// cycles while Turborepo's package graph must remain acyclic.
-    pub compilation_dependencies: Vec<String>,
 }
 
 const VERIFICATION_SUBCOMMANDS: &[(&str, &str)] = &[
@@ -1193,26 +1189,6 @@ impl Toolchain for CargoToolchain {
         self.owns_context(package) && package.native_tasks().defines(task)
     }
 
-    fn additional_affected_packages(&self, package: &str) -> Vec<String> {
-        let details = self
-            .details
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let mut affected: Vec<_> = details
-            .iter()
-            .filter(|(_, details)| details.kind != CargoPackageKind::Workspace)
-            .filter(|(_, details)| {
-                details
-                    .compilation_dependencies
-                    .iter()
-                    .any(|dependency| dependency == package)
-            })
-            .map(|(name, _)| name.clone())
-            .collect();
-        affected.sort();
-        affected
-    }
-
     fn select_task_entrypoints(
         &self,
         task: &str,
@@ -1433,7 +1409,7 @@ impl Toolchain for CargoToolchain {
         }
 
         // Source globs for the crates whose code this task compiles,
-        // filtered to real crates (the synthetic workspace package has no
+        // filtered to real crates (the workspace aggregate has no
         // sources of its own).
         let dependency_globs = || {
             let mut globs: Vec<String> = dependencies
@@ -1447,11 +1423,6 @@ impl Toolchain for CargoToolchain {
                     crate_source_globs(path_to_root, dep.directory().to_unix().as_str())
                 })
                 .collect();
-            for dependency in &details.compilation_dependencies {
-                if let Some(dependency) = self.package_details(dependency) {
-                    globs.extend(crate_source_globs(path_to_root, &dependency.dir));
-                }
-            }
             globs.sort();
             globs.dedup();
             globs
@@ -1607,13 +1578,7 @@ impl Toolchain for CargoToolchain {
             let mut resolutions = Vec::with_capacity(crates.len() + 1);
             let mut crate_names = Vec::with_capacity(crates.len());
             for cargo_crate in crates {
-                let relationships = cargo_crate
-                    .internal_dependencies
-                    .iter()
-                    .map(|dependency| {
-                        Relationship::internal(dependency, DependencyKind::Production)
-                    })
-                    .collect();
+                let relationships = cargo_crate.relationships.clone();
                 let kind = if cargo_crate.is_entrypoint() {
                     CargoPackageKind::Entrypoint
                 } else {
@@ -1632,7 +1597,6 @@ impl Toolchain for CargoToolchain {
                     deliverables: cargo_crate.deliverables,
                     manifest_alters_output_layout: cargo_crate.manifest_alters_output_layout,
                     dir,
-                    compilation_dependencies: cargo_crate.compilation_dependencies,
                 };
                 let native_tasks = native_tasks_for_package(&details, &cargo_crate.name);
                 self.record_details(cargo_crate.name.clone(), details);
@@ -1659,7 +1623,7 @@ impl Toolchain for CargoToolchain {
                 );
             }
 
-            // The synthetic workspace package, anchored at the root
+            // The workspace aggregate, anchored at the root
             // Cargo.toml and named by the user via `[workspace.metadata]
             // name`. It depends on every crate so `--affected` and
             // dependent-filters propagate crate changes to it.
@@ -1669,7 +1633,6 @@ impl Toolchain for CargoToolchain {
                     deliverables: Vec::new(),
                     manifest_alters_output_layout: false,
                     dir: String::new(),
-                    compilation_dependencies: Vec::new(),
                 };
                 let workspace_native_tasks =
                     native_tasks_for_package(&workspace_details, &workspace_name);
@@ -1777,14 +1740,10 @@ pub struct CargoCrate {
     pub name: String,
     /// Absolute path to the crate's `Cargo.toml`.
     pub manifest_path: AbsoluteSystemPathBuf,
-    /// Names of other workspace crates this crate depends on, resolved by
-    /// Cargo itself (`cargo metadata`). Dev-dependency edges that would form
-    /// a cycle are dropped, since Cargo permits dev-dep cycles but the
-    /// package graph must remain a DAG.
-    pub internal_dependencies: Vec<String>,
-    /// A conservative transitive closure of declared local dependencies,
-    /// including dev-dependency edges omitted from `internal_dependencies`.
-    pub compilation_dependencies: Vec<String>,
+    /// Direct relationships to other workspace crates, resolved by Cargo.
+    /// Development edges that would make task ordering cyclic remain as
+    /// hash/affectedness inputs without participating in ordering.
+    pub relationships: Vec<Relationship>,
     /// The crate's deliverable targets. Non-empty exactly when the crate is
     /// an entrypoint (has `bin`/`cdylib`/`staticlib` targets).
     pub deliverables: Vec<Deliverable>,
@@ -2105,7 +2064,7 @@ struct ParsedCrate {
 /// A path dependency resolved to the directory Cargo reports for it.
 struct ResolvedDep {
     dir: AbsoluteSystemPathBuf,
-    dev: bool,
+    kind: DependencyKind,
 }
 
 /// Normalize a path reported by `cargo metadata` into an
@@ -2217,7 +2176,13 @@ fn parse_members(
                 let dir = metadata_path(&path)?;
                 Some(ResolvedDep {
                     dir,
-                    dev: dep.kind.as_deref() == Some("dev"),
+                    kind: if dep.kind.as_deref() == Some("dev") {
+                        DependencyKind::Development
+                    } else if dep.optional {
+                        DependencyKind::Optional
+                    } else {
+                        DependencyKind::Production
+                    },
                 })
             })
             .collect();
@@ -2234,9 +2199,10 @@ fn parse_members(
     parsed
 }
 
-/// Resolve dependency edges to crate names by manifest directory and drop
-/// dev-dependency edges that would form a cycle (Cargo permits dev-dep
-/// cycles; the package graph is a DAG).
+/// Resolve dependency edges to crate names by manifest directory. Development
+/// edges that would form a cycle remain compilation inputs but do not order
+/// tasks, since Cargo permits dev-dependency cycles while the task graph is a
+/// DAG.
 fn connect_crates(parsed: Vec<ParsedCrate>) -> Vec<CargoCrate> {
     let dir_to_name: HashMap<&AbsoluteSystemPath, &str> = parsed
         .iter()
@@ -2244,12 +2210,12 @@ fn connect_crates(parsed: Vec<ParsedCrate>) -> Vec<CargoCrate> {
         .collect();
 
     let mut adjacency: HashMap<&str, BTreeSet<&str>> = HashMap::new();
-    let mut compilation_adjacency: HashMap<&str, BTreeSet<&str>> = HashMap::new();
-    let mut dev_edges: Vec<(&str, &str)> = Vec::new();
+    let mut relationships: HashMap<String, Vec<Relationship>> = HashMap::new();
+    let mut dev_edges: Vec<(&str, &str, DependencyKind)> = Vec::new();
     for parsed_crate in &parsed {
         let from = parsed_crate.name.as_str();
         adjacency.entry(from).or_default();
-        compilation_adjacency.entry(from).or_default();
+        relationships.entry(from.to_string()).or_default();
         for dep in &parsed_crate.dependencies {
             let Some(&to) = dir_to_name.get(&*dep.dir) else {
                 // Path dependency on a non-member (e.g. outside the repo).
@@ -2258,80 +2224,58 @@ fn connect_crates(parsed: Vec<ParsedCrate>) -> Vec<CargoCrate> {
             if to == from {
                 continue;
             }
-            compilation_adjacency.entry(from).or_default().insert(to);
-            if dep.dev {
-                dev_edges.push((from, to));
+            if dep.kind == DependencyKind::Development {
+                dev_edges.push((from, to, dep.kind));
             } else {
                 adjacency.entry(from).or_default().insert(to);
+                relationships
+                    .entry(from.to_string())
+                    .or_default()
+                    .push(Relationship::internal(to, dep.kind));
             }
         }
     }
     // Deterministic order so the same dev edge always wins when a cycle must
     // be broken.
-    dev_edges.sort_unstable();
+    dev_edges.sort_unstable_by(|left, right| (left.0, left.1).cmp(&(right.0, right.1)));
     dev_edges.dedup();
-    for (from, to) in dev_edges {
+    for (from, to, kind) in dev_edges {
         if reaches(&adjacency, to, from) {
             tracing::debug!(
                 "dropping dev-dependency edge {from} -> {to}: it would create a cycle in the \
                  package graph"
             );
+            relationships
+                .entry(from.to_string())
+                .or_default()
+                .push(Relationship::internal_input(to, kind));
         } else {
             adjacency.entry(from).or_default().insert(to);
+            relationships
+                .entry(from.to_string())
+                .or_default()
+                .push(Relationship::internal(to, kind));
         }
     }
-
-    let mut edges: HashMap<String, Vec<String>> = adjacency
-        .into_iter()
-        .map(|(name, deps)| {
-            (
-                name.to_string(),
-                deps.into_iter().map(String::from).collect(),
-            )
-        })
-        .collect();
-    let mut compilation_dependencies: HashMap<String, Vec<String>> = parsed
-        .iter()
-        .map(|parsed_crate| {
-            (
-                parsed_crate.name.clone(),
-                transitive_dependencies(&compilation_adjacency, &parsed_crate.name),
-            )
-        })
-        .collect();
 
     parsed
         .into_iter()
-        .map(|parsed_crate| CargoCrate {
-            internal_dependencies: edges.remove(parsed_crate.name.as_str()).unwrap_or_default(),
-            compilation_dependencies: compilation_dependencies
+        .map(|parsed_crate| {
+            let mut crate_relationships = relationships
                 .remove(parsed_crate.name.as_str())
-                .unwrap_or_default(),
-            name: parsed_crate.name,
-            manifest_path: parsed_crate.manifest_path,
-            deliverables: parsed_crate.deliverables,
-            manifest_alters_output_layout: parsed_crate.manifest_alters_output_layout,
+                .unwrap_or_default();
+            crate_relationships
+                .sort_by(|left, right| left.declaration_name().cmp(right.declaration_name()));
+            crate_relationships.dedup();
+            CargoCrate {
+                relationships: crate_relationships,
+                name: parsed_crate.name,
+                manifest_path: parsed_crate.manifest_path,
+                deliverables: parsed_crate.deliverables,
+                manifest_alters_output_layout: parsed_crate.manifest_alters_output_layout,
+            }
         })
         .collect()
-}
-
-fn transitive_dependencies(adjacency: &HashMap<&str, BTreeSet<&str>>, start: &str) -> Vec<String> {
-    let mut stack = vec![start];
-    let mut visited = HashSet::from([start]);
-    let mut dependencies = BTreeSet::new();
-    while let Some(node) = stack.pop() {
-        if let Some(next) = adjacency.get(node) {
-            for &dependency in next {
-                if visited.insert(dependency) {
-                    stack.push(dependency);
-                }
-                if dependency != start {
-                    dependencies.insert(dependency);
-                }
-            }
-        }
-    }
-    dependencies.into_iter().map(String::from).collect()
 }
 
 /// Whether `target` is reachable from `start` in the current adjacency map.
@@ -2386,6 +2330,8 @@ struct MetadataDependency {
     path: Option<String>,
     /// `null` for normal deps, `"dev"` or `"build"` otherwise.
     kind: Option<String>,
+    #[serde(default)]
+    optional: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -2425,7 +2371,6 @@ mod test {
             deliverables,
             manifest_alters_output_layout: false,
             dir: "crate".to_string(),
-            compilation_dependencies: Vec::new(),
         };
         let deliverable = |name: &str, kind| Deliverable {
             name: name.to_string(),
@@ -2743,7 +2688,6 @@ dependencies = ["lib-a"]
             }],
             manifest_alters_output_layout: false,
             dir: "crates/app".to_string(),
-            compilation_dependencies: Vec::new(),
         }
     }
 
@@ -3326,7 +3270,10 @@ release: 1.96.0-nightly\n",
                 kind: DeliverableKind::Bin,
             }]
         );
-        assert_eq!(app.internal_dependencies, vec!["lib-a".to_string()]);
+        assert_eq!(
+            app.relationships,
+            vec![Relationship::internal("lib-a", DependencyKind::Production)]
+        );
 
         let lib_a = &crates[1];
         assert!(
@@ -3335,23 +3282,64 @@ release: 1.96.0-nightly\n",
         );
         assert!(lib_a.deliverables.is_empty());
         // The dev-dep edge lib-a -> lib-a-test-util closes a cycle with the
-        // normal edge lib-a-test-util -> lib-a, so it must be dropped.
-        assert!(
-            lib_a.internal_dependencies.is_empty(),
-            "cycle-closing dev edge should be dropped, got {:?}",
-            lib_a.internal_dependencies
-        );
+        // normal edge lib-a-test-util -> lib-a, so it remains an input without
+        // ordering tasks.
         assert_eq!(
-            lib_a.compilation_dependencies,
-            vec!["lib-a-test-util".to_string()],
-            "verification hashing must retain the dropped dev edge"
+            lib_a.relationships,
+            vec![Relationship::internal_input(
+                "lib-a-test-util",
+                DependencyKind::Development
+            )]
         );
 
         let test_util = &crates[2];
-        assert_eq!(test_util.internal_dependencies, vec!["lib-a".to_string()]);
         assert_eq!(
-            test_util.compilation_dependencies,
-            vec!["lib-a".to_string()]
+            test_util.relationships,
+            vec![Relationship::internal("lib-a", DependencyKind::Production)]
+        );
+    }
+
+    #[test]
+    fn test_discover_crates_preserves_relationship_kinds() {
+        let (_tmp, root) = tempdir_root();
+        write(
+            &root,
+            &["Cargo.toml"],
+            "[workspace]\nmembers = [\"crates/*\"]\nresolver = \"2\"\n",
+        );
+        write(
+            &root,
+            &["crates", "app", "Cargo.toml"],
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\nedition = \
+             \"2021\"\n\n[dependencies]\noptional-lib = { path = \"../optional-lib\", optional = \
+             true }\n\n[build-dependencies]\nbuild-lib = { path = \"../build-lib\" \
+             }\n\n[target.'cfg(target_os = \"none\")'.dependencies]\ntarget-lib = { path = \
+             \"../target-lib\" }\n",
+        );
+        write(&root, &["crates", "app", "src", "lib.rs"], "");
+        for name in ["optional-lib", "build-lib", "target-lib"] {
+            write(
+                &root,
+                &["crates", name, "Cargo.toml"],
+                &format!("[package]\nname = \"{name}\"\nversion = \"0.1.0\"\nedition = \"2021\"\n"),
+            );
+            write(&root, &["crates", name, "src", "lib.rs"], "");
+        }
+
+        let workspace = discover_crates(&root).unwrap();
+        let app = workspace
+            .crates
+            .iter()
+            .find(|cargo_crate| cargo_crate.name == "app")
+            .unwrap();
+
+        assert_eq!(
+            app.relationships,
+            vec![
+                Relationship::internal("build-lib", DependencyKind::Production),
+                Relationship::internal("optional-lib", DependencyKind::Optional),
+                Relationship::internal("target-lib", DependencyKind::Production),
+            ]
         );
     }
 
@@ -3500,7 +3488,10 @@ release: 1.96.0-nightly\n",
             crates.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
             vec!["app", "helper"]
         );
-        assert_eq!(crates[0].internal_dependencies, vec!["helper".to_string()]);
+        assert_eq!(
+            crates[0].relationships,
+            vec![Relationship::internal("helper", DependencyKind::Production)]
+        );
     }
 
     #[test]
@@ -4024,9 +4015,17 @@ release: 1.96.0-nightly\n",
 
         let app = package_info("app");
         let lib_a = package_info("lib-a");
+        let test_util = package_info("lib-a-test-util");
         let workspace = package_info("fixture-ws");
         let app_ctx = task_context(&toolchain, &root, "app", "crates/app", Some(&app));
         let lib_ctx = task_context(&toolchain, &root, "lib-a", "crates/lib-a", Some(&lib_a));
+        let test_util_ctx = task_context(
+            &toolchain,
+            &root,
+            "lib-a-test-util",
+            "crates/lib-a-test-util",
+            Some(&test_util),
+        );
         let workspace_ctx = task_context(&toolchain, &root, "fixture-ws", "", Some(&workspace));
         let environment = toolchain::TaskIOEnvironment::default();
         let context = toolchain::TaskIOContext {
@@ -4141,8 +4140,9 @@ release: 1.96.0-nightly\n",
 
         // Library verification hashes dev dependencies even when their cycle
         // prevents them from appearing in the package graph.
+        let cycle_inputs = [test_util_ctx];
         let io = toolchain
-            .derived_task_io(&lib_ctx, "test", "../..", &[], true, &context)
+            .derived_task_io(&lib_ctx, "test", "../..", &cycle_inputs, true, &context)
             .expect("library test derives IO");
         assert_eq!(io.package_default_inputs, Some(true));
         assert!(
@@ -4156,7 +4156,7 @@ release: 1.96.0-nightly\n",
         // Library build artifacts are Cargo-internal and cannot be restored as
         // stable Turborepo outputs, so implicit caching fails closed.
         let io = toolchain
-            .derived_task_io(&lib_ctx, "build", "../..", &[], true, &context)
+            .derived_task_io(&lib_ctx, "build", "../..", &cycle_inputs, true, &context)
             .expect("library build derives IO");
         assert_eq!(io.package_default_inputs, Some(true));
         assert_eq!(io.outputs, toolchain::DerivedOutputs::Unavailable);

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -1616,7 +1616,6 @@ impl Toolchain for CargoToolchain {
                         Some(cargo_crate.name.clone()),
                         PackageJson::default(),
                         cargo_crate.manifest_path,
-                        Some(external_dependencies),
                     )
                     .with_native_relationships(relationships)
                     .with_native_tasks(native_tasks),
@@ -1651,9 +1650,6 @@ impl Toolchain for CargoToolchain {
                         workspace_name,
                         PackageJson::default(),
                         self.repo_root.join_component(CARGO_TOML),
-                        // Workspace-scoped verbs run every crate, so the union
-                        // of all closures is this package's external surface.
-                        Some(workspace_externals),
                     )
                     .with_native_relationships(relationships)
                     .with_native_tasks(workspace_native_tasks),
@@ -3626,6 +3622,12 @@ release: 1.96.0-nightly\n",
                 .iter()
                 .any(|identity| identity.key() == "rustc")
         }));
+        assert!(
+            resolution_packages
+                .iter()
+                .all(|package| package.identities().len() == 1),
+            "the all-local fixture should expose only compiler identities"
+        );
         let mut packages: Vec<_> = packages
             .into_iter()
             .map(DiscoveredPackage::into_parts)
@@ -3637,23 +3639,6 @@ release: 1.96.0-nightly\n",
             .map(|package| package.name.as_deref().unwrap())
             .collect();
         assert_eq!(names, vec!["app", "fixture-ws", "lib-a", "lib-a-test-util"]);
-
-        for package in &packages {
-            let rustc = package
-                .external_dependencies
-                .as_ref()
-                .and_then(|dependencies| {
-                    dependencies
-                        .iter()
-                        .find(|dependency| dependency.key == "rustc")
-                })
-                .expect("compiler identity stamps every Cargo package");
-            let mut lines = rustc.version.lines();
-            assert!(lines.next().is_some_and(|line| line.starts_with("rustc ")));
-            assert!(
-                lines.any(|line| { line.starts_with("host: ") && line.len() > "host: ".len() })
-            );
-        }
 
         let app = &packages[0];
         assert!(app.descriptor.dependencies.is_none());
@@ -3667,7 +3652,7 @@ release: 1.96.0-nightly\n",
             root.join_components(&["crates", "app", "Cargo.toml"])
         );
 
-        // The synthetic workspace package is anchored at the root manifest
+        // The workspace aggregate is anchored at the root manifest
         // and depends on every crate.
         let workspace = &packages[1];
         assert_eq!(workspace.manifest_path, root.join_component(CARGO_TOML));
@@ -3682,15 +3667,6 @@ release: 1.96.0-nightly\n",
                 Relationship::internal("lib-a-test-util", DependencyKind::Production),
             ]
         );
-
-        // This all-local fixture has no external lockfile dependencies; the
-        // compiler identity is the only external identity.
-        let app_externals = app.external_dependencies.as_ref().unwrap();
-        assert_eq!(app_externals.len(), 1);
-        let lib_a_externals = packages[2].external_dependencies.as_ref().unwrap();
-        assert_eq!(lib_a_externals.len(), 1);
-        let workspace_externals = workspace.external_dependencies.as_ref().unwrap();
-        assert_eq!(workspace_externals.len(), 1);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/turborepo-repository/src/change_mapper/mod.rs
+++ b/crates/turborepo-repository/src/change_mapper/mod.rs
@@ -190,6 +190,8 @@ impl<'a, PD: PackageChangeMapper> ChangeMapper<'a, PD> {
                             }),
                         );
 
+                        self.add_relationship_affected_packages(&mut changed_pkgs);
+
                         Ok(PackageChanges::Some(changed_pkgs))
                     }
 
@@ -208,6 +210,7 @@ impl<'a, PD: PackageChangeMapper> ChangeMapper<'a, PD> {
                     // We don't know if the lockfile changed or not, so we can't assume anything
                     LockfileContents::Unchanged => {
                         debug!("the lockfile did not change");
+                        self.add_relationship_affected_packages(&mut changed_pkgs);
                         Ok(PackageChanges::Some(changed_pkgs))
                     }
                 }
@@ -259,30 +262,30 @@ impl<'a, PD: PackageChangeMapper> ChangeMapper<'a, PD> {
             }
         }
 
-        self.add_toolchain_affected_packages(&mut changed_packages);
         PackageChanges::Some(changed_packages)
     }
 
-    fn add_toolchain_affected_packages(
+    fn add_relationship_affected_packages(
         &self,
         changed_packages: &mut HashMap<WorkspacePackage, PackageInclusionReason>,
     ) {
-        let directly_changed: Vec<_> = changed_packages
+        let mut directly_changed: Vec<_> = changed_packages
             .keys()
             .map(|package| package.name.clone())
             .collect();
+        directly_changed.sort();
         for dependency in directly_changed {
-            let Some(context) = self.pkg_graph.package_task_context(&dependency) else {
+            let Some(affected_packages) = self
+                .pkg_graph
+                .affected_relationships()
+                .additional_affected_by(&dependency)
+            else {
                 continue;
             };
-            let Some(toolchain_id) = context.toolchain() else {
-                continue;
-            };
-            let Some(toolchain) = self.pkg_graph.toolchains().get(toolchain_id) else {
-                continue;
-            };
-            for affected in toolchain.additional_affected_packages(dependency.as_str()) {
-                let name = PackageName::Other(affected);
+            for name in affected_packages {
+                if name == dependency {
+                    continue;
+                }
                 let Some(context) = self.pkg_graph.package_task_context(&name) else {
                     continue;
                 };

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -524,6 +524,9 @@ impl PackageGraphAssembler {
             let mut seen = HashSet::new();
             let mut internal = HashMap::<&str, DependencyKind>::new();
             for relationship in group.relationships() {
+                if !relationship.orders_tasks() {
+                    continue;
+                }
                 if !seen.insert(relationship.declaration_name()) {
                     continue;
                 }

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -693,7 +693,6 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             scope_kind,
             descriptor: json,
             manifest_path,
-            external_dependencies: _,
             native_relationships,
             native_tasks,
         } = package.into_parts();
@@ -765,7 +764,6 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
                             json.name.as_ref().map(|name| name.as_inner().clone()),
                             json,
                             path,
-                            None,
                         ),
                     )
                 }));
@@ -1596,7 +1594,6 @@ mod test {
                         Some("orphan".to_string()),
                         PackageJson::default(),
                         self.root.join_components(&["orphan", "manifest"]),
-                        None,
                     )],
                     Vec::new(),
                 ))
@@ -1657,7 +1654,6 @@ mod test {
             Some(name.to_string()),
             descriptor,
             root.join_components(&["custom-packages", &directory, "custom-manifest"]),
-            None,
         )
     }
 

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -471,7 +471,7 @@ impl PackageGraph {
         self.relationship_projections().filtering()
     }
 
-    /// Returns reverse ordering relationships for affectedness propagation.
+    /// Returns reverse input relationships for affectedness propagation.
     pub fn affected_relationships(&self) -> &AffectedRelationships {
         self.relationship_projections().affected()
     }

--- a/crates/turborepo-repository/src/package_graph/projections.rs
+++ b/crates/turborepo-repository/src/package_graph/projections.rs
@@ -44,11 +44,15 @@ struct RelationshipIndex {
     non_root_lookup: HashMap<Box<str>, ScopeId>,
     ordering: Adjacency,
     reverse_ordering: Adjacency,
+    inputs: Adjacency,
+    reverse_inputs: Adjacency,
     prune_all: Adjacency,
     prune_production: Adjacency,
     root: ScopeId,
-    root_inputs: Box<[ScopeId]>,
-    is_root_input: Box<[bool]>,
+    root_ordering_inputs: Box<[ScopeId]>,
+    is_root_ordering_input: Box<[bool]>,
+    root_input_dependencies: Box<[ScopeId]>,
+    is_root_input_dependency: Box<[bool]>,
 }
 
 impl RelationshipIndex {
@@ -72,6 +76,7 @@ impl RelationshipIndex {
             .collect();
         let root = ScopeId(0);
         let mut ordering = vec![Vec::new(); names.len()];
+        let mut inputs = vec![Vec::new(); names.len()];
         let mut prune_all = vec![Vec::new(); names.len()];
         let mut prune_production = vec![Vec::new(); names.len()];
 
@@ -79,9 +84,12 @@ impl RelationshipIndex {
             let Some(source) = lookup_identity(&non_root_lookup, root, group.source()) else {
                 unreachable!("validated relationship source must have a scope ID")
             };
-            let mut seen_declarations = std::collections::HashSet::new();
-            let mut seen_targets = std::collections::HashSet::new();
-            let mut effective_concrete = Vec::new();
+            let mut seen_input_declarations = std::collections::HashSet::new();
+            let mut seen_input_targets = std::collections::HashSet::new();
+            let mut seen_ordering_declarations = std::collections::HashSet::new();
+            let mut seen_ordering_targets = std::collections::HashSet::new();
+            let mut effective_inputs = Vec::new();
+            let mut effective_ordering = Vec::new();
             let mut required_peers = Vec::new();
 
             for relationship in group.relationships() {
@@ -98,9 +106,10 @@ impl RelationshipIndex {
                     required_peers.push(target);
                 }
 
-                if !seen_declarations.insert(relationship.declaration_name()) {
-                    continue;
-                }
+                let input_declaration_is_first =
+                    seen_input_declarations.insert(relationship.declaration_name());
+                let ordering_declaration_is_first = relationship.orders_tasks()
+                    && seen_ordering_declarations.insert(relationship.declaration_name());
                 let kind = relationship.kind();
                 let RelationshipTarget::Internal(target) = relationship.target() else {
                     continue;
@@ -116,16 +125,20 @@ impl RelationshipIndex {
                 let Some(target) = lookup_identity(&non_root_lookup, root, target) else {
                     unreachable!("validated internal relationship target must have a scope ID")
                 };
-                if seen_targets.insert(target) {
-                    effective_concrete.push((target, kind));
+                if input_declaration_is_first && seen_input_targets.insert(target) {
+                    effective_inputs.push((target, kind));
+                }
+                if ordering_declaration_is_first && seen_ordering_targets.insert(target) {
+                    effective_ordering.push((target, kind));
                 }
             }
 
-            ordering[source.index()].extend(effective_concrete.iter().map(|(target, _)| *target));
-            prune_all[source.index()].extend(effective_concrete.iter().map(|(target, _)| *target));
+            ordering[source.index()].extend(effective_ordering.iter().map(|(target, _)| *target));
+            inputs[source.index()].extend(effective_inputs.iter().map(|(target, _)| *target));
+            prune_all[source.index()].extend(effective_ordering.iter().map(|(target, _)| *target));
             prune_all[source.index()].extend(required_peers.iter().copied());
             prune_production[source.index()].extend(
-                effective_concrete
+                effective_ordering
                     .iter()
                     .filter(|(_, kind)| {
                         matches!(kind, DependencyKind::Production | DependencyKind::Optional)
@@ -136,23 +149,32 @@ impl RelationshipIndex {
         }
 
         let ordering = normalize_adjacency(ordering);
+        let inputs = normalize_adjacency(inputs);
         let prune_all = normalize_adjacency(prune_all);
         let prune_production = normalize_adjacency(prune_production);
         let reverse_ordering = reverse_adjacency(names.len(), &ordering);
-        let mut root_members = closure_members(&ordering, &[root]);
-        root_members[root.index()] = false;
-        let root_inputs = member_ids(&root_members);
+        let reverse_inputs = reverse_adjacency(names.len(), &inputs);
+        let mut root_ordering_members = closure_members(&ordering, &[root]);
+        root_ordering_members[root.index()] = false;
+        let root_ordering_inputs = member_ids(&root_ordering_members);
+        let mut root_input_members = closure_members(&inputs, &[root]);
+        root_input_members[root.index()] = false;
+        let root_input_dependencies = member_ids(&root_input_members);
 
         Self {
             names,
             non_root_lookup,
             ordering,
             reverse_ordering,
+            inputs,
+            reverse_inputs,
             prune_all,
             prune_production,
             root,
-            root_inputs,
-            is_root_input: root_members.into_boxed_slice(),
+            root_ordering_inputs,
+            is_root_ordering_input: root_ordering_members.into_boxed_slice(),
+            root_input_dependencies,
+            is_root_input_dependency: root_input_members.into_boxed_slice(),
         }
     }
 
@@ -176,18 +198,26 @@ impl RelationshipIndex {
     fn transitive_dependencies(&self, package: &PackageName) -> Option<Vec<PackageName>> {
         let package = self.id(package)?;
         let mut members = closure_members(&self.ordering, &[package]);
-        include_ids(&mut members, &self.root_inputs);
+        include_ids(&mut members, &self.root_ordering_inputs);
         members[package.index()] = false;
         Some(self.names_from_members(&members))
     }
 
     fn transitive_dependents(&self, package: &PackageName) -> Option<Vec<PackageName>> {
         let package = self.id(package)?;
-        let mut members = if self.is_root_input[package.index()] {
+        let mut members = if self.is_root_ordering_input[package.index()] {
             vec![true; self.names.len()]
         } else {
             closure_members(&self.reverse_ordering, &[package])
         };
+        members[package.index()] = false;
+        Some(self.names_from_members(&members))
+    }
+
+    fn transitive_input_dependencies(&self, package: &PackageName) -> Option<Vec<PackageName>> {
+        let package = self.id(package)?;
+        let mut members = closure_members(&self.inputs, &[package]);
+        include_ids(&mut members, &self.root_input_dependencies);
         members[package.index()] = false;
         Some(self.names_from_members(&members))
     }
@@ -344,17 +374,19 @@ impl FilteringRelationships {
             return Ok(Vec::new());
         }
         let mut members = closure_members(&self.0.ordering, &seeds);
-        include_ids(&mut members, &self.0.root_inputs);
+        include_ids(&mut members, &self.0.root_ordering_inputs);
         Ok(self.0.names_from_members(&members))
     }
 }
 
-/// Reverse ordering relationships used to determine affected packages.
+/// Reverse input relationships used to determine affected packages. These may
+/// include non-ordering relationships such as cycle-closing Cargo development
+/// dependencies.
 #[derive(Debug, Clone)]
 pub struct AffectedRelationships(Arc<RelationshipIndex>);
 
 impl AffectedRelationships {
-    /// Returns changed seeds and all transitive ordering dependents.
+    /// Returns changed seeds and all transitive input dependents.
     ///
     /// If any seed is a root internal input, every authoritative identity,
     /// including the root Turbo namespace, is affected. Empty input is valid.
@@ -365,15 +397,42 @@ impl AffectedRelationships {
         packages: &[PackageName],
     ) -> Result<Vec<PackageName>, RelationshipProjectionError> {
         let seeds = self.0.ids(packages)?;
-        if seeds.iter().any(|seed| self.0.is_root_input[seed.index()]) {
+        if seeds
+            .iter()
+            .any(|seed| self.0.is_root_input_dependency[seed.index()])
+        {
             return Ok(self.0.names.to_vec());
         }
-        let members = closure_members(&self.0.reverse_ordering, &seeds);
+        let members = closure_members(&self.0.reverse_inputs, &seeds);
         Ok(self.0.names_from_members(&members))
+    }
+
+    /// Returns dependents reached only through non-ordering input
+    /// relationships. Ordinary ordering dependents are excluded so callers can
+    /// preserve their existing graph-expansion behavior.
+    pub fn additional_affected_by(&self, package: &PackageName) -> Option<Vec<PackageName>> {
+        let seed = self.0.id(package)?;
+        let input_members = if self.0.is_root_input_dependency[seed.index()] {
+            vec![true; self.0.names.len()]
+        } else {
+            closure_members(&self.0.reverse_inputs, &[seed])
+        };
+        let ordering_members = if self.0.is_root_ordering_input[seed.index()] {
+            vec![true; self.0.names.len()]
+        } else {
+            closure_members(&self.0.reverse_ordering, &[seed])
+        };
+        let additional = input_members
+            .iter()
+            .zip(ordering_members)
+            .map(|(input, ordering)| *input && !ordering)
+            .collect::<Vec<_>>();
+        Some(self.0.names_from_members(&additional))
     }
 }
 
-/// Internal dependency inputs used by derived task hashing and I/O.
+/// Internal dependency inputs used by derived task hashing and I/O. These may
+/// include relationships excluded from task ordering.
 ///
 /// External lockfile closures are deliberately outside this projection.
 #[derive(Debug, Clone)]
@@ -384,14 +443,14 @@ impl HashRelationships {
     /// implied root inputs and excluding `package`, or `None` if unknown.
     /// Output is sorted and deduplicated.
     pub fn dependency_inputs(&self, package: &PackageName) -> Option<Vec<PackageName>> {
-        self.0.transitive_dependencies(package)
+        self.0.transitive_input_dependencies(package)
     }
 
     /// Returns the sorted, deduplicated transitive internal inputs declared by
     /// the root JavaScript package. Pure native repositories return an empty
     /// vector while still recognizing [`PackageName::Root`].
     pub fn root_inputs(&self) -> Vec<PackageName> {
-        self.0.names_from_ids(&self.0.root_inputs)
+        self.0.names_from_ids(&self.0.root_input_dependencies)
     }
 }
 
@@ -516,6 +575,7 @@ mod tests {
             "cycle-a",
             "cycle-b",
             "disconnected",
+            "input-only",
         ];
         let toolchain = if with_javascript_root {
             ToolchainId::JAVASCRIPT
@@ -553,6 +613,7 @@ mod tests {
                     Relationship::internal("dev", DependencyKind::Development),
                     Relationship::internal("optional", DependencyKind::Production),
                     Relationship::internal("required-peer", DependencyKind::Development),
+                    Relationship::internal_input("input-only", DependencyKind::Development),
                     Relationship::internal(
                         "optional-peer",
                         DependencyKind::Peer { optional: true },
@@ -614,10 +675,10 @@ mod tests {
         if with_javascript_root {
             groups.push(RelationshipGroup::new(
                 "//",
-                vec![Relationship::internal(
-                    "root-lib",
-                    DependencyKind::Production,
-                )],
+                vec![
+                    Relationship::internal("root-lib", DependencyKind::Production),
+                    Relationship::internal_input("optional-peer", DependencyKind::Development),
+                ],
             ));
         }
         let relationships =
@@ -656,8 +717,18 @@ mod tests {
             projections.filtering().transitive_dependencies(&app),
             Some(transitive.clone())
         );
-        assert_eq!(projections.hash().dependency_inputs(&app), Some(transitive));
-        assert_eq!(projections.hash().root_inputs(), names(&["root-lib"]));
+        let mut hash_inputs = transitive;
+        hash_inputs.push(name("input-only"));
+        hash_inputs.push(name("optional-peer"));
+        hash_inputs.sort();
+        assert_eq!(
+            projections.hash().dependency_inputs(&app),
+            Some(hash_inputs)
+        );
+        assert_eq!(
+            projections.hash().root_inputs(),
+            names(&["optional-peer", "root-lib"])
+        );
         assert_eq!(
             projections
                 .filtering()
@@ -675,6 +746,40 @@ mod tests {
         assert_eq!(
             projections.affected().affected_by(&[name("transitive")]),
             Ok(names(&["app", "prod", "transitive"]))
+        );
+        assert_eq!(
+            projections.affected().affected_by(&[name("input-only")]),
+            Ok(names(&["app", "input-only"]))
+        );
+        assert_eq!(
+            projections
+                .affected()
+                .additional_affected_by(&name("input-only")),
+            Some(names(&["app"]))
+        );
+        assert_eq!(
+            projections
+                .affected()
+                .additional_affected_by(&name("transitive")),
+            Some(Vec::new())
+        );
+        assert_eq!(
+            projections
+                .affected()
+                .additional_affected_by(&name("optional-peer")),
+            Some(with_root(names(&[
+                "app",
+                "cycle-a",
+                "cycle-b",
+                "dev",
+                "disconnected",
+                "input-only",
+                "optional",
+                "prod",
+                "required-peer",
+                "root-lib",
+                "transitive",
+            ])))
         );
         assert_eq!(
             projections.prune().package_closure(
@@ -715,7 +820,7 @@ mod tests {
             .filtering()
             .transitive_dependents(&root_lib)
             .expect("root-lib is authoritative");
-        assert_eq!(all_but_root_lib.len(), 11);
+        assert_eq!(all_but_root_lib.len(), 12);
         assert!(!all_but_root_lib.contains(&root_lib));
         assert_eq!(
             projections.filtering().transitive_dependencies(&cycle_a),
@@ -736,6 +841,7 @@ mod tests {
                 "cycle-b",
                 "dev",
                 "disconnected",
+                "input-only",
                 "optional",
                 "optional-peer",
                 "prod",

--- a/crates/turborepo-repository/src/relationships.rs
+++ b/crates/turborepo-repository/src/relationships.rs
@@ -25,6 +25,7 @@ pub struct Relationship {
     declaration_alias: Option<String>,
     kind: DependencyKind,
     target: RelationshipTarget,
+    orders_tasks: bool,
 }
 
 impl Relationship {
@@ -43,12 +44,22 @@ impl Relationship {
                 .then_some(declaration_name),
             kind,
             target,
+            orders_tasks: true,
         }
     }
 
     pub fn internal(target: impl Into<String>, kind: DependencyKind) -> Self {
         let target = target.into();
         Self::new(target.clone(), kind, RelationshipTarget::Internal(target))
+    }
+
+    /// Construct an internal relationship that contributes to hashing and
+    /// affectedness without adding a task-ordering edge. Cargo uses this for
+    /// development relationships that would make its package graph cyclic.
+    pub fn internal_input(target: impl Into<String>, kind: DependencyKind) -> Self {
+        let mut relationship = Self::internal(target, kind);
+        relationship.orders_tasks = false;
+        relationship
     }
 
     pub fn declaration_name(&self) -> &str {
@@ -66,5 +77,9 @@ impl Relationship {
 
     pub fn target(&self) -> &RelationshipTarget {
         &self.target
+    }
+
+    pub fn orders_tasks(&self) -> bool {
+        self.orders_tasks
     }
 }

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -122,19 +122,6 @@ pub struct DiscoveredPackage {
     /// Absolute path to the package's native manifest (`package.json`,
     /// `Cargo.toml`, ...).
     manifest_path: AbsoluteSystemPathBuf,
-    /// External-dependency identities for this package, when the toolchain
-    /// resolves them at discovery time. They feed the package's
-    /// external-dependency hash: a task's hash changes exactly when an
-    /// identity in its package's set changes. Cargo computes these from
-    /// Cargo.lock (per-crate transitive closures) plus a compiler-version
-    /// stamp.
-    ///
-    /// `None` defers to the toolchain's own pipeline. Known debt (see
-    /// module docs): JavaScript's closures are computed by the graph
-    /// builder's lockfile phase — deliberately concurrent with run setup —
-    /// rather than through this field; folding that in requires a
-    /// deferred-aware trait surface.
-    external_dependencies: Option<std::collections::HashSet<turborepo_lockfiles::Package>>,
     /// Native relationship facts, already classified by the producer. `None`
     /// preserves compatibility by asking core to classify `descriptor`,
     /// regardless of the producer's toolchain id.
@@ -157,8 +144,6 @@ pub(crate) struct DiscoveredPackageParts {
     pub scope_kind: DiscoveredScopeKind,
     pub descriptor: PackageJson,
     pub manifest_path: AbsoluteSystemPathBuf,
-    #[allow(dead_code)]
-    pub external_dependencies: Option<std::collections::HashSet<turborepo_lockfiles::Package>>,
     pub native_relationships: Option<Vec<Relationship>>,
     pub native_tasks: Option<Vec<crate::native_tasks::NativeTask>>,
 }
@@ -241,7 +226,6 @@ impl DiscoveredPackage {
         name: Option<String>,
         mut descriptor: PackageJson,
         manifest_path: AbsoluteSystemPathBuf,
-        external_dependencies: Option<std::collections::HashSet<turborepo_lockfiles::Package>>,
     ) -> Self {
         let name_source = descriptor
             .name
@@ -255,7 +239,6 @@ impl DiscoveredPackage {
             scope_kind: DiscoveredScopeKind::Package,
             descriptor,
             manifest_path,
-            external_dependencies,
             native_relationships: None,
             native_tasks: None,
         }
@@ -267,7 +250,6 @@ impl DiscoveredPackage {
         name: String,
         mut descriptor: PackageJson,
         manifest_path: AbsoluteSystemPathBuf,
-        external_dependencies: Option<std::collections::HashSet<turborepo_lockfiles::Package>>,
     ) -> Self {
         descriptor.name = Some(Spanned::new(name.clone()));
         Self {
@@ -276,7 +258,6 @@ impl DiscoveredPackage {
             scope_kind: DiscoveredScopeKind::Aggregate,
             descriptor,
             manifest_path,
-            external_dependencies,
             native_relationships: None,
             native_tasks: None,
         }
@@ -303,7 +284,6 @@ impl DiscoveredPackage {
             scope_kind,
             descriptor,
             manifest_path,
-            external_dependencies,
             native_relationships,
             native_tasks,
         } = self;
@@ -313,7 +293,6 @@ impl DiscoveredPackage {
             scope_kind,
             descriptor,
             manifest_path,
-            external_dependencies,
             native_relationships,
             native_tasks,
         }
@@ -923,10 +902,6 @@ impl<P: PackageDiscovery + Send + Sync> Toolchain for JavaScriptToolchain<P> {
                             name,
                             descriptor,
                             workspace.package_json,
-                            // JavaScript closures come from the builder's
-                            // (deliberately concurrent) lockfile phase; see
-                            // the field docs.
-                            None,
                         ))
                     })
                     .collect::<Result<Vec<_>, Error>>()
@@ -1004,7 +979,6 @@ mod tests {
             Some("authoritative-name".to_string()),
             mismatched.clone(),
             path.clone(),
-            None,
         )
         .into_parts();
         assert_eq!(package.name.as_deref(), Some("authoritative-name"));
@@ -1014,7 +988,7 @@ mod tests {
             Some("authoritative-name")
         );
 
-        let unnamed = DiscoveredPackage::package(None, mismatched, path.clone(), None).into_parts();
+        let unnamed = DiscoveredPackage::package(None, mismatched, path.clone()).into_parts();
         assert_eq!(unnamed.name, None);
         assert_eq!(unnamed.name_source, None);
         assert_eq!(unnamed.descriptor.name, None);
@@ -1030,18 +1004,13 @@ mod tests {
                 ..Default::default()
             },
             path.clone(),
-            None,
         )
         .into_parts();
         assert_eq!(matching.name_source, Some(authored_name.to(())));
 
-        let aggregate = DiscoveredPackage::aggregate(
-            "workspace".to_string(),
-            PackageJson::default(),
-            path,
-            None,
-        )
-        .into_parts();
+        let aggregate =
+            DiscoveredPackage::aggregate("workspace".to_string(), PackageJson::default(), path)
+                .into_parts();
         assert_eq!(aggregate.name.as_deref(), Some("workspace"));
         assert_eq!(aggregate.name_source, None);
         assert_eq!(aggregate.scope_kind, DiscoveredScopeKind::Aggregate);

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -462,14 +462,6 @@ pub trait Toolchain: Send + Sync {
         false
     }
 
-    /// Packages whose task inputs can depend on `package` beyond the ordinary
-    /// acyclic package graph. Change detection marks these packages affected
-    /// before applying the graph's normal dependent expansion.
-    fn additional_affected_packages(&self, package: &str) -> Vec<String> {
-        let _ = package;
-        Vec::new()
-    }
-
     /// Select package entrypoints for an unqualified task from the packages in
     /// scope. `None` leaves the normal package × task expansion unchanged.
     fn select_task_entrypoints(

--- a/crates/turborepo-scope/src/filter.rs
+++ b/crates/turborepo-scope/src/filter.rs
@@ -997,7 +997,6 @@ mod test {
                         "cargo-workspace".to_string(),
                         PackageJson::default(),
                         self.definition_path.clone(),
-                        None,
                     )],
                     vec![WorkspaceRoot::new("cargo", root)],
                 ))

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -281,6 +281,15 @@ detection is deferred to the task graph layer (engine builder), since
 package-level cycles only matter when they produce task-level cycles via
 topological (`^`) dependencies.
 
+Normalized relationship knowledge also records whether an internal relationship
+orders tasks. Named core projections keep ordering, filtering, and package prune
+closures acyclic while hash and affectedness projections include non-ordering
+inputs. Cargo uses this distinction for cycle-closing development dependencies:
+their sources still invalidate and affect consumers without creating task graph
+cycles. Cargo path, development, optional, build, target-specific, and automatic
+member relationships are emitted directly from `cargo metadata`; no synthetic
+JavaScript dependency maps or behavioral affectedness callback remain.
+
 #### Toolchains (`crates/turborepo-repository/src/toolchain.rs`)
 
 The package graph is generic over language toolchains. The existing discovery
@@ -389,14 +398,14 @@ whether anything changed; Cargo decides how and in what order to build.**
   same-named JavaScript scripts runnable without their usual turbo.json
   definition. The names come from the same verb tables as command resolution
   and participate in task suggestions and add-all/query graph construction.
-- **Hashing and affectedness** (`Toolchain::derived_task_io` and
-  `Toolchain::additional_affected_packages`): crate-scoped tasks hash their own
+- **Hashing and affectedness** (`HashRelationships`, `AffectedRelationships`,
+  and `Toolchain::derived_task_io`): crate-scoped tasks hash their own
   sources plus a conservative transitive closure of declared local Cargo
   dependencies (flattened, so invalidation doesn't depend on `dependsOn`
   wiring). The closure may include optional or target-specific dependencies not
-  compiled by a particular invocation. It is retained separately from the
-  package graph so cycle-closing dev-dependency edges still invalidate and mark
-  their consumers affected. Tasks also hash the
+  compiled by a particular invocation. Non-ordering relationship inputs retain
+  cycle-closing development edges so they still invalidate and mark their
+  consumers affected. Tasks also hash the
   workspace files (root `Cargo.toml`, `.cargo/config*`, `rust-toolchain*`),
   and standard Cargo/cc-rs environment inputs: rustup home/toolchain selection,
   compiler and rustdoc selection and flags, Cargo build/profile/target

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -155,7 +155,7 @@ Represents the workspace structure and package dependencies:
   consumes the normalized external declaration view; inline and deferred
   lockfile closure calculation create the same immutable snapshot. Cargo
   contributes per-crate closures, the aggregate workspace union, and the full
-  `rustc -vV` identity from the same sets used by compatibility payloads. Cargo
+  `rustc -vV` identity directly through its external-resolution domain. Cargo
   keeps missing, stale, or invalid lockfile and compiler identity failures
   fatal. Core validates the combined domains and retains exact opaque
   identities, definition sources, completeness, and stable fingerprints. A


### PR DESCRIPTION
## Intent

Complete the Cargo knowledge cutover in one reviewable unit: produce authoritative relationship knowledge for Cargo scopes, then delete the dead per-package external-resolution compatibility bridge.

**Base:** `main`.

## Changes

- Produce Cargo relationship groups for crates and workspace aggregates
- Project Cargo ordering, filtering, affectedness, and task inputs from shared relationship knowledge
- Keep per-crate and workspace-union identities in `ExternalResolutionDomain`
- Remove `DiscoveredPackage.external_dependencies` and discarded compatibility observations
- Update architecture documentation for direct Cargo relationship and resolution contribution

## Testing

- `cargo test -p turborepo-repository cargo::test`
- `cargo test -p turborepo-repository package_graph::projections::tests`
- `cargo test -p turborepo-repository external_resolution::tests`
- `cargo test -p turborepo-engine`
- `cargo test -p turbo --test relationship_projection_contract`
- `cargo test -p turborepo-task-hash task_hash_uses_resolution_knowledge_without_compatibility_payload`
- `cargo clippy -p turborepo-repository -p turborepo-engine -p turborepo-scope --all-targets -- -D warnings`
- `cargo fmt --check`

Closes TURBO-5794.
Closes TURBO-5795.