### PR TITLE
refactor: Port Cargo task and contract knowledge

### DIFF
--- a/crates/turborepo-engine/src/builder/definitions.rs
+++ b/crates/turborepo-engine/src/builder/definitions.rs
@@ -2,10 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use miette::{NamedSource, SourceSpan};
 use turborepo_errors::Spanned;
-use turborepo_repository::{
-    package_graph::{PackageGraph, PackageName, PackageNode},
-    toolchain::ToolchainId,
-};
+use turborepo_repository::package_graph::{PackageGraph, PackageName, PackageNode};
 use turborepo_task_id::{TaskId, TaskName};
 use turborepo_turbo_json::{
     HasConfigBeyondExtends, ProcessedCommand, ProcessedTaskDefinition, RawTaskDefinition, TurboJson,
@@ -244,10 +241,6 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         let package_context = self
             .package_graph
             .package_task_context(&PackageName::from(task_id.as_inner().package()));
-        let toolchain = package_context
-            .as_ref()
-            .and_then(|context| context.toolchain())
-            .and_then(|toolchain| self.package_graph.toolchains().get(toolchain));
         // Whether the package's toolchain defines a command for this task.
         // Tasks without one are phantom/transit tasks (they exist solely for
         // dependency ordering via `dependsOn: ["^task"]`) and must not hash
@@ -276,11 +269,10 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
                     .get(&task_id.as_inner().as_task_name())
                     .is_some()
             });
-            let javascript = package_context
+            let memoizable_contract = package_context
                 .as_ref()
-                .and_then(|context| context.toolchain())
-                .is_none_or(|toolchain| toolchain == &ToolchainId::JAVASCRIPT);
-            (!package_scoped && javascript).then(|| TaskDefMemoKey {
+                .is_none_or(|context| !context.task_contract().derives_io());
+            (!package_scoped && memoizable_contract).then(|| TaskDefMemoKey {
                 chain: turbo_json_chain
                     .iter()
                     .map(|turbo_json| *turbo_json as *const TurboJson as usize)
@@ -339,26 +331,14 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
                 .map(|(definition, _)| definition),
         );
         let had_explicit_cache = processed_task_definition.cache.is_some();
-        // JavaScript packages compose defaults from foundational task-contract
-        // knowledge (empty today). Other toolchains temporarily retain
-        // Toolchain::task_defaults until their ports.
-        let uses_js_task_contract = package_context.as_ref().is_some_and(|context| {
-            context.task_contract().toolchain()
-                == Some(&turborepo_repository::toolchain::ToolchainId::JAVASCRIPT)
-        });
-        if should_apply_toolchain_defaults(command_override.as_ref()) {
-            if uses_js_task_contract {
-                if let Some(context) = package_context.as_ref() {
-                    let defaults = context.task_contract().defaults();
-                    if processed_task_definition.cache.is_none() {
-                        processed_task_definition.cache = defaults.cache.map(Spanned::new);
-                    }
-                }
-            } else if let Some((context, toolchain)) = package_context.as_ref().zip(toolchain) {
-                let defaults = toolchain.task_defaults(context, task_id.as_inner().task());
-                if processed_task_definition.cache.is_none() {
-                    processed_task_definition.cache = defaults.cache.map(Spanned::new);
-                }
+        if should_apply_toolchain_defaults(command_override.as_ref())
+            && let Some(context) = package_context.as_ref()
+        {
+            let defaults = context
+                .task_contract()
+                .defaults_for_task(task_id.as_inner().task());
+            if processed_task_definition.cache.is_none() {
+                processed_task_definition.cache = defaults.cache.map(Spanned::new);
             }
         }
         let had_explicit_inputs = processed_task_definition.inputs.is_some();
@@ -390,22 +370,17 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
             );
         }
 
-        // Apply derived hash wiring. JavaScript uses foundational task-contract
-        // knowledge and never participates in Toolchain derived-I/O dispatch
-        // (turbo.json is the whole story). Cargo temporarily retains
-        // Toolchain::derived_task_io until its Rust port.
+        // Apply derived hash wiring from foundational task-contract knowledge.
         // `$TURBO_DEFAULT$` on a derived task means "everything the toolchain
         // derives automatically", so explicit `inputs` can append without
         // forfeiting automatic invalidation; explicit inputs without
         // `$TURBO_DEFAULT$` take full control.
         if inherits_toolchain_task_io(task_def.command.as_ref())
-            && !uses_js_task_contract
-            && let Some((package_context, toolchain)) = package_context
-                .as_ref()
-                .zip(toolchain)
-                .filter(|(context, toolchain)| {
-                    toolchain.derives_task_io(context, task_id.as_inner().task())
-                })
+            && let Some(package_context) = package_context.as_ref().filter(|context| {
+                context
+                    .task_contract()
+                    .derives_task_io(task_id.as_inner().task())
+            })
         {
             let wants_automatic_inputs = !had_explicit_inputs || task_def.inputs.default;
             // Only assembled when the toolchain will actually use it:
@@ -430,7 +405,7 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
                     .and_then(|toolchain| self.environments.get(toolchain))
                     .unwrap_or(&empty_environment),
             };
-            if let Some(mut derived) = toolchain.derived_task_io(
+            if let Some(mut derived) = package_context.task_contract().derived_task_io(
                 package_context,
                 task_id.as_inner().task(),
                 path_to_root.as_str(),
@@ -448,7 +423,7 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
                 apply_derived_task_io(
                     &mut task_def,
                     derived,
-                    toolchain.task_io_env_vars(),
+                    package_context.task_contract().env_vars(),
                     had_explicit_outputs,
                     had_explicit_cache,
                 );

--- a/crates/turborepo-engine/src/builder/test.rs
+++ b/crates/turborepo-engine/src/builder/test.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
-    sync::{Arc, Mutex},
+    sync::Arc,
 };
 
 use insta::{assert_json_snapshot, assert_snapshot};
@@ -17,8 +17,7 @@ use turborepo_repository::{
     package_manager::PackageManager,
     toolchain::{
         DerivedInputSafety, DerivedOutputs, DerivedTaskIO, DiscoverPackagesFuture,
-        DiscoveredPackage, DiscoveredPackages, TaskIOContext, Toolchain, ToolchainId,
-        WorkspaceRoot,
+        DiscoveredPackage, DiscoveredPackages, Toolchain, ToolchainId, WorkspaceRoot,
     },
 };
 use turborepo_task_id::{TaskId, TaskName};
@@ -157,23 +156,13 @@ impl Toolchain for AggregateToolchain {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct SeenTaskIO {
-    args: Option<Vec<String>>,
-    layout_env: Option<String>,
-}
-
-type StubIOEngineResult = (
-    Engine<Built, TaskDefinition>,
-    Arc<Mutex<HashMap<String, SeenTaskIO>>>,
-);
+type StubIOEngineResult = Engine<Built, TaskDefinition>;
 
 struct StubIOToolchain {
     repo_root: AbsoluteSystemPathBuf,
     outputs: DerivedOutputs,
     input_safety: DerivedInputSafety,
     environment: Vec<&'static str>,
-    seen: Arc<Mutex<HashMap<String, SeenTaskIO>>>,
 }
 
 impl Toolchain for StubIOToolchain {
@@ -199,6 +188,26 @@ impl Toolchain for StubIOToolchain {
                     self.repo_root
                         .join_components(&["packages", name, "stub.json"]),
                 )
+                .with_task_contract(
+                    turborepo_repository::task_contracts::ScopeTaskContract::derived(
+                        ToolchainId::new("stub-io"),
+                        std::collections::BTreeMap::new(),
+                        self.environment.clone(),
+                        ["build", "test"]
+                            .into_iter()
+                            .map(|task| {
+                                (
+                                    task.to_string(),
+                                    DerivedTaskIO {
+                                        outputs: self.outputs.clone(),
+                                        input_safety: self.input_safety.clone(),
+                                        ..Default::default()
+                                    },
+                                )
+                            })
+                            .collect(),
+                    ),
+                )
             };
             Ok(DiscoveredPackages::new(
                 vec![
@@ -222,42 +231,6 @@ impl Toolchain for StubIOToolchain {
         turborepo_repository::toolchain::Error,
     > {
         Ok(None)
-    }
-
-    fn derives_task_io(
-        &self,
-        _package: &turborepo_repository::package_graph::PackageTaskContext<'_>,
-        _task: &str,
-    ) -> bool {
-        true
-    }
-
-    fn task_io_env_vars(&self) -> &[&str] {
-        &self.environment
-    }
-
-    fn derived_task_io(
-        &self,
-        package: &turborepo_repository::package_graph::PackageTaskContext<'_>,
-        task: &str,
-        _path_to_root: &str,
-        _dependencies: &[turborepo_repository::package_graph::PackageTaskContext<'_>],
-        _wants_automatic_inputs: bool,
-        context: &TaskIOContext<'_>,
-    ) -> Option<DerivedTaskIO> {
-        let package_name = package.package().as_ref();
-        self.seen.lock().unwrap().insert(
-            format!("{package_name}#{task}"),
-            SeenTaskIO {
-                args: context.task_args.map(<[String]>::to_vec),
-                layout_env: context.environment.get("STUB_LAYOUT").map(str::to_string),
-            },
-        );
-        Some(DerivedTaskIO {
-            outputs: self.outputs.clone(),
-            input_safety: self.input_safety.clone(),
-            ..Default::default()
-        })
     }
 }
 

--- a/crates/turborepo-engine/src/builder/test/core.rs
+++ b/crates/turborepo-engine/src/builder/test/core.rs
@@ -975,13 +975,11 @@ fn stub_io_engine_with_safety(
 ) -> StubIOEngineResult {
     let repo_root_dir = TempDir::with_prefix("stub-io").unwrap();
     let repo_root = AbsoluteSystemPathBuf::new(repo_root_dir.path().to_str().unwrap()).unwrap();
-    let seen = Arc::new(Mutex::new(HashMap::new()));
     let toolchain = Arc::new(StubIOToolchain {
         repo_root: repo_root.clone(),
         outputs,
         input_safety,
         environment: vec!["STUB_LAYOUT"],
-        seen: seen.clone(),
     });
     let package_graph = stub_io_package_graph(&repo_root, toolchain);
     let loader = TestTurboJsonLoader::new(
@@ -1002,44 +1000,13 @@ fn stub_io_engine_with_safety(
             "layout-value".to_string(),
         )])),
     )]);
-    let engine = EngineBuilder::new(&repo_root, &package_graph, &loader, false)
+    EngineBuilder::new(&repo_root, &package_graph, &loader, false)
         .with_tasks(Some(Spanned::new(TaskName::from(task).into_owned())))
         .with_workspaces(vec![PackageName::from("app")])
         .with_global_env(global_env)
         .with_task_io_context(pass_through_args, requested_tasks, environments)
         .build()
-        .unwrap();
-    (engine, seen)
-}
-
-#[test]
-fn test_task_io_args_align_with_execution_for_dependencies() {
-    let (_engine, seen) = stub_io_engine(
-        json!({
-            "test": { "dependsOn": ["^build"] },
-            "build": {}
-        }),
-        DerivedOutputs::Resolved(Vec::new()),
-        "test",
-        vec!["--requested".to_string()],
-        vec!["test".to_string()],
-        Vec::new(),
-    );
-    let seen = seen.lock().unwrap();
-    assert_eq!(
-        seen.get("app#test"),
-        Some(&SeenTaskIO {
-            args: Some(vec!["--requested".to_string()]),
-            layout_env: Some("layout-value".to_string()),
-        })
-    );
-    assert_eq!(
-        seen.get("lib#build"),
-        Some(&SeenTaskIO {
-            args: None,
-            layout_env: Some("layout-value".to_string()),
-        })
-    );
+        .unwrap()
 }
 
 #[test]
@@ -1055,7 +1022,7 @@ fn test_unavailable_outputs_respect_merged_task_configuration() {
         ),
         (json!({ "build": { "outputs": [] } }), true, Vec::new()),
     ] {
-        let (engine, _) = stub_io_engine(
+        let engine = stub_io_engine(
             definition,
             DerivedOutputs::Unavailable,
             "build",
@@ -1089,7 +1056,7 @@ fn test_untracked_inputs_respect_only_explicit_cache_configuration() {
             vec!["configured/**".to_string()],
         ),
     ] {
-        let (engine, _) = stub_io_engine_with_safety(
+        let engine = stub_io_engine_with_safety(
             definition,
             DerivedOutputs::Resolved(Vec::new()),
             DerivedInputSafety::Untracked,
@@ -1110,7 +1077,7 @@ fn test_untracked_inputs_respect_only_explicit_cache_configuration() {
 fn test_layout_env_exclusions_disable_implicit_outputs_in_all_env_modes() {
     for env_mode in ["strict", "loose"] {
         for exclusion in ["!STUB_LAYOUT", "!STUB_*"] {
-            let (engine, seen) = stub_io_engine(
+            let engine = stub_io_engine(
                 json!({
                     "build": {
                         "env": [exclusion],
@@ -1130,14 +1097,10 @@ fn test_layout_env_exclusions_disable_implicit_outputs_in_all_env_modes() {
             assert!(task.outputs.inclusions.is_empty());
             assert!(task.env.contains(&exclusion.to_string()));
             assert!(task.env.contains(&"STUB_LAYOUT".to_string()));
-            assert_eq!(
-                seen.lock().unwrap().get("app#build").unwrap().layout_env,
-                Some("layout-value".to_string())
-            );
         }
     }
 
-    let (engine, _) = stub_io_engine(
+    let engine = stub_io_engine(
         json!({ "build": { "envMode": "loose" } }),
         DerivedOutputs::Resolved(vec!["automatic-output".to_string()]),
         "build",
@@ -1155,7 +1118,7 @@ fn test_layout_env_exclusions_disable_implicit_outputs_in_all_env_modes() {
 #[test]
 fn test_nonconflicting_env_exclusions_keep_resolved_outputs() {
     for env_mode in ["strict", "loose"] {
-        let (engine, _) = stub_io_engine(
+        let engine = stub_io_engine(
             json!({
                 "build": {
                     "env": ["!UNRELATED_*"],

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -64,7 +64,10 @@ use crate::{
 };
 
 fn project_task_io_environment(
-    toolchains: &turborepo_repository::toolchain::ToolchainRegistry,
+    patterns: std::collections::BTreeMap<
+        turborepo_repository::toolchain::ToolchainId,
+        Vec<&'static str>,
+    >,
     environment: &EnvironmentVariableMap,
 ) -> Result<
     HashMap<
@@ -73,17 +76,12 @@ fn project_task_io_environment(
     >,
     turborepo_env::Error,
 > {
-    // JavaScript task-I/O environment patterns come from foundational contract
-    // knowledge (empty today). Do not dispatch through Toolchain for JS.
-    toolchains
-        .iter()
-        .filter(|toolchain| {
-            toolchain.id() != turborepo_repository::toolchain::ToolchainId::JAVASCRIPT
-        })
-        .map(|toolchain| {
-            let selected = environment.from_wildcards(toolchain.task_io_env_vars())?;
+    patterns
+        .into_iter()
+        .map(|(toolchain, patterns)| {
+            let selected = environment.from_wildcards(&patterns)?;
             Ok((
-                toolchain.id(),
+                toolchain,
                 turborepo_repository::toolchain::TaskIOEnvironment::new(selected.into_inner()),
             ))
         })
@@ -1330,9 +1328,12 @@ impl RunBuilder {
                 FilterMode::ExcludeOnly { .. } => false,
                 FilterMode::ExplicitSelection => candidate_names.len() == 1,
             };
-            let Some(selected) =
-                toolchain.select_task_entrypoints(task.task(), &candidate_names, prefer_workspace)
-            else {
+            let Some(selected) = pkg_dep_graph.select_task_entrypoints(
+                &toolchain_id,
+                task.task(),
+                &candidate_names,
+                prefer_workspace,
+            ) else {
                 continue;
             };
             let selected: HashSet<_> = selected.into_iter().collect();
@@ -1420,7 +1421,7 @@ impl RunBuilder {
             Vec::new()
         };
         let task_io_environment =
-            project_task_io_environment(pkg_dep_graph.toolchains(), environment)
+            project_task_io_environment(pkg_dep_graph.task_io_env_vars_by_toolchain(), environment)
                 .map_err(Error::Env)?;
         let mut builder = EngineBuilder::new(
             &self.repo_root,
@@ -1541,75 +1542,25 @@ fn has_userinfo(url: &Url) -> bool {
 
 #[cfg(test)]
 mod task_io_context_tests {
-    use std::{collections::HashMap, sync::Arc};
+    use std::collections::HashMap;
 
-    use turbopath::AbsoluteSystemPathBuf;
     use turborepo_env::EnvironmentVariableMap;
     use turborepo_hash::TaskHashable;
-    use turborepo_repository::{
-        cargo::CargoToolchain,
-        toolchain::{
-            DiscoverPackagesFuture, DiscoveredPackages, Toolchain, ToolchainId, ToolchainRegistry,
-        },
-    };
+    use turborepo_repository::toolchain::ToolchainId;
     use turborepo_types::EnvMode;
 
     use super::project_task_io_environment;
 
-    struct Stub {
-        id: ToolchainId,
-        environment: Vec<&'static str>,
-    }
-
-    impl Toolchain for Stub {
-        fn id(&self) -> ToolchainId {
-            self.id.clone()
-        }
-
-        fn discover_packages(&self) -> DiscoverPackagesFuture<'_> {
-            Box::pin(async { Ok(DiscoveredPackages::default()) })
-        }
-
-        fn watch_spec(&self) -> turborepo_repository::toolchain::WatchSpec {
-            turborepo_repository::toolchain::WatchSpec::default()
-        }
-
-        fn prune_plan(
-            &self,
-            _kept_packages: &[String],
-        ) -> Result<
-            Option<turborepo_repository::toolchain::PrunePlan>,
-            turborepo_repository::toolchain::Error,
-        > {
-            Ok(None)
-        }
-
-        fn task_io_env_vars(&self) -> &[&str] {
-            &self.environment
-        }
-    }
-
     #[test]
-    fn javascript_toolchain_is_excluded_from_task_io_projection() {
-        let mut toolchains = ToolchainRegistry::new();
-        toolchains
-            .register(Arc::new(Stub {
-                id: ToolchainId::JAVASCRIPT,
-                environment: vec!["NODE_*"],
-            }))
-            .unwrap();
-        toolchains
-            .register(Arc::new(Stub {
-                id: ToolchainId::new("other"),
-                environment: vec!["OTHER_*"],
-            }))
-            .unwrap();
+    fn empty_contract_patterns_are_excluded_from_task_io_projection() {
+        let patterns =
+            std::collections::BTreeMap::from([(ToolchainId::new("other"), vec!["OTHER_*"])]);
         let environment = EnvironmentVariableMap::from(HashMap::from([
             ("NODE_ENV".to_string(), "production".to_string()),
             ("OTHER_KEY".to_string(), "value".to_string()),
         ]));
 
-        let projected = project_task_io_environment(&toolchains, &environment).unwrap();
+        let projected = project_task_io_environment(patterns, &environment).unwrap();
         assert!(!projected.contains_key(&ToolchainId::JAVASCRIPT));
         assert_eq!(
             projected
@@ -1623,26 +1574,17 @@ mod task_io_context_tests {
     fn projection_is_isolated_per_toolchain() {
         let alpha = ToolchainId::new("alpha");
         let beta = ToolchainId::new("beta");
-        let mut toolchains = ToolchainRegistry::new();
-        toolchains
-            .register(Arc::new(Stub {
-                id: alpha.clone(),
-                environment: vec!["ALPHA_*"],
-            }))
-            .unwrap();
-        toolchains
-            .register(Arc::new(Stub {
-                id: beta.clone(),
-                environment: vec!["BETA_KEY"],
-            }))
-            .unwrap();
+        let patterns = std::collections::BTreeMap::from([
+            (alpha.clone(), vec!["ALPHA_*"]),
+            (beta.clone(), vec!["BETA_KEY"]),
+        ]);
         let environment = EnvironmentVariableMap::from(HashMap::from([
             ("ALPHA_TARGET".to_string(), "alpha".to_string()),
             ("BETA_KEY".to_string(), "beta".to_string()),
             ("UNDECLARED_SECRET".to_string(), "secret".to_string()),
         ]));
 
-        let projected = project_task_io_environment(&toolchains, &environment).unwrap();
+        let projected = project_task_io_environment(patterns, &environment).unwrap();
         assert_eq!(projected.len(), 2);
         let alpha_environment = projected.get(&alpha).unwrap();
         assert_eq!(alpha_environment.get("ALPHA_TARGET"), Some("alpha"));
@@ -1656,10 +1598,10 @@ mod task_io_context_tests {
 
     #[test]
     fn cargo_projection_keeps_only_rustup_selection_environment() {
-        let root = tempfile::tempdir().unwrap();
-        let root = AbsoluteSystemPathBuf::try_from(root.path()).unwrap();
-        let mut toolchains = ToolchainRegistry::new();
-        toolchains.register(CargoToolchain::new(root)).unwrap();
+        let patterns = std::collections::BTreeMap::from([(
+            ToolchainId::RUST,
+            vec!["RUSTUP_HOME", "RUSTUP_TOOLCHAIN"],
+        )]);
         let environment = EnvironmentVariableMap::from(HashMap::from([
             ("RUSTUP_HOME".to_string(), "/rustup".to_string()),
             ("RUSTUP_TOOLCHAIN".to_string(), "stable-host".to_string()),
@@ -1669,7 +1611,7 @@ mod task_io_context_tests {
             ),
         ]));
 
-        let projected = project_task_io_environment(&toolchains, &environment).unwrap();
+        let projected = project_task_io_environment(patterns, &environment).unwrap();
         let cargo = projected.get(&ToolchainId::RUST).unwrap();
         assert_eq!(cargo.get("RUSTUP_HOME"), Some("/rustup"));
         assert_eq!(cargo.get("RUSTUP_TOOLCHAIN"), Some("stable-host"));
@@ -1678,18 +1620,12 @@ mod task_io_context_tests {
 
     fn projected_task_hash(layout: &str, secret: &str) -> String {
         let alpha = ToolchainId::new("alpha");
-        let mut toolchains = ToolchainRegistry::new();
-        toolchains
-            .register(Arc::new(Stub {
-                id: alpha.clone(),
-                environment: vec!["ALPHA_*"],
-            }))
-            .unwrap();
+        let patterns = std::collections::BTreeMap::from([(alpha.clone(), vec!["ALPHA_*"])]);
         let environment = EnvironmentVariableMap::from(HashMap::from([
             ("ALPHA_TARGET".to_string(), layout.to_string()),
             ("UNDECLARED_SECRET".to_string(), secret.to_string()),
         ]));
-        let projected = project_task_io_environment(&toolchains, &environment).unwrap();
+        let projected = project_task_io_environment(patterns, &environment).unwrap();
         let layout = projected
             .get(&alpha)
             .and_then(|environment| environment.get("ALPHA_TARGET"))

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -582,7 +582,7 @@ pub const HASHED_ENV_VARS: &[&str] = &[
     "WASM_MUSL_SYSROOT",
 ];
 
-const TASK_IO_ENV_VARS: &[&str] = &[
+pub(crate) const TASK_IO_ENV_VARS: &[&str] = &[
     "CARGO_BUILD_ARTIFACT_DIR",
     "CARGO_BUILD_TARGET",
     "CARGO_BUILD_TARGET_DIR",
@@ -718,7 +718,7 @@ fn crate_source_globs(prefix: &str, crate_path: &str) -> [String; 2] {
     [format!("{base}/**"), format!("!{base}/.turbo/**")]
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct CargoWorkspaceDetails {
     target_directory: AbsoluteSystemPathBuf,
     host_target: String,
@@ -727,6 +727,156 @@ struct CargoWorkspaceDetails {
     repository_config_untracked: bool,
     external_config_present: bool,
     manifest_alters_profile_dirs: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CargoTaskContract {
+    repo_root: AbsoluteSystemPathBuf,
+    package: CargoPackageDetails,
+    workspace: Option<CargoWorkspaceDetails>,
+}
+
+impl CargoTaskContract {
+    fn new(
+        repo_root: AbsoluteSystemPathBuf,
+        package: CargoPackageDetails,
+        workspace: Option<CargoWorkspaceDetails>,
+    ) -> Self {
+        Self {
+            repo_root,
+            package,
+            workspace,
+        }
+    }
+
+    pub(crate) fn task_defaults(&self, task: &str) -> toolchain::TaskDefaults {
+        let cache = task_subcommand(self.package.kind, task).and_then(|subcommand| {
+            (subcommand == "run"
+                || (self.package.kind == CargoPackageKind::Library && subcommand == "build"))
+                .then_some(false)
+        });
+        toolchain::TaskDefaults { cache }
+    }
+
+    pub(crate) fn derives_task_io(&self, task: &str) -> bool {
+        registered_tasks(&self.package)
+            .into_iter()
+            .any(|registered| registered == task)
+    }
+
+    pub(crate) fn task_entrypoint(
+        &self,
+        task: &str,
+    ) -> Option<crate::task_contracts::TaskEntrypoint> {
+        library_subcommand(task)?;
+        Some(match (task == "build", self.package.kind) {
+            (true, CargoPackageKind::Workspace) => crate::task_contracts::TaskEntrypoint::Excluded,
+            (true, CargoPackageKind::Entrypoint) => {
+                crate::task_contracts::TaskEntrypoint::Preferred
+            }
+            (false, CargoPackageKind::Workspace) => {
+                crate::task_contracts::TaskEntrypoint::PreferredOnly
+            }
+            _ => crate::task_contracts::TaskEntrypoint::Candidate,
+        })
+    }
+
+    pub(crate) fn derived_task_io(
+        &self,
+        package: &crate::package_graph::PackageTaskContext<'_>,
+        task: &str,
+        path_to_root: &str,
+        dependencies: &[crate::package_graph::PackageTaskContext<'_>],
+        wants_automatic_inputs: bool,
+        context: &toolchain::TaskIOContext<'_>,
+    ) -> Option<toolchain::DerivedTaskIO> {
+        let subcommand = task_subcommand(self.package.kind, task)?;
+        let mut io = toolchain::DerivedTaskIO {
+            input_globs: hash_input_globs(path_to_root),
+            env: HASHED_ENV_VARS.iter().map(|var| var.to_string()).collect(),
+            ..Default::default()
+        };
+        if let Some(workspace) = &self.workspace
+            && (workspace.repository_config_untracked || workspace.external_config_present)
+        {
+            io.input_safety = toolchain::DerivedInputSafety::Untracked;
+            if workspace.repository_config_untracked {
+                io.input_globs.retain(|glob| {
+                    !glob.ends_with(".cargo/config.toml") && !glob.ends_with(".cargo/config")
+                });
+            }
+        }
+
+        let dependency_globs = || {
+            let mut globs: Vec<String> = dependencies
+                .iter()
+                .filter(|dependency| {
+                    dependency.toolchain() == Some(&ToolchainId::RUST)
+                        && dependency.kind()
+                            != crate::package_graph::PackageTaskContextKind::Aggregate
+                })
+                .flat_map(|dependency| {
+                    crate_source_globs(path_to_root, dependency.directory().to_unix().as_str())
+                })
+                .collect();
+            globs.sort();
+            globs.dedup();
+            globs
+        };
+
+        match self.package.kind {
+            CargoPackageKind::Entrypoint | CargoPackageKind::Library => {
+                if wants_automatic_inputs {
+                    io.package_default_inputs = Some(true);
+                    io.input_globs.extend(dependency_globs());
+                }
+                if subcommand == "build" {
+                    if self.package.kind == CargoPackageKind::Library {
+                        io.outputs = toolchain::DerivedOutputs::Unavailable;
+                    } else {
+                        io.outputs = self
+                            .workspace
+                            .as_ref()
+                            .and_then(|workspace| {
+                                let layout = cargo_output_layout(
+                                    &self.repo_root,
+                                    workspace,
+                                    &self.package,
+                                    context,
+                                )?;
+                                let effective_target =
+                                    layout.target.as_deref().unwrap_or(&workspace.host_target);
+                                let platform = target_platform(effective_target)?;
+                                let package_directory = self.repo_root.resolve(package.directory());
+                                let target_directory =
+                                    AnchoredSystemPathBuf::relative_path_between(
+                                        &package_directory,
+                                        &layout.target_directory,
+                                    )
+                                    .to_unix();
+                                Some(toolchain::DerivedOutputs::Resolved(
+                                    deliverable_output_paths(
+                                        target_directory.as_str(),
+                                        layout.target.as_deref(),
+                                        &layout.profile,
+                                        platform,
+                                        &self.package.deliverables,
+                                    ),
+                                ))
+                            })
+                            .unwrap_or(toolchain::DerivedOutputs::Unavailable);
+                    }
+                }
+            }
+            CargoPackageKind::Workspace => {
+                if wants_automatic_inputs {
+                    io.package_default_inputs = Some(false);
+                    io.input_globs.extend(dependency_globs());
+                }
+            }
+        }
+        Some(io)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1035,10 +1185,8 @@ fn cargo_output_layout(
 /// root contains a `Cargo.toml`.
 pub struct CargoToolchain {
     repo_root: AbsoluteSystemPathBuf,
-    /// Per-package details recorded during discovery, consumed by command
-    /// resolution. Keyed by package name.
+    /// Per-package details retained for entrypoint selection and pruning.
     details: std::sync::Mutex<HashMap<String, CargoPackageDetails>>,
-    workspace_details: std::sync::Mutex<Option<CargoWorkspaceDetails>>,
 }
 
 impl CargoToolchain {
@@ -1046,7 +1194,6 @@ impl CargoToolchain {
         Arc::new(Self {
             repo_root,
             details: std::sync::Mutex::new(HashMap::new()),
-            workspace_details: std::sync::Mutex::new(None),
         })
     }
 
@@ -1064,46 +1211,11 @@ impl CargoToolchain {
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .insert(package, details);
     }
-
-    fn workspace_details(&self) -> Option<CargoWorkspaceDetails> {
-        self.workspace_details
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .clone()
-    }
-
-    fn owns_context(&self, context: &crate::package_graph::PackageTaskContext<'_>) -> bool {
-        context.repository_root() == self.repo_root.as_ref()
-            && context.toolchain() == Some(&ToolchainId::RUST)
-    }
 }
 
 impl Toolchain for CargoToolchain {
     fn id(&self) -> ToolchainId {
         ToolchainId::RUST
-    }
-
-    fn task_io_env_vars(&self) -> &[&str] {
-        TASK_IO_ENV_VARS
-    }
-
-    fn task_defaults(
-        &self,
-        context: &crate::package_graph::PackageTaskContext<'_>,
-        task: &str,
-    ) -> toolchain::TaskDefaults {
-        let cache = self
-            .owns_context(context)
-            .then(|| context.package().as_ref())
-            .and_then(|name| self.package_details(name))
-            .and_then(|details| {
-                let subcommand = task_subcommand(details.kind, task)?;
-                (subcommand == "run"
-                    || (details.kind == CargoPackageKind::Library && subcommand == "build"))
-                    .then_some(false)
-            });
-
-        toolchain::TaskDefaults { cache }
     }
 
     /// Route rustc invocations through the embedded sccache, with the
@@ -1177,75 +1289,6 @@ impl Toolchain for CargoToolchain {
             vars.push(("CARGO_INCREMENTAL".to_string(), "0".to_string()));
         }
         vars
-    }
-
-    fn derives_task_io(
-        &self,
-        package: &crate::package_graph::PackageTaskContext<'_>,
-        task: &str,
-    ) -> bool {
-        // Mirrors the early returns of `derived_task_io`: a known crate
-        // with a Cargo subcommand for this task.
-        self.owns_context(package) && package.native_tasks().defines(task)
-    }
-
-    fn select_task_entrypoints(
-        &self,
-        task: &str,
-        candidates: &[String],
-        prefer_workspace: bool,
-    ) -> Option<Vec<String>> {
-        let subcommand = library_subcommand(task)?;
-        let details = self
-            .details
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if subcommand == "build" {
-            let crates: Vec<_> = candidates
-                .iter()
-                .filter(|candidate| {
-                    details
-                        .get(candidate.as_str())
-                        .is_some_and(|details| details.kind != CargoPackageKind::Workspace)
-                })
-                .cloned()
-                .collect();
-            if prefer_workspace {
-                let entrypoints: Vec<_> = crates
-                    .iter()
-                    .filter(|candidate| {
-                        details
-                            .get(candidate.as_str())
-                            .is_some_and(|details| details.kind == CargoPackageKind::Entrypoint)
-                    })
-                    .cloned()
-                    .collect();
-                if !entrypoints.is_empty() {
-                    return Some(entrypoints);
-                }
-            }
-            return Some(crates);
-        }
-        if prefer_workspace
-            && let Some(workspace) = candidates.iter().find(|candidate| {
-                details
-                    .get(candidate.as_str())
-                    .is_some_and(|details| details.kind == CargoPackageKind::Workspace)
-            })
-        {
-            return Some(vec![workspace.clone()]);
-        }
-        Some(
-            candidates
-                .iter()
-                .filter(|candidate| {
-                    details
-                        .get(candidate.as_str())
-                        .is_some_and(|details| details.kind != CargoPackageKind::Workspace)
-                })
-                .cloned()
-                .collect(),
-        )
     }
 
     fn watch_spec(&self) -> toolchain::WatchSpec {
@@ -1373,124 +1416,6 @@ impl Toolchain for CargoToolchain {
         vec![CARGO_LOCK.to_string()]
     }
 
-    fn derived_task_io(
-        &self,
-        package: &crate::package_graph::PackageTaskContext<'_>,
-        task: &str,
-        path_to_root: &str,
-        dependencies: &[crate::package_graph::PackageTaskContext<'_>],
-        wants_automatic_inputs: bool,
-        context: &toolchain::TaskIOContext<'_>,
-    ) -> Option<toolchain::DerivedTaskIO> {
-        self.owns_context(package).then_some(())?;
-        let name = package.package().as_ref();
-        let details = self.package_details(name)?;
-        let subcommand = task_subcommand(details.kind, task)?;
-
-        // The workspace lockfile/manifest, Cargo config, and pinned
-        // rust-toolchain files are hashed (dependency, profile, or toolchain
-        // changes invalidate the cache), along with the env vars that change
-        // what Cargo builds. These apply regardless of explicit user
-        // `inputs`.
-        let mut io = toolchain::DerivedTaskIO {
-            input_globs: hash_input_globs(path_to_root),
-            env: HASHED_ENV_VARS.iter().map(|var| var.to_string()).collect(),
-            ..Default::default()
-        };
-        if let Some(workspace) = self.workspace_details()
-            && (workspace.repository_config_untracked || workspace.external_config_present)
-        {
-            io.input_safety = toolchain::DerivedInputSafety::Untracked;
-            if workspace.repository_config_untracked {
-                io.input_globs.retain(|glob| {
-                    !glob.ends_with(".cargo/config.toml") && !glob.ends_with(".cargo/config")
-                });
-            }
-        }
-
-        // Source globs for the crates whose code this task compiles,
-        // filtered to real crates (the workspace aggregate has no
-        // sources of its own).
-        let dependency_globs = || {
-            let mut globs: Vec<String> = dependencies
-                .iter()
-                .filter(|dep| dep.toolchain() == Some(&ToolchainId::RUST))
-                .filter(|dep| {
-                    self.package_details(dep.package().as_ref())
-                        .is_some_and(|details| details.kind != CargoPackageKind::Workspace)
-                })
-                .flat_map(|dep| {
-                    crate_source_globs(path_to_root, dep.directory().to_unix().as_str())
-                })
-                .collect();
-            globs.sort();
-            globs.dedup();
-            globs
-        };
-
-        match details.kind {
-            // A crate-scoped task hashes a conservative closure of declared
-            // local dependencies, flattening their sources into this task's
-            // inputs. Entrypoint builds additionally cache their
-            // bin/cdylib/staticlib deliverables; Cargo's internal target/
-            // state remains its own incremental cache.
-            CargoPackageKind::Entrypoint | CargoPackageKind::Library => {
-                if wants_automatic_inputs {
-                    io.package_default_inputs = Some(true);
-                    io.input_globs.extend(dependency_globs());
-                }
-                if subcommand == "build" {
-                    if details.kind == CargoPackageKind::Library {
-                        io.outputs = toolchain::DerivedOutputs::Unavailable;
-                    } else {
-                        io.outputs = self
-                            .workspace_details()
-                            .and_then(|workspace| {
-                                let layout = cargo_output_layout(
-                                    &self.repo_root,
-                                    &workspace,
-                                    &details,
-                                    context,
-                                )?;
-                                let effective_target =
-                                    layout.target.as_deref().unwrap_or(&workspace.host_target);
-                                let platform = target_platform(effective_target)?;
-                                let package_directory = self.repo_root.resolve(package.directory());
-                                let target_directory =
-                                    AnchoredSystemPathBuf::relative_path_between(
-                                        &package_directory,
-                                        &layout.target_directory,
-                                    )
-                                    .to_unix();
-                                Some(toolchain::DerivedOutputs::Resolved(
-                                    deliverable_output_paths(
-                                        target_directory.as_str(),
-                                        layout.target.as_deref(),
-                                        &layout.profile,
-                                        platform,
-                                        &details.deliverables,
-                                    ),
-                                ))
-                            })
-                            .unwrap_or(toolchain::DerivedOutputs::Unavailable);
-                    }
-                }
-            }
-            // The workspace package's directory is the repo root, so
-            // default hashing would pull in the entire repository
-            // (including JS packages). Hash the crate directories instead —
-            // its dependencies are exactly the crates.
-            CargoPackageKind::Workspace => {
-                if wants_automatic_inputs {
-                    io.package_default_inputs = Some(false);
-                    io.input_globs.extend(dependency_globs());
-                }
-            }
-        }
-
-        Some(io)
-    }
-
     fn discover_packages(&self) -> DiscoverPackagesFuture<'_> {
         Box::pin(async move {
             // Discovery spawns `cargo metadata` synchronously, so keep it off
@@ -1549,24 +1474,19 @@ impl Toolchain for CargoToolchain {
                     ))
                 })
                 .map_err(|err| toolchain::Error::Failed(Box::new(err)))?;
-            if let Some(target_directory) = target_directory {
+            let workspace_contract_details = target_directory.map(|target_directory| {
                 let startup_environment = CargoHomeEnvironment::current();
                 let config = cargo_config_influence(&self.repo_root, &startup_environment);
-                *self
-                    .workspace_details
-                    .lock()
-                    .unwrap_or_else(|poisoned| poisoned.into_inner()) =
-                    Some(CargoWorkspaceDetails {
-                        target_directory,
-                        host_target,
-                        supported_targets,
-                        repository_config_alters_output_layout: config
-                            .repository_alters_output_layout,
-                        repository_config_untracked: config.repository_config_untracked,
-                        external_config_present: config.external_present,
-                        manifest_alters_profile_dirs: manifest_alters_profile_dirs(&self.repo_root),
-                    });
-            }
+                CargoWorkspaceDetails {
+                    target_directory,
+                    host_target,
+                    supported_targets,
+                    repository_config_alters_output_layout: config.repository_alters_output_layout,
+                    repository_config_untracked: config.repository_config_untracked,
+                    external_config_present: config.external_present,
+                    manifest_alters_profile_dirs: manifest_alters_profile_dirs(&self.repo_root),
+                }
+            });
             let workspace_externals: HashSet<turborepo_lockfiles::Package> = closures
                 .values()
                 .flatten()
@@ -1599,6 +1519,11 @@ impl Toolchain for CargoToolchain {
                     dir,
                 };
                 let native_tasks = native_tasks_for_package(&details, &cargo_crate.name);
+                let task_contract = CargoTaskContract::new(
+                    self.repo_root.clone(),
+                    details.clone(),
+                    workspace_contract_details.clone(),
+                );
                 self.record_details(cargo_crate.name.clone(), details);
                 let external_dependencies: HashSet<turborepo_lockfiles::Package> = closures
                     .remove(&cargo_crate.name)
@@ -1618,7 +1543,10 @@ impl Toolchain for CargoToolchain {
                         cargo_crate.manifest_path,
                     )
                     .with_native_relationships(relationships)
-                    .with_native_tasks(native_tasks),
+                    .with_native_tasks(native_tasks)
+                    .with_task_contract(
+                        crate::task_contracts::ScopeTaskContract::cargo(task_contract),
+                    ),
                 );
             }
 
@@ -1627,15 +1555,20 @@ impl Toolchain for CargoToolchain {
             // name`. It depends on every crate so `--affected` and
             // dependent-filters propagate crate changes to it.
             if !crate_names.is_empty() {
-                let workspace_details = CargoPackageDetails {
+                let workspace_package_details = CargoPackageDetails {
                     kind: CargoPackageKind::Workspace,
                     deliverables: Vec::new(),
                     manifest_alters_output_layout: false,
                     dir: String::new(),
                 };
                 let workspace_native_tasks =
-                    native_tasks_for_package(&workspace_details, &workspace_name);
-                self.record_details(workspace_name.clone(), workspace_details);
+                    native_tasks_for_package(&workspace_package_details, &workspace_name);
+                let task_contract = CargoTaskContract::new(
+                    self.repo_root.clone(),
+                    workspace_package_details.clone(),
+                    workspace_contract_details.clone(),
+                );
+                self.record_details(workspace_name.clone(), workspace_package_details);
                 crate_names.sort();
                 let relationships = crate_names
                     .into_iter()
@@ -1652,7 +1585,10 @@ impl Toolchain for CargoToolchain {
                         self.repo_root.join_component(CARGO_TOML),
                     )
                     .with_native_relationships(relationships)
-                    .with_native_tasks(workspace_native_tasks),
+                    .with_native_tasks(workspace_native_tasks)
+                    .with_task_contract(
+                        crate::task_contracts::ScopeTaskContract::cargo(task_contract),
+                    ),
                 );
             }
 
@@ -3773,17 +3709,21 @@ release: 1.96.0-nightly\n",
         write_fixture_workspace(&root);
 
         let toolchain = CargoToolchain::new(root.clone());
-        // Discovery records the per-package details command resolution uses.
-        toolchain.discover_packages().await.unwrap();
+        let discovered = toolchain.discover_packages().await.unwrap();
+        let contracts: HashMap<_, _> = discovered
+            .packages()
+            .iter()
+            .cloned()
+            .filter_map(|package| {
+                let parts = package.into_parts();
+                Some((parts.name?, parts.task_contract?))
+            })
+            .collect();
 
         let stale_package = package_info("stale-name");
         let app_context = task_context(&toolchain, &root, "app", "crates/app", Some(&stale_package));
         let lib_a_context = task_context(&toolchain, &root, "lib-a", "crates/lib-a", None);
         let workspace_context = task_context(&toolchain, &root, "fixture-ws", "", Some(&stale_package));
-
-        let foreign_root = root.join_component("foreign");
-        let foreign_context = task_context(&toolchain, &foreign_root, "app", "crates/app", None);
-        assert!(!toolchain.owns_context(&foreign_context));
 
         // Entrypoint build: scoped to the crate, serialized on the cargo
         // group, run from the workspace root.
@@ -3859,76 +3799,43 @@ release: 1.96.0-nightly\n",
             Some("cargo build --package=lib-a --locked")
         );
 
-        assert_eq!(toolchain.task_defaults(&app_context, "run").cache, Some(false));
-        assert_eq!(toolchain.task_defaults(&app_context, "dev").cache, Some(false));
-        assert_eq!(toolchain.task_defaults(&app_context, "build").cache, None);
-        assert_eq!(toolchain.task_defaults(&workspace_context, "test").cache, None);
-        assert_eq!(toolchain.task_defaults(&lib_a_context, "test").cache, None);
-        assert_eq!(toolchain.task_defaults(&lib_a_context, "build").cache, Some(false));
+        let app_contract = &contracts["app"];
+        let library_contract = &contracts["lib-a"];
+        let workspace_contract = &contracts["fixture-ws"];
+        assert_eq!(app_contract.defaults_for_task("run").cache, Some(false));
+        assert_eq!(app_contract.defaults_for_task("dev").cache, Some(false));
+        assert_eq!(app_contract.defaults_for_task("build").cache, None);
+        assert_eq!(workspace_contract.defaults_for_task("test").cache, None);
+        assert_eq!(library_contract.defaults_for_task("test").cache, None);
+        assert_eq!(library_contract.defaults_for_task("build").cache, Some(false));
+        assert_eq!(
+            app_context
+                .native_tasks()
+                .override_serial_group(&["cargo".to_string(), "fuzz".to_string()]),
+            Some("cargo".to_string())
+        );
+        assert_eq!(
+            app_context
+                .native_tasks()
+                .override_serial_group(&["./script".to_string()]),
+            None
+        );
 
         assert_eq!(
-            toolchain.select_task_entrypoints(
-                "test",
-                &[
-                    "app".to_string(),
-                    "lib-a".to_string(),
-                    "fixture-ws".to_string()
-                ],
-                true,
-            ),
-            Some(vec!["fixture-ws".to_string()])
+            app_contract.task_entrypoint("build"),
+            Some(crate::task_contracts::TaskEntrypoint::Preferred)
         );
         assert_eq!(
-            toolchain.select_task_entrypoints(
-                "test",
-                &[
-                    "app".to_string(),
-                    "lib-a".to_string(),
-                    "fixture-ws".to_string()
-                ],
-                false,
-            ),
-            Some(vec!["app".to_string(), "lib-a".to_string()])
+            library_contract.task_entrypoint("build"),
+            Some(crate::task_contracts::TaskEntrypoint::Candidate)
         );
         assert_eq!(
-            toolchain.select_task_entrypoints(
-                "test",
-                &["app".to_string(), "lib-a".to_string()],
-                false,
-            ),
-            Some(vec!["app".to_string(), "lib-a".to_string()])
+            workspace_contract.task_entrypoint("build"),
+            Some(crate::task_contracts::TaskEntrypoint::Excluded)
         );
         assert_eq!(
-            toolchain.select_task_entrypoints(
-                "build",
-                &[
-                    "app".to_string(),
-                    "lib-a".to_string(),
-                    "fixture-ws".to_string()
-                ],
-                true,
-            ),
-            Some(vec!["app".to_string()])
-        );
-        assert_eq!(
-            toolchain.select_task_entrypoints(
-                "build",
-                &[
-                    "app".to_string(),
-                    "lib-a".to_string(),
-                    "fixture-ws".to_string()
-                ],
-                false,
-            ),
-            Some(vec!["app".to_string(), "lib-a".to_string()])
-        );
-        assert_eq!(
-            toolchain.select_task_entrypoints(
-                "build",
-                &["lib-a".to_string(), "fixture-ws".to_string()],
-                true,
-            ),
-            Some(vec!["lib-a".to_string()])
+            workspace_contract.task_entrypoint("test"),
+            Some(crate::task_contracts::TaskEntrypoint::PreferredOnly)
         );
     }
 
@@ -3987,7 +3894,19 @@ release: 1.96.0-nightly\n",
         write_fixture_workspace(&root);
 
         let toolchain = CargoToolchain::new(root.clone());
-        toolchain.discover_packages().await.unwrap();
+        let discovered = toolchain.discover_packages().await.unwrap();
+        let contracts: HashMap<_, _> = discovered
+            .packages()
+            .iter()
+            .cloned()
+            .filter_map(|package| {
+                let parts = package.into_parts();
+                Some((parts.name?, parts.task_contract?))
+            })
+            .collect();
+        let app_contract = &contracts["app"];
+        let library_contract = &contracts["lib-a"];
+        let workspace_contract = &contracts["fixture-ws"];
 
         let app = package_info("app");
         let lib_a = package_info("lib-a");
@@ -4020,7 +3939,7 @@ release: 1.96.0-nightly\n",
         // dependency crate closure as inputs (own sources via default
         // hashing), deliverables as outputs.
         let deps = [lib_ctx.clone()];
-        let io = toolchain
+        let io = app_contract
             .derived_task_io(&app_ctx, "build", "../..", &deps, true, &context)
             .expect("entrypoint build derives IO");
         assert!(
@@ -4058,8 +3977,8 @@ release: 1.96.0-nightly\n",
         let toolchain::DerivedOutputs::Resolved(outputs) = &io.outputs else {
             panic!("Cargo host outputs must remain resolved");
         };
-        let workspace_details = toolchain.workspace_details().unwrap();
-        let platform = target_platform(&workspace_details.host_target).unwrap();
+        let (_, host_target) = rustc_info(&root).unwrap();
+        let platform = target_platform(&host_target).unwrap();
         let basename = deliverable_basename(
             &Deliverable {
                 name: "app".to_string(),
@@ -4075,7 +3994,7 @@ release: 1.96.0-nightly\n",
             task_args: Some(&unsupported_target),
             environment: &environment,
         };
-        let unsupported = toolchain
+        let unsupported = app_contract
             .derived_task_io(
                 &app_ctx,
                 "build",
@@ -4089,7 +4008,7 @@ release: 1.96.0-nightly\n",
 
         // Explicit inputs without $TURBO_DEFAULT$: workspace files still
         // apply, but no closure globs and no default-hashing override.
-        let io = toolchain
+        let io = app_contract
             .derived_task_io(&app_ctx, "build", "../..", &deps, false, &context)
             .expect("entrypoint build derives IO");
         assert!(io.input_globs.contains(&"../../Cargo.toml".to_string()));
@@ -4097,7 +4016,7 @@ release: 1.96.0-nightly\n",
         assert_eq!(io.package_default_inputs, None);
 
         // Non-build entrypoint verbs cache no deliverables.
-        let io = toolchain
+        let io = app_contract
             .derived_task_io(&app_ctx, "dev", "../..", &deps, true, &context)
             .expect("entrypoint dev derives IO");
         assert_eq!(io.outputs, toolchain::DerivedOutputs::Resolved(Vec::new()));
@@ -4105,7 +4024,7 @@ release: 1.96.0-nightly\n",
         // The workspace package hashes crate directories instead of the
         // repo root's default file set.
         let deps = [app_ctx.clone(), lib_ctx.clone()];
-        let io = toolchain
+        let io = workspace_contract
             .derived_task_io(&workspace_ctx, "test", "", &deps, true, &context)
             .expect("workspace test derives IO");
         assert_eq!(io.package_default_inputs, Some(false));
@@ -4117,7 +4036,7 @@ release: 1.96.0-nightly\n",
         // Library verification hashes dev dependencies even when their cycle
         // prevents them from appearing in the package graph.
         let cycle_inputs = [test_util_ctx];
-        let io = toolchain
+        let io = library_contract
             .derived_task_io(&lib_ctx, "test", "../..", &cycle_inputs, true, &context)
             .expect("library test derives IO");
         assert_eq!(io.package_default_inputs, Some(true));
@@ -4131,7 +4050,7 @@ release: 1.96.0-nightly\n",
 
         // Library build artifacts are Cargo-internal and cannot be restored as
         // stable Turborepo outputs, so implicit caching fails closed.
-        let io = toolchain
+        let io = library_contract
             .derived_task_io(&lib_ctx, "build", "../..", &cycle_inputs, true, &context)
             .expect("library build derives IO");
         assert_eq!(io.package_default_inputs, Some(true));

--- a/crates/turborepo-repository/src/native_tasks.rs
+++ b/crates/turborepo-repository/src/native_tasks.rs
@@ -1,7 +1,6 @@
 //! Parser-neutral native task and command knowledge.
 //!
 //! Ecosystems contribute observations once; core consumes an immutable catalog.
-//! Toolchain task callbacks are compatibility adapters over this catalog.
 
 use std::{
     collections::{BTreeMap, HashMap},
@@ -173,6 +172,19 @@ impl ScopeNativeTasks {
             .map(|task| task.name().to_string())
             .collect()
     }
+
+    /// Resource group retained when an override uses this scope's native
+    /// command family. This also applies to override-only task names that have
+    /// no catalog entry.
+    pub fn override_serial_group(&self, override_command: &[String]) -> Option<String> {
+        let invokes_cargo = override_command.first().map(String::as_str) == Some("cargo");
+        (invokes_cargo
+            && self
+                .tasks()
+                .iter()
+                .any(|task| matches!(task.command(), Some(NativeCommandTemplate::Cargo { .. }))))
+        .then(|| "cargo".to_string())
+    }
 }
 
 /// Producer-supplied native task facts for one scope, before catalog
@@ -181,6 +193,7 @@ impl ScopeNativeTasks {
 pub struct NativeTaskObservation {
     pub scope: String,
     pub tasks: Vec<NativeTask>,
+    pub task_contract: crate::task_contracts::ScopeTaskContract,
 }
 
 /// Immutable native-task catalog for one repository generation.
@@ -282,7 +295,11 @@ pub fn observation_from_scripts(
             cwd_policy: WorkingDirectoryPolicy::PackageDirectory,
         });
     }
-    NativeTaskObservation { scope, tasks }
+    NativeTaskObservation {
+        scope,
+        tasks,
+        task_contract: crate::task_contracts::ScopeTaskContract::javascript(),
+    }
 }
 
 /// Convert a package.json descriptor into a native-task observation.
@@ -304,13 +321,9 @@ pub fn resolve_task_command(
     override_command: Option<&[String]>,
 ) -> Result<Option<TaskCommand>, ResolveNativeCommandError> {
     if let Some(override_command) = override_command {
-        let serial_group = match task.command() {
-            Some(NativeCommandTemplate::Cargo { .. }) => {
-                (override_command.first().map(String::as_str) == Some("cargo"))
-                    .then(|| "cargo".to_string())
-            }
-            _ => None,
-        };
+        let serial_group = context
+            .native_tasks()
+            .override_serial_group(override_command);
         return Ok(override_task_command(
             context,
             override_command,

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -695,19 +695,37 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             manifest_path,
             native_relationships,
             native_tasks,
+            task_contract,
         } = package.into_parts();
         // Toolchain-resolved external identities are contributed to the
         // resolution generation separately; PackageInfo no longer carries
         // closure/hash compatibility projections.
+        let task_contract = task_contract.unwrap_or_else(|| {
+            if toolchain == ToolchainId::JAVASCRIPT {
+                crate::task_contracts::ScopeTaskContract::javascript()
+            } else {
+                crate::task_contracts::ScopeTaskContract::empty()
+            }
+        });
+        if let Some(contract_toolchain) = task_contract.toolchain()
+            && contract_toolchain != &toolchain
+        {
+            return Err(Error::TaskContracts(format!(
+                "scope task contract belongs to {contract_toolchain}, not {toolchain}"
+            )));
+        }
         let native_task_observation = match (name.as_ref(), native_tasks) {
             (Some(identity), Some(tasks)) => Some(crate::native_tasks::NativeTaskObservation {
                 scope: identity.clone(),
                 tasks,
+                task_contract,
             }),
-            (Some(identity), None) => Some(crate::native_tasks::observation_from_package_json(
-                identity.clone(),
-                &json,
-            )),
+            (Some(identity), None) => {
+                let mut observation =
+                    crate::native_tasks::observation_from_package_json(identity.clone(), &json);
+                observation.task_contract = task_contract;
+                Some(observation)
+            }
             (None, _) => None,
         };
         let entry = PackageInfo { package_json: json };
@@ -940,7 +958,6 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
                 // Command resolution is synchronous; record the resolved
                 // package manager on the toolchain so it does not re-run
                 // discovery.
-                javascript.set_resolved_package_manager(package_manager.clone());
                 Some(package_manager)
             }
             None => None,
@@ -954,27 +971,16 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
                 root_package_json,
             ));
         }
+        let task_contract_observations = native_task_observations
+            .iter()
+            .map(|observation| (observation.scope.clone(), observation.task_contract.clone()))
+            .collect::<Vec<_>>();
         let native_task_knowledge = Arc::new(
             crate::native_tasks::NativeTaskKnowledge::build(&knowledge, native_task_observations)
                 .map_err(|error| Error::NativeTasks(error.to_string()))?,
         );
 
         let task_contract_knowledge = Arc::new({
-            let observations = knowledge.scopes().map(|scope| {
-                let contract = if scope.toolchain() == &crate::toolchain::ToolchainId::JAVASCRIPT {
-                    crate::task_contracts::ScopeTaskContract::javascript()
-                } else {
-                    crate::task_contracts::ScopeTaskContract::empty()
-                };
-                (scope.identity().to_owned(), contract)
-            });
-            let mut observations: Vec<_> = observations.collect();
-            if knowledge.root_javascript_scope().is_some() {
-                observations.push((
-                    "//".to_string(),
-                    crate::task_contracts::ScopeTaskContract::javascript(),
-                ));
-            }
             let root_engines = root_package_json
                 .as_ref()
                 .and_then(|package_json| package_json.engines())
@@ -986,7 +992,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
                 })
                 .unwrap_or_default();
             crate::task_contracts::TaskContractKnowledge::build_with_engines(
-                observations,
+                task_contract_observations,
                 root_engines,
             )
             .map_err(|error| Error::TaskContracts(error.to_string()))?
@@ -1283,9 +1289,6 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             .clone()
             .ok_or_else(|| build_failure(Error::MissingRepositoryKnowledge))?;
         let package_manager = self.package_manager.clone();
-        if let (Some(javascript), Some(package_manager)) = (&self.javascript, &package_manager) {
-            javascript.set_resolved_package_manager(package_manager.clone());
-        }
         let definition_source = package_manager
             .as_ref()
             .map(|package_manager| AnchoredSystemPathBuf::from_raw(package_manager.lockfile_name()))
@@ -1388,6 +1391,10 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
                 root_package_json,
             ));
         }
+        let task_contract_observations = native_task_observations
+            .iter()
+            .map(|observation| (observation.scope.clone(), observation.task_contract.clone()))
+            .collect::<Vec<_>>();
         let native_task_knowledge = Arc::new(
             crate::native_tasks::NativeTaskKnowledge::build(&knowledge, native_task_observations)
                 .map_err(|error| {
@@ -1395,21 +1402,6 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             })?,
         );
         let task_contract_knowledge = Arc::new({
-            let observations = knowledge.scopes().map(|scope| {
-                let contract = if scope.toolchain() == &crate::toolchain::ToolchainId::JAVASCRIPT {
-                    crate::task_contracts::ScopeTaskContract::javascript()
-                } else {
-                    crate::task_contracts::ScopeTaskContract::empty()
-                };
-                (scope.identity().to_owned(), contract)
-            });
-            let mut observations: Vec<_> = observations.collect();
-            if knowledge.root_javascript_scope().is_some() {
-                observations.push((
-                    "//".to_string(),
-                    crate::task_contracts::ScopeTaskContract::javascript(),
-                ));
-            }
             let root_engines = root_package_json
                 .as_ref()
                 .and_then(|package_json| package_json.engines())
@@ -1421,7 +1413,7 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
                 })
                 .unwrap_or_default();
             crate::task_contracts::TaskContractKnowledge::build_with_engines(
-                observations,
+                task_contract_observations,
                 root_engines,
             )
             .map_err(|error| {

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -289,11 +289,7 @@ impl<'a> PackageTaskContext<'a> {
         };
         let requires_compatibility_payload = package != PackageName::Root
             || toolchain == Some(&crate::toolchain::ToolchainId::JAVASCRIPT);
-        let task_contract = if toolchain == Some(&crate::toolchain::ToolchainId::JAVASCRIPT) {
-            crate::task_contracts::ScopeTaskContract::javascript()
-        } else {
-            crate::task_contracts::ScopeTaskContract::empty()
-        };
+        let task_contract = crate::task_contracts::ScopeTaskContract::empty();
         Self {
             package,
             repository_root,
@@ -678,6 +674,68 @@ impl PackageGraph {
         self.task_contract_knowledge.root_engines()
     }
 
+    pub fn task_io_env_vars_by_toolchain(
+        &self,
+    ) -> std::collections::BTreeMap<crate::toolchain::ToolchainId, Vec<&'static str>> {
+        self.task_contract_knowledge.env_vars_by_toolchain()
+    }
+
+    pub fn select_task_entrypoints(
+        &self,
+        toolchain: &crate::toolchain::ToolchainId,
+        task: &str,
+        candidates: &[String],
+        prefer: bool,
+    ) -> Option<Vec<String>> {
+        let classified = candidates
+            .iter()
+            .filter_map(|candidate| {
+                let context = self.package_task_context(&PackageName::from(candidate.as_str()))?;
+                (context.toolchain() == Some(toolchain))
+                    .then(|| (candidate, context.task_contract().task_entrypoint(task)))
+            })
+            .collect::<Vec<_>>();
+        if !classified
+            .iter()
+            .any(|(_, entrypoint)| entrypoint.is_some())
+        {
+            return None;
+        }
+        if prefer {
+            let preferred = classified
+                .iter()
+                .filter(|(_, entrypoint)| {
+                    matches!(
+                        entrypoint,
+                        Some(
+                            crate::task_contracts::TaskEntrypoint::Preferred
+                                | crate::task_contracts::TaskEntrypoint::PreferredOnly
+                        )
+                    )
+                })
+                .map(|(name, _)| (*name).clone())
+                .collect::<Vec<_>>();
+            if !preferred.is_empty() {
+                return Some(preferred);
+            }
+        }
+        Some(
+            classified
+                .into_iter()
+                .filter(|(_, entrypoint)| {
+                    !matches!(
+                        entrypoint,
+                        Some(
+                            crate::task_contracts::TaskEntrypoint::Excluded
+                                | crate::task_contracts::TaskEntrypoint::PreferredOnly
+                        )
+                    )
+                })
+                .map(|(name, _)| name.clone())
+                .collect(),
+        )
+    }
+
     /// Foundational change knowledge for watch classification.
     pub fn change_knowledge(&self) -> &crate::change_knowledge::ChangeKnowledge {
         &self.change_knowledge
@@ -1022,50 +1080,6 @@ impl PackageGraph {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .generation = None;
-    }
-
-    /// Resolve a native or override command plan from the catalog.
-    ///
-    /// Binary lookup (`which`) is performed here so callers receive a concrete
-    /// [`TaskCommand`]. Package-manager / cargo framing comes from the
-    /// catalog templates, not from `Toolchain::task_command`.
-    pub fn resolve_native_task_command(
-        &self,
-        context: &PackageTaskContext<'_>,
-        task: &str,
-        pass_through_args: Option<&[String]>,
-        override_command: Option<&[String]>,
-    ) -> Result<Option<crate::toolchain::TaskCommand>, crate::native_tasks::ResolveNativeCommandError>
-    {
-        let package_manager = self.package_manager();
-        let package_manager_binary = package_manager
-            .and_then(|package_manager| which::which(package_manager.command()).ok());
-        let cargo_binary = which::which("cargo").ok();
-
-        if let Some(native_task) = context.native_tasks().get(task) {
-            return crate::native_tasks::resolve_task_command(
-                context,
-                native_task,
-                package_manager,
-                package_manager_binary.as_deref(),
-                cargo_binary.as_deref(),
-                pass_through_args,
-                override_command,
-            );
-        }
-
-        let Some(override_command) = override_command else {
-            return Ok(None);
-        };
-        let serial_group = (context.toolchain() == Some(&crate::toolchain::ToolchainId::RUST)
-            && override_command.first().map(String::as_str) == Some("cargo"))
-        .then(|| "cargo".to_string());
-        Ok(crate::toolchain::override_task_command(
-            context,
-            override_command,
-            pass_through_args,
-            serial_group,
-        ))
     }
 
     pub fn package_json(&self, package: &PackageName) -> Option<&PackageJson> {
@@ -3161,7 +3175,7 @@ version = "0.1.0"
             "a pure Cargo workspace has no root package.json"
         );
 
-        // The Cargo crates and synthetic workspace package populate the graph.
+        // The Cargo crates and workspace aggregate populate the graph.
         assert_eq!(
             pkg_graph.package_toolchain(&PackageName::from("app")),
             Some(&crate::toolchain::ToolchainId::RUST)
@@ -3175,8 +3189,6 @@ version = "0.1.0"
             Some(&crate::toolchain::ToolchainId::RUST)
         );
 
-        // Command resolution receives identity, path, and provenance from the
-        // graph-created context.
         let app_name = PackageName::from("app");
         let app_context = pkg_graph.package_task_context(&app_name).unwrap();
         assert_eq!(app_context.package(), &app_name);
@@ -3188,20 +3200,6 @@ version = "0.1.0"
             app_context.toolchain(),
             Some(&crate::toolchain::ToolchainId::RUST)
         );
-        let command = pkg_graph
-            .resolve_native_task_command(&app_context, "build", None, None)
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            command.args,
-            vec![
-                std::ffi::OsString::from("build"),
-                std::ffi::OsString::from("--package=app"),
-                std::ffi::OsString::from("--locked"),
-            ]
-        );
-        assert_eq!(command.cwd, root);
-
         // Crate path dependencies still become graph edges without a package
         // manager: the `workspace:*` protocol resolves internally regardless.
         let app_deps = pkg_graph

--- a/crates/turborepo-repository/src/task_contracts.rs
+++ b/crates/turborepo-repository/src/task_contracts.rs
@@ -1,30 +1,39 @@
 //! Foundational task-contract knowledge.
 //!
 //! Ecosystems contribute immutable observations about derived I/O defaults,
-//! environment patterns, and whether a scope participates in toolchain-derived
+//! environment patterns, and whether a scope participates in contract-derived
 //! hash wiring. Core composes these with turbo.json into effective contracts.
 //!
 //! JavaScript packages contribute empty contract observations: turbo.json is
-//! the whole story. Cargo temporarily retains `Toolchain` derived-I/O
-//! callbacks until its Rust port.
+//! the whole story. Cargo contributes immutable derivation plans.
 
 use std::collections::BTreeMap;
 
 use crate::toolchain::{TaskDefaults, ToolchainId};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskEntrypoint {
+    Preferred,
+    PreferredOnly,
+    Candidate,
+    Excluded,
+}
 
 /// Per-scope task-contract observation produced at repository construction.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ScopeTaskContract {
     /// Whether this scope participates in derived task I/O composition.
     ///
-    /// JavaScript is always `false`. Cargo remains on toolchain callbacks
-    /// until its port and is not recorded here yet.
+    /// JavaScript is always `false`; Cargo contributes immutable plans.
     derives_io: bool,
     defaults: TaskDefaults,
     /// Startup environment patterns this scope needs for derived I/O.
     env_vars: Vec<&'static str>,
     /// Toolchain provenance when the observation came from a known ecosystem.
     toolchain: Option<ToolchainId>,
+    cargo: Option<crate::cargo::CargoTaskContract>,
+    static_defaults: BTreeMap<String, TaskDefaults>,
+    static_io: BTreeMap<String, crate::toolchain::DerivedTaskIO>,
 }
 
 impl ScopeTaskContract {
@@ -35,6 +44,9 @@ impl ScopeTaskContract {
             defaults: TaskDefaults::default(),
             env_vars: Vec::new(),
             toolchain: Some(ToolchainId::JAVASCRIPT),
+            cargo: None,
+            static_defaults: BTreeMap::new(),
+            static_io: BTreeMap::new(),
         }
     }
 
@@ -45,6 +57,39 @@ impl ScopeTaskContract {
             defaults: TaskDefaults::default(),
             env_vars: Vec::new(),
             toolchain: None,
+            cargo: None,
+            static_defaults: BTreeMap::new(),
+            static_io: BTreeMap::new(),
+        }
+    }
+
+    pub(crate) fn cargo(contract: crate::cargo::CargoTaskContract) -> Self {
+        Self {
+            derives_io: true,
+            defaults: TaskDefaults::default(),
+            env_vars: crate::cargo::TASK_IO_ENV_VARS.to_vec(),
+            toolchain: Some(ToolchainId::RUST),
+            cargo: Some(contract),
+            static_defaults: BTreeMap::new(),
+            static_io: BTreeMap::new(),
+        }
+    }
+
+    /// Static derived contract for simple native producers and tests.
+    pub fn derived(
+        toolchain: ToolchainId,
+        defaults: BTreeMap<String, TaskDefaults>,
+        env_vars: Vec<&'static str>,
+        io: BTreeMap<String, crate::toolchain::DerivedTaskIO>,
+    ) -> Self {
+        Self {
+            derives_io: true,
+            defaults: TaskDefaults::default(),
+            env_vars,
+            toolchain: Some(toolchain),
+            cargo: None,
+            static_defaults: defaults,
+            static_io: io,
         }
     }
 
@@ -62,6 +107,52 @@ impl ScopeTaskContract {
 
     pub fn toolchain(&self) -> Option<&ToolchainId> {
         self.toolchain.as_ref()
+    }
+
+    pub fn defaults_for_task(&self, task: &str) -> TaskDefaults {
+        self.cargo.as_ref().map_or_else(
+            || {
+                self.static_defaults
+                    .get(task)
+                    .cloned()
+                    .unwrap_or_else(|| self.defaults.clone())
+            },
+            |cargo| cargo.task_defaults(task),
+        )
+    }
+
+    pub fn derives_task_io(&self, task: &str) -> bool {
+        self.static_io.contains_key(task)
+            || self
+                .cargo
+                .as_ref()
+                .is_some_and(|cargo| cargo.derives_task_io(task))
+    }
+
+    pub fn derived_task_io(
+        &self,
+        package: &crate::package_graph::PackageTaskContext<'_>,
+        task: &str,
+        path_to_root: &str,
+        dependencies: &[crate::package_graph::PackageTaskContext<'_>],
+        wants_automatic_inputs: bool,
+        context: &crate::toolchain::TaskIOContext<'_>,
+    ) -> Option<crate::toolchain::DerivedTaskIO> {
+        if let Some(io) = self.static_io.get(task) {
+            return Some(io.clone());
+        }
+        self.cargo.as_ref()?.derived_task_io(
+            package,
+            task,
+            path_to_root,
+            dependencies,
+            wants_automatic_inputs,
+            context,
+        )
+    }
+
+    pub fn task_entrypoint(&self, task: &str) -> Option<TaskEntrypoint> {
+        self.cargo.as_ref()?.task_entrypoint(task)
     }
 }
 
@@ -112,6 +203,27 @@ impl TaskContractKnowledge {
         self.by_scope
             .iter()
             .map(|(scope, contract)| (scope.as_str(), contract))
+    }
+
+    pub fn env_vars_by_toolchain(&self) -> BTreeMap<ToolchainId, Vec<&'static str>> {
+        let mut patterns = BTreeMap::<ToolchainId, Vec<&'static str>>::new();
+        for contract in self.by_scope.values() {
+            if contract.env_vars.is_empty() {
+                continue;
+            }
+            let Some(toolchain) = contract.toolchain.clone() else {
+                continue;
+            };
+            patterns
+                .entry(toolchain)
+                .or_default()
+                .extend(contract.env_vars.iter().copied());
+        }
+        for values in patterns.values_mut() {
+            values.sort_unstable();
+            values.dedup();
+        }
+        patterns
     }
 }
 

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -130,6 +130,7 @@ pub struct DiscoveredPackage {
     /// graph builder should derive tasks from `descriptor.scripts` when
     /// present (JavaScript). Cargo fills this with verb-table facts.
     native_tasks: Option<Vec<crate::native_tasks::NativeTask>>,
+    task_contract: Option<crate::task_contracts::ScopeTaskContract>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -146,6 +147,7 @@ pub(crate) struct DiscoveredPackageParts {
     pub manifest_path: AbsoluteSystemPathBuf,
     pub native_relationships: Option<Vec<Relationship>>,
     pub native_tasks: Option<Vec<crate::native_tasks::NativeTask>>,
+    pub task_contract: Option<crate::task_contracts::ScopeTaskContract>,
 }
 
 /// Parser-neutral observation of one contributed native workspace root.
@@ -241,6 +243,7 @@ impl DiscoveredPackage {
             manifest_path,
             native_relationships: None,
             native_tasks: None,
+            task_contract: None,
         }
     }
 
@@ -260,6 +263,7 @@ impl DiscoveredPackage {
             manifest_path,
             native_relationships: None,
             native_tasks: None,
+            task_contract: None,
         }
     }
 
@@ -277,6 +281,14 @@ impl DiscoveredPackage {
         self
     }
 
+    pub fn with_task_contract(
+        mut self,
+        contract: crate::task_contracts::ScopeTaskContract,
+    ) -> Self {
+        self.task_contract = Some(contract);
+        self
+    }
+
     pub(crate) fn into_parts(self) -> DiscoveredPackageParts {
         let Self {
             name,
@@ -286,6 +298,7 @@ impl DiscoveredPackage {
             manifest_path,
             native_relationships,
             native_tasks,
+            task_contract,
         } = self;
         DiscoveredPackageParts {
             name,
@@ -295,6 +308,7 @@ impl DiscoveredPackage {
             manifest_path,
             native_relationships,
             native_tasks,
+            task_contract,
         }
     }
 }
@@ -371,87 +385,6 @@ pub trait Toolchain: Send + Sync {
     /// Discover this toolchain's packages/scopes and native workspace roots in
     /// one observation envelope.
     fn discover_packages(&self) -> DiscoverPackagesFuture<'_>;
-
-    /// Defaults this toolchain supplies for `task` when turbo.json does not
-    /// configure the corresponding field. Explicit user configuration always
-    /// wins.
-    fn task_defaults(
-        &self,
-        context: &crate::package_graph::PackageTaskContext<'_>,
-        task: &str,
-    ) -> TaskDefaults {
-        let _ = (context, task);
-        TaskDefaults::default()
-    }
-
-    /// Startup environment patterns this toolchain needs to derive task I/O.
-    /// The run retains only matching keys, and the engine automatically adds
-    /// every declared pattern to the task's hashed environment when derived I/O
-    /// applies.
-    fn task_io_env_vars(&self) -> &[&str] {
-        &[]
-    }
-
-    /// Hash wiring this toolchain derives for `task` in `package`, beyond
-    /// what turbo.json declares: extra input globs and env vars that
-    /// participate in the task hash, output globs to cache, and whether the
-    /// package's own default (git-index based) file hashing applies.
-    ///
-    /// `path_to_root` is the unix path from the package directory to the
-    /// repo root (empty for a package at the root); returned globs are
-    /// relative to the package directory. `dependencies` are the package's
-    /// transitive internal dependencies. `wants_automatic_inputs` reflects
-    /// the task's `inputs` configuration: `true` unless explicit inputs
-    /// omitted `$TURBO_DEFAULT$` — for toolchains that derive inputs,
-    /// `$TURBO_DEFAULT$` means "everything the toolchain derives", so users
-    /// can append inputs without forfeiting automatic invalidation.
-    ///
-    /// `None` means the toolchain derives nothing and turbo.json is the
-    /// whole story.
-    fn derived_task_io(
-        &self,
-        package: &crate::package_graph::PackageTaskContext<'_>,
-        task: &str,
-        path_to_root: &str,
-        dependencies: &[crate::package_graph::PackageTaskContext<'_>],
-        wants_automatic_inputs: bool,
-        context: &TaskIOContext<'_>,
-    ) -> Option<DerivedTaskIO> {
-        let _ = (
-            package,
-            task,
-            path_to_root,
-            dependencies,
-            wants_automatic_inputs,
-            context,
-        );
-        None
-    }
-
-    /// Whether [`Toolchain::derived_task_io`] can return `Some` for this
-    /// package/task. Callers use this to skip assembling the (expensive)
-    /// dependency-closure argument when the answer is knowably `None` —
-    /// notably engine construction, which resolves a definition per task.
-    fn derives_task_io(
-        &self,
-        package: &crate::package_graph::PackageTaskContext<'_>,
-        task: &str,
-    ) -> bool {
-        let _ = (package, task);
-        false
-    }
-
-    /// Select package entrypoints for an unqualified task from the packages in
-    /// scope. `None` leaves the normal package × task expansion unchanged.
-    fn select_task_entrypoints(
-        &self,
-        task: &str,
-        candidates: &[String],
-        prefer_workspace: bool,
-    ) -> Option<Vec<String>> {
-        let _ = (task, candidates, prefer_workspace);
-        None
-    }
 
     /// How filesystem events relate to this toolchain in watch mode:
     /// workspace-definition files whose change requires rediscovery, and
@@ -560,8 +493,7 @@ pub struct WatchSpec {
     pub ignore_prefixes: Vec<String>,
 }
 
-/// Default task behavior supplied by a toolchain. See
-/// [`Toolchain::task_defaults`].
+/// Default task behavior supplied by task-contract knowledge.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct TaskDefaults {
     /// Whether task logs and outputs are cacheable.
@@ -657,8 +589,7 @@ pub enum DerivedInputSafety {
     Untracked,
 }
 
-/// Hash wiring derived by a toolchain for one task. See
-/// [`Toolchain::derived_task_io`].
+/// Hash wiring derived by task-contract knowledge for one task.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct DerivedTaskIO {
     /// Extra input globs, relative to the package directory.
@@ -747,10 +678,6 @@ pub struct JavaScriptToolchain<P> {
     discovery: P,
     repo_root: AbsoluteSystemPathBuf,
     known_package_manager: Option<PackageManager>,
-    /// The package manager as resolved during graph construction, recorded
-    /// by the builder so synchronous concerns (command resolution) can use
-    /// it without re-running discovery.
-    resolved_package_manager: std::sync::OnceLock<PackageManager>,
 }
 
 impl<P: PackageDiscovery + Send + Sync> JavaScriptToolchain<P> {
@@ -763,7 +690,6 @@ impl<P: PackageDiscovery + Send + Sync> JavaScriptToolchain<P> {
             discovery,
             repo_root,
             known_package_manager,
-            resolved_package_manager: std::sync::OnceLock::new(),
         }
     }
 
@@ -777,12 +703,6 @@ impl<P: PackageDiscovery + Send + Sync> JavaScriptToolchain<P> {
             Some(package_manager) => Ok(package_manager.clone()),
             None => Ok(self.discovery.discover_packages().await?.package_manager),
         }
-    }
-
-    /// Record the package manager resolved during graph construction. Called
-    /// by the package graph builder; later calls are no-ops.
-    pub fn set_resolved_package_manager(&self, package_manager: PackageManager) {
-        let _ = self.resolved_package_manager.set(package_manager);
     }
 
     pub(crate) async fn workspace_root(&self) -> Result<WorkspaceRoot, Error> {
@@ -841,9 +761,6 @@ impl<P: PackageDiscovery + Send + Sync> Toolchain for JavaScriptToolchain<P> {
     fn id(&self) -> ToolchainId {
         ToolchainId::JAVASCRIPT
     }
-
-    // Task-contract derived I/O for JavaScript is foundational knowledge
-    // (empty / turbo.json-owned). Do not override Toolchain::derived_task_io.
 
     fn watch_spec(&self) -> WatchSpec {
         // Deliberately nothing: JavaScript workspace redefinition (a new or
@@ -1068,34 +985,9 @@ mod tests {
 
     #[test]
     fn test_javascript_task_command() {
-        struct StubDiscovery;
-        impl PackageDiscovery for StubDiscovery {
-            async fn discover_packages(
-                &self,
-            ) -> Result<discovery::DiscoveryResponse, discovery::Error> {
-                Ok(discovery::DiscoveryResponse {
-                    package_manager: PackageManager::Npm,
-                    workspaces: vec![],
-                })
-            }
-            async fn discover_packages_blocking(
-                &self,
-            ) -> Result<discovery::DiscoveryResponse, discovery::Error> {
-                self.discover_packages().await
-            }
-        }
-
         let repo_root_buf =
             AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
         let repo_root = repo_root_buf.as_ref() as &AbsoluteSystemPath;
-
-        let toolchain = JavaScriptToolchain::new(
-            StubDiscovery,
-            repo_root_buf.clone(),
-            Some(PackageManager::Npm),
-        );
-        toolchain.set_resolved_package_manager(PackageManager::Npm);
-
         let package = crate::package_graph::PackageInfo {
             package_json: PackageJson::from_value(serde_json::json!({
                 "name": "stale-web",

--- a/crates/turborepo-run-summary/src/task_factory.rs
+++ b/crates/turborepo-run-summary/src/task_factory.rs
@@ -107,12 +107,7 @@ where
         // the display string (JavaScript: the script text; Cargo: the cargo
         // invocation), derived from the same tables as execution so display
         // cannot drift from what runs.
-        let command = summary_command(
-            self.package_graph,
-            package_context,
-            task_definition,
-            task_id.task(),
-        );
+        let command = summary_command(package_context, task_definition, task_id.task());
 
         let expanded_outputs = self
             .hash_tracker
@@ -264,12 +259,10 @@ where
 }
 
 fn summary_command(
-    package_graph: &PackageGraph,
     package_context: &PackageTaskContext<'_>,
     task_definition: &TaskDefinition,
     task: &str,
 ) -> String {
-    let _ = package_graph;
     match &task_definition.command {
         Some(turborepo_types::TaskCommandOverride::Argv(argv)) => argv.join(" "),
         Some(turborepo_types::TaskCommandOverride::OptOut) => "<OPT OUT>".to_string(),

--- a/crates/turborepo-task-executor/src/command.rs
+++ b/crates/turborepo-task-executor/src/command.rs
@@ -300,10 +300,9 @@ impl<'a, M: MfeConfigProvider, E: From<CommandProviderError>> CommandProvider<E>
                 ))
             })?
         } else if let Some(override_command) = override_command {
-            let serial_group = (toolchain_id
-                == &turborepo_repository::toolchain::ToolchainId::RUST
-                && override_command.first().map(String::as_str) == Some("cargo"))
-            .then(|| "cargo".to_string());
+            let serial_group = package_context
+                .native_tasks()
+                .override_serial_group(override_command);
             turborepo_repository::toolchain::override_task_command(
                 &package_context,
                 override_command,

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -367,7 +367,7 @@ whether anything changed; Cargo decides how and in what order to build.**
   workspace-scoped verification verbs.
 - **Execution and entrypoint selection** (`NativeTaskKnowledge`, native command
   resolution in `turborepo-task-executor`, and
-  `Toolchain::select_task_entrypoints`): crate-scoped build and verification
+  `PackageGraph::select_task_entrypoints`): crate-scoped build and verification
   tasks run `cargo <verb> --package=<crate> --locked`; entrypoints also expose
   `run`/`dev`. Unfiltered builds prefer entrypoints, falling back to libraries
   when the workspace has no entrypoints. Unfiltered verification uses the Cargo
@@ -399,7 +399,7 @@ whether anything changed; Cargo decides how and in what order to build.**
   definition. The names come from the same verb tables as command resolution
   and participate in task suggestions and add-all/query graph construction.
 - **Hashing and affectedness** (`HashRelationships`, `AffectedRelationships`,
-  and `Toolchain::derived_task_io`): crate-scoped tasks hash their own
+  and `TaskContractKnowledge`): crate-scoped tasks hash their own
   sources plus a conservative transitive closure of declared local Cargo
   dependencies (flattened, so invalidation doesn't depend on `dependsOn`
   wiring). The closure may include optional or target-specific dependencies not
@@ -590,7 +590,7 @@ The core task graph consists of:
   argv in their frame: cwd is the package directory, nothing is prepended,
   and Cargo keeps its serial group when the override still invokes cargo.
   Because an argv override is otherwise arbitrary, it does not inherit the
-  native command's toolchain-derived inputs, outputs, default-input behavior,
+  native command's contract-derived inputs, outputs, default-input behavior,
   or hash environment; its turbo.json `inputs`, `outputs`, and `env` are the
   authoritative task-level I/O configuration. Toolchain task defaults and
   execution-only compile-cache environment injection likewise apply only to


### PR DESCRIPTION
## Intent

Move Cargo task commands, entrypoint selection, defaults, derived inputs, environment, exact outputs, and cache safety into immutable repository knowledge.

**Base:** `main`.

## Changes

- Retain Cargo override framing and serial grouping in native-task scope knowledge.
- Remove dead command-era package-manager and graph resolution helpers.
- Produce immutable Cargo task contracts during discovery.
- Compose cache defaults, dependency-source inputs, hashed environment, output layout, and safety states from `PackageTaskContext`.
- Move task entrypoint selection from mutable `CargoToolchain` state to immutable contracts.
- Preserve query task enumeration and exclude-only Cargo entrypoint selection.
- Project task-I/O environment patterns from contract knowledge.
- Delete task defaults, task-I/O, and entrypoint-selection callbacks from `Toolchain`.
- Preserve fail-closed output and untracked-input behavior.

## Testing

- `cargo test -p turborepo-repository cargo::test` (41 passed)
- `cargo test -p turborepo-engine` (126 passed)
- `cargo test -p turbo --test cargo_workspace_test` (57 passed)
- `cargo clippy -p turborepo-repository -p turborepo-engine -p turborepo-lib -p turborepo-task-executor -p turborepo-run-summary --all-targets -- -D warnings`
- `cargo fmt --check`

Closes TURBO-5792.
Closes TURBO-5791.