### PR TITLE
refactor: Remove runtime toolchain dispatch

### DIFF
--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -374,13 +374,12 @@ pub async fn prune(
         prune.materialize_javascript_render(root_definition, &rendered)?;
     }
 
-    // The pruned output is complete; let each toolchain polish its own
-    // files in place (e.g. Cargo canonicalizes the pruned lockfile).
-    for toolchain in prune.package_graph.toolchains().iter() {
-        if !planned_toolchains.contains(&toolchain.id()) {
-            continue;
-        }
-        let finalized_files = toolchain.prune_finalize(&prune.full_directory);
+    // The pruned output is complete; let each planned generation-owned domain
+    // polish its own files in place (e.g. Cargo canonicalizes its lockfile).
+    for toolchain in planned_toolchains {
+        let finalized_files = prune
+            .package_graph
+            .finalize_prune(&toolchain, &prune.full_directory);
         if prune.docker {
             sync_prune_finalize_files(
                 &prune.full_directory,

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeSet, HashMap, HashSet},
     io::{ErrorKind, IsTerminal},
     sync::Arc,
     time::{Duration, SystemTime},
@@ -1312,8 +1312,11 @@ impl RunBuilder {
         filter_mode: &FilterMode,
     ) -> HashSet<TaskId<'static>> {
         let mut exclusions = HashSet::new();
-        for toolchain in pkg_dep_graph.toolchains().iter() {
-            let toolchain_id = toolchain.id();
+        let toolchains: BTreeSet<_> = candidates
+            .iter()
+            .filter_map(|name| pkg_dep_graph.package_toolchain(name).cloned())
+            .collect();
+        for toolchain_id in toolchains {
             let candidate_names: Vec<_> = candidates
                 .iter()
                 .filter(|name| {

--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -73,7 +73,7 @@ pub struct Visitor<'a> {
     micro_frontends_configs: Option<&'a MicrofrontendsConfigs>,
     /// The compile cache proxy endpoint for this run, when one is being
     /// served (`futureFlags.experimentalCargoSccache`). Toolchains translate
-    /// it into task env vars via `Toolchain::compile_cache_env`.
+    /// task-contract knowledge projects it into execution-only task env vars.
     compile_cache_endpoint: Option<CompileCacheEndpoint>,
 }
 

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -755,6 +755,14 @@ impl CargoTaskContract {
         toolchain::TaskDefaults { cache }
     }
 
+    pub(crate) fn compile_cache_env(
+        &self,
+        endpoint: &toolchain::CompileCacheEndpoint,
+        task_env: &std::collections::HashMap<String, String>,
+    ) -> Vec<(String, String)> {
+        cargo_compile_cache_env(endpoint, task_env)
+    }
+
     pub(crate) fn derives_task_io(&self, task: &str) -> bool {
         registered_tasks(&self.package)
             .into_iter()
@@ -1280,6 +1288,10 @@ impl PruneDomain for CargoPruneKnowledge {
             .collect(),
         }))
     }
+
+    fn finalize(&self, pruned_root: &AbsoluteSystemPath) -> Vec<String> {
+        finalize_cargo_prune(pruned_root)
+    }
 }
 
 /// The Cargo toolchain. Registered in the
@@ -1296,126 +1308,81 @@ impl CargoToolchain {
     }
 }
 
+/// Project execution-only compiler-cache settings from Cargo task knowledge.
+/// User-managed wrappers and sccache settings remain authoritative.
+fn cargo_compile_cache_env(
+    endpoint: &toolchain::CompileCacheEndpoint,
+    task_env: &std::collections::HashMap<String, String>,
+) -> Vec<(String, String)> {
+    if task_env.contains_key("RUSTC_WRAPPER")
+        || task_env.keys().any(|key| key.starts_with("SCCACHE_"))
+    {
+        return Vec::new();
+    }
+    let ambient_incremental = task_env.get("CARGO_INCREMENTAL").map(String::as_str);
+    if ambient_incremental.is_some_and(|value| value != "0") {
+        return Vec::new();
+    }
+
+    let mut vars = vec![
+        ("RUSTC_WRAPPER".to_string(), endpoint.wrapper.clone()),
+        (
+            toolchain::COMPILE_CACHE_WRAPPER_ENV.to_string(),
+            "1".to_string(),
+        ),
+        ("SCCACHE_WEBDAV_ENDPOINT".to_string(), endpoint.url.clone()),
+        ("SCCACHE_WEBDAV_TOKEN".to_string(), endpoint.token.clone()),
+        (
+            "SCCACHE_SERVER_PORT".to_string(),
+            endpoint.server_port.to_string(),
+        ),
+        (
+            "SCCACHE_IGNORE_SERVER_IO_ERROR".to_string(),
+            "1".to_string(),
+        ),
+    ];
+    if ambient_incremental.is_none() {
+        vars.push(("CARGO_INCREMENTAL".to_string(), "0".to_string()));
+    }
+    vars
+}
+
+/// Let Cargo remove feature-dead entries after the reachability-based lockfile
+/// projection. Failure is non-fatal: the superset lock remains buildable.
+fn finalize_cargo_prune(pruned_root: &AbsoluteSystemPath) -> Vec<String> {
+    let sync = |offline: bool| {
+        let mut cmd = std::process::Command::new("cargo");
+        cmd.args(["metadata", "--format-version", "1"]);
+        if offline {
+            cmd.arg("--offline");
+        }
+        cmd.current_dir(pruned_root.as_std_path()).output()
+    };
+    match sync(true).and_then(|offline| {
+        if offline.status.success() {
+            Ok(offline)
+        } else {
+            sync(false)
+        }
+    }) {
+        Ok(output) if output.status.success() => {}
+        Ok(output) => {
+            tracing::warn!(
+                "unable to canonicalize the pruned Cargo.lock; `cargo build --locked` may require \
+                 a lockfile refresh: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        Err(error) => {
+            tracing::warn!("unable to run cargo to canonicalize the pruned Cargo.lock: {error}");
+        }
+    }
+    vec![CARGO_LOCK.to_string()]
+}
+
 impl Toolchain for CargoToolchain {
     fn id(&self) -> ToolchainId {
         ToolchainId::RUST
-    }
-
-    /// Route rustc invocations through the embedded sccache, with the
-    /// Turborepo-served endpoint as its webdav storage backend. The wrapper
-    /// is the running turbo binary itself (which dispatches invocations
-    /// marked by [`toolchain::COMPILE_CACHE_WRAPPER_ENV`] to the sccache it
-    /// embeds), so nothing needs to be installed. sccache fetches per
-    /// compilation-unit objects lazily at rustc invocation time, so no
-    /// state needs restoring before the task starts.
-    ///
-    /// `CARGO_INCREMENTAL=0` accompanies the wrapper because sccache cannot
-    /// cache incrementally-compiled crates and would fall back to plain
-    /// compilation for them.
-    ///
-    /// These are injected at execution time only and deliberately do not
-    /// participate in the task hash: a compile cache is output-transparent,
-    /// so enabling it must not invalidate existing task artifacts.
-    ///
-    /// Composition with the task environment:
-    ///
-    /// - A pre-existing `RUSTC_WRAPPER` or any `SCCACHE_*` variable signals a
-    ///   competing compiler-cache configuration; injecting on top of it could
-    ///   hijack that setup's backend, so the whole set stands down.
-    ///   (`RUSTC_WRAPPER` participates in task hashes via [`HASHED_ENV_VARS`],
-    ///   so a user wrapper also invalidates caches — the injected one
-    ///   deliberately does not.)
-    /// - A pre-existing `CARGO_INCREMENTAL=0` is common CI hygiene, not a
-    ///   competing cache: the rest is injected and the explicit value is left
-    ///   alone. (When absent, `CARGO_INCREMENTAL=0` is injected because sccache
-    ///   cannot cache incrementally-compiled crates.) Any *other* explicit
-    ///   `CARGO_INCREMENTAL` value stands the set down: incremental compilation
-    ///   was deliberately requested, and sccache's wrapper hard-exits when it
-    ///   sees `CARGO_INCREMENTAL=1`, which would fail the build.
-    fn compile_cache_env(
-        &self,
-        endpoint: &toolchain::CompileCacheEndpoint,
-        task_env: &std::collections::HashMap<String, String>,
-    ) -> Vec<(String, String)> {
-        if task_env.contains_key("RUSTC_WRAPPER")
-            || task_env.keys().any(|key| key.starts_with("SCCACHE_"))
-        {
-            return Vec::new();
-        }
-        let ambient_incremental = task_env.get("CARGO_INCREMENTAL").map(String::as_str);
-        if ambient_incremental.is_some_and(|value| value != "0") {
-            return Vec::new();
-        }
-
-        let mut vars = vec![
-            ("RUSTC_WRAPPER".to_string(), endpoint.wrapper.clone()),
-            (
-                toolchain::COMPILE_CACHE_WRAPPER_ENV.to_string(),
-                "1".to_string(),
-            ),
-            ("SCCACHE_WEBDAV_ENDPOINT".to_string(), endpoint.url.clone()),
-            ("SCCACHE_WEBDAV_TOKEN".to_string(), endpoint.token.clone()),
-            (
-                "SCCACHE_SERVER_PORT".to_string(),
-                endpoint.server_port.to_string(),
-            ),
-            // The compile cache is an optimization: if the server cannot be
-            // reached or started (storage outage mid-run, port trouble),
-            // the wrapper warns and runs the compiler directly instead of
-            // failing the build.
-            (
-                "SCCACHE_IGNORE_SERVER_IO_ERROR".to_string(),
-                "1".to_string(),
-            ),
-        ];
-        if ambient_incremental.is_none() {
-            vars.push(("CARGO_INCREMENTAL".to_string(), "0".to_string()));
-        }
-        vars
-    }
-
-    /// Our lock subset is reachability-based, but Cargo's real resolution
-    /// is feature-aware: shrinking the workspace can deactivate features
-    /// that were the only reason some packages were in the closure. Rather
-    /// than reimplement feature unification, let Cargo minimally sync its
-    /// own lockfile (every retained pin is preserved; only feature-dead
-    /// entries are dropped) so `cargo build --locked` passes in the pruned
-    /// output. Try `--offline` first — removals need no network — but
-    /// workspaces with git patches need their git databases, which a cold
-    /// machine won't have cached, so fall back to a networked sync. Failure
-    /// is not fatal: the superset lock still builds correctly, it just
-    /// isn't `--locked`-clean.
-    fn prune_finalize(&self, pruned_root: &AbsoluteSystemPath) -> Vec<String> {
-        let sync = |offline: bool| {
-            let mut cmd = std::process::Command::new("cargo");
-            cmd.args(["metadata", "--format-version", "1"]);
-            if offline {
-                cmd.arg("--offline");
-            }
-            cmd.current_dir(pruned_root.as_std_path()).output()
-        };
-        match sync(true).and_then(|offline| {
-            if offline.status.success() {
-                Ok(offline)
-            } else {
-                sync(false)
-            }
-        }) {
-            Ok(output) if output.status.success() => {}
-            Ok(output) => {
-                tracing::warn!(
-                    "unable to canonicalize the pruned Cargo.lock; `cargo build --locked` may \
-                     require a lockfile refresh: {}",
-                    String::from_utf8_lossy(&output.stderr).trim()
-                );
-            }
-            Err(error) => {
-                tracing::warn!(
-                    "unable to run cargo to canonicalize the pruned Cargo.lock: {error}"
-                );
-            }
-        }
-        vec![CARGO_LOCK.to_string()]
     }
 
     fn discover_packages(&self) -> DiscoverPackagesFuture<'_> {
@@ -3406,8 +3373,6 @@ release: 1.96.0-nightly\n",
 
     #[test]
     fn test_compile_cache_env_routes_rustc_through_sccache() {
-        let (_tmp, root) = tempdir_root();
-        let toolchain = CargoToolchain::new(root);
         let endpoint = toolchain::CompileCacheEndpoint {
             url: "http://127.0.0.1:42123".to_string(),
             token: "proxy-token".to_string(),
@@ -3415,7 +3380,7 @@ release: 1.96.0-nightly\n",
             server_port: 46123,
         };
         assert_eq!(
-            toolchain.compile_cache_env(&endpoint, &std::collections::HashMap::new()),
+            cargo_compile_cache_env(&endpoint, &std::collections::HashMap::new()),
             vec![
                 ("RUSTC_WRAPPER".to_string(), "/path/to/turbo".to_string()),
                 ("TURBO_SCCACHE_WRAPPER".to_string(), "1".to_string()),
@@ -3443,8 +3408,6 @@ release: 1.96.0-nightly\n",
 
     #[test]
     fn test_compile_cache_env_stands_down_for_competing_configuration() {
-        let (_tmp, root) = tempdir_root();
-        let toolchain = CargoToolchain::new(root);
         let endpoint = toolchain::CompileCacheEndpoint {
             url: "http://127.0.0.1:42123".to_string(),
             token: "proxy-token".to_string(),
@@ -3458,14 +3421,14 @@ release: 1.96.0-nightly\n",
             "RUSTC_WRAPPER".to_string(),
             "/home/user/bin/my-wrapper".to_string(),
         )]);
-        assert!(toolchain.compile_cache_env(&endpoint, &env).is_empty());
+        assert!(cargo_compile_cache_env(&endpoint, &env).is_empty());
 
         // Any SCCACHE_* variable signals a user-managed sccache setup.
         let env = std::collections::HashMap::from([(
             "SCCACHE_GHA_ENABLED".to_string(),
             "true".to_string(),
         )]);
-        assert!(toolchain.compile_cache_env(&endpoint, &env).is_empty());
+        assert!(cargo_compile_cache_env(&endpoint, &env).is_empty());
     }
 
     #[test]
@@ -3474,8 +3437,6 @@ release: 1.96.0-nightly\n",
         // own setup-environment action does). That is ambient hygiene, not
         // a competing compiler cache: the injection proceeds and the
         // explicit value is left alone.
-        let (_tmp, root) = tempdir_root();
-        let toolchain = CargoToolchain::new(root);
         let endpoint = toolchain::CompileCacheEndpoint {
             url: "http://127.0.0.1:42123".to_string(),
             token: "proxy-token".to_string(),
@@ -3485,7 +3446,7 @@ release: 1.96.0-nightly\n",
         let env =
             std::collections::HashMap::from([("CARGO_INCREMENTAL".to_string(), "0".to_string())]);
 
-        let vars = toolchain.compile_cache_env(&endpoint, &env);
+        let vars = cargo_compile_cache_env(&endpoint, &env);
         assert!(
             vars.iter().any(|(key, _)| key == "RUSTC_WRAPPER"),
             "injection must proceed despite ambient CARGO_INCREMENTAL=0"
@@ -3500,7 +3461,7 @@ release: 1.96.0-nightly\n",
         // hard-exits on CARGO_INCREMENTAL=1. Stand down entirely.
         let env =
             std::collections::HashMap::from([("CARGO_INCREMENTAL".to_string(), "1".to_string())]);
-        assert!(toolchain.compile_cache_env(&endpoint, &env).is_empty());
+        assert!(cargo_compile_cache_env(&endpoint, &env).is_empty());
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -3577,6 +3538,24 @@ release: 1.96.0-nightly\n",
         let app = &packages[0];
         assert!(app.descriptor.dependencies.is_none());
         assert!(app.descriptor.dev_dependencies.is_none());
+        let compile_cache_env = app
+            .task_contract
+            .as_ref()
+            .expect("Cargo discovery contributes a task contract")
+            .compile_cache_env(
+                &toolchain::CompileCacheEndpoint {
+                    url: "http://127.0.0.1:42123".to_string(),
+                    token: "proxy-token".to_string(),
+                    wrapper: "/path/to/turbo".to_string(),
+                    server_port: 46123,
+                },
+                &std::collections::HashMap::new(),
+            );
+        assert!(
+            compile_cache_env
+                .iter()
+                .any(|(key, _)| key == "RUSTC_WRAPPER")
+        );
         assert_eq!(
             app.native_relationships.as_deref(),
             Some(&[Relationship::internal("lib-a", DependencyKind::Production)][..])

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -898,7 +898,6 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             root_package_json,
             lockfile,
             javascript,
-            toolchains,
             repo_root,
             ..
         } = self;
@@ -1031,7 +1030,6 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             external_resolution: std::sync::Mutex::new(ExternalResolutionKnowledge::absent()),
             external_dep_to_internal_dependents: std::sync::OnceLock::new(),
             root_internal_dependencies: std::sync::OnceLock::new(),
-            toolchains,
             native_task_knowledge,
             task_contract_knowledge,
             change_knowledge,
@@ -1386,7 +1384,6 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             native_change_observations,
             native_prune_domains,
             root_package_json,
-            toolchains,
             ..
         } = self;
         let knowledge = knowledge.ok_or(discovery::Error::Failed(Box::new(
@@ -1465,7 +1462,6 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             external_resolution: std::sync::Mutex::new(external_resolution),
             external_dep_to_internal_dependents: std::sync::OnceLock::new(),
             root_internal_dependencies: std::sync::OnceLock::new(),
-            toolchains,
             native_task_knowledge,
             task_contract_knowledge,
             change_knowledge,

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -97,9 +97,6 @@ pub struct PackageGraph {
     /// `dependencies` and `ancestors` consult them on every call; the set is
     /// invariant once the graph is built.
     root_internal_dependencies: OnceLock<HashSet<PackageNode>>,
-    /// Toolchains registered during graph construction. Authoritative contexts
-    /// determine which registrations were active for a particular concern.
-    toolchains: crate::toolchain::ToolchainRegistry,
     /// Immutable native-task catalog produced during repository construction.
     native_task_knowledge: Arc<crate::native_tasks::NativeTaskKnowledge>,
     /// Immutable task-contract catalog produced during repository construction.
@@ -743,11 +740,6 @@ impl PackageGraph {
         &self.change_knowledge
     }
 
-    /// Toolchains registered during graph construction.
-    pub fn toolchains(&self) -> &crate::toolchain::ToolchainRegistry {
-        &self.toolchains
-    }
-
     /// Watch classification facts retained by this graph generation.
     pub fn active_watch_spec(&self) -> crate::toolchain::WatchSpec {
         self.change_knowledge.to_watch_spec()
@@ -763,6 +755,14 @@ impl PackageGraph {
         kept_packages: &[String],
     ) -> Result<Option<crate::prune_knowledge::PrunePlan>, crate::prune_knowledge::Error> {
         self.prune_knowledge.plan(toolchain, kept_packages)
+    }
+
+    pub fn finalize_prune(
+        &self,
+        toolchain: &crate::toolchain::ToolchainId,
+        pruned_root: &AbsoluteSystemPath,
+    ) -> Vec<String> {
+        self.prune_knowledge.finalize(toolchain, pruned_root)
     }
 
     pub fn repo_root(&self) -> &AbsoluteSystemPath {

--- a/crates/turborepo-repository/src/prune_knowledge.rs
+++ b/crates/turborepo-repository/src/prune_knowledge.rs
@@ -1,6 +1,9 @@
-//! Immutable, generation-owned knowledge used to plan native prune output.
+//! Immutable, generation-owned knowledge used to plan and finalize native
+//! prune output.
 
 use std::{collections::BTreeMap, fmt::Debug, sync::Arc};
+
+use turbopath::AbsoluteSystemPath;
 
 use crate::toolchain::ToolchainId;
 
@@ -22,16 +25,24 @@ pub enum Error {
     Failed(Box<dyn std::error::Error + Send + Sync>),
 }
 
-/// Immutable discovery output capable of projecting a prune plan.
+/// Immutable discovery output capable of projecting and finalizing a prune.
 ///
 /// Implementations contain only data captured for one repository generation;
 /// they are not live toolchains and cannot mutate discovery authority.
 pub trait PruneDomain: Debug + Send + Sync {
     fn toolchain(&self) -> &ToolchainId;
     fn plan(&self, kept_packages: &[String]) -> Result<Option<PrunePlan>, Error>;
+
+    /// Polish a fully materialized prune and return the repo-relative files
+    /// changed so alternate output layers can synchronize them.
+    fn finalize(&self, pruned_root: &AbsoluteSystemPath) -> Vec<String> {
+        let _ = pruned_root;
+        Vec::new()
+    }
 }
 
-/// All native prune domains retained by a package-graph generation.
+/// All native prune domains retained by a package-graph generation. Runtime
+/// orchestration never consults the live discovery producer.
 #[derive(Debug, Default)]
 pub struct PruneKnowledge {
     domains: BTreeMap<ToolchainId, Arc<dyn PruneDomain>>,
@@ -61,5 +72,15 @@ impl PruneKnowledge {
             .map(|domain| domain.plan(kept_packages))
             .transpose()
             .map(Option::flatten)
+    }
+
+    pub fn finalize(
+        &self,
+        toolchain: &ToolchainId,
+        pruned_root: &AbsoluteSystemPath,
+    ) -> Vec<String> {
+        self.domains
+            .get(toolchain)
+            .map_or_else(Vec::new, |domain| domain.finalize(pruned_root))
     }
 }

--- a/crates/turborepo-repository/src/task_contracts.rs
+++ b/crates/turborepo-repository/src/task_contracts.rs
@@ -6,6 +6,8 @@
 //!
 //! JavaScript packages contribute empty contract observations: turbo.json is
 //! the whole story. Cargo contributes immutable derivation plans.
+//! Execution-only decorations such as compile-cache variables are also
+//! projected here, but deliberately do not participate in task hashes.
 
 use std::collections::BTreeMap;
 
@@ -153,6 +155,18 @@ impl ScopeTaskContract {
 
     pub fn task_entrypoint(&self, task: &str) -> Option<TaskEntrypoint> {
         self.cargo.as_ref()?.task_entrypoint(task)
+    }
+
+    /// Environment decorations for a compiler cache served by Turborepo.
+    /// These are output-transparent execution settings, not hash inputs.
+    pub fn compile_cache_env(
+        &self,
+        endpoint: &crate::toolchain::CompileCacheEndpoint,
+        task_env: &std::collections::HashMap<String, String>,
+    ) -> Vec<(String, String)> {
+        self.cargo.as_ref().map_or_else(Vec::new, |cargo| {
+            cargo.compile_cache_env(endpoint, task_env)
+        })
     }
 }
 

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -1,17 +1,10 @@
 //! Toolchains: the abstraction that makes Turborepo generic over language
 //! ecosystems.
 //!
-//! A [`Toolchain`] answers ecosystem-specific questions about packages —
-//! starting with "which packages exist?" — so that the package graph and the
-//! rest of the system never branch on a specific ecosystem. JavaScript is the
-//! first implementation ([`JavaScriptToolchain`]); additional toolchains
-//! (e.g. Cargo) register alongside it in the [`ToolchainRegistry`].
-//!
-//! The trait grows one concern at a time (discovery today; command
-//! resolution, derived task inputs/outputs, and external-dependency hashing
-//! as they are needed), and every
-//! concern must ship with real implementations for every registered
-//! toolchain.
+//! A [`Toolchain`] discovers ecosystem packages and contributes immutable
+//! observations. JavaScript is the first implementation
+//! ([`JavaScriptToolchain`]); additional producers (e.g. Cargo) register
+//! alongside it during package-graph construction.
 //!
 //! # Design rules
 //!
@@ -24,8 +17,8 @@
 //!    internal graph types, no lifetime-carrying views, no callbacks.
 //! 2. [`ToolchainId`] is an open identifier, never a closed enum. A future
 //!    toolchain (or plugin) mints a new id without touching existing code.
-//! 3. All toolchain lookups go through the [`ToolchainRegistry`]. Scattered
-//!    per-toolchain branch points (`if id == "rust"`) are a design defect.
+//! 3. The [`ToolchainRegistry`] is construction-scoped. Runtime consumers use
+//!    immutable knowledge retained by the completed package graph.
 //!
 //! # Known debt
 //!
@@ -351,7 +344,7 @@ pub enum Error {
 pub type DiscoverPackagesFuture<'a> =
     Pin<Box<dyn Future<Output = Result<DiscoveredPackages, Error>> + Send + 'a>>;
 
-/// A command resolved by a toolchain for a task, as plain data. The executor
+/// A command resolved from native-task knowledge, as plain data. The executor
 /// turns it into a process, applying the task's environment, stdin policy,
 /// and any decorations that are not toolchain concerns (e.g.
 /// microfrontends proxy variables).
@@ -405,45 +398,9 @@ pub trait Toolchain: Send + Sync {
     /// Discover this toolchain's packages/scopes and native workspace roots in
     /// one observation envelope.
     fn discover_packages(&self) -> DiscoverPackagesFuture<'_>;
-
-    /// Called after the pruned output is fully written, with its root
-    /// directory. Toolchains may polish their own files in place (e.g.
-    /// Cargo canonicalizes the pruned lockfile through `cargo metadata`) and
-    /// return their repo-relative paths so alternate output layers can be
-    /// synchronized without repeating finalization. Failures must be
-    /// non-fatal: log and continue.
-    fn prune_finalize(&self, pruned_root: &AbsoluteSystemPath) -> Vec<String> {
-        let _ = pruned_root;
-        Vec::new()
-    }
-
-    /// Environment variables to inject into this toolchain's task processes
-    /// when Turborepo is serving a compile cache endpoint (a local proxy in
-    /// front of the remote cache that a compiler wrapper like sccache can
-    /// use as its storage backend).
-    ///
-    /// `task_env` is the environment the task process will receive; the
-    /// toolchain decides how its injection composes with it. Only the
-    /// toolchain knows which pre-existing variables signal a *competing*
-    /// configuration that must win (e.g. a user-supplied `RUSTC_WRAPPER`)
-    /// versus ones that are merely common ambient settings (e.g. CI images
-    /// exporting `CARGO_INCREMENTAL=0`, which is exactly what the compile
-    /// cache wants anyway). The executor injects the returned variables
-    /// verbatim; an empty result means inject nothing — either no
-    /// integration exists (the JavaScript default) or the toolchain chose
-    /// to stand down.
-    fn compile_cache_env(
-        &self,
-        endpoint: &CompileCacheEndpoint,
-        task_env: &std::collections::HashMap<String, String>,
-    ) -> Vec<(String, String)> {
-        let _ = (endpoint, task_env);
-        Vec::new()
-    }
 }
 
-/// A Turborepo-served compile cache endpoint, as plain data. See
-/// [`Toolchain::compile_cache_env`].
+/// A Turborepo-served compile cache endpoint, as plain data.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CompileCacheEndpoint {
     /// HTTP endpoint of the local compile-cache proxy.
@@ -584,12 +541,12 @@ pub struct DerivedTaskIO {
     pub outputs: DerivedOutputs,
 }
 
-/// The set of toolchains contributing packages to the repository.
+/// The construction-scoped set of producers contributing repository knowledge.
 ///
-/// All toolchain lookups go through the registry; it is the single place
-/// that knows which toolchains exist. Today entries are registered
-/// statically during package graph construction. A future plugin system
-/// would construct entries from a manifest instead — an additive change.
+/// Entries are registered statically during package graph construction and the
+/// registry is dropped after immutable knowledge is built. A future plugin
+/// system could construct entries from a manifest without changing runtime
+/// consumers.
 #[derive(Default)]
 pub struct ToolchainRegistry {
     toolchains: Vec<Arc<dyn Toolchain>>,

--- a/crates/turborepo-task-executor/src/command.rs
+++ b/crates/turborepo-task-executor/src/command.rs
@@ -36,8 +36,9 @@ fn apply_environment(cmd: &mut Command, environment: &EnvironmentVariableMap) {
 /// - `E`: The error type returned when command creation fails
 ///
 /// # Implementors
-/// - `ToolchainCommandProvider` (resolves commands through the package's
-///   toolchain: package.json scripts for JavaScript, cargo verbs for Cargo)
+/// - `ToolchainCommandProvider` (resolves commands from the package's immutable
+///   native-task catalog: package.json scripts for JavaScript, Cargo verbs for
+///   Rust)
 /// - `MicroFrontendProxyProvider` in turborepo-lib (starts MFE proxy)
 pub trait CommandProvider<E> {
     /// Create a command for the given task.
@@ -160,9 +161,8 @@ pub struct ToolchainCommandProvider<'a, M = crate::NoMfeConfig> {
     package_graph: &'a PackageGraph,
     task_args: TaskArgs<'a>,
     mfe_configs: Option<&'a M>,
-    /// A Turborepo-served compile cache endpoint (see
-    /// [`turborepo_repository::toolchain::Toolchain::compile_cache_env`]), when
-    /// one is running for this run.
+    /// A Turborepo-served compile cache endpoint, when one is running for this
+    /// run. Immutable task contracts determine whether and how to use it.
     compile_cache: Option<&'a CompileCacheEndpoint>,
     /// Resolved `command` overrides by task, from the engine's task
     /// definitions. An argv replaces the native catalog resolution; an
@@ -226,7 +226,7 @@ impl<'a, M: MfeConfigProvider> ToolchainCommandProvider<'a, M> {
     }
 }
 
-fn should_inject_toolchain_compile_cache(command_override: Option<&TaskCommandOverride>) -> bool {
+fn should_inject_compile_cache(command_override: Option<&TaskCommandOverride>) -> bool {
     command_override.is_none()
 }
 
@@ -242,8 +242,8 @@ impl<'a, M: MfeConfigProvider, E: From<CommandProviderError>> CommandProvider<E>
 
         // A resolved `command` override is authoritative in both
         // directions: an opt-out is an explicit no-op (same outcome as a
-        // missing script), and an argv replaces the toolchain's own
-        // resolution while the toolchain keeps framing it.
+        // missing script), and an argv replaces native-catalog resolution
+        // while retaining ecosystem framing.
         let command_override = self.command_overrides.get(task_id);
         let override_command = match command_override {
             Some(TaskCommandOverride::OptOut) => return Ok(None),
@@ -254,7 +254,7 @@ impl<'a, M: MfeConfigProvider, E: From<CommandProviderError>> CommandProvider<E>
         // A pure-native repository still has Turbo's root task namespace, but
         // no root language toolchain. Explicit root command overrides are
         // generic argv and execute directly at the knowledge-backed repo root.
-        let Some(toolchain_id) = package_context.toolchain() else {
+        if package_context.toolchain().is_none() {
             let Some(override_command) = override_command else {
                 return Ok(None);
             };
@@ -271,7 +271,7 @@ impl<'a, M: MfeConfigProvider, E: From<CommandProviderError>> CommandProvider<E>
             apply_environment(&mut cmd, environment);
             cmd.open_stdin();
             return Ok(Some(cmd));
-        };
+        }
 
         let spec = if let Some(native_task) = package_context.native_tasks().get(task_id.task()) {
             let (package_manager_binary, cargo_binary) = if override_command.is_some() {
@@ -350,13 +350,14 @@ impl<'a, M: MfeConfigProvider, E: From<CommandProviderError>> CommandProvider<E>
             cmd.env("TURBO_MFE_PORT", port.to_string());
         }
 
-        // Compile-cache injection remains toolchain-owned until environment
-        // contracts move; look up the toolchain only for that decoration.
-        if should_inject_toolchain_compile_cache(command_override)
+        // Compile-cache injection is execution-only: it deliberately does not
+        // participate in the task hash represented by this contract.
+        if should_inject_compile_cache(command_override)
             && let Some(endpoint) = self.compile_cache
-            && let Some(toolchain) = self.package_graph.toolchains().get(toolchain_id)
         {
-            let vars = toolchain.compile_cache_env(endpoint, environment);
+            let vars = package_context
+                .task_contract()
+                .compile_cache_env(endpoint, environment);
             if vars.is_empty() {
                 debug!("no compile cache env to inject for {task_id}");
             }
@@ -648,12 +649,12 @@ mod tests {
     }
 
     #[test]
-    fn command_override_suppresses_toolchain_compile_cache() {
-        assert!(should_inject_toolchain_compile_cache(None));
-        assert!(!should_inject_toolchain_compile_cache(Some(
+    fn command_override_suppresses_compile_cache() {
+        assert!(should_inject_compile_cache(None));
+        assert!(!should_inject_compile_cache(Some(
             &TaskCommandOverride::Argv(vec!["node".to_string()])
         )));
-        assert!(!should_inject_toolchain_compile_cache(Some(
+        assert!(!should_inject_compile_cache(Some(
             &TaskCommandOverride::OptOut
         )));
     }

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -221,9 +221,9 @@ The remaining payload deletion phases are explicit:
   remain a temporary classification input.
 - **Phase 3:** Complete. External resolution lives in the immutable generation; query, prune, hashing, and summaries consume it. `PackageInfo` no longer carries `unresolved_external_dependencies`, `transitive_dependencies`, or `external_deps_hash`, and deferred closure installation is gone.
 - **Phase 4 (complete):** Native task/command knowledge is an immutable catalog produced at repository construction. JavaScript scripts and Cargo verb tables contribute observations; engine, turbo-json, executor, query, devtools, LSP, and summary consumers read the catalog. `Toolchain::task_command` / `task_display_command` / `authors_task` / `registered_tasks` / `registers_task` / `defines_task` have been deleted — only the JavaScript producer and the LSP unsaved-source adapter parse scripts.
-- **Phase 5 (in progress):** Task-contract knowledge catalog is produced for JavaScript scopes; engine composition and global `engines` hashing consume it; JS packages are excluded from Toolchain task-I/O environment dispatch. Remaining: fuller hash/framework contract production and final Phase 5 gate. Later: Delete `PackageInfo`, its payload map, and optional-payload compatibility plumbing once all fail-closed consumers use those queries.
+- **Phase 5 (complete for JavaScript and Cargo):** Task-contract knowledge catalogs are produced for every scope. Engine composition, task hashing, entrypoint selection, derived I/O, and execution-only compile-cache decoration consume those immutable contracts without live toolchain dispatch.
 - **Phase 6 (complete for JavaScript and Cargo):** Change knowledge is produced at repository construction. Cargo discovery contributes `Cargo.toml` rediscovery names, the `Cargo.lock` resolution/rediscovery path, and the effective in-repository target-directory ignore prefix. `PackageGraph::active_watch_spec` is now a projection of only the immutable facts retained by that graph generation; it never calls live toolchains. Before the first generation is published, the watcher conservatively retains all in-repository events, closing the subscription/bootstrap race without mutable toolchain callbacks. Single-package generations retain no inactive Cargo facts.
-- **Phase 7 (complete):** JavaScript prune rendering is a distinct pure step (`render_javascript_prune`) producing typed artifacts; `commands/prune.rs` selects closures, performs path-safe layout, and materializes those artifacts without inline lockfile/manifest/patch format interpretation. Cargo discovery captures an immutable, generation-owned prune domain containing lockfile, root-manifest, and package-directory facts. Cargo lock pruning, extra-member selection, manifest rewriting, and root/config file planning are projected from that graph-owned domain rather than mutable `CargoToolchain` state. Live toolchains remain involved only in post-write finalization pending TURBO-5798. Golden inventories cover standard and Docker layouts.
+- **Phase 7 (complete):** JavaScript prune rendering is a distinct pure step (`render_javascript_prune`) producing typed artifacts; `commands/prune.rs` selects closures, performs path-safe layout, and materializes those artifacts without inline lockfile/manifest/patch format interpretation. Cargo discovery captures an immutable, generation-owned prune domain containing lockfile, root-manifest, package-directory, and post-write finalization authority. Cargo lock pruning, extra-member selection, manifest rewriting, root/config file planning, and final lockfile canonicalization run through that graph-owned domain without live toolchain dispatch. Golden inventories cover standard and Docker layouts.
 - **Phase 8 (audit complete for owned consumers):** Query/devtools/summary/run/engine/watch/prune task and resolution views consume knowledge catalogs. Remaining `PackageJson` / `PackageInfo` reads are construction entry points, LSP unsaved-buffer adapters, and package-manager detection — tracked for deletion under TURBO-5787 (`PackageInfo` / `JavaScriptToolchain` removal), not deferred silently. Boundary tag diagnostics consume optional authored-name provenance from repository knowledge only when the authored name matches the authoritative identity.
 
 Task hashing, run-cache path construction, and run-summary task directories use
@@ -292,27 +292,17 @@ JavaScript dependency maps or behavioral affectedness callback remain.
 
 #### Toolchains (`crates/turborepo-repository/src/toolchain.rs`)
 
-The package graph is generic over language toolchains. The existing discovery
-method returns one envelope containing packages/scopes and workspace-root
-observations. Core validates the combined contributed roots
-without adding another behavioral toolchain method. Watch classification consumes foundational change knowledge (JavaScript
-membership/workspace/resolution triggers) combined with active toolchain
-`WatchSpec`s; remaining marker-only edge cases stay follow-up work.
-Native discovery output contributes package/scope observations to repository
-knowledge, while a
-`Toolchain` continues to answer ecosystem-specific behavioral questions such as
-entrypoint selection, derived task I/O, affectedness, and prune rendering. Native
-task availability and commands come from immutable repository catalogs. Remaining
-behavioral lookups go through the
-`ToolchainRegistry` (carried by the `PackageGraph`); `ToolchainId` is an
-open string identifier, not a closed enum; and trait methods are
-coarse-grained and data-in/data-out, keeping the door open to out-of-process
-plugin adapters. JavaScript is the first, production implementation: its
-discovery produces package, relationship, task, contract, change, and prune
-knowledge without runtime task-command callbacks. Machinery that predates the
-abstraction and has no trait surface yet (package-manager resolution for
-dependency splitting and the JS lockfile closure phase) is documented as known
-debt in the module.
+`Toolchain` is a construction-time discovery abstraction. Its discovery method
+returns one envelope containing packages/scopes, workspace roots, and
+ecosystem observations. A construction-scoped `ToolchainRegistry` combines
+those envelopes; core validates them, builds immutable relationship, task,
+contract, resolution, change, and prune knowledge, then drops the registry.
+Runtime consumers query those retained catalogs and never dispatch through live
+toolchains. `ToolchainId` remains open provenance data rather than a closed
+enum, keeping discovery extensible to future out-of-process plugin adapters.
+JavaScript is the first production producer. Machinery that predates the
+abstraction (package-manager resolution for dependency splitting and the JS
+lockfile closure phase) remains documented debt.
 
 Toolchain-derived I/O receives the same task-scoped arguments as execution plus
 a narrow, platform-aware startup-environment projection keyed by toolchain.
@@ -469,25 +459,26 @@ whether anything changed; Cargo decides how and in what order to build.**
   requested process, and library artifacts have no stable final path to restore.
   An explicit turbo.json `cache` setting overrides the toolchain default.
 
-- **Watch mode** (`Toolchain::watch_spec`, consumed by
-  `turborepo-lib/src/package_changes_watcher.rs`): each toolchain declares
-  its workspace-definition files and build-byproduct directories. For
+- **Watch mode** (`ChangeKnowledge` and `PackageGraph::active_watch_spec`,
+  consumed by `turborepo-lib/src/package_changes_watcher.rs`): discovery
+  observations declare workspace-definition files and build-byproduct
+  directories, and the current graph generation projects one active spec. For
   Cargo, any `Cargo.toml` or the root `Cargo.lock` triggers full
   rediscovery (the crate set or its edges may have changed), while events
   under the root `target/` directory are dropped — Cargo writes there
   continuously during builds, and the feedback loop must not depend on a
   `.gitignore` entry (`Cargo.toml` files under `target/` are build
   byproducts, not workspace definition). The watcher builds its package
-  graph with the same toolchains a run would register, so watch sees the
-  same package set. JavaScript declares nothing extra: workspace
+  graph through the same construction path as a run, so watch sees the same
+  package set. JavaScript declares nothing extra: workspace
   redefinition is caught by the change mapper's conservative
   all-packages fallback. Known gap: the hash watcher's content-hash dedup
   is JS-glob-based, so a no-op save inside a crate re-runs its tasks as a
   fast cache hit rather than being suppressed.
 
-- **Prune** (`Toolchain::prune_plan` / `prune_finalize`, consumed by
-  `turborepo-lib/src/commands/prune.rs`): each toolchain reports what a
-  self-contained pruned repository needs beyond the copied packages. For
+- **Prune** (`PruneKnowledge` and `PruneDomain::{plan, finalize}`, consumed by
+  `turborepo-lib/src/commands/prune.rs`): each generation-owned domain reports
+  what a self-contained pruned repository needs beyond copied packages. For
   Cargo: the kept-member set comes from a `Cargo.lock` reachability walk
   (not the package graph — the lockfile merges dev-dependency edges, so
   members reachable only through dev-deps are retained, since kept crates'
@@ -496,7 +487,7 @@ whether anything changed; Cargo decides how and in what order to build.**
   filtered `default-members`, `[workspace.dependencies]` path entries to
   removed crates dropped — comments and formatting preserved). Toolchain
   and Cargo config files are carried over. Reachability pruning cannot see
-  Cargo's feature unification, so `prune_finalize` runs `cargo metadata`
+  Cargo's feature unification, so the retained Cargo domain runs `cargo metadata`
   once in the complete output (offline first, then networked) to let Cargo
   minimally sync its own lockfile; failure downgrades to a warning.
   Only toolchains that contributed a prune plan are finalized. Finalizers
@@ -510,7 +501,7 @@ whether anything changed; Cargo decides how and in what order to build.**
   aggregate anchored at the repo root (the Cargo workspace scope) is not
   a pruneable target.
 
-- **Compile cache** (`Toolchain::compile_cache_env`, consumed by
+- **Compile cache** (`ScopeTaskContract::compile_cache_env`, consumed by
   `ToolchainCommandProvider`; gated by `futureFlags.experimentalCargoSccache`):
   when enabled alongside `experimentalCargoWorkspaces` in a CI environment
   with a linked Remote Cache, the run serves a local HTTP proxy
@@ -533,7 +524,7 @@ whether anything changed; Cargo decides how and in what order to build.**
   is derived from the repo root and the bearer token is persisted at
   `.turbo/sccache-proxy-token`. Injection is execution-only and does not
   participate in task hashes (a compile cache is output-transparent). The
-  toolchain decides how injection composes with the task environment: a
+  Cargo task contract decides how injection composes with the task environment: a
   user-supplied `RUSTC_WRAPPER` or any `SCCACHE_*` variable signals a
   competing compiler-cache configuration and suppresses the whole injected
   set, while an ambient `CARGO_INCREMENTAL` (CI images commonly export
@@ -592,9 +583,9 @@ The core task graph consists of:
   Because an argv override is otherwise arbitrary, it does not inherit the
   native command's contract-derived inputs, outputs, default-input behavior,
   or hash environment; its turbo.json `inputs`, `outputs`, and `env` are the
-  authoritative task-level I/O configuration. Toolchain task defaults and
+  authoritative task-level I/O configuration. Contract-derived task defaults and
   execution-only compile-cache environment injection likewise apply only to
-  native toolchain-resolved commands.
+  native-catalog-resolved commands.
 
 #### Run Entrypoint Selection (`crates/turborepo-lib/src/run/builder.rs`)
 
@@ -605,7 +596,7 @@ The core task graph consists of:
   only in scoped packages where that task resolves a command. A missing task is
   therefore not allowed to pull its configured dependencies into a run merely
   because another package implements the requested task.
-- When no package resolves a command for a configured or toolchain-registered
+- When no package resolves a command for a configured or native-catalog task,
   task, its scoped package nodes remain entrypoints so graph-only orchestration
   tasks continue to fan out to their configured dependencies. If any branch
   reaches a runnable command, only paths to runnable work are retained; when no
@@ -619,8 +610,8 @@ The core task graph consists of:
   Missing requested nodes are dropped after selector expansion: a plain filter
   runs nothing for a missing command, while trailing or leading `...` may retain
   executable tasks reached through that node in the Task Graph.
-- Native package scripts, resolved `command` overrides, and toolchain-provided
-  commands all count as executable definitions. Toolchain-specific entrypoint
+- Native package scripts, resolved `command` overrides, and native-catalog
+  commands all count as executable definitions. Contract-derived entrypoint
   selection, including Cargo workspace/crate selection, remains authoritative
   and is composed with this generic command-aware pruning.
 
@@ -667,8 +658,8 @@ The core task graph consists of:
   interpret ripgrep `.ignore` files. On macOS, a global excludes file on a
   different device is conservatively not applied because one FSEvents stream
   cannot monitor both devices. The package scope
-  refreshes the merged toolchain `WatchSpec` whenever the package graph is
-  initialized or rediscovered. Turbo config and toolchain definition changes
+  refreshes the active `WatchSpec` from the current graph generation whenever
+  the package graph is initialized or rediscovered. Turbo config and ecosystem definition changes
   trigger full rediscovery after routing.
 - Git index and `.git/info/exclude` control paths are watched separately so
   tracked-file and exclude state stays current without exposing `.git` events


### PR DESCRIPTION
## Intent

Remove the final runtime consumers of the behavioral toolchain registry while keeping discovery deletion as a separate reviewable step.

**Base:** `main`.

## Changes

- Project compile-cache environment decoration from immutable per-scope task contracts.
- Move Cargo post-write prune finalization into generation-owned prune knowledge.
- Derive task-entrypoint provenance from active candidates instead of registered toolchains.
- Stop retaining `ToolchainRegistry` on completed package graphs.
- Update architecture documentation for construction-scoped producers and knowledge-backed runtime consumers.
- Preserve command-override, sccache composition, Docker synchronization, and nonfatal Cargo finalization behavior.

## Testing

- `cargo test -p turborepo-repository cargo::test` (41 passed)
- `USER=vercel cargo test -p turborepo-task-executor` (18 passed)
- `cargo test -p turbo --test cargo_workspace_test` (57 passed)
- `cargo clippy -p turborepo-repository -p turborepo-task-executor -p turborepo-lib --all-targets -- -D warnings`
- `cargo fmt --check`

Advances TURBO-5798.