### PR TITLE
refactor: Replace toolchains with repository contributors

### DIFF
--- a/crates/turborepo-engine/src/builder/definitions.rs
+++ b/crates/turborepo-engine/src/builder/definitions.rs
@@ -785,7 +785,7 @@ fn resolve_command_override(
     }
 
     // Level 3: a package-authored definition shadows unscoped defaults —
-    // lean into what the toolchain does natively. Toolchain-synthesized
+    // lean into what the ecosystem does natively. Catalog-synthesized
     // fallbacks (Cargo verb tables) are authored by nobody and sit below
     // the defaults instead.
     if package_toolchain.is_some_and(|(_, authors)| authors) {

--- a/crates/turborepo-engine/src/builder/test.rs
+++ b/crates/turborepo-engine/src/builder/test.rs
@@ -17,7 +17,7 @@ use turborepo_repository::{
     package_manager::PackageManager,
     toolchain::{
         DerivedInputSafety, DerivedOutputs, DerivedTaskIO, DiscoverPackagesFuture,
-        DiscoveredPackage, DiscoveredPackages, Toolchain, ToolchainId, WorkspaceRoot,
+        DiscoveredPackage, DiscoveredPackages, RepositoryContributor, ToolchainId, WorkspaceRoot,
     },
 };
 use turborepo_task_id::{TaskId, TaskName};
@@ -119,11 +119,11 @@ impl PackageDiscovery for MockDiscovery {
     }
 }
 
-struct AggregateToolchain {
+struct AggregateContributor {
     repo_root: AbsoluteSystemPathBuf,
 }
 
-impl Toolchain for AggregateToolchain {
+impl RepositoryContributor for AggregateContributor {
     fn id(&self) -> ToolchainId {
         ToolchainId::new("aggregate-test")
     }
@@ -144,14 +144,14 @@ impl Toolchain for AggregateToolchain {
 
 type StubIOEngineResult = Engine<Built, TaskDefinition>;
 
-struct StubIOToolchain {
+struct StubIOContributor {
     repo_root: AbsoluteSystemPathBuf,
     outputs: DerivedOutputs,
     input_safety: DerivedInputSafety,
     environment: Vec<&'static str>,
 }
 
-impl Toolchain for StubIOToolchain {
+impl RepositoryContributor for StubIOContributor {
     fn id(&self) -> ToolchainId {
         ToolchainId::new("stub-io")
     }
@@ -208,7 +208,7 @@ impl Toolchain for StubIOToolchain {
 
 fn stub_io_package_graph(
     repo_root: &turbopath::AbsoluteSystemPath,
-    toolchain: Arc<StubIOToolchain>,
+    toolchain: Arc<StubIOContributor>,
 ) -> PackageGraph {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -219,7 +219,7 @@ fn stub_io_package_graph(
             .with_package_discovery(MockDiscovery)
             .with_lockfile(Some(Box::new(MockLockfile)))
             .with_package_jsons(Some(HashMap::new()))
-            .with_toolchain(toolchain)
+            .with_contributor(toolchain)
             .build(),
     )
     .unwrap()
@@ -238,7 +238,7 @@ fn task_definition_repo_enumeration_uses_authoritative_scopes() {
             PackageGraph::builder_optional(&repo_root, None)
                 .with_package_discovery(MockDiscovery)
                 .with_package_jsons(Some(HashMap::new()))
-                .with_toolchain(Arc::new(AggregateToolchain {
+                .with_contributor(Arc::new(AggregateContributor {
                     repo_root: repo_root.clone(),
                 }))
                 .build(),
@@ -288,7 +288,7 @@ fn task_definition_repo_enumeration_uses_authoritative_scopes() {
                 .with_package_discovery(MockDiscovery)
                 .with_lockfile(Some(Box::new(MockLockfile)))
                 .with_package_jsons(Some(HashMap::new()))
-                .with_toolchain(Arc::new(AggregateToolchain {
+                .with_contributor(Arc::new(AggregateContributor {
                     repo_root: repo_root.clone(),
                 }))
                 .build(),

--- a/crates/turborepo-engine/src/builder/test/core.rs
+++ b/crates/turborepo-engine/src/builder/test/core.rs
@@ -975,7 +975,7 @@ fn stub_io_engine_with_safety(
 ) -> StubIOEngineResult {
     let repo_root_dir = TempDir::with_prefix("stub-io").unwrap();
     let repo_root = AbsoluteSystemPathBuf::new(repo_root_dir.path().to_str().unwrap()).unwrap();
-    let toolchain = Arc::new(StubIOToolchain {
+    let toolchain = Arc::new(StubIOContributor {
         repo_root: repo_root.clone(),
         outputs,
         input_safety,

--- a/crates/turborepo-lib/src/commands/config.rs
+++ b/crates/turborepo-lib/src/commands/config.rs
@@ -1,7 +1,7 @@
 use camino::Utf8Path;
 use serde::Serialize;
 use turbopath::AbsoluteSystemPathBuf;
-use turborepo_repository::{cargo::CargoToolchain, package_graph::PackageGraph};
+use turborepo_repository::{cargo::CargoContributor, package_graph::PackageGraph};
 use turborepo_types::{EnvMode, UIMode};
 
 use crate::{
@@ -46,7 +46,7 @@ pub async fn run(repo_root: AbsoluteSystemPathBuf, args: Args) -> Result<(), cli
     let mut builder = PackageGraph::builder_optional(&repo_root, root_package_json)
         .with_allow_no_package_manager(config.allow_no_package_manager());
     if cargo_enabled {
-        builder = builder.with_toolchain(CargoToolchain::new(repo_root.clone()));
+        builder = builder.with_contributor(CargoContributor::new(repo_root.clone()));
     }
     let package_graph = builder.build().await?;
 

--- a/crates/turborepo-lib/src/commands/daemon.rs
+++ b/crates/turborepo-lib/src/commands/daemon.rs
@@ -348,11 +348,11 @@ pub async fn daemon_server(
             move |args| {
                 // Mirror the run builder: the daemon-side watcher must see
                 // the same package set a run would.
-                let mut extra_toolchains: Vec<
-                    std::sync::Arc<dyn turborepo_repository::toolchain::Toolchain>,
+                let mut extra_contributors: Vec<
+                    std::sync::Arc<dyn turborepo_repository::toolchain::RepositoryContributor>,
                 > = Vec::new();
                 if cargo_enabled {
-                    extra_toolchains.push(turborepo_repository::cargo::CargoToolchain::new(
+                    extra_contributors.push(turborepo_repository::cargo::CargoContributor::new(
                         args.repo_root.clone(),
                     ));
                 }
@@ -363,7 +363,7 @@ pub async fn daemon_server(
                     args.custom_turbo_json_path,
                     false,
                     args.allow_no_package_manager,
-                    extra_toolchains,
+                    extra_contributors,
                 )
             }
         },

--- a/crates/turborepo-lib/src/commands/get_mfe_port.rs
+++ b/crates/turborepo-lib/src/commands/get_mfe_port.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 use turborepo_microfrontends::TurborepoMfeConfig;
 use turborepo_repository::{
-    cargo::{CargoToolchain, CARGO_TOML},
+    cargo::{CargoContributor, CARGO_TOML},
     package_graph::{PackageGraph, PackageGraphNodeKind, PackageName, PackageNode},
     package_json::PackageJson,
     toolchain::ToolchainId,
@@ -71,7 +71,7 @@ async fn build_package_graph(base: &CommandBase) -> Result<PackageGraph, Error> 
         .with_single_package_mode(base.opts().run_opts.single_package)
         .with_allow_no_package_manager(base.opts().repo_opts.allow_no_package_manager);
     if cargo_enabled {
-        builder = builder.with_toolchain(CargoToolchain::new(repo_root.to_owned()));
+        builder = builder.with_contributor(CargoContributor::new(repo_root.to_owned()));
     }
 
     Ok(builder.build().await?)

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -84,7 +84,7 @@ pub enum Error {
     )]
     PackageNotPruneable(String),
     #[error(transparent)]
-    Toolchain(#[from] turborepo_repository::toolchain::Error),
+    Contribution(#[from] turborepo_repository::toolchain::Error),
     #[error(transparent)]
     PruneKnowledge(#[from] turborepo_repository::prune_knowledge::Error),
 }
@@ -532,8 +532,8 @@ impl<'a> Prune<'a> {
         let mut graph_builder = PackageGraph::builder_optional(&base.repo_root, root_package_json)
             .with_allow_no_package_manager(allow_missing_package_manager);
         if cargo_enabled {
-            graph_builder = graph_builder.with_toolchain(
-                turborepo_repository::cargo::CargoToolchain::new(base.repo_root.clone()),
+            graph_builder = graph_builder.with_contributor(
+                turborepo_repository::cargo::CargoContributor::new(base.repo_root.clone()),
             );
         }
         let package_graph = graph_builder.build().await?;

--- a/crates/turborepo-lib/src/devtools.rs
+++ b/crates/turborepo-lib/src/devtools.rs
@@ -12,7 +12,7 @@ use turborepo_devtools::{
     TaskGraphError, TaskNode,
 };
 use turborepo_repository::{
-    cargo::CargoToolchain,
+    cargo::CargoContributor,
     package_graph::{PackageGraph, PackageGraphBuilder, PackageName},
 };
 use turborepo_task_id::TaskName;
@@ -69,7 +69,7 @@ impl ProperTaskGraphBuilder {
             .with_single_package_mode(opts.run_opts.single_package)
             .with_allow_no_package_manager(opts.repo_opts.allow_no_package_manager);
         if cargo_enabled(&opts.future_flags) {
-            builder = builder.with_toolchain(CargoToolchain::new(self.repo_root.clone()));
+            builder = builder.with_contributor(CargoContributor::new(self.repo_root.clone()));
         }
 
         builder

--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -380,7 +380,7 @@ mod test {
             .with_package_discovery(DummyDiscovery(
                 turbopath::AbsoluteSystemPathBuf::try_from(tmp.path()).unwrap(),
             ))
-            .with_toolchain(turborepo_repository::cargo::CargoToolchain::new(
+            .with_contributor(turborepo_repository::cargo::CargoContributor::new(
                 root.to_owned(),
             ))
             .build()

--- a/crates/turborepo-lib/src/microfrontends.rs
+++ b/crates/turborepo-lib/src/microfrontends.rs
@@ -583,7 +583,7 @@ mod test {
     use turbopath::AbsoluteSystemPathBuf;
     use turborepo_microfrontends::MICROFRONTENDS_PACKAGE;
     use turborepo_repository::{
-        cargo::CargoToolchain, package_graph::PackageGraph, package_json::PackageJson,
+        cargo::CargoContributor, package_graph::PackageGraph, package_json::PackageJson,
         package_manager::PackageManager,
     };
 
@@ -657,7 +657,7 @@ mod test {
         write_mfe_config(&root, "aggregate");
 
         let graph = PackageGraph::builder_optional(&root, None)
-            .with_toolchain(CargoToolchain::new(root.clone()))
+            .with_contributor(CargoContributor::new(root.clone()))
             .build()
             .await
             .unwrap();

--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -24,7 +24,7 @@ use turborepo_repository::{
     },
     package_graph::{PackageGraph, PackageName, WorkspacePackage},
     package_json::{self, PackageJson},
-    toolchain::{Toolchain, WatchSpec},
+    toolchain::{RepositoryContributor, WatchSpec},
 };
 use turborepo_scm::GitHashes;
 
@@ -70,7 +70,7 @@ impl PackageChangesWatcher {
         custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
         single_package: bool,
         allow_no_package_manager: bool,
-        extra_toolchains: Vec<Arc<dyn Toolchain>>,
+        extra_contributors: Vec<Arc<dyn RepositoryContributor>>,
     ) -> Self {
         let (exit_tx, exit_rx) = oneshot::channel();
         let (package_change_events_tx, package_change_events_rx) =
@@ -83,7 +83,7 @@ impl PackageChangesWatcher {
             custom_turbo_json_path,
             single_package,
             allow_no_package_manager,
-            extra_toolchains,
+            extra_contributors,
         );
 
         let _handle = tokio::spawn(subscriber.watch(exit_rx));
@@ -137,7 +137,7 @@ struct Subscriber {
     /// Toolchains registered in addition to JavaScript (e.g. Cargo when
     /// futureFlags.experimentalCargoWorkspaces is enabled), mirroring the
     /// run builder so the watcher sees the same package graph a run would.
-    extra_toolchains: Vec<Arc<dyn Toolchain>>,
+    extra_contributors: Vec<Arc<dyn RepositoryContributor>>,
 }
 
 fn is_in_git_folder(path: &AnchoredSystemPath) -> bool {
@@ -252,8 +252,7 @@ fn classify_changed_files(
         return FileChangeAction::ConfigChanged;
     }
 
-    // Whether an anchored path is under one of the toolchains'
-    // build-byproduct directories.
+    // Whether an anchored path is under an ecosystem build-byproduct directory.
     let in_ignored_prefix = |path: &AnchoredSystemPathBuf| {
         watch_spec
             .ignore_prefixes
@@ -261,8 +260,8 @@ fn classify_changed_files(
             .any(|prefix| path_is_under_prefix(path, prefix))
     };
 
-    // Toolchain workspace-definition files (e.g. Cargo manifests and the
-    // Cargo lockfile) define the package set and its edges; the watcher's
+    // Ecosystem workspace-definition files (e.g. Cargo manifests and
+    // the Cargo lockfile) define the package set and its edges; the watcher's
     // package graph is stale after any of them change, so trigger full
     // rediscovery. Definition-named files inside a byproduct directory
     // (e.g. a Cargo.toml cargo itself writes under target/) are exempt.
@@ -310,7 +309,7 @@ fn classify_changed_files(
                 .is_relevant(repo_root.as_std_path().join(p.as_path()).as_path(), false)
                 && !is_in_git_folder(p)
         })
-        // Toolchain build byproducts (e.g. Cargo's target/) are written
+        // Ecosystem build byproducts (e.g. Cargo's target/) are written
         // continuously by the very tasks a change would re-trigger; letting
         // them through would create a feedback loop. Usually gitignored and
         // dropped above, but the loop must not depend on that.
@@ -373,7 +372,7 @@ impl Subscriber {
         custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
         single_package: bool,
         allow_no_package_manager: bool,
-        extra_toolchains: Vec<Arc<dyn Toolchain>>,
+        extra_contributors: Vec<Arc<dyn RepositoryContributor>>,
     ) -> Self {
         // Try to canonicalize the custom path to match what the file watcher reports
         let normalized_custom_path = custom_turbo_json_path.map(|path| {
@@ -425,13 +424,13 @@ impl Subscriber {
             custom_turbo_json_path: normalized_custom_path,
             single_package,
             allow_no_package_manager,
-            extra_toolchains,
+            extra_contributors,
         }
     }
 
     async fn initialize_repo_state(&self) -> Option<RepoState> {
         let cargo_registered = self
-            .extra_toolchains
+            .extra_contributors
             .iter()
             .any(|toolchain| toolchain.id() == turborepo_repository::toolchain::ToolchainId::RUST);
         let allow_missing_for_cargo = cargo_registered
@@ -454,8 +453,8 @@ impl Subscriber {
             PackageGraph::builder_optional(&self.repo_root, root_package_json.clone())
                 .with_single_package_mode(self.single_package)
                 .with_allow_no_package_manager(self.allow_no_package_manager);
-        for toolchain in &self.extra_toolchains {
-            builder = builder.with_toolchain(toolchain.clone());
+        for toolchain in &self.extra_contributors {
+            builder = builder.with_contributor(toolchain.clone());
         }
         let Ok(pkg_dep_graph) = builder.build().await else {
             tracing::debug!("package graph not available, package watcher not available");
@@ -887,11 +886,11 @@ mod test {
         hash_watcher::HashWatcher, NotifyError, OptionalWatch, WatchEventSender, WatchSource,
     };
     use turborepo_repository::{
-        cargo::CargoToolchain,
+        cargo::CargoContributor,
         change_mapper::{ChangeMapper, GlobalDepsPackageChangeMapper, PackageChanges},
         package_graph::{PackageGraph, PackageGraphBuilder, PackageName, PackageTaskContextKind},
         package_json::PackageJson,
-        toolchain::{Toolchain, WatchSpec},
+        toolchain::{RepositoryContributor, WatchSpec},
     };
     use turborepo_scm::{GitHashes, SCM};
 
@@ -983,7 +982,7 @@ mod test {
     fn test_subscriber(
         repo_root: &AbsoluteSystemPathBuf,
         single_package: bool,
-        extra_toolchains: Vec<Arc<dyn Toolchain>>,
+        extra_contributors: Vec<Arc<dyn RepositoryContributor>>,
     ) -> Subscriber {
         let (_file_events_tx, file_events) = WatchSource::channel_for_root(repo_root.as_std_path());
         let (_discovery_tx, discovery_rx) = watch::channel(None);
@@ -1001,15 +1000,15 @@ mod test {
             None,
             single_package,
             false,
-            extra_toolchains,
+            extra_contributors,
         )
     }
 
     async fn initialize_test_state(
         repo_root: &AbsoluteSystemPathBuf,
-        extra_toolchains: Vec<Arc<dyn Toolchain>>,
+        extra_contributors: Vec<Arc<dyn RepositoryContributor>>,
     ) -> Option<super::RepoState> {
-        test_subscriber(repo_root, false, extra_toolchains)
+        test_subscriber(repo_root, false, extra_contributors)
             .initialize_repo_state()
             .await
     }
@@ -1032,9 +1031,10 @@ mod test {
             .create_with_contents(b"{\"tasks\":{\"build\":{}}}")
             .unwrap();
 
-        let state = initialize_test_state(&repo_root, vec![CargoToolchain::new(repo_root.clone())])
-            .await
-            .expect("native toolchain permits an absent root package.json");
+        let state =
+            initialize_test_state(&repo_root, vec![CargoContributor::new(repo_root.clone())])
+                .await
+                .expect("native toolchain permits an absent root package.json");
         assert!(!state.pkg_dep_graph.has_root_javascript_scope());
         assert!(state.root_turbo_json.is_some());
         assert_eq!(state.pkg_dep_graph.active_watch_spec(), cargo_watch_spec());
@@ -1076,9 +1076,10 @@ mod test {
             .create_with_contents(br#"{"name":"web"}"#)
             .unwrap();
 
-        let state = initialize_test_state(&repo_root, vec![CargoToolchain::new(repo_root.clone())])
-            .await
-            .expect("mixed graph initializes");
+        let state =
+            initialize_test_state(&repo_root, vec![CargoContributor::new(repo_root.clone())])
+                .await
+                .expect("mixed graph initializes");
         let names: HashSet<_> = hash_scopes(&state.pkg_dep_graph)
             .map(|scope| scope.name)
             .collect();
@@ -1096,7 +1097,7 @@ mod test {
         let tmp = tempfile::tempdir().unwrap();
         let repo_root = canonical_temp_root(&tmp);
         assert!(
-            initialize_test_state(&repo_root, vec![CargoToolchain::new(repo_root.clone())])
+            initialize_test_state(&repo_root, vec![CargoContributor::new(repo_root.clone())])
                 .await
                 .is_none(),
             "registered Cargo without a root Cargo.toml must not permit a missing package.json"
@@ -1106,7 +1107,7 @@ mod test {
         let subscriber = test_subscriber(
             &repo_root,
             true,
-            vec![CargoToolchain::new(repo_root.clone())],
+            vec![CargoContributor::new(repo_root.clone())],
         );
         let state = subscriber
             .initialize_repo_state()
@@ -1142,7 +1143,7 @@ mod test {
             .unwrap();
         assert!(load_root_package_json(&repo_root, true).is_err());
         assert!(
-            initialize_test_state(&repo_root, vec![CargoToolchain::new(repo_root.clone())])
+            initialize_test_state(&repo_root, vec![CargoContributor::new(repo_root.clone())])
                 .await
                 .is_none()
         );
@@ -1153,7 +1154,7 @@ mod test {
             .create_with_contents(b"[workspace")
             .unwrap();
         assert!(
-            initialize_test_state(&repo_root, vec![CargoToolchain::new(repo_root.clone())])
+            initialize_test_state(&repo_root, vec![CargoContributor::new(repo_root.clone())])
                 .await
                 .is_none()
         );
@@ -1202,7 +1203,7 @@ mod test {
         let subscriber = test_subscriber(
             &repo_root,
             true,
-            vec![CargoToolchain::new(repo_root.clone())],
+            vec![CargoContributor::new(repo_root.clone())],
         );
         assert_eq!(
             *subscriber

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -571,9 +571,9 @@ impl RunBuilder {
                         turborepo_task_hash::hash_sorted_closures,
                     ));
             if cargo_enabled(&self.opts.future_flags) {
-                builder = builder.with_toolchain(turborepo_repository::cargo::CargoToolchain::new(
-                    self.repo_root.to_owned(),
-                ));
+                builder = builder.with_contributor(
+                    turborepo_repository::cargo::CargoContributor::new(self.repo_root.to_owned()),
+                );
             }
 
             let graph = builder

--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -302,11 +302,11 @@ impl WatchClient {
         ));
         // The watcher builds its own package graph; register the same
         // toolchains a run would so it watches the same package set.
-        let mut extra_toolchains: Vec<
-            std::sync::Arc<dyn turborepo_repository::toolchain::Toolchain>,
+        let mut extra_contributors: Vec<
+            std::sync::Arc<dyn turborepo_repository::toolchain::RepositoryContributor>,
         > = Vec::new();
         if crate::run::builder::cargo_enabled(&base.opts().future_flags) {
-            extra_toolchains.push(turborepo_repository::cargo::CargoToolchain::new(
+            extra_contributors.push(turborepo_repository::cargo::CargoContributor::new(
                 base.repo_root.clone(),
             ));
         }
@@ -317,7 +317,7 @@ impl WatchClient {
             custom_turbo_json_path,
             base.opts().run_opts.single_package,
             base.opts().repo_opts.allow_no_package_manager,
-            extra_toolchains,
+            extra_contributors,
         );
 
         // Subscribe before building the Run so we don't miss the initial

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -51,7 +51,7 @@ use crate::{
     prune_knowledge::{PruneDomain, PrunePlan},
     relationships::Relationship,
     toolchain::{
-        self, DiscoverPackagesFuture, DiscoveredPackage, DiscoveredPackages, Toolchain,
+        self, DiscoverPackagesFuture, DiscoveredPackage, DiscoveredPackages, RepositoryContributor,
         ToolchainId, WorkspaceRoot,
     },
 };
@@ -1294,15 +1294,14 @@ impl PruneDomain for CargoPruneKnowledge {
     }
 }
 
-/// The Cargo toolchain. Registered in the
-/// [`crate::toolchain::ToolchainRegistry`] when
+/// The Cargo repository contributor. Registered during graph construction when
 /// `futureFlags.experimentalCargoWorkspaces` is enabled and the repository
 /// root contains a `Cargo.toml`.
-pub struct CargoToolchain {
+pub struct CargoContributor {
     repo_root: AbsoluteSystemPathBuf,
 }
 
-impl CargoToolchain {
+impl CargoContributor {
     pub fn new(repo_root: AbsoluteSystemPathBuf) -> Arc<Self> {
         Arc::new(Self { repo_root })
     }
@@ -1380,7 +1379,7 @@ fn finalize_cargo_prune(pruned_root: &AbsoluteSystemPath) -> Vec<String> {
     vec![CARGO_LOCK.to_string()]
 }
 
-impl Toolchain for CargoToolchain {
+impl RepositoryContributor for CargoContributor {
     fn id(&self) -> ToolchainId {
         ToolchainId::RUST
     }
@@ -1644,8 +1643,8 @@ pub struct DiscoveredWorkspace {
     /// The workspace's name from `[workspace.metadata] name`, validated
     /// against the crate set when present. Not required at this layer —
     /// it only becomes mandatory when the workspace package is actually
-    /// synthesized (see [`Toolchain::discover_packages`]), so manifests
-    /// without members don't demand a name for nothing.
+    /// synthesized (see [`RepositoryContributor::discover_packages`]), so
+    /// manifests without members don't demand a name for nothing.
     pub name: Option<String>,
     pub crates: Vec<CargoCrate>,
     /// Whether Cargo reported any workspace packages before Turborepo's
@@ -2530,7 +2529,7 @@ dependencies = ["lib-a"]
         write(&root, &["src", "lib.rs"], "");
         generate_lockfile(&root);
 
-        let error = CargoToolchain::new(root)
+        let error = CargoContributor::new(root)
             .discover_packages()
             .await
             .unwrap_err();
@@ -3287,7 +3286,7 @@ release: 1.96.0-nightly\n",
             "[workspace]\nmembers = [\"crates/*\"]\nresolver = \"2\"\n",
         );
 
-        let toolchain = CargoToolchain::new(root.clone());
+        let toolchain = CargoContributor::new(root.clone());
         let err = toolchain.discover_packages().await.unwrap_err();
         assert!(
             err.to_string().contains("[workspace.metadata]"),
@@ -3469,7 +3468,7 @@ release: 1.96.0-nightly\n",
         let (_tmp, root) = tempdir_root();
         write_fixture_workspace(&root);
 
-        let toolchain = CargoToolchain::new(root.clone());
+        let toolchain = CargoContributor::new(root.clone());
         assert_eq!(toolchain.id(), ToolchainId::RUST);
 
         let (packages, roots, resolutions, changes, prune_domains) =
@@ -3585,7 +3584,7 @@ release: 1.96.0-nightly\n",
     #[tokio::test(flavor = "multi_thread")]
     async fn test_cargo_toolchain_empty_without_manifest() {
         let (_tmp, root) = tempdir_root();
-        let toolchain = CargoToolchain::new(root);
+        let toolchain = CargoContributor::new(root);
         let (packages, roots, resolutions, changes, prune_domains) =
             toolchain.discover_packages().await.unwrap().into_parts();
         assert!(packages.is_empty());
@@ -3600,7 +3599,7 @@ release: 1.96.0-nightly\n",
         let (_tmp, root) = tempdir_root();
         write(&root, &["Cargo.toml"], "[workspace]\nmembers = []\n");
 
-        let toolchain = CargoToolchain::new(root);
+        let toolchain = CargoContributor::new(root);
         let (packages, roots, resolutions, changes, prune_domains) =
             toolchain.discover_packages().await.unwrap().into_parts();
         assert!(packages.is_empty());
@@ -3621,7 +3620,7 @@ release: 1.96.0-nightly\n",
 
     #[rustfmt::skip]
     fn task_context<'a>(
-        _toolchain: &CargoToolchain,
+        _toolchain: &CargoContributor,
         root: &'a AbsoluteSystemPath,
         name: &str,
         directory: &'a str,
@@ -3707,7 +3706,7 @@ release: 1.96.0-nightly\n",
         let (_tmp, root) = tempdir_root();
         write_fixture_workspace(&root);
 
-        let toolchain = CargoToolchain::new(root.clone());
+        let toolchain = CargoContributor::new(root.clone());
         let discovered = toolchain.discover_packages().await.unwrap();
         let contracts: HashMap<_, _> = discovered
             .packages()
@@ -3843,7 +3842,7 @@ release: 1.96.0-nightly\n",
         let (_tmp, root) = tempdir_root();
         write_fixture_workspace(&root);
 
-        let toolchain = CargoToolchain::new(root.clone());
+        let toolchain = CargoContributor::new(root.clone());
         toolchain.discover_packages().await.unwrap();
 
         let stale_package = package_info("stale-name");
@@ -3892,7 +3891,7 @@ release: 1.96.0-nightly\n",
         let (_tmp, root) = tempdir_root();
         write_fixture_workspace(&root);
 
-        let toolchain = CargoToolchain::new(root.clone());
+        let toolchain = CargoContributor::new(root.clone());
         let discovered = toolchain.discover_packages().await.unwrap();
         let contracts: HashMap<_, _> = discovered
             .packages()

--- a/crates/turborepo-repository/src/knowledge.rs
+++ b/crates/turborepo-repository/src/knowledge.rs
@@ -92,7 +92,7 @@ impl RelationshipKnowledge {
     }
 }
 
-/// A workspace root paired by core with the registry entry that produced its
+/// A workspace root paired by core with the contributor that produced its
 /// discovery envelope. The public adapter output cannot supply provenance.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct WorkspaceRootObservation {

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -33,8 +33,8 @@ use crate::{
     package_manager::{PackageManager, pnpm::PnpmCatalogs},
     relationships::{Relationship, RelationshipTarget},
     toolchain::{
-        DiscoveredPackage, DiscoveredPackageParts, DiscoveredScopeKind, JavaScriptToolchain,
-        Toolchain, ToolchainId, ToolchainRegistry,
+        DiscoveredPackage, DiscoveredPackageParts, DiscoveredScopeKind, JavaScriptContributor,
+        RepositoryContributor, ToolchainId,
     },
 };
 
@@ -55,7 +55,7 @@ pub struct PackageGraphBuilder<'a, T> {
     /// `futureFlags.experimentalCargoWorkspaces` is enabled). Their packages
     /// are discovered alongside JavaScript packages; name collisions across
     /// toolchains are a hard error.
-    extra_toolchains: Vec<Arc<dyn Toolchain>>,
+    extra_contributors: Vec<Arc<dyn RepositoryContributor>>,
 }
 
 #[derive(Debug, Diagnostic, thiserror::Error)]
@@ -104,8 +104,8 @@ pub enum Error {
     UnknownRelationshipSource { identity: String },
     #[error("internal relationship target {identity} has no authoritative repository scope")]
     UnknownRelationshipTarget { identity: String },
-    #[error(transparent)]
-    DuplicateToolchain(#[from] crate::toolchain::DuplicateToolchainError),
+    #[error("repository contributor {id} was registered more than once")]
+    DuplicateContributor { id: ToolchainId },
     #[error(
         "toolchain {toolchain} contributed multiple workspace roots: accepted {accepted_kind} \
          root {accepted_root}, conflicting {conflicting_kind} root {conflicting_root}"
@@ -123,26 +123,26 @@ pub enum Error {
         path: AbsoluteSystemPathBuf,
         repository_root: AbsoluteSystemPathBuf,
     },
-    #[error("toolchain {toolchain} contributed packages without a workspace root")]
+    #[error("ecosystem {toolchain} contributed packages without a workspace root")]
     MissingWorkspaceRoot { toolchain: ToolchainId },
     #[error(transparent)]
     Lockfile(#[from] turborepo_lockfiles::Error),
     #[error(transparent)]
     Discovery(#[from] crate::discovery::Error),
     #[error(transparent)]
-    Toolchain(Box<dyn std::error::Error + Send + Sync>),
+    Contribution(Box<dyn std::error::Error + Send + Sync>),
 }
 
-// JavaScript toolchain errors map onto the pre-existing variants rather than
+// JavaScript contribution errors map onto the pre-existing variants rather than
 // new ones: consumers match on `Error::PackageJson` (diagnostic rendering,
 // io-NotFound telemetry in the run builder), and those contracts must not
-// depend on whether the error surfaced through a toolchain.
+// depend on whether the error surfaced through a contributor.
 impl From<crate::toolchain::Error> for Error {
     fn from(err: crate::toolchain::Error) -> Self {
         match err {
             crate::toolchain::Error::Discovery(err) => Error::Discovery(err),
             crate::toolchain::Error::Descriptor(err) => Error::PackageJson(err),
-            crate::toolchain::Error::Failed(err) => Error::Toolchain(err),
+            crate::toolchain::Error::Failed(err) => Error::Contribution(err),
         }
     }
 }
@@ -226,10 +226,10 @@ impl<'a> PackageGraphBuilder<'a, LocalPackageDiscoveryBuilder> {
     }
 
     /// Build over a repository that may have no root `package.json`. When
-    /// `root_package_json` is `None`, the JavaScript toolchain contributes
+    /// `root_package_json` is `None`, the JavaScript contributor supplies
     /// nothing (no package manager, no lockfile); the graph is populated
-    /// entirely by the extra toolchains registered via
-    /// [`PackageGraphBuilder::with_toolchain`] (Cargo). When it is `Some`,
+    /// entirely by the extra contributors registered via
+    /// [`PackageGraphBuilder::with_contributor`] (Cargo). When it is `Some`,
     /// this behaves exactly like [`PackageGraphBuilder::new`].
     pub fn new_optional(
         repo_root: &'a AbsoluteSystemPath,
@@ -248,7 +248,7 @@ impl<'a> PackageGraphBuilder<'a, LocalPackageDiscoveryBuilder> {
             lockfile: None,
             package_manager: None,
             closure_hasher: None,
-            extra_toolchains: Vec::new(),
+            extra_contributors: Vec::new(),
         }
     }
 
@@ -292,11 +292,11 @@ impl<'a, P> PackageGraphBuilder<'a, P> {
         self
     }
 
-    /// Register a toolchain in addition to JavaScript. Its packages are
+    /// Register a contributor in addition to JavaScript. Its packages are
     /// discovered alongside JavaScript packages; a package name collision
-    /// across toolchains is a hard error, like any duplicate package name.
-    pub fn with_toolchain(mut self, toolchain: Arc<dyn Toolchain>) -> Self {
-        self.extra_toolchains.push(toolchain);
+    /// across ecosystems are a hard error, like any duplicate package name.
+    pub fn with_contributor(mut self, contributor: Arc<dyn RepositoryContributor>) -> Self {
+        self.extra_contributors.push(contributor);
         self
     }
 
@@ -316,7 +316,7 @@ impl<'a, P> PackageGraphBuilder<'a, P> {
             package_discovery: discovery,
             package_manager: self.package_manager,
             closure_hasher: self.closure_hasher,
-            extra_toolchains: self.extra_toolchains,
+            extra_contributors: self.extra_contributors,
         }
     }
 }
@@ -402,10 +402,10 @@ struct BuildState<'a, S, T> {
     /// documented debt, see `crate::toolchain` module docs. Absent for a
     /// pure Cargo workspace, where there is no JavaScript project to resolve
     /// a package manager or lockfile from.
-    javascript: Option<Arc<JavaScriptToolchain<T>>>,
+    javascript: Option<Arc<JavaScriptContributor<T>>>,
     /// Every toolchain contributing packages, JavaScript included. Package
     /// discovery goes through this and only this.
-    toolchains: ToolchainRegistry,
+    contributors: Vec<Arc<dyn RepositoryContributor>>,
 }
 
 struct PackageGraphAssembler {
@@ -625,7 +625,7 @@ where
             lockfile,
             package_discovery,
             package_manager,
-            extra_toolchains,
+            extra_contributors,
         } = builder;
         // Pure Cargo workspace: with no root package.json there is no
         // JavaScript project, so the JavaScript toolchain is neither
@@ -642,11 +642,11 @@ where
         // caching wrapper guarantees the underlying strategy runs once. For a
         // pure Cargo workspace there is no JavaScript project, so discovery is
         // not built and the toolchain is left unregistered.
-        let mut toolchains = ToolchainRegistry::new();
+        let mut contributors: Vec<Arc<dyn RepositoryContributor>> = Vec::new();
         let javascript = if no_javascript {
             None
         } else {
-            let javascript = Arc::new(JavaScriptToolchain::new(
+            let javascript = Arc::new(JavaScriptContributor::new(
                 CachingPackageDiscovery::new(package_discovery.build().map_err(Into::into)?),
                 repo_root.to_owned(),
                 package_manager,
@@ -654,11 +654,15 @@ where
             // JavaScript registers first: its packages claim names before any
             // other toolchain's, so a cross-toolchain collision surfaces as the
             // non-JS package failing to add.
-            toolchains.register(javascript.clone())?;
+            contributors.push(javascript.clone());
             Some(javascript)
         };
-        for toolchain in extra_toolchains {
-            toolchains.register(toolchain)?;
+        for contributor in extra_contributors {
+            let id = contributor.id();
+            if contributors.iter().any(|existing| existing.id() == id) {
+                return Err(Error::DuplicateContributor { id });
+            }
+            contributors.push(contributor);
         }
 
         Ok(BuildState {
@@ -680,7 +684,7 @@ where
             closure_hasher,
             state: std::marker::PhantomData,
             javascript,
-            toolchains,
+            contributors,
         })
     }
 }
@@ -701,7 +705,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             native_tasks,
             task_contract,
         } = package.into_parts();
-        // Toolchain-resolved external identities are contributed to the
+        // Producer-resolved external identities are contributed to the
         // resolution generation separately; PackageInfo no longer carries
         // closure/hash compatibility projections.
         let task_contract = task_contract.unwrap_or_else(|| {
@@ -768,8 +772,8 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
         let mut pre_supplied = self.package_jsons.take();
         let mut discovered: Vec<(ToolchainId, DiscoveredPackage)> = Vec::new();
         let mut workspace_roots = Vec::new();
-        for toolchain in self.toolchains.iter() {
-            let id = toolchain.id();
+        for contributor in &self.contributors {
+            let id = contributor.id();
             if id == ToolchainId::JAVASCRIPT
                 && let Some(jsons) = pre_supplied.take()
             {
@@ -791,7 +795,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
                 }));
                 continue;
             }
-            let output = toolchain.discover_packages().await?;
+            let output = contributor.discover_packages().await?;
             let (packages, roots, external_resolutions, changes, prune_domains) =
                 output.into_parts();
             self.native_external_resolutions
@@ -860,7 +864,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             lockfile,
             package_manager,
             javascript,
-            toolchains,
+            contributors,
             closure_hasher,
             ..
         } = self;
@@ -879,7 +883,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             lockfile,
             package_manager,
             javascript,
-            toolchains,
+            contributors,
             closure_hasher,
             package_jsons: None,
             state: std::marker::PhantomData,
@@ -1194,7 +1198,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
             native_prune_domains,
             root_package_json,
             javascript,
-            toolchains,
+            contributors,
             closure_hasher,
             ..
         } = self;
@@ -1217,7 +1221,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
             package_jsons: None,
             state: std::marker::PhantomData,
             javascript,
-            toolchains,
+            contributors,
         })
     }
 }
@@ -1565,12 +1569,12 @@ mod test {
         }
     }
 
-    struct RootObservingToolchain {
+    struct RootObservingContributor {
         id: ToolchainId,
         roots: Vec<WorkspaceRoot>,
     }
 
-    impl Toolchain for RootObservingToolchain {
+    impl RepositoryContributor for RootObservingContributor {
         fn id(&self) -> ToolchainId {
             self.id.clone()
         }
@@ -1580,11 +1584,11 @@ mod test {
         }
     }
 
-    struct PackageWithoutRootToolchain {
+    struct PackageWithoutRootContributor {
         root: AbsoluteSystemPathBuf,
     }
 
-    impl Toolchain for PackageWithoutRootToolchain {
+    impl RepositoryContributor for PackageWithoutRootContributor {
         fn id(&self) -> ToolchainId {
             ToolchainId::new("missing-root")
         }
@@ -1603,13 +1607,13 @@ mod test {
         }
     }
 
-    struct PackageContributingToolchain {
+    struct PackageContributor {
         id: ToolchainId,
         root: AbsoluteSystemPathBuf,
         packages: Vec<DiscoveredPackage>,
     }
 
-    impl Toolchain for PackageContributingToolchain {
+    impl RepositoryContributor for PackageContributor {
         fn id(&self) -> ToolchainId {
             self.id.clone()
         }
@@ -1653,7 +1657,7 @@ mod test {
         let native = custom_package(&root, "native-app", dependency_descriptor())
             .with_native_relationships(Vec::new());
         let library = custom_package(&root, "custom-lib", PackageJson::default());
-        let toolchain = PackageContributingToolchain {
+        let toolchain = PackageContributor {
             id: ToolchainId::new("custom-relationships"),
             root: root.clone(),
             packages: vec![legacy, native, library],
@@ -1661,7 +1665,7 @@ mod test {
 
         let graph = PackageGraphBuilder::new(&root, PackageJson::default())
             .with_package_discovery(MockDiscovery)
-            .with_toolchain(Arc::new(toolchain))
+            .with_contributor(Arc::new(toolchain))
             .build()
             .await
             .unwrap();
@@ -1696,7 +1700,7 @@ mod test {
         let root =
             AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
         for mixed in [false, true] {
-            let toolchain = PackageContributingToolchain {
+            let toolchain = PackageContributor {
                 id: ToolchainId::new("reserved-root"),
                 root: root.clone(),
                 packages: vec![
@@ -1706,7 +1710,7 @@ mod test {
             };
             let result = PackageGraphBuilder::new_optional(&root, mixed.then(PackageJson::default))
                 .with_package_discovery(MockDiscovery)
-                .with_toolchain(Arc::new(toolchain))
+                .with_contributor(Arc::new(toolchain))
                 .build()
                 .await;
 
@@ -2864,13 +2868,13 @@ mod test {
     }
 
     #[tokio::test]
-    async fn single_package_reports_only_javascript_root_without_running_extra_toolchains() {
+    async fn single_package_reports_only_javascript_root_without_running_extra_contributors() {
         let root =
             AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
         let graph = PackageGraphBuilder::new(&root, PackageJson::default())
             .with_package_manager(PackageManager::Npm)
             .with_single_package_mode(true)
-            .with_toolchain(Arc::new(RootObservingToolchain {
+            .with_contributor(Arc::new(RootObservingContributor {
                 id: ToolchainId::new("unused-extra"),
                 roots: vec![WorkspaceRoot::new(
                     "unused-extra",
@@ -2889,7 +2893,44 @@ mod test {
     }
 
     #[tokio::test]
-    async fn toolchain_cannot_contribute_multiple_workspace_root_kinds() {
+    async fn contributor_ids_are_unique() {
+        let root =
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+        let id = ToolchainId::new("duplicate");
+        let result = PackageGraphBuilder::new(&root, PackageJson::default())
+            .with_package_discovery(MockDiscovery)
+            .with_package_jsons(Some(HashMap::new()))
+            .with_contributor(Arc::new(RootObservingContributor {
+                id: id.clone(),
+                roots: Vec::new(),
+            }))
+            .with_contributor(Arc::new(RootObservingContributor {
+                id: id.clone(),
+                roots: Vec::new(),
+            }))
+            .build()
+            .await;
+
+        assert!(
+            matches!(result, Err(Error::DuplicateContributor { id: duplicate }) if duplicate == id)
+        );
+
+        let result = PackageGraphBuilder::new(&root, PackageJson::default())
+            .with_package_discovery(MockDiscovery)
+            .with_contributor(Arc::new(RootObservingContributor {
+                id: ToolchainId::JAVASCRIPT,
+                roots: Vec::new(),
+            }))
+            .build()
+            .await;
+        assert!(matches!(
+            result,
+            Err(Error::DuplicateContributor { id }) if id == ToolchainId::JAVASCRIPT
+        ));
+    }
+
+    #[tokio::test]
+    async fn contributor_cannot_contribute_multiple_workspace_root_kinds() {
         let root =
             AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
         let first = root.join_component("first");
@@ -2898,7 +2939,7 @@ mod test {
         let duplicate = PackageGraphBuilder::new(&root, PackageJson::default())
             .with_package_discovery(MockDiscovery)
             .with_package_jsons(Some(HashMap::new()))
-            .with_toolchain(Arc::new(RootObservingToolchain {
+            .with_contributor(Arc::new(RootObservingContributor {
                 id: ToolchainId::new("future-one"),
                 roots: vec![
                     WorkspaceRoot::new("npm", first.clone()),
@@ -2922,11 +2963,11 @@ mod test {
         let graph = PackageGraphBuilder::new(&root, PackageJson::default())
             .with_package_discovery(MockDiscovery)
             .with_package_jsons(Some(HashMap::new()))
-            .with_toolchain(Arc::new(RootObservingToolchain {
+            .with_contributor(Arc::new(RootObservingContributor {
                 id: ToolchainId::new("future-two"),
                 roots: vec![WorkspaceRoot::new("future-a", first)],
             }))
-            .with_toolchain(Arc::new(RootObservingToolchain {
+            .with_contributor(Arc::new(RootObservingContributor {
                 id: ToolchainId::new("future-three"),
                 roots: vec![WorkspaceRoot::new("future-b", second)],
             }))
@@ -2945,11 +2986,11 @@ mod test {
         let graph = PackageGraphBuilder::new(&root, PackageJson::default())
             .with_package_discovery(MockDiscovery)
             .with_package_jsons(Some(HashMap::new()))
-            .with_toolchain(Arc::new(RootObservingToolchain {
+            .with_contributor(Arc::new(RootObservingContributor {
                 id: first.clone(),
                 roots: vec![WorkspaceRoot::new("shared", root.clone())],
             }))
-            .with_toolchain(Arc::new(RootObservingToolchain {
+            .with_contributor(Arc::new(RootObservingContributor {
                 id: second.clone(),
                 roots: vec![WorkspaceRoot::new("shared", root.clone())],
             }))
@@ -2973,7 +3014,9 @@ mod test {
         let result = PackageGraphBuilder::new(&root, PackageJson::default())
             .with_package_discovery(MockDiscovery)
             .with_package_jsons(Some(HashMap::new()))
-            .with_toolchain(Arc::new(PackageWithoutRootToolchain { root: root.clone() }))
+            .with_contributor(Arc::new(PackageWithoutRootContributor {
+                root: root.clone(),
+            }))
             .build()
             .await;
         assert!(matches!(
@@ -2988,11 +3031,13 @@ mod test {
         let cross_producer = PackageGraphBuilder::new(&root, PackageJson::default())
             .with_package_discovery(MockDiscovery)
             .with_package_jsons(Some(HashMap::new()))
-            .with_toolchain(Arc::new(RootObservingToolchain {
+            .with_contributor(Arc::new(RootObservingContributor {
                 id: ToolchainId::new("spoof-attempt"),
                 roots: vec![WorkspaceRoot::new("claimed", root.clone())],
             }))
-            .with_toolchain(Arc::new(PackageWithoutRootToolchain { root: root.clone() }))
+            .with_contributor(Arc::new(PackageWithoutRootContributor {
+                root: root.clone(),
+            }))
             .build()
             .await;
         assert!(matches!(
@@ -3004,7 +3049,7 @@ mod test {
         PackageGraphBuilder::new(&root, PackageJson::default())
             .with_package_discovery(MockDiscovery)
             .with_package_jsons(Some(HashMap::new()))
-            .with_toolchain(Arc::new(RootObservingToolchain {
+            .with_contributor(Arc::new(RootObservingContributor {
                 id: ToolchainId::new("empty-no-op"),
                 roots: Vec::new(),
             }))
@@ -3056,7 +3101,7 @@ mod test {
         let result = PackageGraphBuilder::new(&root, PackageJson::default())
             .with_package_discovery(MockDiscovery)
             .with_package_jsons(Some(HashMap::new()))
-            .with_toolchain(Arc::new(RootObservingToolchain {
+            .with_contributor(Arc::new(RootObservingContributor {
                 id: ToolchainId::new("future-cargo-adapter"),
                 roots: vec![
                     WorkspaceRoot::new("cargo", root.join_component("first")),
@@ -3085,7 +3130,7 @@ mod test {
         let graph = PackageGraphBuilder::new(&root, PackageJson::default())
             .with_package_discovery(MockDiscovery)
             .with_package_jsons(Some(HashMap::new()))
-            .with_toolchain(Arc::new(RootObservingToolchain {
+            .with_contributor(Arc::new(RootObservingContributor {
                 id: ToolchainId::new("future-symlink"),
                 roots: vec![
                     WorkspaceRoot::new("future-build", physical),
@@ -3119,7 +3164,7 @@ mod test {
         let result = PackageGraphBuilder::new(&root, PackageJson::default())
             .with_package_discovery(MockDiscovery)
             .with_package_jsons(Some(HashMap::new()))
-            .with_toolchain(Arc::new(RootObservingToolchain {
+            .with_contributor(Arc::new(RootObservingContributor {
                 id: ToolchainId::new("future-symlink-escape"),
                 roots: vec![WorkspaceRoot::new("future-build", unresolved_root.clone())],
             }))

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -985,7 +985,7 @@ impl PackageGraph {
         self.package_view(package)?.definition_path()
     }
 
-    /// Toolchain provenance for a package or execution scope.
+    /// Ecosystem provenance for a package or execution scope.
     pub fn package_toolchain(
         &self,
         package: &PackageName,
@@ -2840,7 +2840,7 @@ version = "0.1.0"
                 map
             }))
             .with_lockfile(Some(Box::new(MockLockfile {})))
-            .with_toolchain(crate::cargo::CargoToolchain::new(root.clone()))
+            .with_contributor(crate::cargo::CargoContributor::new(root.clone()))
             .build()
             .await
             .unwrap();
@@ -3044,7 +3044,7 @@ version = "0.1.0"
         write_cargo_workspace_fixture(&root);
 
         let mut pkg_graph = PackageGraph::builder_optional(&root, None)
-            .with_toolchain(crate::cargo::CargoToolchain::new(root.clone()))
+            .with_contributor(crate::cargo::CargoContributor::new(root.clone()))
             .build()
             .await
             .unwrap();
@@ -3287,7 +3287,7 @@ version = "0.1.0"
             map
         }))
         .with_lockfile(Some(Box::new(MockLockfile {})))
-        .with_toolchain(crate::cargo::CargoToolchain::new(root.clone()))
+        .with_contributor(crate::cargo::CargoContributor::new(root.clone()))
         .build()
         .await;
 

--- a/crates/turborepo-repository/src/task_contracts.rs
+++ b/crates/turborepo-repository/src/task_contracts.rs
@@ -31,7 +31,7 @@ pub struct ScopeTaskContract {
     defaults: TaskDefaults,
     /// Startup environment patterns this scope needs for derived I/O.
     env_vars: Vec<&'static str>,
-    /// Toolchain provenance when the observation came from a known ecosystem.
+    /// Ecosystem provenance when the observation came from a known producer.
     toolchain: Option<ToolchainId>,
     cargo: Option<crate::cargo::CargoTaskContract>,
     static_defaults: BTreeMap<String, TaskDefaults>,

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -1,9 +1,8 @@
-//! Toolchains: the abstraction that makes Turborepo generic over language
-//! ecosystems.
+//! Repository contributors: construction-time adapters for language ecosystems.
 //!
-//! A [`Toolchain`] discovers ecosystem packages and contributes immutable
-//! observations. JavaScript is the first implementation
-//! ([`JavaScriptToolchain`]); additional producers (e.g. Cargo) register
+//! A [`RepositoryContributor`] discovers ecosystem packages and contributes
+//! immutable observations. JavaScript is the first implementation
+//! ([`JavaScriptContributor`]); additional producers (e.g. Cargo) register
 //! alongside it during package-graph construction.
 //!
 //! # Design rules
@@ -17,8 +16,8 @@
 //!    internal graph types, no lifetime-carrying views, no callbacks.
 //! 2. [`ToolchainId`] is an open identifier, never a closed enum. A future
 //!    toolchain (or plugin) mints a new id without touching existing code.
-//! 3. The [`ToolchainRegistry`] is construction-scoped. Runtime consumers use
-//!    immutable knowledge retained by the completed package graph.
+//! 3. Contributors are construction-scoped. Runtime consumers use immutable
+//!    knowledge retained by the completed package graph.
 //!
 //! # Known debt
 //!
@@ -29,10 +28,10 @@
 //! goes away. When the list is empty, JavaScript is fully behind the
 //! abstraction.
 //!
-//! - [`JavaScriptToolchain::package_manager`]: package-manager resolution feeds
-//!   dependency splitting and lockfile handling in the package graph builder.
-//!   Lockfile handling gains a trait surface with external dependency hashing;
-//!   dependency splitting remains JS-native for now.
+//! - [`JavaScriptContributor::package_manager`]: package-manager resolution
+//!   feeds dependency splitting and lockfile handling in the package graph
+//!   builder. Lockfile handling gains a trait surface with external dependency
+//!   hashing; dependency splitting remains JS-native for now.
 //! - The prune command's JavaScript machinery (lockfile subgraphing,
 //!   workspace-file rewriting, patches) remains on its native path rather than
 //!   the immutable prune-knowledge path.
@@ -169,7 +168,7 @@ impl WorkspaceRoot {
     }
 }
 
-/// One toolchain's package/scope and native workspace-root observations.
+/// One contributor's package/scope and native workspace-root observations.
 #[derive(Debug, Default)]
 pub struct DiscoveredPackages {
     packages: Vec<DiscoveredPackage>,
@@ -338,9 +337,8 @@ pub enum Error {
     Failed(Box<dyn std::error::Error + Send + Sync>),
 }
 
-/// The future returned by [`Toolchain::discover_packages`]. Boxed so the
-/// trait stays object-safe; toolchains live behind `dyn Toolchain` in the
-/// [`ToolchainRegistry`].
+/// The future returned by [`RepositoryContributor::discover_packages`]. Boxed
+/// so the contributor trait stays object-safe.
 pub type DiscoverPackagesFuture<'a> =
     Pin<Box<dyn Future<Output = Result<DiscoveredPackages, Error>> + Send + 'a>>;
 
@@ -391,12 +389,12 @@ pub fn override_task_command(
 /// A language ecosystem that contributes packages to the repository.
 ///
 /// See the module docs for the design rules trait methods must follow.
-pub trait Toolchain: Send + Sync {
-    /// This toolchain's identifier.
+pub trait RepositoryContributor: Send + Sync {
+    /// This contributor's ecosystem identifier.
     fn id(&self) -> ToolchainId;
 
-    /// Discover this toolchain's packages/scopes and native workspace roots in
-    /// one observation envelope.
+    /// Discover this contributor's packages/scopes and native workspace roots
+    /// in one observation envelope.
     fn discover_packages(&self) -> DiscoverPackagesFuture<'_>;
 }
 
@@ -541,75 +539,20 @@ pub struct DerivedTaskIO {
     pub outputs: DerivedOutputs,
 }
 
-/// The construction-scoped set of producers contributing repository knowledge.
-///
-/// Entries are registered statically during package graph construction and the
-/// registry is dropped after immutable knowledge is built. A future plugin
-/// system could construct entries from a manifest without changing runtime
-/// consumers.
-#[derive(Default)]
-pub struct ToolchainRegistry {
-    toolchains: Vec<Arc<dyn Toolchain>>,
-}
-
-#[derive(Debug, thiserror::Error)]
-#[error("toolchain {id} was registered more than once")]
-pub struct DuplicateToolchainError {
-    pub id: ToolchainId,
-}
-
-impl ToolchainRegistry {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Register a toolchain. Registration order is discovery order.
-    pub fn register(
-        &mut self,
-        toolchain: Arc<dyn Toolchain>,
-    ) -> Result<(), DuplicateToolchainError> {
-        let id = toolchain.id();
-        if self.get(&id).is_some() {
-            return Err(DuplicateToolchainError { id });
-        }
-        self.toolchains.push(toolchain);
-        Ok(())
-    }
-
-    pub fn get(&self, id: &ToolchainId) -> Option<&dyn Toolchain> {
-        self.toolchains
-            .iter()
-            .find(|toolchain| toolchain.id() == *id)
-            .map(AsRef::as_ref)
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = &dyn Toolchain> {
-        self.toolchains.iter().map(AsRef::as_ref)
-    }
-}
-
-impl fmt::Debug for ToolchainRegistry {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_list()
-            .entries(self.toolchains.iter().map(|toolchain| toolchain.id()))
-            .finish()
-    }
-}
-
-/// The JavaScript toolchain: packages discovered from `package.json`
+/// The JavaScript contributor: packages discovered from `package.json`
 /// manifests.
 ///
 /// Wraps a [`PackageDiscovery`] strategy (local filesystem walk,
 /// daemon-backed, or a composition) — the strategy decides *how* manifests
-/// are found, the toolchain owns *what a JavaScript package is*: it loads
+/// are found, the contributor owns *what a JavaScript package is*: it loads
 /// and parses each manifest into the package descriptor.
-pub struct JavaScriptToolchain<P> {
+pub struct JavaScriptContributor<P> {
     discovery: P,
     repo_root: AbsoluteSystemPathBuf,
     known_package_manager: Option<PackageManager>,
 }
 
-impl<P: PackageDiscovery + Send + Sync> JavaScriptToolchain<P> {
+impl<P: PackageDiscovery + Send + Sync> JavaScriptContributor<P> {
     pub fn new(
         discovery: P,
         repo_root: AbsoluteSystemPathBuf,
@@ -686,7 +629,7 @@ pub(crate) fn package_manager_command(
     (package_manager_binary.as_os_str().to_owned(), Vec::new())
 }
 
-impl<P: PackageDiscovery + Send + Sync> Toolchain for JavaScriptToolchain<P> {
+impl<P: PackageDiscovery + Send + Sync> RepositoryContributor for JavaScriptContributor<P> {
     fn id(&self) -> ToolchainId {
         ToolchainId::JAVASCRIPT
     }
@@ -873,7 +816,7 @@ mod tests {
         package_json
             .create_with_contents(r#"{"name":"app"}"#)
             .unwrap();
-        let toolchain = JavaScriptToolchain::new(
+        let toolchain = JavaScriptContributor::new(
             StubDiscovery(discovery::DiscoveryResponse {
                 workspaces: vec![discovery::WorkspaceData {
                     package_json,
@@ -1029,35 +972,5 @@ mod tests {
 
         assert_eq!(program, npm_cmd.into_os_string());
         assert!(args.is_empty());
-    }
-
-    #[test]
-    fn test_registry_lookup() {
-        struct Fake(ToolchainId);
-        impl Toolchain for Fake {
-            fn id(&self) -> ToolchainId {
-                self.0.clone()
-            }
-            fn discover_packages(&self) -> DiscoverPackagesFuture<'_> {
-                Box::pin(async { Ok(DiscoveredPackages::default()) })
-            }
-        }
-
-        let mut registry = ToolchainRegistry::new();
-        registry
-            .register(Arc::new(Fake(ToolchainId::JAVASCRIPT)))
-            .unwrap();
-        registry
-            .register(Arc::new(Fake(ToolchainId::new("gleam"))))
-            .unwrap();
-        let duplicate = registry
-            .register(Arc::new(Fake(ToolchainId::new("gleam"))))
-            .unwrap_err();
-        assert_eq!(duplicate.id, ToolchainId::new("gleam"));
-
-        assert!(registry.get(&ToolchainId::JAVASCRIPT).is_some());
-        assert!(registry.get(&ToolchainId::new("gleam")).is_some());
-        assert!(registry.get(&ToolchainId::new("zig")).is_none());
-        assert_eq!(registry.iter().count(), 2);
     }
 }

--- a/crates/turborepo-run-cache/src/lib.rs
+++ b/crates/turborepo-run-cache/src/lib.rs
@@ -957,7 +957,7 @@ mod test {
     use turborepo_cache::{AsyncCache, CacheActions, CacheConfig, CacheOpts, LazyScmState};
     use turborepo_log::{LogSink, Logger, OutputChannel, grouping::GroupingLayer};
     use turborepo_repository::{
-        cargo::CargoToolchain,
+        cargo::CargoContributor,
         package_graph::{PackageGraph, PackageName},
         package_json::PackageJson,
     };
@@ -1038,7 +1038,7 @@ mod test {
             )
             .unwrap();
         PackageGraph::builder_optional(repo_root, None)
-            .with_toolchain(CargoToolchain::new(repo_root.clone()))
+            .with_contributor(CargoContributor::new(repo_root.clone()))
             .build()
             .await
             .unwrap()

--- a/crates/turborepo-run-summary/src/execution.rs
+++ b/crates/turborepo-run-summary/src/execution.rs
@@ -47,7 +47,7 @@ pub struct ExecutionSummary<'a> {
 
 /// Totals for reuse below the task boundary: work units a tool running
 /// inside a task fetched from (hits) or had to rebuild (misses) via the
-/// incremental cache. Toolchain-agnostic — for Rust this is sccache
+/// incremental cache. Ecosystem-agnostic — for Rust this is sccache
 /// compile units served through the Remote Cache; other toolchains can
 /// contribute the same shape.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/turborepo-scope/src/filter.rs
+++ b/crates/turborepo-scope/src/filter.rs
@@ -926,8 +926,8 @@ mod test {
         package_json::PackageJson,
         package_manager::PackageManager,
         toolchain::{
-            DiscoverPackagesFuture, DiscoveredPackage, DiscoveredPackages, Toolchain, ToolchainId,
-            WorkspaceRoot,
+            DiscoverPackagesFuture, DiscoveredPackage, DiscoveredPackages, RepositoryContributor,
+            ToolchainId, WorkspaceRoot,
         },
     };
 
@@ -976,11 +976,11 @@ mod test {
         }
     }
 
-    struct AggregateToolchain {
+    struct AggregateContributor {
         definition_path: AbsoluteSystemPathBuf,
     }
 
-    impl Toolchain for AggregateToolchain {
+    impl RepositoryContributor for AggregateContributor {
         fn id(&self) -> ToolchainId {
             ToolchainId::new("aggregate-test")
         }
@@ -1710,7 +1710,7 @@ mod test {
         let turbo_root = Box::leak(Box::new(
             AbsoluteSystemPathBuf::new(temp_folder.path().as_os_str().to_str().unwrap()).unwrap(),
         ));
-        let aggregate = Arc::new(AggregateToolchain {
+        let aggregate = Arc::new(AggregateContributor {
             definition_path: turbo_root.join_component("Cargo.toml"),
         });
         let graph = tokio::runtime::Builder::new_current_thread()
@@ -1721,7 +1721,7 @@ mod test {
                 PackageGraph::builder_optional(turbo_root, root_package_json)
                     .with_package_discovery(MockDiscovery)
                     .with_package_jsons(Some(HashMap::new()))
-                    .with_toolchain(aggregate)
+                    .with_contributor(aggregate)
                     .build(),
             )
             .unwrap();

--- a/crates/turborepo-task-executor/src/command.rs
+++ b/crates/turborepo-task-executor/src/command.rs
@@ -146,7 +146,7 @@ pub enum CommandProviderError {
     #[error("Unable to find package manager binary: {0}")]
     Which(#[from] which::Error),
     #[error(transparent)]
-    Toolchain(#[from] turborepo_repository::toolchain::Error),
+    NativeTask(#[from] turborepo_repository::toolchain::Error),
 }
 
 /// Command provider that resolves commands through the native-task catalog.
@@ -295,7 +295,7 @@ impl<'a, M: MfeConfigProvider, E: From<CommandProviderError>> CommandProvider<E>
                 override_command,
             )
             .map_err(|error| {
-                CommandProviderError::Toolchain(turborepo_repository::toolchain::Error::Failed(
+                CommandProviderError::NativeTask(turborepo_repository::toolchain::Error::Failed(
                     Box::new(error),
                 ))
             })?

--- a/crates/turborepo-task-hash/src/lib.rs
+++ b/crates/turborepo-task-hash/src/lib.rs
@@ -1078,7 +1078,7 @@ mod test {
     use tempfile::tempdir;
     use turbopath::AbsoluteSystemPathBuf;
     use turborepo_repository::{
-        cargo::CargoToolchain,
+        cargo::CargoContributor,
         package_graph::{PackageGraph, PackageTaskContextKind},
         package_json::PackageJson,
     };
@@ -1173,7 +1173,7 @@ mod test {
             .unwrap();
 
         PackageGraph::builder_optional(repo_root, None)
-            .with_toolchain(CargoToolchain::new(repo_root.clone()))
+            .with_contributor(CargoContributor::new(repo_root.clone()))
             .with_closure_hasher(Arc::new(hash_sorted_closures))
             .build()
             .await

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -220,11 +220,11 @@ The remaining payload deletion phases are explicit:
   relationship knowledge now owns graph assembly, while JavaScript declarations
   remain a temporary classification input.
 - **Phase 3:** Complete. External resolution lives in the immutable generation; query, prune, hashing, and summaries consume it. `PackageInfo` no longer carries `unresolved_external_dependencies`, `transitive_dependencies`, or `external_deps_hash`, and deferred closure installation is gone.
-- **Phase 4 (complete):** Native task/command knowledge is an immutable catalog produced at repository construction. JavaScript scripts and Cargo verb tables contribute observations; engine, turbo-json, executor, query, devtools, LSP, and summary consumers read the catalog. `Toolchain::task_command` / `task_display_command` / `authors_task` / `registered_tasks` / `registers_task` / `defines_task` have been deleted — only the JavaScript producer and the LSP unsaved-source adapter parse scripts.
+- **Phase 4 (complete):** Native task/command knowledge is an immutable catalog produced at repository construction. JavaScript scripts and Cargo verb tables contribute observations; engine, turbo-json, executor, query, devtools, LSP, and summary consumers read the catalog. Behavioral task-command callbacks have been deleted; only the JavaScript contributor and the LSP unsaved-source adapter parse scripts.
 - **Phase 5 (complete for JavaScript and Cargo):** Task-contract knowledge catalogs are produced for every scope. Engine composition, task hashing, entrypoint selection, derived I/O, and execution-only compile-cache decoration consume those immutable contracts without live toolchain dispatch.
 - **Phase 6 (complete for JavaScript and Cargo):** Change knowledge is produced at repository construction. Cargo discovery contributes `Cargo.toml` rediscovery names, the `Cargo.lock` resolution/rediscovery path, and the effective in-repository target-directory ignore prefix. `PackageGraph::active_watch_spec` is now a projection of only the immutable facts retained by that graph generation; it never calls live toolchains. Before the first generation is published, the watcher conservatively retains all in-repository events, closing the subscription/bootstrap race without mutable toolchain callbacks. Single-package generations retain no inactive Cargo facts.
 - **Phase 7 (complete):** JavaScript prune rendering is a distinct pure step (`render_javascript_prune`) producing typed artifacts; `commands/prune.rs` selects closures, performs path-safe layout, and materializes those artifacts without inline lockfile/manifest/patch format interpretation. Cargo discovery captures an immutable, generation-owned prune domain containing lockfile, root-manifest, package-directory, and post-write finalization authority. Cargo lock pruning, extra-member selection, manifest rewriting, root/config file planning, and final lockfile canonicalization run through that graph-owned domain without live toolchain dispatch. Golden inventories cover standard and Docker layouts.
-- **Phase 8 (audit complete for owned consumers):** Query/devtools/summary/run/engine/watch/prune task and resolution views consume knowledge catalogs. Remaining `PackageJson` / `PackageInfo` reads are construction entry points, LSP unsaved-buffer adapters, and package-manager detection — tracked for deletion under TURBO-5787 (`PackageInfo` / `JavaScriptToolchain` removal), not deferred silently. Boundary tag diagnostics consume optional authored-name provenance from repository knowledge only when the authored name matches the authoritative identity.
+- **Phase 8 (audit complete for owned consumers):** Query/devtools/summary/run/engine/watch/prune task and resolution views consume knowledge catalogs. Remaining `PackageJson` / `PackageInfo` reads are construction entry points, LSP unsaved-buffer adapters, and package-manager detection. Boundary tag diagnostics consume optional authored-name provenance from repository knowledge only when the authored name matches the authoritative identity.
 
 Task hashing, run-cache path construction, and run-summary task directories use
 a graph-created `PackageTaskContext` that binds identity, repository root,
@@ -264,9 +264,9 @@ Repository knowledge accepts at most one physical workspace root for each open
 `ToolchainId`, so a repository cannot combine multiple package managers for one
 language. Repeated observations from one producer of the same kind and
 canonical root deduplicate, while observations from different producers may
-coexist. Public toolchain output supplies only root kind and path; core binds
-each root to the `ToolchainId` of the registry entry whose discovery envelope
-contained it. Every toolchain that contributes packages must own an accepted
+coexist. Public contributor output supplies only root kind and path; core binds
+each root to the `ToolchainId` of the contributor whose discovery envelope
+contained it. Every contributor that supplies packages must own an accepted
 root, and contributed roots must remain physically within the repository.
 JavaScript reports only the repository root for its authoritative package-manager
 command family; if discovery reports a different family than an explicitly
@@ -290,21 +290,21 @@ cycles. Cargo path, development, optional, build, target-specific, and automatic
 member relationships are emitted directly from `cargo metadata`; no synthetic
 JavaScript dependency maps or behavioral affectedness callback remain.
 
-#### Toolchains (`crates/turborepo-repository/src/toolchain.rs`)
+#### Repository Contributors (`crates/turborepo-repository/src/toolchain.rs`)
 
-`Toolchain` is a construction-time discovery abstraction. Its discovery method
+`RepositoryContributor` is a construction-time discovery abstraction. Its method
 returns one envelope containing packages/scopes, workspace roots, and
-ecosystem observations. A construction-scoped `ToolchainRegistry` combines
-those envelopes; core validates them, builds immutable relationship, task,
-contract, resolution, change, and prune knowledge, then drops the registry.
+ecosystem observations. The builder combines those envelopes in a local vector;
+core validates them, builds immutable relationship, task,
+contract, resolution, change, and prune knowledge, then drops the collection.
 Runtime consumers query those retained catalogs and never dispatch through live
-toolchains. `ToolchainId` remains open provenance data rather than a closed
+contributors. `ToolchainId` remains open provenance data rather than a closed
 enum, keeping discovery extensible to future out-of-process plugin adapters.
 JavaScript is the first production producer. Machinery that predates the
 abstraction (package-manager resolution for dependency splitting and the JS
 lockfile closure phase) remains documented debt.
 
-Toolchain-derived I/O receives the same task-scoped arguments as execution plus
+Contract-derived I/O receives the same task-scoped arguments as execution plus
 a narrow, platform-aware startup-environment projection keyed by toolchain.
 Dependency tasks do not inherit arguments for a different requested task, each
 toolchain can observe only the variables it declares, Windows lookup remains
@@ -325,7 +325,7 @@ root and adds them to the package graph. Cargo workspaces can stand alone or
 coexist with JavaScript workspaces; a root `package.json` and JavaScript package
 manager are only required when JavaScript packages participate. Cargo-only
 repositories may omit `package.json`; when one exists, it must still be valid.
-`CargoToolchain` is the second `Toolchain` implementation.
+`CargoContributor` is the second `RepositoryContributor` implementation.
 
 Turborepo does not replace Cargo. Cargo is itself a build system with its
 own dependency graph, scheduler, and incremental cache (`target/`), so the
@@ -485,7 +485,7 @@ whether anything changed; Cargo decides how and in what order to build.**
   manifests reference them), the lockfile is subset to that closure, and
   the root `Cargo.toml` is rewritten with `toml_edit` (explicit `members`,
   filtered `default-members`, `[workspace.dependencies]` path entries to
-  removed crates dropped — comments and formatting preserved). Toolchain
+  removed crates dropped — comments and formatting preserved). Ecosystem
   and Cargo config files are carried over. Reachability pruning cannot see
   Cargo's feature unification, so the retained Cargo domain runs `cargo metadata`
   once in the complete output (offline first, then networked) to let Cargo


### PR DESCRIPTION
## Intent

Replace the remaining behavioral Toolchain architecture with a discovery-only repository contribution boundary.

**Stack:** Behavioral Toolchain removal, part 2. Base = `shew/turbo-5798-remove-toolchain-registry`.

## Changes

- Replace `Toolchain` with the discovery-only `RepositoryContributor` contract.
- Replace JavaScript and Cargo toolchain implementations with knowledge contributors.
- Delete `ToolchainRegistry`; graph construction now uses and drops a local contributor collection.
- Rename builder and watcher registration surfaces to contributor terminology.
- Validate duplicate contributor IDs directly in the package graph builder, including built-in JavaScript collisions.
- Update architecture and inline documentation to distinguish contributor construction from runtime knowledge consumption.

## Testing

- `cargo test -p turborepo-repository --lib` (377 passed; three failures reproduced on the stacked base)
- `cargo test -p turborepo-engine` (126 passed)
- `cargo test -p turborepo-scope` (100 passed)
- `cargo test -p turborepo-lib package_changes_watcher` (44 passed)
- `cargo clippy -p turborepo-repository -p turborepo-engine -p turborepo-scope -p turborepo-task-executor -p turborepo-lib -p turborepo-task-hash -p turborepo-run-cache --all-targets -- -D warnings`
- Pre-push `format` and `check:toml` hooks

Advances TURBO-5798.