### PR TITLE
refactor: Remove ToolchainId runtime dispatch

### DIFF
--- a/crates/turborepo-engine/src/builder/definitions.rs
+++ b/crates/turborepo-engine/src/builder/definitions.rs
@@ -317,11 +317,11 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         let command_override = resolve_command_override(
             scoped_command,
             unscoped_command,
-            package_context.as_ref().and_then(|context| {
-                Some((
-                    context.toolchain()?,
+            package_context.as_ref().map(|context| {
+                (
+                    context.task_contract(),
                     context.native_tasks().authors(task_id.as_inner().task()),
-                ))
+                )
             }),
         );
 
@@ -770,7 +770,10 @@ fn apply_derived_task_io(
 fn resolve_command_override(
     scoped_command: Option<ProcessedCommand>,
     unscoped_command: Option<ProcessedCommand>,
-    package_toolchain: Option<(&turborepo_repository::toolchain::ToolchainId, bool)>,
+    package_contract: Option<(
+        &turborepo_repository::task_contracts::ScopeTaskContract,
+        bool,
+    )>,
 ) -> Option<TaskCommandOverride> {
     // Levels 1–2: an explicit per-package command beats everything,
     // including the package's own script — the user targeted this package
@@ -788,7 +791,7 @@ fn resolve_command_override(
     // lean into what the ecosystem does natively. Catalog-synthesized
     // fallbacks (Cargo verb tables) are authored by nobody and sit below
     // the defaults instead.
-    if package_toolchain.is_some_and(|(_, authors)| authors) {
+    if package_contract.is_some_and(|(_, authors)| authors) {
         return None;
     }
 
@@ -797,12 +800,10 @@ fn resolve_command_override(
     match unscoped_command? {
         ProcessedCommand::Argv(argv) => Some(TaskCommandOverride::Argv(argv.into_inner())),
         ProcessedCommand::PerToolchain(entries) => {
-            let (toolchain, _) = package_toolchain?;
-            entries
-                .into_inner()
-                .into_iter()
-                .find(|(toolchain_id, _)| toolchain.as_str() == toolchain_id.as_str())
-                .map(|(_, argv)| TaskCommandOverride::Argv(argv))
+            let (contract, _) = package_contract?;
+            contract
+                .command_map_argv(&entries.into_inner())
+                .map(TaskCommandOverride::Argv)
         }
         // The validator rejects unscoped opt-outs.
         ProcessedCommand::OptOut(_) => None,
@@ -823,7 +824,7 @@ fn inherits_toolchain_task_io(command: Option<&TaskCommandOverride>) -> bool {
 #[cfg(test)]
 mod command_override_tests {
     use turborepo_errors::Spanned;
-    use turborepo_repository::toolchain::ToolchainId;
+    use turborepo_repository::task_contracts::{CommandMapTarget, ScopeTaskContract};
     use turborepo_types::TaskCommandOverride;
 
     use super::{ProcessedCommand, inherits_toolchain_task_io, resolve_command_override};
@@ -848,9 +849,12 @@ mod command_override_tests {
 
     #[test]
     fn test_precedence_levels() {
-        let rust = (&ToolchainId::RUST, false);
-        let js_with_script = (&ToolchainId::JAVASCRIPT, true);
-        let js_without_script = (&ToolchainId::JAVASCRIPT, false);
+        let rust_contract =
+            ScopeTaskContract::empty().with_command_map_target(CommandMapTarget::Rust);
+        let javascript_contract = ScopeTaskContract::javascript();
+        let rust = (&rust_contract, false);
+        let js_with_script = (&javascript_contract, true);
+        let js_without_script = (&javascript_contract, false);
 
         // Levels 1–2: a scoped command beats everything, including an
         // authored script and any unscoped default.

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeSet, HashMap, HashSet},
+    collections::{HashMap, HashSet},
     io::{ErrorKind, IsTerminal},
     sync::Arc,
     time::{Duration, SystemTime},
@@ -16,7 +16,7 @@ use turborepo_errors::Spanned;
 use turborepo_process::ProcessManager;
 use turborepo_repository::{
     change_mapper::PackageInclusionReason,
-    package_graph::{PackageGraph, PackageName},
+    package_graph::{PackageGraph, PackageName, TaskEntrypointPreference},
     package_json,
     package_json::PackageJson,
 };
@@ -1309,49 +1309,16 @@ impl RunBuilder {
         exclusion_candidates: &[PackageName],
         filter_mode: &FilterMode,
     ) -> HashSet<TaskId<'static>> {
-        let mut exclusions = HashSet::new();
-        let toolchains: BTreeSet<_> = candidates
-            .iter()
-            .filter_map(|name| pkg_dep_graph.package_toolchain(name).cloned())
-            .collect();
-        for toolchain_id in toolchains {
-            let candidate_names: Vec<_> = candidates
-                .iter()
-                .filter(|name| {
-                    pkg_dep_graph
-                        .package_toolchain(name)
-                        .is_some_and(|candidate_toolchain| candidate_toolchain == &toolchain_id)
-                })
-                .map(|name| name.as_str().to_string())
-                .collect();
-            let prefer_workspace = match filter_mode {
-                FilterMode::AllPackages => true,
-                FilterMode::ExcludeOnly { .. } => false,
-                FilterMode::ExplicitSelection => candidate_names.len() == 1,
-            };
-            let Some(selected) = pkg_dep_graph.select_task_entrypoints(
-                &toolchain_id,
-                task.task(),
-                &candidate_names,
-                prefer_workspace,
-            ) else {
-                continue;
-            };
-            let selected: HashSet<_> = selected.into_iter().collect();
-            exclusions.extend(
-                exclusion_candidates
-                    .iter()
-                    .filter(|name| {
-                        pkg_dep_graph
-                            .package_toolchain(name)
-                            .is_some_and(|candidate_toolchain| candidate_toolchain == &toolchain_id)
-                    })
-                    .map(|name| name.as_str().to_string())
-                    .filter(|name| !selected.contains(name))
-                    .map(|name| TaskId::new(&name, task.task()).into_owned()),
-            );
-        }
-        exclusions
+        let preference = match filter_mode {
+            FilterMode::AllPackages => TaskEntrypointPreference::Always,
+            FilterMode::ExcludeOnly { .. } => TaskEntrypointPreference::Never,
+            FilterMode::ExplicitSelection => TaskEntrypointPreference::WhenSingleCandidate,
+        };
+        pkg_dep_graph
+            .task_entrypoint_exclusions(task.task(), candidates, exclusion_candidates, preference)
+            .into_iter()
+            .map(|name| TaskId::new(name.as_str(), task.task()).into_owned())
+            .collect()
     }
 
     fn select_engine_task_entrypoints(

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -720,15 +720,27 @@ impl PackageGraph {
                     TaskEntrypointPreference::WhenSingleCandidate => classified.len() == 1,
                 };
                 let has_preferred = classified.iter().any(|(_, entrypoint)| {
-                    *entrypoint == crate::task_contracts::TaskEntrypoint::Preferred
+                    matches!(
+                        entrypoint,
+                        crate::task_contracts::TaskEntrypoint::Preferred
+                            | crate::task_contracts::TaskEntrypoint::PreferredOnly
+                    )
                 });
                 classified
                     .into_iter()
                     .filter_map(move |(name, entrypoint)| {
                         let selected = if prefer && has_preferred {
-                            entrypoint == crate::task_contracts::TaskEntrypoint::Preferred
+                            matches!(
+                                entrypoint,
+                                crate::task_contracts::TaskEntrypoint::Preferred
+                                    | crate::task_contracts::TaskEntrypoint::PreferredOnly
+                            )
                         } else {
-                            entrypoint != crate::task_contracts::TaskEntrypoint::Excluded
+                            !matches!(
+                                entrypoint,
+                                crate::task_contracts::TaskEntrypoint::Excluded
+                                    | crate::task_contracts::TaskEntrypoint::PreferredOnly
+                            )
                         };
                         selected.then_some(name)
                     })

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     fmt,
     sync::{Arc, Mutex, OnceLock},
 };
@@ -239,6 +239,13 @@ pub enum PackageTaskContextKind {
     Root,
     Package,
     Aggregate,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskEntrypointPreference {
+    Always,
+    Never,
+    WhenSingleCandidate,
 }
 
 impl<'a> PackageTaskContext<'a> {
@@ -679,60 +686,70 @@ impl PackageGraph {
         self.task_contract_knowledge.env_vars_by_toolchain()
     }
 
-    pub fn select_task_entrypoints(
+    pub fn task_entrypoint_exclusions(
         &self,
-        toolchain: &crate::toolchain::ToolchainId,
         task: &str,
-        candidates: &[String],
-        prefer: bool,
-    ) -> Option<Vec<String>> {
-        let classified = candidates
-            .iter()
-            .filter_map(|candidate| {
-                let context = self.package_task_context(&PackageName::from(candidate.as_str()))?;
-                (context.toolchain() == Some(toolchain))
-                    .then(|| (candidate, context.task_contract().task_entrypoint(task)))
-            })
-            .collect::<Vec<_>>();
-        if !classified
-            .iter()
-            .any(|(_, entrypoint)| entrypoint.is_some())
-        {
-            return None;
-        }
-        if prefer {
-            let preferred = classified
-                .iter()
-                .filter(|(_, entrypoint)| {
-                    matches!(
-                        entrypoint,
-                        Some(
-                            crate::task_contracts::TaskEntrypoint::Preferred
-                                | crate::task_contracts::TaskEntrypoint::PreferredOnly
-                        )
-                    )
-                })
-                .map(|(name, _)| (*name).clone())
-                .collect::<Vec<_>>();
-            if !preferred.is_empty() {
-                return Some(preferred);
-            }
-        }
-        Some(
+        candidates: &[PackageName],
+        exclusion_candidates: &[PackageName],
+        preference: TaskEntrypointPreference,
+    ) -> Vec<PackageName> {
+        let mut classified = BTreeMap::<_, Vec<_>>::new();
+        for candidate in candidates {
+            let Some(context) = self.package_task_context(candidate) else {
+                continue;
+            };
+            let contract = context.task_contract();
+            let Some(domain) = contract.task_entrypoint_domain() else {
+                continue;
+            };
+            let Some(entrypoint) = contract.task_entrypoint(task) else {
+                continue;
+            };
             classified
-                .into_iter()
-                .filter(|(_, entrypoint)| {
-                    !matches!(
-                        entrypoint,
-                        Some(
-                            crate::task_contracts::TaskEntrypoint::Excluded
-                                | crate::task_contracts::TaskEntrypoint::PreferredOnly
-                        )
-                    )
-                })
-                .map(|(name, _)| name.clone())
-                .collect(),
-        )
+                .entry(domain.clone())
+                .or_default()
+                .push((candidate.clone(), entrypoint));
+        }
+        let active_domains: BTreeSet<_> = classified.keys().cloned().collect();
+        let selected: HashSet<_> = classified
+            .into_values()
+            .flat_map(|classified| {
+                let prefer = match preference {
+                    TaskEntrypointPreference::Always => true,
+                    TaskEntrypointPreference::Never => false,
+                    TaskEntrypointPreference::WhenSingleCandidate => classified.len() == 1,
+                };
+                let has_preferred = classified.iter().any(|(_, entrypoint)| {
+                    *entrypoint == crate::task_contracts::TaskEntrypoint::Preferred
+                });
+                classified
+                    .into_iter()
+                    .filter_map(move |(name, entrypoint)| {
+                        let selected = if prefer && has_preferred {
+                            entrypoint == crate::task_contracts::TaskEntrypoint::Preferred
+                        } else {
+                            entrypoint != crate::task_contracts::TaskEntrypoint::Excluded
+                        };
+                        selected.then_some(name)
+                    })
+            })
+            .collect();
+
+        exclusion_candidates
+            .iter()
+            .filter(|candidate| !selected.contains(*candidate))
+            .filter(|candidate| {
+                let Some(context) = self.package_task_context(candidate) else {
+                    return false;
+                };
+                let contract = context.task_contract();
+                contract
+                    .task_entrypoint_domain()
+                    .is_some_and(|domain| active_domains.contains(domain))
+                    && contract.task_entrypoint(task).is_some()
+            })
+            .cloned()
+            .collect()
     }
 
     /// Foundational change knowledge for watch classification.
@@ -3198,6 +3215,17 @@ version = "0.1.0"
         assert_eq!(
             app_context.toolchain(),
             Some(&crate::toolchain::ToolchainId::RUST)
+        );
+        assert!(
+            pkg_graph
+                .task_entrypoint_exclusions(
+                    "test",
+                    &[PackageName::Root],
+                    std::slice::from_ref(&app_name),
+                    TaskEntrypointPreference::Always,
+                )
+                .is_empty(),
+            "an unclassified root candidate must not activate Cargo exclusions"
         );
         // Crate path dependencies still become graph edges without a package
         // manager: the `workspace:*` protocol resolves internally regardless.

--- a/crates/turborepo-repository/src/task_contracts.rs
+++ b/crates/turborepo-repository/src/task_contracts.rs
@@ -9,7 +9,7 @@
 //! Execution-only decorations such as compile-cache variables are also
 //! projected here, but deliberately do not participate in task hashes.
 
-use std::collections::BTreeMap;
+use std::{borrow::Cow, collections::BTreeMap};
 
 use crate::toolchain::{TaskDefaults, ToolchainId};
 
@@ -19,6 +19,34 @@ pub enum TaskEntrypoint {
     PreferredOnly,
     Candidate,
     Excluded,
+}
+
+/// Groups scopes whose preferred entrypoints compete with one another.
+/// Deliberately independent from ecosystem provenance.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct TaskEntrypointDomain(Cow<'static, str>);
+
+impl TaskEntrypointDomain {
+    pub fn new(value: impl Into<Cow<'static, str>>) -> Self {
+        Self(value.into())
+    }
+}
+
+/// A public `command` map key supported by this scope's native command model.
+/// This is explicit behavior, separate from open-ended ecosystem provenance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandMapTarget {
+    JavaScript,
+    Rust,
+}
+
+impl CommandMapTarget {
+    fn matches(self, key: &str) -> bool {
+        matches!(
+            (self, key),
+            (Self::JavaScript, "javascript") | (Self::Rust, "rust")
+        )
+    }
 }
 
 /// Per-scope task-contract observation produced at repository construction.
@@ -33,9 +61,12 @@ pub struct ScopeTaskContract {
     env_vars: Vec<&'static str>,
     /// Ecosystem provenance when the observation came from a known producer.
     toolchain: Option<ToolchainId>,
+    command_map_target: Option<CommandMapTarget>,
+    entrypoint_domain: Option<TaskEntrypointDomain>,
     cargo: Option<crate::cargo::CargoTaskContract>,
     static_defaults: BTreeMap<String, TaskDefaults>,
     static_io: BTreeMap<String, crate::toolchain::DerivedTaskIO>,
+    static_entrypoints: BTreeMap<String, TaskEntrypoint>,
 }
 
 impl ScopeTaskContract {
@@ -46,9 +77,12 @@ impl ScopeTaskContract {
             defaults: TaskDefaults::default(),
             env_vars: Vec::new(),
             toolchain: Some(ToolchainId::JAVASCRIPT),
+            command_map_target: Some(CommandMapTarget::JavaScript),
+            entrypoint_domain: None,
             cargo: None,
             static_defaults: BTreeMap::new(),
             static_io: BTreeMap::new(),
+            static_entrypoints: BTreeMap::new(),
         }
     }
 
@@ -59,9 +93,12 @@ impl ScopeTaskContract {
             defaults: TaskDefaults::default(),
             env_vars: Vec::new(),
             toolchain: None,
+            command_map_target: None,
+            entrypoint_domain: None,
             cargo: None,
             static_defaults: BTreeMap::new(),
             static_io: BTreeMap::new(),
+            static_entrypoints: BTreeMap::new(),
         }
     }
 
@@ -71,9 +108,12 @@ impl ScopeTaskContract {
             defaults: TaskDefaults::default(),
             env_vars: crate::cargo::TASK_IO_ENV_VARS.to_vec(),
             toolchain: Some(ToolchainId::RUST),
+            command_map_target: Some(CommandMapTarget::Rust),
+            entrypoint_domain: Some(TaskEntrypointDomain(Cow::Borrowed("cargo"))),
             cargo: Some(contract),
             static_defaults: BTreeMap::new(),
             static_io: BTreeMap::new(),
+            static_entrypoints: BTreeMap::new(),
         }
     }
 
@@ -89,9 +129,12 @@ impl ScopeTaskContract {
             defaults: TaskDefaults::default(),
             env_vars,
             toolchain: Some(toolchain),
+            command_map_target: None,
+            entrypoint_domain: None,
             cargo: None,
             static_defaults: defaults,
             static_io: io,
+            static_entrypoints: BTreeMap::new(),
         }
     }
 
@@ -109,6 +152,19 @@ impl ScopeTaskContract {
 
     pub fn toolchain(&self) -> Option<&ToolchainId> {
         self.toolchain.as_ref()
+    }
+
+    pub fn with_command_map_target(mut self, target: CommandMapTarget) -> Self {
+        self.command_map_target = Some(target);
+        self
+    }
+
+    pub fn command_map_argv(&self, entries: &[(String, Vec<String>)]) -> Option<Vec<String>> {
+        let target = self.command_map_target?;
+        entries
+            .iter()
+            .find(|(key, _)| target.matches(key))
+            .map(|(_, argv)| argv.clone())
     }
 
     pub fn defaults_for_task(&self, task: &str) -> TaskDefaults {
@@ -154,7 +210,24 @@ impl ScopeTaskContract {
     }
 
     pub fn task_entrypoint(&self, task: &str) -> Option<TaskEntrypoint> {
-        self.cargo.as_ref()?.task_entrypoint(task)
+        self.static_entrypoints
+            .get(task)
+            .copied()
+            .or_else(|| self.cargo.as_ref()?.task_entrypoint(task))
+    }
+
+    pub fn task_entrypoint_domain(&self) -> Option<&TaskEntrypointDomain> {
+        self.entrypoint_domain.as_ref()
+    }
+
+    pub fn with_task_entrypoints(
+        mut self,
+        domain: TaskEntrypointDomain,
+        entrypoints: BTreeMap<String, TaskEntrypoint>,
+    ) -> Self {
+        self.entrypoint_domain = Some(domain);
+        self.static_entrypoints = entrypoints;
+        self
     }
 
     /// Environment decorations for a compiler cache served by Turborepo.
@@ -258,6 +331,29 @@ mod tests {
         assert_eq!(contract.defaults().cache, None);
         assert!(contract.env_vars().is_empty());
         assert_eq!(contract.toolchain(), Some(&ToolchainId::JAVASCRIPT));
+        assert_eq!(
+            contract.command_map_argv(&[("javascript".into(), vec!["node".into()])]),
+            Some(vec!["node".into()])
+        );
+    }
+
+    #[test]
+    fn command_map_behavior_is_independent_of_provenance() {
+        let contract = ScopeTaskContract::derived(
+            ToolchainId::new("custom-rust-producer"),
+            BTreeMap::new(),
+            Vec::new(),
+            BTreeMap::new(),
+        )
+        .with_command_map_target(CommandMapTarget::Rust);
+
+        assert_eq!(
+            contract.command_map_argv(&[
+                ("javascript".into(), vec!["node".into()]),
+                ("rust".into(), vec!["cargo".into()]),
+            ]),
+            Some(vec!["cargo".into()])
+        );
     }
 
     #[test]

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -362,7 +362,7 @@ whether anything changed; Cargo decides how and in what order to build.**
   workspace-scoped verification verbs.
 - **Execution and entrypoint selection** (`NativeTaskKnowledge`, native command
   resolution in `turborepo-task-executor`, and
-  `PackageGraph::select_task_entrypoints`): crate-scoped build and verification
+  `PackageGraph::task_entrypoint_exclusions`): crate-scoped build and verification
   tasks run `cargo <verb> --package=<crate> --locked`; entrypoints also expose
   `run`/`dev`. Unfiltered builds prefer entrypoints, falling back to libraries
   when the workspace has no entrypoints. Unfiltered verification uses the Cargo
@@ -576,8 +576,8 @@ The core task graph consists of:
   (`resolve_command_override`, `turborepo-engine`'s
   `builder/definitions.rs`), across five precedence levels: Package
   Configuration `command` → root `pkg#task` `command` → authored native task
-  from `NativeTaskKnowledge` → unscoped root default (per-toolchain maps fan out
-  by toolchain id) → the catalog's synthesized native command. The
+  from `NativeTaskKnowledge` → unscoped root default (command maps fan out by
+  explicit task-contract capability) → the catalog's synthesized native command. The
   resolved override is authoritative in both directions — an argv executes
   even where the toolchain defines nothing, an opt-out never executes even
   where it does — and feeds global-deps hashing, the TUI task list, the


### PR DESCRIPTION
## Intent

Keep `ToolchainId` as provenance while moving command-map and entrypoint behavior into explicit immutable task-contract capabilities.

**Stack:** Behavioral Toolchain removal, part 4. Base = `shew/turbo-5798-remove-contributor-plumbing`.

## Changes

- Add explicit command-map targets to scope task contracts.
- Resolve experimental JavaScript/Rust command maps without inspecting package provenance IDs.
- Add open entrypoint selection domains independent of ecosystem identity.
- Project entrypoint exclusions from contract knowledge instead of grouping in the run builder by `ToolchainId`.
- Isolate preference and exclusions per active domain so mixed repositories and pure root namespaces retain unrelated tasks.
- Update architecture documentation and add contract/provenance and root-domain regression coverage.

## Testing

- `cargo test -p turborepo-engine` (126 passed)
- `cargo test -p turborepo-repository task_contracts` (3 passed)
- `cargo test -p turborepo-repository test_pure_cargo_workspace_has_no_javascript`
- `cargo test -p turbo --test cargo_workspace_test` (55 passed; two failures reproduced on the stacked base)
- `cargo clippy -p turborepo-repository -p turborepo-engine -p turborepo-lib --all-targets -- -D warnings`
- Pre-push `format` and `check:toml` hooks

Advances TURBO-5798.