### PR TITLE
ci: Restore Cargo target for lockfile tests

### DIFF
--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -376,6 +376,7 @@ jobs:
             with:
               shared-cache-key: turborepo-debug-build
               save-cache: true
+              cache: "false"
               github-token: ${{ secrets.GITHUB_TOKEN }}
 
           - name: Setup Zig
@@ -383,6 +384,14 @@ jobs:
 
           - name: Setup capnproto
             uses: ./.github/actions/setup-capnproto
+
+          - name: Restore Cargo target
+            uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+            with:
+              path: target
+              key: cargo-target-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml', '.cargo/config.toml', 'Cargo.lock') }}-${{ hashFiles('Cargo.toml', 'crates/**', 'packages/turbo-repository/rust/**', 'version.txt') }}
+              restore-keys: |
+                cargo-target-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml', '.cargo/config.toml', 'Cargo.lock') }}-
 
           - name: Install Bun
             uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1


### PR DESCRIPTION
## Why

The lockfile parser integration job builds the Turbo binary but does not restore the full Cargo target snapshot used by the Rust test jobs. This causes avoidable recompilation.

## What

- Restore the shared OS- and architecture-specific Cargo target snapshot before running lockfile tests.
- Disable the overlapping `Swatinem/rust-cache` target cache for this job.
- Keep the lockfile job restore-only so Rust test jobs remain the sole cache writers.

## Testing

- `git diff --check`
- Parsed `.github/workflows/turborepo-test.yml` with Ruby YAML