### PR TITLE
refactor: Route MFE eligibility by manifest

### DIFF
--- a/crates/turborepo-lib/src/commands/get_mfe_port.rs
+++ b/crates/turborepo-lib/src/commands/get_mfe_port.rs
@@ -7,7 +7,6 @@ use turborepo_repository::{
     cargo::CARGO_TOML,
     package_graph::{PackageGraph, PackageGraphNodeKind, PackageName, PackageNode},
     package_json::PackageJson,
-    toolchain::ToolchainId,
 };
 
 use crate::{
@@ -94,29 +93,22 @@ fn package_for_directory(
                 return None;
             }
             let component_count = directory.components().count();
-            let is_javascript_package = matches!(
-                view.kind(),
-                PackageGraphNodeKind::Package | PackageGraphNodeKind::RootJavaScript
-            ) && view.toolchain() == Some(&ToolchainId::JAVASCRIPT);
+            let is_package_json_scope = view.is_package_json_scope();
             cwd.strip_prefix(directory)
-                .map(|_| (component_count, is_javascript_package, node, view))
+                .map(|_| (component_count, is_package_json_scope, node, view))
         })
-        .max_by_key(|(component_count, is_javascript_package, _, _)| {
-            (*component_count, *is_javascript_package)
+        .max_by_key(|(component_count, is_package_json_scope, _, _)| {
+            (*component_count, *is_package_json_scope)
         })
         .ok_or(Error::NoPackageJson)?;
 
     match owner {
         (_, _, PackageNode::Workspace(PackageName::Other(name)), view)
-            if view.kind() == PackageGraphNodeKind::Package
-                && view.toolchain() == Some(&ToolchainId::JAVASCRIPT) =>
+            if view.is_package_json_scope() =>
         {
             Ok(name)
         }
-        (_, _, PackageNode::Workspace(PackageName::Root), view)
-            if view.kind() == PackageGraphNodeKind::RootJavaScript
-                && view.toolchain() == Some(&ToolchainId::JAVASCRIPT) =>
-        {
+        (_, _, PackageNode::Workspace(PackageName::Root), view) if view.is_package_json_scope() => {
             package_graph
                 .root_javascript_scope_name()
                 .flatten()

--- a/crates/turborepo-lib/src/microfrontends.rs
+++ b/crates/turborepo-lib/src/microfrontends.rs
@@ -4,10 +4,7 @@ use itertools::Itertools;
 use tracing::warn;
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPath, RelativeUnixPath, RelativeUnixPathBuf};
 use turborepo_microfrontends::{Error, TurborepoMfeConfig as MfeConfig, MICROFRONTENDS_PACKAGE};
-use turborepo_repository::{
-    package_graph::{PackageGraph, PackageGraphNodeKind, PackageName},
-    toolchain::ToolchainId,
-};
+use turborepo_repository::package_graph::{PackageGraph, PackageName};
 use turborepo_task_executor::MfeConfigProvider;
 use turborepo_task_id::{TaskId, TaskName};
 
@@ -46,7 +43,7 @@ impl MicrofrontendsConfigs {
             configs: Vec<(&'a str, Result<Option<MfeConfig>, Error>)>,
         }
 
-        let packages = javascript_packages(package_graph).collect::<Vec<_>>();
+        let packages = microfrontend_packages(package_graph).collect::<Vec<_>>();
 
         let any_has_mfe_dep = packages
             .iter()
@@ -348,18 +345,14 @@ impl MicrofrontendsConfigs {
     }
 }
 
-/// The scopes historically probed by microfrontends: the JavaScript root and
-/// real JavaScript workspace packages. Native packages and aggregate execution
-/// scopes are not package directories and must not be interpreted as such.
-fn javascript_packages(
+/// Real package scopes backed by an authoritative package.json definition.
+/// Non-package.json scopes, such as Cargo crates, and aggregate execution
+/// scopes must not be probed for MFE configuration.
+fn microfrontend_packages(
     package_graph: &PackageGraph,
 ) -> impl Iterator<Item = (&str, PackageName, &turbopath::AnchoredSystemPath)> {
     package_graph.node_views().filter_map(|(node, view)| {
-        let is_historical_js_scope = matches!(
-            view.kind(),
-            PackageGraphNodeKind::Package | PackageGraphNodeKind::RootJavaScript
-        ) && view.toolchain() == Some(&ToolchainId::JAVASCRIPT);
-        if !is_historical_js_scope {
+        if !view.is_package_json_scope() {
             return None;
         }
         let name = match node {
@@ -628,7 +621,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn from_disk_does_not_probe_cargo_aggregate_as_a_package() {
+    async fn from_disk_does_not_probe_cargo_scopes_as_packages() {
         let tmp = TempDir::new().unwrap();
         let root = temp_root(&tmp);
         root.join_component("Cargo.toml")
@@ -654,6 +647,7 @@ mod test {
             )
             .unwrap();
         write_mfe_config(&root, "aggregate");
+        write_mfe_config(&root.join_component("member"), "member");
 
         let graph = PackageGraph::builder_optional(&root, None)
             .with_cargo()

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -225,6 +225,7 @@ pub struct PackageTaskContext<'a> {
     package: PackageName,
     repository_root: &'a AbsoluteSystemPath,
     directory: &'a AnchoredSystemPath,
+    definition_path: Option<&'a AnchoredSystemPath>,
     package_info: Option<&'a PackageInfo>,
     external_declarations: &'a ExternalDeclarations,
     native_tasks: &'a crate::native_tasks::ScopeNativeTasks,
@@ -300,6 +301,7 @@ impl<'a> PackageTaskContext<'a> {
             package,
             repository_root,
             directory,
+            definition_path: None,
             package_info,
             external_declarations,
             native_tasks,
@@ -320,6 +322,17 @@ impl<'a> PackageTaskContext<'a> {
 
     pub fn directory(&self) -> &'a AnchoredSystemPath {
         self.directory
+    }
+
+    /// Whether this real package/root scope is defined by package.json.
+    pub fn is_package_json_scope(&self) -> bool {
+        is_package_json_definition(
+            matches!(
+                self.kind,
+                PackageTaskContextKind::Root | PackageTaskContextKind::Package
+            ),
+            self.definition_path,
+        )
     }
 
     pub fn package_info(&self) -> Option<&'a PackageInfo> {
@@ -369,9 +382,29 @@ impl<'a> PackageGraphNodeView<'a> {
         self.definition_path
     }
 
+    /// Whether this real package/root scope is defined by package.json.
+    pub fn is_package_json_scope(&self) -> bool {
+        is_package_json_definition(
+            matches!(
+                self.kind,
+                PackageGraphNodeKind::Package | PackageGraphNodeKind::RootJavaScript
+            ),
+            self.definition_path,
+        )
+    }
+
     pub fn toolchain(&self) -> Option<&'a crate::toolchain::ToolchainId> {
         self.toolchain
     }
+}
+
+fn is_package_json_definition(
+    is_package_scope: bool,
+    definition_path: Option<&AnchoredSystemPath>,
+) -> bool {
+    is_package_scope
+        && definition_path
+            .is_some_and(|path| path.as_path().file_name() == Some("package.json".as_ref()))
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -873,31 +906,35 @@ impl PackageGraph {
     /// required to construct a context. The root identity denotes Turbo's root
     /// task namespace and is always anchored at the repository directory.
     pub fn package_task_context(&self, package: &PackageName) -> Option<PackageTaskContext<'_>> {
-        let (package, directory, kind, toolchain, requires_compatibility_payload) = match package {
-            PackageName::Root => (
-                PackageName::Root,
-                self.knowledge.repository_directory(),
-                PackageTaskContextKind::Root,
-                self.knowledge
-                    .root_javascript_scope()
-                    .map(|scope| scope.toolchain()),
-                self.knowledge.root_javascript_scope().is_some(),
-            ),
-            PackageName::Other(name) => {
-                let scope = self.knowledge.scope(name)?;
-                let kind = match scope.kind() {
-                    crate::knowledge::ScopeKind::Package => PackageTaskContextKind::Package,
-                    crate::knowledge::ScopeKind::Aggregate => PackageTaskContextKind::Aggregate,
-                };
-                (
-                    PackageName::Other(scope.identity().to_owned()),
-                    scope.directory(),
-                    kind,
-                    Some(scope.toolchain()),
-                    true,
-                )
-            }
-        };
+        let (package, directory, definition_path, kind, toolchain, requires_compatibility_payload) =
+            match package {
+                PackageName::Root => {
+                    let scope = self.knowledge.root_javascript_scope();
+                    (
+                        PackageName::Root,
+                        self.knowledge.repository_directory(),
+                        scope.map(|scope| scope.definition_path()),
+                        PackageTaskContextKind::Root,
+                        scope.map(|scope| scope.toolchain()),
+                        scope.is_some(),
+                    )
+                }
+                PackageName::Other(name) => {
+                    let scope = self.knowledge.scope(name)?;
+                    let kind = match scope.kind() {
+                        crate::knowledge::ScopeKind::Package => PackageTaskContextKind::Package,
+                        crate::knowledge::ScopeKind::Aggregate => PackageTaskContextKind::Aggregate,
+                    };
+                    (
+                        PackageName::Other(scope.identity().to_owned()),
+                        scope.directory(),
+                        Some(scope.definition_path()),
+                        kind,
+                        Some(scope.toolchain()),
+                        true,
+                    )
+                }
+            };
         let package_info = self.package_payloads.get(&package);
         let native_tasks = self.native_task_knowledge.for_scope(package.as_str());
         let task_contract = self.task_contract_knowledge.for_scope(package.as_str());
@@ -906,6 +943,7 @@ impl PackageGraph {
             package,
             repository_root: self.knowledge.repository_root(),
             directory,
+            definition_path,
             package_info,
             external_declarations: self.external_declaration_view(),
             native_tasks,
@@ -1673,6 +1711,30 @@ mod test {
         },
         discovery::PackageDiscovery,
     };
+
+    #[test]
+    fn package_json_scope_is_independent_of_toolchain_provenance() {
+        let custom_toolchain = crate::toolchain::ToolchainId::new("custom");
+        let package_json = AnchoredSystemPath::new("packages/app/package.json").unwrap();
+        let custom_view = PackageGraphNodeView {
+            kind: PackageGraphNodeKind::Package,
+            name_source: None,
+            directory: None,
+            definition_path: Some(package_json),
+            toolchain: Some(&custom_toolchain),
+        };
+        assert!(custom_view.is_package_json_scope());
+
+        let cargo_toml = AnchoredSystemPath::new("packages/app/Cargo.toml").unwrap();
+        let javascript_view = PackageGraphNodeView {
+            kind: PackageGraphNodeKind::Package,
+            name_source: None,
+            directory: None,
+            definition_path: Some(cargo_toml),
+            toolchain: Some(&crate::toolchain::ToolchainId::JAVASCRIPT),
+        };
+        assert!(!javascript_view.is_package_json_scope());
+    }
 
     struct MockDiscovery;
     impl PackageDiscovery for MockDiscovery {

--- a/crates/turborepo-task-executor/src/command.rs
+++ b/crates/turborepo-task-executor/src/command.rs
@@ -115,7 +115,7 @@ pub enum CommandProviderError {
         package_name: PackageName,
         task_id: TaskId<'static>,
     },
-    #[error("Package {package_name} is not a JavaScript package execution scope.")]
+    #[error("Package {package_name} is not a package.json-backed package execution scope.")]
     InvalidMfePackageContext { package_name: PackageName },
     #[error("Package directory {directory} is outside repository root {repository_root}.")]
     PackageDirectoryOutsideRepository {
@@ -429,9 +429,9 @@ impl<'a, M: MfeConfigProvider> MicroFrontendProxyProvider<'a, M> {
         Self::validate_package_context(context)
     }
 
-    fn validate_package_context(
-        context: PackageTaskContext<'_>,
-    ) -> Result<PackageTaskContext<'_>, CommandProviderError> {
+    fn validate_package_context<'b>(
+        context: PackageTaskContext<'b>,
+    ) -> Result<PackageTaskContext<'b>, CommandProviderError> {
         let package_directory = context.repository_root().resolve(context.directory());
         if !context.repository_root().contains(&package_directory) {
             return Err(CommandProviderError::PackageDirectoryOutsideRepository {
@@ -439,10 +439,7 @@ impl<'a, M: MfeConfigProvider> MicroFrontendProxyProvider<'a, M> {
                 directory: package_directory.to_string(),
             });
         }
-        if context.toolchain() != Some(&turborepo_repository::toolchain::ToolchainId::JAVASCRIPT)
-            || context.kind()
-                == turborepo_repository::package_graph::PackageTaskContextKind::Aggregate
-        {
+        if !context.is_package_json_scope() {
             return Err(CommandProviderError::InvalidMfePackageContext {
                 package_name: context.package().clone(),
             });
@@ -752,6 +749,42 @@ mod tests {
             .with_package_manager(PackageManager::Npm)
             .with_package_jsons(Some(HashMap::new()))
             .with_allow_no_package_manager(true)
+            .build()
+            .await
+            .unwrap()
+    }
+
+    async fn cargo_package_graph(repo_root: &AbsoluteSystemPathBuf) -> PackageGraph {
+        repo_root
+            .join_component("Cargo.toml")
+            .create_with_contents(
+                "[workspace]\nmembers = [\"member\"]\n\n[workspace.metadata]\nname = \
+                 \"workspace\"\n",
+            )
+            .unwrap();
+        repo_root
+            .join_components(&["member", "src"])
+            .create_dir_all()
+            .unwrap();
+        repo_root
+            .join_components(&["member", "Cargo.toml"])
+            .create_with_contents(
+                "[package]\nname = \"member\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+            )
+            .unwrap();
+        repo_root
+            .join_components(&["member", "src", "lib.rs"])
+            .create_with_contents("")
+            .unwrap();
+        repo_root
+            .join_component("Cargo.lock")
+            .create_with_contents(
+                "version = 4\n\n[[package]]\nname = \"member\"\nversion = \"0.1.0\"\n",
+            )
+            .unwrap();
+
+        PackageGraph::builder_optional(repo_root, None)
+            .with_cargo()
             .build()
             .await
             .unwrap()
@@ -1152,5 +1185,22 @@ mod tests {
                 .as_std_path()
                 .as_os_str()
         );
+    }
+
+    #[tokio::test]
+    async fn test_microfrontend_proxy_rejects_cargo_package_context() {
+        let (_tempdir, repo_root, _package_dir) = create_test_repo();
+        let graph = cargo_package_graph(&repo_root).await;
+        let error = MicroFrontendProxyProvider::<MockMfeConfig>::validate_package_context(
+            graph
+                .package_task_context(&PackageName::from("member"))
+                .expect("Cargo member context"),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            CommandProviderError::InvalidMfePackageContext { .. }
+        ));
     }
 }

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -186,6 +186,9 @@ Represents the workspace structure and package dependencies:
   relationship knowledge rather than raw manifests or PackageInfo maps. MFE
   enablement checks exact declaration names in the same relationship generation
   so internal workspace declarations and alias-key behavior remain unchanged.
+  MFE configuration discovery, directory ownership, and proxy execution accept
+  package/root scopes backed by authoritative `package.json` definitions;
+  aggregate and Cargo-manifest scopes are excluded without provenance dispatch.
   Framework inference and boundaries validation consume the package-scoped
   declaration projection directly;
   aliases, duplicate


### PR DESCRIPTION
## Intent

Remove microfrontend behavior selected by contributor provenance.

## Changes

- Add a canonical package-graph predicate for real package/root scopes backed by authoritative `package.json` definitions.
- Carry authoritative definition paths into task contexts without consulting compatibility payloads.
- Route MFE configuration discovery, `get-mfe-port` directory ownership, and proxy validation through the canonical predicate.
- Preserve deepest-directory and colocated-manifest selection while excluding pure-native roots, Cargo aggregates, and Cargo members.
- Document the manifest-based MFE eligibility contract.

## Testing

- `cargo test -p turborepo-repository package_graph`
- `cargo test -p turborepo-lib commands::get_mfe_port`
- `cargo test -p turborepo-lib microfrontends`
- `USER=opencode cargo test -p turborepo-task-executor`
- `cargo clippy -p turborepo-repository -p turborepo-lib -p turborepo-task-executor --all-targets -- -D warnings`
- Pre-push `format` and `check:toml` hooks

Advances TURBO-5798.