### PR TITLE
refactor: Project manifest-derived repository facts

### DIFF
--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -1188,7 +1188,7 @@ fn cargo_change_observation(
     repo_root: &AbsoluteSystemPath,
     target_directory: Option<&AbsoluteSystemPath>,
 ) -> ChangeObservation {
-    let mut observation = ChangeObservation::new(ToolchainId::RUST)
+    let mut observation = ChangeObservation::new()
         .with_rediscovery_file_name(CARGO_TOML)
         .with_resolution_path(CARGO_LOCK);
     if let Some(prefix) = target_directory

--- a/crates/turborepo-repository/src/change_knowledge.rs
+++ b/crates/turborepo-repository/src/change_knowledge.rs
@@ -1,19 +1,17 @@
 //! Foundational change knowledge for watch and affectedness.
 //!
-//! Ecosystems contribute immutable observations about package ownership,
-//! membership/resolution triggers, and ignored byproduct prefixes. Core owns
-//! subscriptions, coalescing, and generation publication.
+//! Repository knowledge projects package ownership. Ecosystems contribute
+//! immutable observations about membership/resolution triggers and ignored
+//! byproduct prefixes. Core owns subscriptions, coalescing, and publication.
 //!
-//! JavaScript observations are produced from repository knowledge plus the
+//! JavaScript change facts are projected from repository knowledge plus the
 //! active package manager. Native ecosystems contribute observations with
 //! their package discovery result.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
 use crate::{
-    knowledge::RepositoryKnowledge,
-    package_manager::PackageManager,
-    toolchain::{ToolchainId, WatchSpec},
+    knowledge::RepositoryKnowledge, package_manager::PackageManager, toolchain::WatchSpec,
 };
 
 /// Immutable change facts for the repository.
@@ -40,22 +38,20 @@ pub struct ChangeKnowledge {
 }
 
 /// Parser-neutral change facts contributed by one discovery producer.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// Definition names must be basenames. Resolution paths and ignore prefixes
+/// must be non-empty, normalized repository-relative Unix paths. Invalid
+/// observations fail package-graph construction.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ChangeObservation {
-    toolchain: ToolchainId,
     rediscovery_file_names: Vec<String>,
     resolution_paths: Vec<String>,
     ignore_prefixes: Vec<String>,
 }
 
 impl ChangeObservation {
-    pub fn new(toolchain: ToolchainId) -> Self {
-        Self {
-            toolchain,
-            rediscovery_file_names: Vec::new(),
-            resolution_paths: Vec::new(),
-            ignore_prefixes: Vec::new(),
-        }
+    pub fn new() -> Self {
+        Self::default()
     }
 
     pub fn with_rediscovery_file_name(mut self, name: impl Into<String>) -> Self {
@@ -72,23 +68,49 @@ impl ChangeObservation {
         self.ignore_prefixes.push(path.into());
         self
     }
+
+    fn validate(&self) -> Result<(), Error> {
+        for name in &self.rediscovery_file_names {
+            if name.is_empty() || matches!(name.as_str(), "." | "..") || name.contains(['/', '\\'])
+            {
+                return Err(Error::InvalidFileName(name.clone()));
+            }
+        }
+        for path in self.resolution_paths.iter().chain(&self.ignore_prefixes) {
+            let valid = !path.is_empty()
+                && !path.contains('\\')
+                && turbopath::RelativeUnixPath::new(path).is_ok()
+                && path
+                    .split('/')
+                    .all(|component| !component.is_empty() && !matches!(component, "." | ".."));
+            if !valid {
+                return Err(Error::InvalidPath(path.clone()));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum Error {
+    #[error("invalid change observation file name {0:?}")]
+    InvalidFileName(String),
+    #[error("invalid change observation path {0:?}")]
+    InvalidPath(String),
 }
 
 impl ChangeKnowledge {
-    /// Produce JavaScript change observations from repository knowledge.
+    /// Project package.json change facts and compose validated native facts.
     pub(crate) fn build(
         knowledge: &RepositoryKnowledge,
         package_manager: Option<&PackageManager>,
         native: Vec<ChangeObservation>,
-    ) -> Self {
+    ) -> Result<Self, Error> {
         let mut membership_file_names = Vec::new();
         let mut membership_paths = Vec::new();
         let mut resolution_paths = Vec::new();
 
-        let has_js = knowledge.root_javascript_scope().is_some()
-            || knowledge
-                .scopes()
-                .any(|scope| scope.toolchain() == &ToolchainId::JAVASCRIPT);
+        let has_js = knowledge.package_json_packages().next().is_some();
 
         if has_js {
             membership_file_names.push("package.json".to_string());
@@ -101,14 +123,9 @@ impl ChangeKnowledge {
         }
 
         let package_directories = knowledge
-            .scopes()
-            .filter(|scope| scope.toolchain() == &ToolchainId::JAVASCRIPT)
-            .map(|scope| {
-                (
-                    scope.identity().to_owned(),
-                    scope.directory().to_unix().to_string(),
-                )
-            })
+            .package_json_packages()
+            .filter(|(identity, _)| *identity != "//")
+            .map(|(identity, directory)| (identity.to_owned(), directory.to_unix().to_string()))
             .collect();
 
         let mut change = Self {
@@ -122,12 +139,7 @@ impl ChangeKnowledge {
         };
 
         for observation in native {
-            let active = knowledge
-                .scopes()
-                .any(|scope| scope.toolchain() == &observation.toolchain);
-            if !active {
-                continue;
-            }
+            observation.validate()?;
             change
                 .membership_file_names
                 .extend(observation.rediscovery_file_names.iter().cloned());
@@ -140,7 +152,22 @@ impl ChangeKnowledge {
             change.resolution_paths.extend(observation.resolution_paths);
             change.ignore_prefixes.extend(observation.ignore_prefixes);
         }
-        change
+        change.canonicalize();
+        Ok(change)
+    }
+
+    fn canonicalize(&mut self) {
+        for values in [
+            &mut self.membership_file_names,
+            &mut self.rediscovery_file_names,
+            &mut self.membership_paths,
+            &mut self.rediscovery_paths,
+            &mut self.resolution_paths,
+            &mut self.ignore_prefixes,
+        ] {
+            let mut seen = HashSet::with_capacity(values.len());
+            values.retain(|value| seen.insert(value.clone()));
+        }
     }
 
     pub fn membership_file_names(&self) -> &[String] {
@@ -193,7 +220,7 @@ mod tests {
     use crate::{
         knowledge::{PackageScopeObservation, ScopeKind, WorkspaceRootObservation},
         package_manager::PackageManager,
-        toolchain::WorkspaceRoot,
+        toolchain::{ToolchainId, WorkspaceRoot},
     };
 
     fn empty_repository() -> RepositoryKnowledge {
@@ -226,7 +253,7 @@ mod tests {
     #[test]
     fn empty_repository_has_no_js_triggers() {
         let knowledge = empty_repository();
-        let change = ChangeKnowledge::build(&knowledge, None, Vec::new());
+        let change = ChangeKnowledge::build(&knowledge, None, Vec::new()).unwrap();
         assert!(change.membership_file_names().is_empty());
         assert!(change.resolution_paths().is_empty());
         assert!(change.package_directories().is_empty());
@@ -235,7 +262,8 @@ mod tests {
     #[test]
     fn javascript_includes_package_json_and_lockfile() {
         let knowledge = javascript_repository();
-        let change = ChangeKnowledge::build(&knowledge, Some(&PackageManager::Npm), Vec::new());
+        let change =
+            ChangeKnowledge::build(&knowledge, Some(&PackageManager::Npm), Vec::new()).unwrap();
         assert_eq!(change.membership_file_names(), ["package.json"]);
         assert_eq!(change.resolution_paths(), ["package-lock.json"]);
         assert!(change.package_directories().contains_key("web"));
@@ -247,7 +275,8 @@ mod tests {
     #[test]
     fn pnpm_workspace_config_projects_into_watch_spec() {
         let knowledge = javascript_repository();
-        let change = ChangeKnowledge::build(&knowledge, Some(&PackageManager::Pnpm), Vec::new());
+        let change =
+            ChangeKnowledge::build(&knowledge, Some(&PackageManager::Pnpm), Vec::new()).unwrap();
         assert_eq!(change.resolution_paths(), ["pnpm-lock.yaml"]);
         let watch = change.to_watch_spec();
         assert!(
@@ -256,5 +285,83 @@ mod tests {
                 .iter()
                 .any(|path| path.contains("pnpm-workspace"))
         );
+    }
+
+    #[test]
+    fn package_json_change_facts_ignore_producer_identity() {
+        let root =
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+        let custom = ToolchainId::new("custom");
+        let knowledge = RepositoryKnowledge::build(
+            &root,
+            None,
+            &[PackageScopeObservation {
+                identity: Some("web".to_string()),
+                name_source: None,
+                definition_path: root.join_components(&["apps", "web", "package.json"]),
+                toolchain: custom.clone(),
+                scope_kind: ScopeKind::Package,
+            }],
+            &[WorkspaceRootObservation::new(
+                WorkspaceRoot::new("custom", root.clone()),
+                custom,
+            )],
+        )
+        .unwrap();
+
+        let change =
+            ChangeKnowledge::build(&knowledge, Some(&PackageManager::Npm), Vec::new()).unwrap();
+        assert_eq!(change.membership_file_names(), ["package.json"]);
+        assert!(change.package_directories().contains_key("web"));
+    }
+
+    #[test]
+    fn native_observations_do_not_require_matching_scope_provenance() {
+        let observation = ChangeObservation::new()
+            .with_rediscovery_file_name("Cargo.toml")
+            .with_resolution_path("Cargo.lock")
+            .with_ignore_prefix("target");
+        let change = ChangeKnowledge::build(&empty_repository(), None, vec![observation]).unwrap();
+
+        assert_eq!(change.membership_file_names(), ["Cargo.toml"]);
+        assert_eq!(change.resolution_paths(), ["Cargo.lock"]);
+        assert_eq!(change.ignore_prefixes(), ["target"]);
+    }
+
+    #[test]
+    fn change_facts_preserve_core_resolution_priority_and_deduplicate() {
+        let cargo = ChangeObservation::new()
+            .with_rediscovery_file_name("Cargo.toml")
+            .with_resolution_path("Cargo.lock");
+        let duplicate = ChangeObservation::new()
+            .with_resolution_path("Cargo.lock")
+            .with_rediscovery_file_name("Cargo.toml");
+
+        let change = ChangeKnowledge::build(
+            &javascript_repository(),
+            Some(&PackageManager::Npm),
+            vec![cargo, duplicate],
+        )
+        .unwrap();
+
+        assert_eq!(
+            change.membership_file_names(),
+            ["package.json", "Cargo.toml"]
+        );
+        assert_eq!(
+            change.resolution_paths(),
+            ["package-lock.json", "Cargo.lock"]
+        );
+    }
+
+    #[test]
+    fn malformed_native_observations_are_rejected() {
+        for observation in [
+            ChangeObservation::new().with_rediscovery_file_name("../Cargo.toml"),
+            ChangeObservation::new().with_resolution_path("../Cargo.lock"),
+            ChangeObservation::new().with_ignore_prefix(""),
+        ] {
+            assert!(ChangeKnowledge::build(&empty_repository(), None, vec![observation]).is_err());
+        }
     }
 }

--- a/crates/turborepo-repository/src/knowledge.rs
+++ b/crates/turborepo-repository/src/knowledge.rs
@@ -158,6 +158,11 @@ impl ScopeKnowledge {
     pub(crate) fn kind(&self) -> ScopeKind {
         self.kind
     }
+
+    fn is_package_json_package(&self) -> bool {
+        self.kind == ScopeKind::Package
+            && self.definition_path.as_path().file_name() == Some("package.json".as_ref())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -219,6 +224,27 @@ impl RepositoryKnowledge {
             || self.scope_lookup.contains_key(identity)
     }
 
+    /// Real package scopes whose authoritative definition is package.json.
+    /// Contributor identity remains provenance and does not select membership.
+    pub(crate) fn package_json_packages(
+        &self,
+    ) -> impl Iterator<Item = (&str, &AnchoredSystemPath)> {
+        let root = self.root_javascript_scope.as_ref().and_then(|scope| {
+            (scope.definition_path.as_path().file_name() == Some("package.json".as_ref()))
+                .then_some(("//", self.repository_directory.as_ref()))
+        });
+        root.into_iter().chain(
+            self.scopes
+                .iter()
+                .filter(|scope| {
+                    scope.is_package_json_package()
+                        && !(self.root_javascript_scope.is_some()
+                            && scope.directory().as_str().is_empty())
+                })
+                .map(|scope| (scope.identity(), scope.directory())),
+        )
+    }
+
     pub(crate) fn repository_root(&self) -> &AbsoluteSystemPath {
         &self.repository_root
     }
@@ -270,10 +296,14 @@ impl RepositoryKnowledge {
                 definition_path: root_definition_path,
                 toolchain: ToolchainId::JAVASCRIPT,
             });
+        let root_physical_definition = root_javascript_scope.as_ref().and_then(|_| {
+            canonical_physical_path(repository_root.join_component("package.json").as_std_path())
+        });
 
         let mut scopes = Vec::with_capacity(observations.len());
         let mut scope_lookup = HashMap::with_capacity(observations.len());
         let mut definitions = HashMap::<String, AnchoredSystemPathBuf>::new();
+        let mut definition_owners = HashMap::<std::path::PathBuf, String>::new();
         let workspace_roots =
             validate_workspace_roots(repository_root, workspace_root_observations)?;
 
@@ -302,6 +332,9 @@ impl RepositoryKnowledge {
                 repository_root,
                 &observation.definition_path,
             );
+            let physical_definition_path =
+                canonical_physical_path(observation.definition_path.as_std_path())
+                    .unwrap_or_else(|| observation.definition_path.as_std_path().to_owned());
             if identity == "//" {
                 return Err(Error::ReservedRootIdentity {
                     path: definition_path,
@@ -314,6 +347,24 @@ impl RepositoryKnowledge {
                     name: identity.clone(),
                     path: definition_path,
                     existing_path,
+                });
+            }
+            if root_physical_definition.as_ref() == Some(&physical_definition_path)
+                && definition_path.as_str() != "package.json"
+            {
+                return Err(Error::DuplicateDefinitionPath {
+                    path: definition_path,
+                    identity: identity.clone(),
+                    existing_identity: "//".to_string(),
+                });
+            }
+            if let Some(existing_identity) =
+                definition_owners.insert(physical_definition_path, identity.clone())
+            {
+                return Err(Error::DuplicateDefinitionPath {
+                    path: definition_path,
+                    identity: identity.clone(),
+                    existing_identity,
                 });
             }
             let directory = definition_path
@@ -447,6 +498,12 @@ pub(crate) enum Error {
         name: String,
         path: AnchoredSystemPathBuf,
         existing_path: AnchoredSystemPathBuf,
+    },
+    #[error("package definition {path} is claimed by both {existing_identity} and {identity}")]
+    DuplicateDefinitionPath {
+        path: AnchoredSystemPathBuf,
+        identity: String,
+        existing_identity: String,
     },
     #[error("package definition {path} is outside repository root {repository_root}")]
     DefinitionOutsideRepository {
@@ -591,6 +648,118 @@ mod tests {
             repository.scope("app").unwrap().name_source(),
             Some(&source)
         );
+    }
+
+    #[test]
+    fn package_json_projection_uses_definition_and_scope_kind_not_provenance() {
+        let root =
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+        let custom = ToolchainId::new("custom");
+        let repository = RepositoryKnowledge::build(
+            &root,
+            None,
+            &[
+                PackageScopeObservation {
+                    identity: Some("custom-web".to_string()),
+                    name_source: None,
+                    definition_path: root.join_components(&["apps", "custom-web", "package.json"]),
+                    toolchain: custom.clone(),
+                    scope_kind: ScopeKind::Package,
+                },
+                PackageScopeObservation {
+                    identity: Some("spoofed-js".to_string()),
+                    name_source: None,
+                    definition_path: root.join_components(&["crates", "spoofed-js", "Cargo.toml"]),
+                    toolchain: ToolchainId::JAVASCRIPT,
+                    scope_kind: ScopeKind::Package,
+                },
+                PackageScopeObservation {
+                    identity: Some("aggregate".to_string()),
+                    name_source: None,
+                    definition_path: root.join_components(&["aggregate", "package.json"]),
+                    toolchain: custom.clone(),
+                    scope_kind: ScopeKind::Aggregate,
+                },
+            ],
+            &[
+                WorkspaceRootObservation::new(WorkspaceRoot::new("custom", root.clone()), custom),
+                WorkspaceRootObservation::new(
+                    WorkspaceRoot::new("javascript", root.clone()),
+                    ToolchainId::JAVASCRIPT,
+                ),
+            ],
+        )
+        .unwrap();
+
+        let packages = repository
+            .package_json_packages()
+            .map(|(identity, _)| identity)
+            .collect::<Vec<_>>();
+        assert_eq!(packages, ["custom-web"]);
+    }
+
+    #[test]
+    fn repository_knowledge_rejects_duplicate_definition_owners() {
+        let root =
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+        let definition_path = root.join_components(&["apps", "shared", "package.json"]);
+        let custom = ToolchainId::new("custom");
+        let result = RepositoryKnowledge::build(
+            &root,
+            None,
+            &[
+                PackageScopeObservation {
+                    identity: Some("first".to_string()),
+                    name_source: None,
+                    definition_path: definition_path.clone(),
+                    toolchain: custom.clone(),
+                    scope_kind: ScopeKind::Package,
+                },
+                PackageScopeObservation {
+                    identity: Some("second".to_string()),
+                    name_source: None,
+                    definition_path,
+                    toolchain: custom.clone(),
+                    scope_kind: ScopeKind::Package,
+                },
+            ],
+            &[WorkspaceRootObservation::new(
+                WorkspaceRoot::new("custom", root.clone()),
+                custom,
+            )],
+        );
+
+        assert!(matches!(result, Err(Error::DuplicateDefinitionPath { .. })));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn repository_knowledge_rejects_root_definition_symlink_alias() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPathBuf::new(temp.path().to_string_lossy().to_string()).unwrap();
+        root.join_component("package.json")
+            .create_with_contents("{}")
+            .unwrap();
+        let alias = root.join_component("alias");
+        std::os::unix::fs::symlink(root.as_std_path(), alias.as_std_path()).unwrap();
+
+        let result = RepositoryKnowledge::build(
+            &root,
+            Some(Some("root".to_string())),
+            &[PackageScopeObservation {
+                identity: Some("alias".to_string()),
+                name_source: None,
+                definition_path: alias.join_component("package.json"),
+                toolchain: ToolchainId::JAVASCRIPT,
+                scope_kind: ScopeKind::Package,
+            }],
+            &[WorkspaceRootObservation::new(
+                WorkspaceRoot::new("npm", root.clone()),
+                ToolchainId::JAVASCRIPT,
+            )],
+        );
+
+        assert!(matches!(result, Err(Error::DuplicateDefinitionPath { .. })));
     }
 
     #[test]

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -100,6 +100,14 @@ pub enum Error {
     TaskContracts(String),
     #[error("Prune knowledge error: {0}")]
     PruneKnowledge(String),
+    #[error("change knowledge is invalid: {0}")]
+    ChangeKnowledge(String),
+    #[error("package definition {path} is claimed by both {existing_identity} and {identity}")]
+    DuplicateDefinitionPath {
+        path: AnchoredSystemPathBuf,
+        identity: String,
+        existing_identity: String,
+    },
     #[error("package or aggregate scope at {path} uses reserved root identity //")]
     ReservedRootIdentity { path: AnchoredSystemPathBuf },
     #[error("relationship source {identity} has no authoritative repository scope")]
@@ -167,6 +175,15 @@ impl From<crate::knowledge::Error> for Error {
             } => Error::DefinitionOutsideRepository {
                 path,
                 repository_root,
+            },
+            crate::knowledge::Error::DuplicateDefinitionPath {
+                path,
+                identity,
+                existing_identity,
+            } => Error::DuplicateDefinitionPath {
+                path,
+                identity,
+                existing_identity,
             },
             crate::knowledge::Error::MultipleWorkspaceRoots {
                 toolchain,
@@ -1019,11 +1036,14 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             )
             .map_err(|error| Error::TaskContracts(error.to_string()))?
         });
-        let change_knowledge = Arc::new(crate::change_knowledge::ChangeKnowledge::build(
-            &knowledge,
-            package_manager.as_ref(),
-            Vec::new(),
-        ));
+        let change_knowledge = Arc::new(
+            crate::change_knowledge::ChangeKnowledge::build(
+                &knowledge,
+                package_manager.as_ref(),
+                Vec::new(),
+            )
+            .map_err(|error| Error::ChangeKnowledge(error.to_string()))?,
+        );
         let prune_knowledge = Arc::new(crate::prune_knowledge::PruneKnowledge::default());
 
         Ok(PackageGraph {
@@ -1449,11 +1469,16 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
                 discovery::Error::Failed(Box::new(Error::TaskContracts(error.to_string())))
             })?
         });
-        let change_knowledge = Arc::new(crate::change_knowledge::ChangeKnowledge::build(
-            &knowledge,
-            package_manager.as_ref(),
-            native_change_observations,
-        ));
+        let change_knowledge = Arc::new(
+            crate::change_knowledge::ChangeKnowledge::build(
+                &knowledge,
+                package_manager.as_ref(),
+                native_change_observations,
+            )
+            .map_err(|error| {
+                discovery::Error::Failed(Box::new(Error::ChangeKnowledge(error.to_string())))
+            })?,
+        );
         let referenced_prune_domains =
             task_contract_knowledge
                 .scopes()

--- a/crates/turborepo-repository/src/package_graph/dep_splitter.rs
+++ b/crates/turborepo-repository/src/package_graph/dep_splitter.rs
@@ -11,37 +11,19 @@ use crate::{knowledge::RepositoryKnowledge, package_manager::pnpm::PnpmCatalogs}
 /// Reverse index from package path to package name, built once and shared
 /// across all `DependencySplitter` instances.
 ///
-/// Non-JavaScript packages are excluded: JS `workspace:`/`file:` path
-/// specifiers can never target them, and the synthetic Cargo workspace
-/// package lives at the repo root, which would otherwise collide with the
-/// Root package's path.
+/// Non-package.json scopes are excluded: JS `workspace:`/`file:` path
+/// specifiers can never target them, and a Cargo aggregate at the repo root
+/// would otherwise collide with the Root package's path.
 pub struct WorkspacePathIndex<'a>(HashMap<&'a AnchoredSystemPath, PackageName>);
 
 impl<'a> WorkspacePathIndex<'a> {
-    /// Builds the production index from authoritative package/scope paths and
-    /// provenance rather than compatibility `PackageInfo` fields.
+    /// Builds the production index from authoritative package definitions
+    /// rather than compatibility `PackageInfo` fields or contributor identity.
     pub(crate) fn from_knowledge(knowledge: &'a RepositoryKnowledge) -> Self {
-        let root = knowledge.root_javascript_scope().map(|scope| {
-            (
-                knowledge.repository_directory(),
-                PackageName::Root,
-                scope.toolchain(),
-            )
-        });
-        let scopes = knowledge.scopes().map(|scope| {
-            (
-                scope.directory(),
-                PackageName::Other(scope.identity().to_string()),
-                scope.toolchain(),
-            )
-        });
         Self(
-            root.into_iter()
-                .chain(scopes)
-                .filter(|(_, _, toolchain)| {
-                    *toolchain == &crate::toolchain::ToolchainId::JAVASCRIPT
-                })
-                .map(|(directory, name, _)| (directory, name))
+            knowledge
+                .package_json_packages()
+                .map(|(identity, directory)| (directory, PackageName::from(identity)))
                 .collect(),
         )
     }
@@ -294,7 +276,13 @@ mod test {
     use turbopath::AbsoluteSystemPathBuf;
 
     use super::*;
-    use crate::package_json::PackageJson;
+    use crate::{
+        knowledge::{
+            PackageScopeObservation, RepositoryKnowledge, ScopeKind, WorkspaceRootObservation,
+        },
+        package_json::PackageJson,
+        toolchain::{ToolchainId, WorkspaceRoot},
+    };
 
     fn path_index() -> WorkspacePathIndex<'static> {
         let foo = if cfg!(windows) {
@@ -317,6 +305,52 @@ mod test {
                 PackageName::from("baz"),
             ),
         ]))
+    }
+
+    #[test]
+    fn workspace_path_index_uses_authoritative_package_json_definitions() {
+        let root =
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+        let custom = ToolchainId::new("custom");
+        let knowledge = RepositoryKnowledge::build(
+            &root,
+            None,
+            &[
+                PackageScopeObservation {
+                    identity: Some("web".to_string()),
+                    name_source: None,
+                    definition_path: root.join_components(&["apps", "web", "package.json"]),
+                    toolchain: custom.clone(),
+                    scope_kind: ScopeKind::Package,
+                },
+                PackageScopeObservation {
+                    identity: Some("rust".to_string()),
+                    name_source: None,
+                    definition_path: root.join_components(&["crates", "rust", "Cargo.toml"]),
+                    toolchain: ToolchainId::JAVASCRIPT,
+                    scope_kind: ScopeKind::Package,
+                },
+            ],
+            &[
+                WorkspaceRootObservation::new(WorkspaceRoot::new("custom", root.clone()), custom),
+                WorkspaceRootObservation::new(
+                    WorkspaceRoot::new("javascript", root.clone()),
+                    ToolchainId::JAVASCRIPT,
+                ),
+            ],
+        )
+        .unwrap();
+
+        let index = WorkspacePathIndex::from_knowledge(&knowledge);
+        assert_eq!(
+            index.0.get(AnchoredSystemPath::new("apps/web").unwrap()),
+            Some(&PackageName::from("web"))
+        );
+        assert!(
+            !index
+                .0
+                .contains_key(AnchoredSystemPath::new("crates/rust").unwrap())
+        );
     }
 
     #[test_case("1.2.3", None, "1.2.3", Some("@scope/foo"), true ; "handles exact match")]

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -303,6 +303,11 @@ contract, resolution, change, and prune knowledge, then drops the collection.
 Runtime consumers query those retained catalogs and never dispatch through live
 contributors. `ToolchainId` remains open provenance data rather than a closed
 enum, keeping discovery extensible to future out-of-process plugin adapters.
+Package-json membership is projected from real scopes with authoritative
+`package.json` definition paths, independent of that provenance. Change
+ownership and workspace path dependency splitting consume the same projection;
+duplicate contributed definition owners and physical aliases of the root
+definition are rejected during construction.
 JavaScript is the first production producer. Machinery that predates the
 abstraction (package-manager resolution for dependency splitting and the JS
 lockfile closure phase) remains documented debt.
@@ -470,7 +475,8 @@ whether anything changed; Cargo decides how and in what order to build.**
 - **Watch mode** (`ChangeKnowledge` and `PackageGraph::active_watch_spec`,
   consumed by `turborepo-lib/src/package_changes_watcher.rs`): discovery
   observations declare workspace-definition files and build-byproduct
-  directories, and the current graph generation projects one active spec. For
+  directories; accepted observations compose directly without reactivation by
+  producer identity, and the current graph generation projects one active spec. For
   Cargo, any `Cargo.toml` or the root `Cargo.lock` triggers full
   rediscovery (the crate set or its edges may have changed), while events
   under the root `target/` directory are dropped — Cargo writes there


### PR DESCRIPTION
## Intent

Remove package-change and workspace-path behavior selected by contributor provenance.

## Changes

- Project real package.json-backed scopes from authoritative repository definitions independently of `ToolchainId`.
- Route change ownership and JavaScript workspace path dependency splitting through that projection.
- Compose accepted native change observations without reactivating them by producer identity.
- Validate and stably deduplicate native change facts while preserving JavaScript lockfile priority.
- Reject duplicate physical definition owners and root-manifest symlink aliases during repository construction.
- Document the manifest-derived projection and change-observation contract.

## Testing

- `cargo test -p turborepo-repository` (391 passed)
- `cargo test -p turborepo-lib package_changes_watcher` (44 passed)
- `cargo clippy -p turborepo-repository -p turborepo-lib --all-targets -- -D warnings`
- Pre-push `format` and `check:toml` hooks

Advances TURBO-5798.