### PR TITLE
refactor: Route residual task behavior by capability

### DIFF
--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -755,6 +755,16 @@ impl CargoTaskContract {
         toolchain::TaskDefaults { cache }
     }
 
+    /// Classifies Cargo package sources for dependent derived-input closures.
+    /// Workspace aggregates have no package source directory to include.
+    pub(crate) fn dependency_source_inputs(&self) -> crate::task_contracts::DependencySourceInputs {
+        if self.package.kind == CargoPackageKind::Workspace {
+            crate::task_contracts::DependencySourceInputs::Exclude
+        } else {
+            crate::task_contracts::DependencySourceInputs::Include
+        }
+    }
+
     pub(crate) fn compile_cache_env(
         &self,
         endpoint: &toolchain::CompileCacheEndpoint,
@@ -813,27 +823,37 @@ impl CargoTaskContract {
         }
 
         let dependency_globs = || {
+            let mut unknown = false;
             let mut globs: Vec<String> = dependencies
                 .iter()
-                .filter(|dependency| {
-                    dependency.toolchain() == Some(&ToolchainId::RUST)
-                        && dependency.kind()
-                            != crate::package_graph::PackageTaskContextKind::Aggregate
-                })
+                .filter(
+                    |dependency| match dependency.task_contract().dependency_source_inputs() {
+                        crate::task_contracts::DependencySourceInputs::Include => true,
+                        crate::task_contracts::DependencySourceInputs::Exclude => false,
+                        crate::task_contracts::DependencySourceInputs::Unknown => {
+                            unknown = true;
+                            false
+                        }
+                    },
+                )
                 .flat_map(|dependency| {
                     crate_source_globs(path_to_root, dependency.directory().to_unix().as_str())
                 })
                 .collect();
             globs.sort();
             globs.dedup();
-            globs
+            (globs, unknown)
         };
 
         match self.package.kind {
             CargoPackageKind::Entrypoint | CargoPackageKind::Library => {
                 if wants_automatic_inputs {
                     io.package_default_inputs = Some(true);
-                    io.input_globs.extend(dependency_globs());
+                    let (globs, unknown) = dependency_globs();
+                    io.input_globs.extend(globs);
+                    if unknown {
+                        io.input_safety = toolchain::DerivedInputSafety::Untracked;
+                    }
                 }
                 if subcommand == "build" {
                     if self.package.kind == CargoPackageKind::Library {
@@ -876,7 +896,11 @@ impl CargoTaskContract {
             CargoPackageKind::Workspace => {
                 if wants_automatic_inputs {
                     io.package_default_inputs = Some(false);
-                    io.input_globs.extend(dependency_globs());
+                    let (globs, unknown) = dependency_globs();
+                    io.input_globs.extend(globs);
+                    if unknown {
+                        io.input_safety = toolchain::DerivedInputSafety::Untracked;
+                    }
                 }
             }
         }
@@ -3652,6 +3676,17 @@ release: 1.96.0-nightly\n",
             manifest_alters_output_layout: false,
         };
         let native_tasks = Some(native_tasks_for_package(&details, name));
+        let task_contract = (kind == crate::package_graph::PackageTaskContextKind::Package).then(|| {
+            crate::task_contracts::ScopeTaskContract::derived(
+                ToolchainId::RUST,
+                None,
+                std::collections::BTreeMap::new(),
+                std::collections::BTreeMap::new(),
+            )
+            .with_dependency_source_inputs(
+                crate::task_contracts::DependencySourceInputs::Include,
+            )
+        });
         crate::package_graph::PackageTaskContext::new_for_test_with_native_tasks(
             name.into(),
             root,
@@ -3660,6 +3695,7 @@ release: 1.96.0-nightly\n",
             kind,
             Some(&ToolchainId::RUST),
             native_tasks,
+            task_contract,
         )
     }
 
@@ -3972,6 +4008,106 @@ release: 1.96.0-nightly\n",
         assert!(io.env.contains(&"CARGO_TARGET_*".to_string()));
         assert!(io.env.contains(&"CC_*".to_string()));
         assert!(io.env.contains(&"TARGET_CFLAGS".to_string()));
+
+        let custom_toolchain = ToolchainId::new("custom-cargo-producer");
+        let custom_dependency =
+            crate::package_graph::PackageTaskContext::new_for_test_with_native_tasks(
+                "custom-dep".into(),
+                &root,
+                turbopath::AnchoredSystemPath::new("crates/custom-dep").unwrap(),
+                None,
+                crate::package_graph::PackageTaskContextKind::Package,
+                Some(&custom_toolchain),
+                None,
+                Some(
+                    crate::task_contracts::ScopeTaskContract::derived(
+                        custom_toolchain.clone(),
+                        None,
+                        std::collections::BTreeMap::new(),
+                        std::collections::BTreeMap::new(),
+                    )
+                    .with_dependency_source_inputs(
+                        crate::task_contracts::DependencySourceInputs::Include,
+                    ),
+                ),
+            );
+        let unclassified_rust_dependency =
+            crate::package_graph::PackageTaskContext::new_for_test_with_native_tasks(
+                "rust-by-id-only".into(),
+                &root,
+                turbopath::AnchoredSystemPath::new("crates/rust-by-id-only").unwrap(),
+                None,
+                crate::package_graph::PackageTaskContextKind::Package,
+                Some(&ToolchainId::RUST),
+                None,
+                None,
+            );
+        let capability_io = app_contract
+            .derived_task_io(
+                &app_ctx,
+                "build",
+                "../..",
+                &[custom_dependency, unclassified_rust_dependency],
+                true,
+                &context,
+            )
+            .unwrap();
+        assert!(
+            capability_io
+                .input_globs
+                .contains(&"../../crates/custom-dep/**".to_string())
+        );
+        assert!(
+            !capability_io
+                .input_globs
+                .iter()
+                .any(|glob| glob.contains("rust-by-id-only"))
+        );
+        assert_eq!(
+            capability_io.input_safety,
+            toolchain::DerivedInputSafety::Untracked
+        );
+        let excluded_dependency =
+            crate::package_graph::PackageTaskContext::new_for_test_with_native_tasks(
+                "generated-scope".into(),
+                &root,
+                turbopath::AnchoredSystemPath::new("generated/scope").unwrap(),
+                None,
+                crate::package_graph::PackageTaskContextKind::Package,
+                Some(&custom_toolchain),
+                None,
+                Some(
+                    crate::task_contracts::ScopeTaskContract::derived(
+                        custom_toolchain.clone(),
+                        None,
+                        std::collections::BTreeMap::new(),
+                        std::collections::BTreeMap::new(),
+                    )
+                    .with_dependency_source_inputs(
+                        crate::task_contracts::DependencySourceInputs::Exclude,
+                    ),
+                ),
+            );
+        let excluded_io = app_contract
+            .derived_task_io(
+                &app_ctx,
+                "build",
+                "../..",
+                &[excluded_dependency],
+                true,
+                &context,
+            )
+            .unwrap();
+        assert!(
+            !excluded_io
+                .input_globs
+                .iter()
+                .any(|glob| glob.contains("generated/scope"))
+        );
+        assert_eq!(
+            excluded_io.input_safety,
+            toolchain::DerivedInputSafety::Tracked
+        );
         let toolchain::DerivedOutputs::Resolved(outputs) = &io.outputs else {
             panic!("Cargo host outputs must remain resolved");
         };

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -422,15 +422,15 @@ struct BuildState<'a, S, T> {
     package_jsons: Option<HashMap<AbsoluteSystemPathBuf, PackageJson>>,
     closure_hasher: Option<ClosureHasher>,
     state: std::marker::PhantomData<S>,
-    /// The JavaScript toolchain, typed. Package-manager resolution for
+    /// The JavaScript contributor, kept typed. Package-manager resolution for
     /// dependency splitting and lockfile handling reaches through this —
     /// documented debt, see `crate::toolchain` module docs. Absent for a
     /// pure Cargo workspace, where there is no JavaScript project to resolve
     /// a package manager or lockfile from.
     javascript: Option<Arc<JavaScriptContributor<T>>>,
-    /// Every toolchain contributing packages, JavaScript included. Package
-    /// discovery goes through this and only this.
-    contributors: Vec<Arc<dyn RepositoryContributor>>,
+    /// Additional package contributors. JavaScript is kept typed above so
+    /// pre-parsed manifest input cannot be routed through an open ID.
+    extra_contributors: Vec<Arc<dyn RepositoryContributor>>,
 }
 
 struct PackageGraphAssembler {
@@ -653,21 +653,21 @@ where
             extra_contributors,
         } = builder;
         // Pure Cargo workspace: with no root package.json there is no
-        // JavaScript project, so the JavaScript toolchain is neither
-        // registered nor queried for a package manager. The graph is built
-        // entirely from the extra toolchains (Cargo).
+        // JavaScript project, so the typed JavaScript contributor is neither
+        // constructed nor queried for a package manager. The graph is built
+        // entirely from the extra contributors (Cargo).
         let no_javascript = root_package_json.is_none();
         let root_package_info = root_package_json
             .clone()
             .map(|package_json| PackageInfo { package_json });
         let assembler = PackageGraphAssembler::new(root_package_info);
 
-        // The discovery strategy is shared (via the JavaScript toolchain)
+        // The discovery strategy is shared (via the JavaScript contributor)
         // between package discovery and package-manager resolution; the
         // caching wrapper guarantees the underlying strategy runs once. For a
-        // pure Cargo workspace there is no JavaScript project, so discovery is
-        // not built and the toolchain is left unregistered.
-        let mut contributors: Vec<Arc<dyn RepositoryContributor>> = Vec::new();
+        // pure Cargo workspace there is no JavaScript project, so discovery and
+        // the typed contributor are not constructed.
+        let mut additional_contributors: Vec<Arc<dyn RepositoryContributor>> = Vec::new();
         let javascript = if no_javascript {
             None
         } else {
@@ -676,18 +676,18 @@ where
                 repo_root.to_owned(),
                 package_manager,
             ));
-            // JavaScript registers first: its packages claim names before any
-            // other toolchain's, so a cross-toolchain collision surfaces as the
-            // non-JS package failing to add.
-            contributors.push(javascript.clone());
             Some(javascript)
         };
         for contributor in extra_contributors {
             let id = contributor.id();
-            if contributors.iter().any(|existing| existing.id() == id) {
+            if (javascript.is_some() && id == ToolchainId::JAVASCRIPT)
+                || additional_contributors
+                    .iter()
+                    .any(|existing| existing.id() == id)
+            {
                 return Err(Error::DuplicateContributor { id });
             }
-            contributors.push(contributor);
+            additional_contributors.push(contributor);
         }
 
         Ok(BuildState {
@@ -709,7 +709,7 @@ where
             closure_hasher,
             state: std::marker::PhantomData,
             javascript,
-            contributors,
+            extra_contributors: additional_contributors,
         })
     }
 }
@@ -733,13 +733,8 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
         // Producer-resolved external identities are contributed to the
         // resolution generation separately; PackageInfo no longer carries
         // closure/hash compatibility projections.
-        let task_contract = task_contract.unwrap_or_else(|| {
-            if toolchain == ToolchainId::JAVASCRIPT {
-                crate::task_contracts::ScopeTaskContract::javascript()
-            } else {
-                crate::task_contracts::ScopeTaskContract::empty()
-            }
-        });
+        let task_contract =
+            task_contract.unwrap_or_else(crate::task_contracts::ScopeTaskContract::empty);
         if let Some(contract_toolchain) = task_contract.toolchain()
             && contract_toolchain != &toolchain
         {
@@ -794,33 +789,26 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
         // A pre-supplied set of parsed package.json files (used by the
         // package-change watcher and tests) stands in for JavaScript
         // discovery only; other toolchains always discover for themselves.
-        let mut pre_supplied = self.package_jsons.take();
         let mut discovered: Vec<(ToolchainId, DiscoveredPackage)> = Vec::new();
         let mut workspace_roots = Vec::new();
-        for contributor in &self.contributors {
-            let id = contributor.id();
-            if id == ToolchainId::JAVASCRIPT
-                && let Some(jsons) = pre_supplied.take()
-            {
-                if let Some(javascript) = self.javascript.as_ref() {
-                    workspace_roots.push(WorkspaceRootObservation::new(
-                        javascript.workspace_root().await?,
-                        id.clone(),
-                    ));
+        let mut contributor_outputs = Vec::with_capacity(self.extra_contributors.len() + 1);
+        if let Some(javascript) = self.javascript.as_ref() {
+            let output = match self.package_jsons.take() {
+                Some(package_jsons) => {
+                    javascript
+                        .discover_preparsed_packages(package_jsons)
+                        .await?
                 }
-                discovered.extend(jsons.into_iter().map(|(path, json)| {
-                    (
-                        ToolchainId::JAVASCRIPT,
-                        DiscoveredPackage::package(
-                            json.name.as_ref().map(|name| name.as_inner().clone()),
-                            json,
-                            path,
-                        ),
-                    )
-                }));
-                continue;
-            }
+                None => javascript.discover_packages().await?,
+            };
+            contributor_outputs.push((ToolchainId::JAVASCRIPT, output));
+        }
+        for contributor in &self.extra_contributors {
+            let id = contributor.id();
             let output = contributor.discover_packages().await?;
+            contributor_outputs.push((id, output));
+        }
+        for (id, output) in contributor_outputs {
             let (packages, roots, external_resolutions, changes, prune_domains) =
                 output.into_parts();
             self.native_external_resolutions
@@ -889,7 +877,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             lockfile,
             package_manager,
             javascript,
-            contributors,
+            extra_contributors,
             closure_hasher,
             ..
         } = self;
@@ -908,7 +896,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             lockfile,
             package_manager,
             javascript,
-            contributors,
+            extra_contributors,
             closure_hasher,
             package_jsons: None,
             state: std::marker::PhantomData,
@@ -1226,7 +1214,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
             native_prune_domains,
             root_package_json,
             javascript,
-            contributors,
+            extra_contributors,
             closure_hasher,
             ..
         } = self;
@@ -1249,7 +1237,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
             package_jsons: None,
             state: std::marker::PhantomData,
             javascript,
-            contributors,
+            extra_contributors,
         })
     }
 }
@@ -1741,6 +1729,15 @@ mod test {
                 .relationships()
                 .is_empty()
         );
+        let custom_context = graph
+            .package_task_context(&PackageName::from("legacy-app"))
+            .unwrap();
+        let custom_contract = custom_context.task_contract();
+        assert_eq!(custom_contract.toolchain(), None);
+        assert_eq!(
+            custom_contract.command_map_argv(&[("javascript".into(), vec!["node".into()])]),
+            None
+        );
     }
 
     #[tokio::test]
@@ -1882,6 +1879,16 @@ mod test {
                 Some("apps/app/package.json".to_string())
             );
             assert_eq!(app_view.toolchain(), Some(&ToolchainId::JAVASCRIPT));
+            let app_contract = graph
+                .package_task_context(&PackageName::from("app"))
+                .unwrap()
+                .task_contract()
+                .clone();
+            assert_eq!(app_contract.toolchain(), Some(&ToolchainId::JAVASCRIPT));
+            assert_eq!(
+                app_contract.command_map_argv(&[("javascript".into(), vec!["node".into()])]),
+                Some(vec!["node".into()])
+            );
             let app_name_source = app_view
                 .name_source()
                 .expect("the authored JavaScript name retains diagnostic provenance");

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -253,7 +253,7 @@ impl<'a> PackageTaskContext<'a> {
     #[cfg(test)]
     #[rustfmt::skip]
     pub(crate) fn new_for_test(package: PackageName, repository_root: &'a AbsoluteSystemPath, directory: &'a AnchoredSystemPath, package_info: Option<&'a PackageInfo>, kind: PackageTaskContextKind, toolchain: Option<&'a crate::toolchain::ToolchainId>) -> Self {
-        Self::new_for_test_with_native_tasks(package, repository_root, directory, package_info, kind, toolchain, None)
+        Self::new_for_test_with_native_tasks(package, repository_root, directory, package_info, kind, toolchain, None, None)
     }
 
     #[cfg(test)]
@@ -265,6 +265,7 @@ impl<'a> PackageTaskContext<'a> {
         kind: PackageTaskContextKind,
         toolchain: Option<&'a crate::toolchain::ToolchainId>,
         native_tasks: Option<Vec<crate::native_tasks::NativeTask>>,
+        task_contract: Option<crate::task_contracts::ScopeTaskContract>,
     ) -> Self {
         static EXTERNAL_DECLARATIONS: OnceLock<ExternalDeclarations> = OnceLock::new();
         static UNKNOWN_NATIVE_TASKS: crate::native_tasks::ScopeNativeTasks =
@@ -296,7 +297,8 @@ impl<'a> PackageTaskContext<'a> {
         };
         let requires_compatibility_payload = package != PackageName::Root
             || toolchain == Some(&crate::toolchain::ToolchainId::JAVASCRIPT);
-        let task_contract = crate::task_contracts::ScopeTaskContract::empty();
+        let task_contract =
+            task_contract.unwrap_or_else(crate::task_contracts::ScopeTaskContract::empty);
         Self {
             package,
             repository_root,

--- a/crates/turborepo-repository/src/task_contracts.rs
+++ b/crates/turborepo-repository/src/task_contracts.rs
@@ -70,6 +70,18 @@ pub enum PrunePackageMode {
     NativeDomain(crate::prune_knowledge::PruneDomainId),
 }
 
+/// Whether this scope's source directory participates in dependent automatic
+/// input derivation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DependencySourceInputs {
+    /// The producer did not classify participation. Consumers must fail closed.
+    Unknown,
+    /// Include this scope's source directory in dependent input closures.
+    Include,
+    /// Authoritatively exclude this scope from dependent source inputs.
+    Exclude,
+}
+
 impl CommandMapTarget {
     fn matches(self, key: &str) -> bool {
         matches!(
@@ -94,6 +106,7 @@ pub struct ScopeTaskContract {
     command_map_target: Option<CommandMapTarget>,
     entrypoint_domain: Option<TaskEntrypointDomain>,
     prune_package_mode: Option<PrunePackageMode>,
+    dependency_source_inputs: DependencySourceInputs,
     cargo: Option<crate::cargo::CargoTaskContract>,
     static_defaults: BTreeMap<String, TaskDefaults>,
     static_io: BTreeMap<String, crate::toolchain::DerivedTaskIO>,
@@ -111,6 +124,7 @@ impl ScopeTaskContract {
             command_map_target: Some(CommandMapTarget::JavaScript),
             entrypoint_domain: None,
             prune_package_mode: Some(PrunePackageMode::JavaScript),
+            dependency_source_inputs: DependencySourceInputs::Exclude,
             cargo: None,
             static_defaults: BTreeMap::new(),
             static_io: BTreeMap::new(),
@@ -128,6 +142,7 @@ impl ScopeTaskContract {
             command_map_target: None,
             entrypoint_domain: None,
             prune_package_mode: None,
+            dependency_source_inputs: DependencySourceInputs::Unknown,
             cargo: None,
             static_defaults: BTreeMap::new(),
             static_io: BTreeMap::new(),
@@ -136,6 +151,7 @@ impl ScopeTaskContract {
     }
 
     pub(crate) fn cargo(contract: crate::cargo::CargoTaskContract) -> Self {
+        let dependency_source_inputs = contract.dependency_source_inputs();
         Self {
             derives_io: true,
             defaults: TaskDefaults::default(),
@@ -149,6 +165,7 @@ impl ScopeTaskContract {
             prune_package_mode: Some(PrunePackageMode::NativeDomain(
                 crate::prune_knowledge::CARGO_PRUNE_DOMAIN.clone(),
             )),
+            dependency_source_inputs,
             cargo: Some(contract),
             static_defaults: BTreeMap::new(),
             static_io: BTreeMap::new(),
@@ -171,6 +188,7 @@ impl ScopeTaskContract {
             command_map_target: None,
             entrypoint_domain: None,
             prune_package_mode: Some(PrunePackageMode::NativeCopy),
+            dependency_source_inputs: DependencySourceInputs::Unknown,
             cargo: None,
             static_defaults: defaults,
             static_io: io,
@@ -204,6 +222,18 @@ impl ScopeTaskContract {
 
     pub fn with_prune_package_mode(mut self, mode: PrunePackageMode) -> Self {
         self.prune_package_mode = Some(mode);
+        self
+    }
+
+    /// Classifies whether this scope's source directory may participate in a
+    /// dependent task's derived input closure.
+    pub fn dependency_source_inputs(&self) -> DependencySourceInputs {
+        self.dependency_source_inputs
+    }
+
+    /// Explicitly classifies dependency source input participation.
+    pub fn with_dependency_source_inputs(mut self, participation: DependencySourceInputs) -> Self {
+        self.dependency_source_inputs = participation;
         self
     }
 
@@ -407,6 +437,41 @@ mod tests {
                 ("rust".into(), vec!["cargo".into()]),
             ]),
             Some(vec!["cargo".into()])
+        );
+    }
+
+    #[test]
+    fn dependency_source_inputs_are_independent_of_provenance() {
+        let contract = ScopeTaskContract::derived(
+            ToolchainId::new("custom-cargo-producer"),
+            None,
+            BTreeMap::new(),
+            BTreeMap::new(),
+        )
+        .with_dependency_source_inputs(DependencySourceInputs::Include);
+
+        assert_eq!(
+            contract.dependency_source_inputs(),
+            DependencySourceInputs::Include
+        );
+        assert_eq!(
+            ScopeTaskContract::javascript().dependency_source_inputs(),
+            DependencySourceInputs::Exclude
+        );
+        assert_eq!(
+            ScopeTaskContract::empty().dependency_source_inputs(),
+            DependencySourceInputs::Unknown
+        );
+        let excluded = ScopeTaskContract::derived(
+            ToolchainId::new("custom-aggregate"),
+            None,
+            BTreeMap::new(),
+            BTreeMap::new(),
+        )
+        .with_dependency_source_inputs(DependencySourceInputs::Exclude);
+        assert_eq!(
+            excluded.dependency_source_inputs(),
+            DependencySourceInputs::Exclude
         );
     }
 

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -544,8 +544,9 @@ pub struct DerivedTaskIO {
 ///
 /// Wraps a [`PackageDiscovery`] strategy (local filesystem walk,
 /// daemon-backed, or a composition) — the strategy decides *how* manifests
-/// are found, the contributor owns *what a JavaScript package is*: it loads
-/// and parses each manifest into the package descriptor.
+/// are found, the contributor owns *what a JavaScript package is*: it either
+/// loads and parses discovered manifests or accepts typed pre-parsed manifests,
+/// then attaches the same JavaScript package contract to both paths.
 pub struct JavaScriptContributor<P> {
     discovery: P,
     repo_root: AbsoluteSystemPathBuf,
@@ -583,6 +584,29 @@ impl<P: PackageDiscovery + Send + Sync> JavaScriptContributor<P> {
             package_manager.command(),
             self.repo_root.clone(),
         ))
+    }
+
+    fn package_from_json(
+        manifest_path: AbsoluteSystemPathBuf,
+        descriptor: PackageJson,
+    ) -> DiscoveredPackage {
+        let name = descriptor.name.as_ref().map(|name| name.as_inner().clone());
+        DiscoveredPackage::package(name, descriptor, manifest_path)
+            .with_task_contract(crate::task_contracts::ScopeTaskContract::javascript())
+    }
+
+    /// Converts typed pre-parsed manifests into the same package and workspace
+    /// observations as filesystem discovery, including explicit JS contracts.
+    pub(crate) async fn discover_preparsed_packages(
+        &self,
+        package_jsons: std::collections::HashMap<AbsoluteSystemPathBuf, PackageJson>,
+    ) -> Result<DiscoveredPackages, Error> {
+        let workspace_root = self.workspace_root().await?;
+        let packages = package_jsons
+            .into_iter()
+            .map(|(path, descriptor)| Self::package_from_json(path, descriptor))
+            .collect();
+        Ok(DiscoveredPackages::new(packages, vec![workspace_root]))
     }
 }
 
@@ -666,12 +690,7 @@ impl<P: PackageDiscovery + Send + Sync> RepositoryContributor for JavaScriptCont
                     .into_par_iter()
                     .map(|workspace| {
                         let descriptor = PackageJson::load(&workspace.package_json)?;
-                        let name = descriptor.name.as_ref().map(|name| name.as_inner().clone());
-                        Ok(DiscoveredPackage::package(
-                            name,
-                            descriptor,
-                            workspace.package_json,
-                        ))
+                        Ok(Self::package_from_json(workspace.package_json, descriptor))
                     })
                     .collect::<Result<Vec<_>, Error>>()
             })?;
@@ -833,6 +852,16 @@ mod tests {
         assert_eq!(discovered.workspace_roots().len(), 1);
         assert_eq!(discovered.workspace_roots()[0].kind(), "pnpm");
         assert_eq!(discovered.workspace_roots()[0].path(), repo_root.as_ref());
+        let contract = discovered.packages()[0]
+            .clone()
+            .into_parts()
+            .task_contract
+            .expect("JavaScript discovery supplies its task contract");
+        assert_eq!(contract.toolchain(), Some(&ToolchainId::JAVASCRIPT));
+        assert_eq!(
+            contract.command_map_argv(&[("javascript".into(), vec!["node".into()])]),
+            Some(vec!["node".into()])
+        );
     }
 
     #[test]

--- a/crates/turborepo-task-executor/src/command.rs
+++ b/crates/turborepo-task-executor/src/command.rs
@@ -251,28 +251,6 @@ impl<'a, M: MfeConfigProvider, E: From<CommandProviderError>> CommandProvider<E>
             None => None,
         };
 
-        // A pure-native repository still has Turbo's root task namespace, but
-        // no root language toolchain. Explicit root command overrides are
-        // generic argv and execute directly at the knowledge-backed repo root.
-        if package_context.toolchain().is_none() {
-            let Some(override_command) = override_command else {
-                return Ok(None);
-            };
-            let Some(spec) = turborepo_repository::toolchain::override_task_command(
-                &package_context,
-                override_command,
-                self.task_args.args_for_task(task_id),
-                None,
-            ) else {
-                return Ok(None);
-            };
-            let mut cmd = Command::new(spec.program);
-            cmd.args(spec.args).current_dir(spec.cwd);
-            apply_environment(&mut cmd, environment);
-            cmd.open_stdin();
-            return Ok(Some(cmd));
-        }
-
         let spec = if let Some(native_task) = package_context.native_tasks().get(task_id.task()) {
             let (package_manager_binary, cargo_binary) = if override_command.is_some() {
                 (None, None)
@@ -694,6 +672,43 @@ mod tests {
         )
         .unwrap();
         assert!(command.is_some(), "override should bypass binary lookup");
+    }
+
+    #[tokio::test]
+    async fn pure_root_override_uses_generic_command_path() {
+        let (_tempdir, repo_root, _package_dir) = create_test_repo();
+        let graph = PackageGraph::builder_optional(&repo_root, None)
+            .build()
+            .await
+            .unwrap();
+        let task_id = TaskId::from_graph(&PackageName::Root, &TaskName::from("build"));
+        let provider = ToolchainCommandProvider::<crate::NoMfeConfig>::new(
+            &graph,
+            TaskArgs::new(&[], &[]),
+            None,
+            None,
+            HashMap::from([(
+                task_id.clone(),
+                TaskCommandOverride::Argv(vec!["custom-build".to_string()]),
+            )]),
+        );
+
+        let command = CommandProvider::<CommandProviderError>::command(
+            &provider,
+            &task_id,
+            &EnvironmentVariableMap::default(),
+        )
+        .unwrap()
+        .expect("root override should execute");
+
+        assert_eq!(command.program(), OsStr::new("custom-build"));
+        let label = command.label();
+        assert!(
+            label.contains(repo_root.as_str()),
+            "unexpected label: {label}"
+        );
+        assert_eq!(command.serial_group_name(), None);
+        assert!(command.will_open_stdin());
     }
 
     fn create_test_repo() -> (TempDir, AbsoluteSystemPathBuf, PathBuf) {

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -275,8 +275,8 @@ JavaScript reports only the repository root for its authoritative package-manage
 command family; if discovery reports a different family than an explicitly
 resolved manager, the response is rejected. Pnpm versions and Yarn/Berry share
 their respective canonical families. Cargo reports the current workspace root.
-Resolution-domain/root validation remains Phase 3 work; this package/scope
-knowledge validates workspace authorities only.
+Resolution domains are validated against these authoritative roots during
+generation construction.
 
 The package graph intentionally allows cyclic dependencies between packages —
 this aligns with how npm, pnpm, and yarn handle cyclic workspace deps. Cycle
@@ -308,6 +308,11 @@ Package-json membership is projected from real scopes with authoritative
 ownership and workspace path dependency splitting consume the same projection;
 duplicate contributed definition owners and physical aliases of the root
 definition are rejected during construction.
+JavaScript discovery and typed pre-parsed manifest input both attach explicit
+JavaScript task contracts; core defaults omitted contracts to empty behavior
+without consulting contributor identity. Generic argv overrides for scopes
+without native tasks are core execution policy; pure-root execution is one case
+and does not depend on whether provenance is present.
 JavaScript is the first production producer. Machinery that predates the
 abstraction (package-manager resolution for dependency splitting and the JS
 lockfile closure phase) remains documented debt.
@@ -318,11 +323,13 @@ prune, query, hashing, and cache paths carry only the feature decision; each
 graph generation creates and drops its own Cargo contributor.
 
 Contract-derived I/O receives the same task-scoped arguments as execution plus
-a narrow, platform-aware startup-environment projection keyed by toolchain.
+a narrow, platform-aware startup-environment projection keyed by an explicit
+contract domain. Dependency source participation is likewise declared by each
+scope contract rather than inferred from contributor provenance.
 Dependency tasks do not inherit arguments for a different requested task, each
-toolchain can observe only the variables it declares, Windows lookup remains
+contract can observe only the variables it declares, Windows lookup remains
 case-insensitive, and every declared pattern automatically participates in task
-hashing. If a user env exclusion matches a projected toolchain I/O variable,
+hashing. If a user env exclusion matches a projected contract-derived I/O variable,
 automatic outputs become unavailable rather than deriving cacheable paths from
 an unhashed value. Derived outputs distinguish exact/resolved paths from
 unavailable automatic resolution. When outputs are unavailable, the engine
@@ -358,7 +365,7 @@ whether anything changed; Cargo decides how and in what order to build.**
   package: automatic in-repository workspace members are supported, while
   excluded/non-member, outside-repository, and root-manifest local packages
   hard-error because Turborepo cannot hash, watch, or prune their sources
-  safely. The Cargo compatibility producer reports the current workspace root.
+  safely. The Cargo contributor reports the current workspace root.
 - **Package shapes**: crates are classified via `CargoPackageKind`.
   *Entrypoints* (crates with `bin`/`cdylib`/`staticlib` targets) are the
   workspace's deliverables. *Libraries* exist in the package graph and expose
@@ -403,10 +410,13 @@ whether anything changed; Cargo decides how and in what order to build.**
   and participate in task suggestions and add-all/query graph construction.
 - **Hashing and affectedness** (`HashRelationships`, `AffectedRelationships`,
   and `TaskContractKnowledge`): crate-scoped tasks hash their own
-  sources plus a conservative transitive closure of declared local Cargo
-  dependencies (flattened, so invalidation doesn't depend on `dependsOn`
-  wiring). The closure may include optional or target-specific dependencies not
-  compiled by a particular invocation. Non-ordering relationship inputs retain
+  sources plus a conservative transitive closure of local dependencies whose
+  scope contracts explicitly include dependency source inputs (Cargo package
+  scopes opt in; the workspace aggregate opts out). Unknown participation makes
+  automatic inputs untracked rather than silently cacheable. The closure is
+  flattened, so invalidation doesn't depend on `dependsOn` wiring, and may
+  include optional or target-specific dependencies not compiled by a particular
+  invocation. Non-ordering relationship inputs retain
   cycle-closing development edges so they still invalidate and mark their
   consumers affected. Tasks also hash the
   workspace files (root `Cargo.toml`, `.cargo/config*`, `rust-toolchain*`),


### PR DESCRIPTION
## Intent

Remove residual task and execution behavior selected by contributor provenance.

## Changes

- Route generic argv overrides through one core path, including pure-native roots.
- Add explicit `Unknown`/`Include`/`Exclude` dependency source participation to task contracts.
- Mark Cargo automatic inputs untracked when dependency participation is unknown, preventing fail-open caching.
- Make normal and pre-parsed JavaScript discovery attach explicit JavaScript contracts.
- Default omitted contracts to empty behavior without consulting `ToolchainId`.
- Keep pre-parsed package-json input on the typed JavaScript contributor while additional contributors discover normally.
- Update architecture and API documentation.

## Testing

- `cargo test -p turborepo-repository` (384 passed before rebase; focused task/builder tests passed after rebase)
- `USER=opencode cargo test -p turborepo-task-executor` (21 passed)
- `cargo test -p turborepo-engine` (126 passed)
- `cargo test -p turbo --test cargo_workspace_test` (57 passed)
- `cargo clippy -p turborepo-repository -p turborepo-task-executor -p turborepo-engine --all-targets -- -D warnings`
- Pre-push `format` and `check:toml` hooks

Advances TURBO-5798.