### PR TITLE
refactor: Route resolution through explicit domains

### DIFF
--- a/crates/turborepo-repository/README.md
+++ b/crates/turborepo-repository/README.md
@@ -12,6 +12,7 @@ Repository root
         ├── inference/ - Detect repo type and package manager
         ├── package_manager/ - npm, pnpm, yarn, bun support
         ├── package_graph/ - Dependency graph of workspace packages
+        ├── external_resolution.rs - Explicit external dependency resolution domains
         ├── package_json/ - package.json parsing
         └── discovery/ - Find all workspace packages
 ```
@@ -21,6 +22,7 @@ Key types:
 - `RepositoryKnowledge` - Immutable authority for package and aggregate identities, paths, kinds, and toolchain provenance
 - `PackageInfo` - Temporary JavaScript-shaped manifest compatibility payload; not package identity or path authority
 - `PackageManager` - Abstraction over npm/pnpm/yarn/bun
+- `ExternalResolutionDomain` - Immutable domain identity, membership, and resolution data
 
 ## Notes
 

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -1578,9 +1578,15 @@ impl RepositoryContributor for CargoContributor {
             }
 
             let fingerprint = ResolutionFingerprint::from_packages(&resolutions);
+            let members = resolutions
+                .iter()
+                .map(|resolution| resolution.package().to_string())
+                .collect::<Vec<_>>();
             let resolution = ExternalResolutionDomain::new(
+                crate::external_resolution::CARGO_RESOLUTION_DOMAIN.clone(),
                 ToolchainId::RUST,
                 AnchoredSystemPathBuf::default(),
+                members,
                 [AnchoredSystemPathBuf::from_raw(CARGO_LOCK)
                     .map_err(Error::from)
                     .map_err(|error| toolchain::Error::Failed(Box::new(error)))?],

--- a/crates/turborepo-repository/src/external_resolution.rs
+++ b/crates/turborepo-repository/src/external_resolution.rs
@@ -1,7 +1,9 @@
 //! Parser-neutral external dependency declarations and exact resolutions.
 
 use std::{
+    borrow::Cow,
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    fmt,
     ops::Range,
 };
 
@@ -385,28 +387,74 @@ impl PackageResolutionState {
     }
 }
 
-/// One parser-neutral external resolution domain contributed by a toolchain.
+/// Open, stable identity for one external-resolution behavior domain.
+///
+/// IDs are unique within a generation. Built-in IDs are reserved to their
+/// canonical producers; custom producers may define other IDs.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ExternalResolutionDomainId(Cow<'static, str>);
+
+impl ExternalResolutionDomainId {
+    /// Creates an open domain ID from borrowed static or owned text.
+    pub fn new(value: impl Into<Cow<'static, str>>) -> Self {
+        Self(value.into())
+    }
+
+    /// Stable text used to identify the domain during composition and lookup.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for ExternalResolutionDomainId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Built-in JavaScript package-manager lockfile domain.
+pub const JAVASCRIPT_RESOLUTION_DOMAIN: ExternalResolutionDomainId =
+    ExternalResolutionDomainId(Cow::Borrowed("javascript"));
+/// Built-in Cargo lockfile and compiler-identity domain.
+pub const CARGO_RESOLUTION_DOMAIN: ExternalResolutionDomainId =
+    ExternalResolutionDomainId(Cow::Borrowed("cargo"));
+
+/// One parser-neutral external resolution domain contributed by a producer.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExternalResolutionDomain {
+    id: ExternalResolutionDomainId,
     toolchain: ToolchainId,
     root: AnchoredSystemPathBuf,
+    members: Vec<String>,
     definition_sources: Vec<AnchoredSystemPathBuf>,
     data: ExternalResolutionData,
 }
 
 impl ExternalResolutionDomain {
+    /// Creates a domain with explicit identity, provenance, root, and exclusive
+    /// package membership. Complete resolved data must contain exactly one row
+    /// for every member; member names use authoritative repository identities.
     pub fn new(
+        id: ExternalResolutionDomainId,
         toolchain: ToolchainId,
         root: AnchoredSystemPathBuf,
+        members: impl IntoIterator<Item = String>,
         definition_sources: impl IntoIterator<Item = AnchoredSystemPathBuf>,
         data: ExternalResolutionData,
     ) -> Self {
         Self {
+            id,
             toolchain,
             root,
+            members: members.into_iter().collect(),
             definition_sources: definition_sources.into_iter().collect(),
             data,
         }
+    }
+
+    /// Behavioral domain identity, independent from retained provenance.
+    pub fn id(&self) -> &ExternalResolutionDomainId {
+        &self.id
     }
 
     pub fn toolchain(&self) -> &ToolchainId {
@@ -415,6 +463,11 @@ impl ExternalResolutionDomain {
 
     pub fn root(&self) -> &AnchoredSystemPath {
         &self.root
+    }
+
+    /// Authoritative package identities exclusively claimed by this domain.
+    pub fn members(&self) -> &[String] {
+        &self.members
     }
 
     pub fn definition_sources(&self) -> &[AnchoredSystemPathBuf] {
@@ -450,6 +503,8 @@ impl ExternalResolutionGeneration {
         mut domains: Vec<ExternalResolutionDomain>,
     ) -> Result<Self, ExternalResolutionError> {
         for domain in &mut domains {
+            domain.members.sort();
+            domain.members.dedup();
             domain.definition_sources.sort();
             domain.definition_sources.dedup();
             if let ExternalResolutionData::Resolved { packages, .. } = &mut domain.data {
@@ -460,29 +515,58 @@ impl ExternalResolutionGeneration {
                 packages.sort_by(|left, right| left.package.cmp(&right.package));
             }
         }
-        domains.sort_by(|left, right| {
-            left.toolchain
-                .cmp(&right.toolchain)
-                .then_with(|| left.root.cmp(&right.root))
-        });
+        domains.sort_by(|left, right| left.id.cmp(&right.id));
 
-        if let Some(duplicate) = domains
-            .windows(2)
-            .find(|pair| pair[0].toolchain == pair[1].toolchain)
-        {
+        if let Some(duplicate) = domains.windows(2).find(|pair| pair[0].id == pair[1].id) {
             return Err(ExternalResolutionError::DuplicateDomain {
-                toolchain: duplicate[0].toolchain.clone(),
+                id: duplicate[0].id.clone(),
             });
         }
 
+        let mut claimed = HashMap::<String, ExternalResolutionDomainId>::new();
         for domain in &mut domains {
+            let valid_builtin = if domain.id == JAVASCRIPT_RESOLUTION_DOMAIN {
+                domain.toolchain == ToolchainId::JAVASCRIPT
+                    && domain.root.as_str().is_empty()
+                    && repository.root_javascript_scope().is_some()
+            } else if domain.id == CARGO_RESOLUTION_DOMAIN {
+                domain.toolchain == ToolchainId::RUST && domain.root.as_str().is_empty()
+            } else {
+                true
+            };
+            if !valid_builtin {
+                return Err(ExternalResolutionError::InvalidBuiltinDomain {
+                    id: domain.id.clone(),
+                    toolchain: domain.toolchain.clone(),
+                    root: domain.root.clone(),
+                });
+            }
             if !repository.workspace_roots().any(|root| {
                 root.toolchain() == &domain.toolchain && root.path() == domain.root.as_ref()
             }) {
                 return Err(ExternalResolutionError::UnknownDomain {
-                    toolchain: domain.toolchain.clone(),
+                    id: domain.id.clone(),
                     root: domain.root.clone(),
                 });
+            }
+
+            for member in &domain.members {
+                let is_authoritative = (member == "//"
+                    && repository.root_javascript_scope().is_some())
+                    || repository.scope(member).is_some();
+                if !is_authoritative {
+                    return Err(ExternalResolutionError::UnknownPackage {
+                        id: domain.id.clone(),
+                        identity: member.clone(),
+                    });
+                }
+                if let Some(existing) = claimed.insert(member.clone(), domain.id.clone()) {
+                    return Err(ExternalResolutionError::DuplicateMembership {
+                        identity: member.clone(),
+                        first: existing,
+                        second: domain.id.clone(),
+                    });
+                }
             }
 
             let ExternalResolutionData::Resolved { packages, .. } = &mut domain.data else {
@@ -493,18 +577,40 @@ impl ExternalResolutionGeneration {
                 .find(|pair| pair[0].package == pair[1].package)
             {
                 return Err(ExternalResolutionError::DuplicatePackage {
-                    toolchain: domain.toolchain.clone(),
+                    id: domain.id.clone(),
                     identity: duplicate[0].package.clone(),
                 });
             }
             for package in packages {
-                let is_authoritative = (package.package() == "//"
-                    && repository.root_javascript_scope().is_some())
-                    || repository.scope(package.package()).is_some();
-                if !is_authoritative {
-                    return Err(ExternalResolutionError::UnknownPackage {
-                        toolchain: domain.toolchain.clone(),
+                if domain
+                    .members
+                    .binary_search_by(|member| member.as_str().cmp(package.package()))
+                    .is_err()
+                {
+                    return Err(ExternalResolutionError::PackageOutsideDomain {
+                        id: domain.id.clone(),
                         identity: package.package.clone(),
+                    });
+                }
+            }
+            if let ExternalResolutionData::Resolved {
+                completeness: ResolutionCompleteness::Complete,
+                packages,
+                ..
+            } = &domain.data
+            {
+                let package_names = packages
+                    .iter()
+                    .map(|package| package.package())
+                    .collect::<Vec<_>>();
+                let members = domain
+                    .members
+                    .iter()
+                    .map(String::as_str)
+                    .collect::<Vec<_>>();
+                if package_names != members {
+                    return Err(ExternalResolutionError::IncompleteDomain {
+                        id: domain.id.clone(),
                     });
                 }
             }
@@ -517,27 +623,56 @@ impl ExternalResolutionGeneration {
     pub(crate) fn domains(&self) -> &[ExternalResolutionDomain] {
         &self.domains
     }
+
+    pub(crate) fn domain(
+        &self,
+        id: &ExternalResolutionDomainId,
+    ) -> Option<&ExternalResolutionDomain> {
+        self.domains
+            .binary_search_by(|domain| domain.id.cmp(id))
+            .ok()
+            .map(|index| &self.domains[index])
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub(crate) enum ExternalResolutionError {
-    #[error("toolchain {toolchain} contributed multiple external resolution domains")]
-    DuplicateDomain { toolchain: ToolchainId },
-    #[error("toolchain {toolchain} contributed unknown resolution domain root {root}")]
+    #[error("external resolution domain {id} was contributed more than once")]
+    DuplicateDomain { id: ExternalResolutionDomainId },
+    #[error("external resolution domain {id} has unknown root {root}")]
     UnknownDomain {
+        id: ExternalResolutionDomainId,
+        root: AnchoredSystemPathBuf,
+    },
+    #[error("built-in resolution domain {id} has invalid producer {toolchain} or root {root}")]
+    InvalidBuiltinDomain {
+        id: ExternalResolutionDomainId,
         toolchain: ToolchainId,
         root: AnchoredSystemPathBuf,
     },
-    #[error("toolchain {toolchain} resolved unknown package {identity}")]
+    #[error("external resolution domain {id} claims unknown package {identity}")]
     UnknownPackage {
-        toolchain: ToolchainId,
+        id: ExternalResolutionDomainId,
         identity: String,
     },
-    #[error("toolchain {toolchain} resolved package {identity} more than once")]
+    #[error("external resolution domain {id} resolved package {identity} outside its membership")]
+    PackageOutsideDomain {
+        id: ExternalResolutionDomainId,
+        identity: String,
+    },
+    #[error("package {identity} is claimed by both resolution domains {first} and {second}")]
+    DuplicateMembership {
+        identity: String,
+        first: ExternalResolutionDomainId,
+        second: ExternalResolutionDomainId,
+    },
+    #[error("external resolution domain {id} resolved package {identity} more than once")]
     DuplicatePackage {
-        toolchain: ToolchainId,
+        id: ExternalResolutionDomainId,
         identity: String,
     },
+    #[error("complete external resolution domain {id} does not contain exactly one row per member")]
+    IncompleteDomain { id: ExternalResolutionDomainId },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -735,8 +870,10 @@ mod tests {
         let complete_empty = ExternalResolutionGeneration::build(
             &repository(),
             vec![ExternalResolutionDomain::new(
+                JAVASCRIPT_RESOLUTION_DOMAIN.clone(),
                 ToolchainId::JAVASCRIPT,
                 AnchoredSystemPathBuf::default(),
+                Vec::new(),
                 [AnchoredSystemPathBuf::from_raw("package-lock.json").unwrap()],
                 resolved(Vec::new()),
             )],
@@ -745,8 +882,10 @@ mod tests {
         let unavailable = ExternalResolutionGeneration::build(
             &repository(),
             vec![ExternalResolutionDomain::new(
+                JAVASCRIPT_RESOLUTION_DOMAIN.clone(),
                 ToolchainId::JAVASCRIPT,
                 AnchoredSystemPathBuf::default(),
+                Vec::new(),
                 [AnchoredSystemPathBuf::from_raw("package-lock.json").unwrap()],
                 ExternalResolutionData::Unavailable(ResolutionUnavailableReason::new(
                     "missing-definition",
@@ -780,6 +919,13 @@ mod tests {
     }
 
     #[test]
+    fn resolution_domain_id_is_open_and_constants_are_distinct() {
+        let custom = ExternalResolutionDomainId::new("custom");
+        assert_eq!(custom.as_str(), "custom");
+        assert_ne!(JAVASCRIPT_RESOLUTION_DOMAIN, CARGO_RESOLUTION_DOMAIN);
+    }
+
+    #[test]
     fn generation_normalizes_all_ordering() {
         let source_a = AnchoredSystemPathBuf::from_raw("a.lock").unwrap();
         let source_z = AnchoredSystemPathBuf::from_raw("z.lock").unwrap();
@@ -798,14 +944,18 @@ mod tests {
                 )
             };
             let javascript = ExternalResolutionDomain::new(
+                JAVASCRIPT_RESOLUTION_DOMAIN.clone(),
                 ToolchainId::JAVASCRIPT,
                 AnchoredSystemPathBuf::default(),
+                vec!["app".to_string()],
                 sources,
                 resolved(vec![PackageResolution::new("app", identities)]),
             );
             let rust = ExternalResolutionDomain::new(
+                CARGO_RESOLUTION_DOMAIN.clone(),
                 ToolchainId::RUST,
                 AnchoredSystemPathBuf::default(),
+                vec!["crate".to_string()],
                 [AnchoredSystemPathBuf::from_raw("Cargo.lock").unwrap()],
                 resolved(vec![PackageResolution::new("crate", Vec::new())]),
             );
@@ -820,8 +970,9 @@ mod tests {
         let ordered = make(false);
         let reversed = make(true);
         assert_eq!(ordered, reversed);
-        assert_eq!(ordered.domains()[0].toolchain(), &ToolchainId::JAVASCRIPT);
-        let ExternalResolutionData::Resolved { packages, .. } = ordered.domains()[0].data() else {
+        assert_eq!(ordered.domains()[0].id(), &CARGO_RESOLUTION_DOMAIN);
+        let javascript = ordered.domain(&JAVASCRIPT_RESOLUTION_DOMAIN).unwrap();
+        let ExternalResolutionData::Resolved { packages, .. } = javascript.data() else {
             panic!("expected resolved data")
         };
         assert_eq!(packages[0].identities(), &[identity_a, identity_z]);
@@ -831,21 +982,87 @@ mod tests {
     fn generation_rejects_duplicate_domains_and_unknown_packages() {
         let domain = || {
             ExternalResolutionDomain::new(
+                JAVASCRIPT_RESOLUTION_DOMAIN.clone(),
                 ToolchainId::JAVASCRIPT,
                 AnchoredSystemPathBuf::default(),
+                Vec::new(),
                 Vec::new(),
                 resolved(Vec::new()),
             )
         };
         assert!(matches!(
             ExternalResolutionGeneration::build(&repository(), vec![domain(), domain()]),
-            Err(ExternalResolutionError::DuplicateDomain { toolchain })
-                if toolchain == ToolchainId::JAVASCRIPT
+            Err(ExternalResolutionError::DuplicateDomain { id })
+                if id == JAVASCRIPT_RESOLUTION_DOMAIN
+        ));
+
+        let outside = ExternalResolutionDomain::new(
+            JAVASCRIPT_RESOLUTION_DOMAIN.clone(),
+            ToolchainId::JAVASCRIPT,
+            AnchoredSystemPathBuf::default(),
+            vec!["app".to_string()],
+            Vec::new(),
+            resolved(vec![PackageResolution::new("crate", Vec::new())]),
+        );
+        assert!(matches!(
+            ExternalResolutionGeneration::build(&repository(), vec![outside]),
+            Err(ExternalResolutionError::PackageOutsideDomain { identity, .. })
+                if identity == "crate"
+        ));
+
+        let first = ExternalResolutionDomain::new(
+            ExternalResolutionDomainId::new("first"),
+            ToolchainId::JAVASCRIPT,
+            AnchoredSystemPathBuf::default(),
+            vec!["app".to_string()],
+            Vec::new(),
+            resolved(vec![PackageResolution::new("app", Vec::new())]),
+        );
+        let second = ExternalResolutionDomain::new(
+            ExternalResolutionDomainId::new("second"),
+            ToolchainId::RUST,
+            AnchoredSystemPathBuf::default(),
+            vec!["app".to_string()],
+            Vec::new(),
+            resolved(vec![PackageResolution::new("app", Vec::new())]),
+        );
+        assert!(matches!(
+            ExternalResolutionGeneration::build(&repository(), vec![first, second]),
+            Err(ExternalResolutionError::DuplicateMembership { identity, .. })
+                if identity == "app"
+        ));
+
+        let spoofed_builtin = ExternalResolutionDomain::new(
+            JAVASCRIPT_RESOLUTION_DOMAIN.clone(),
+            ToolchainId::RUST,
+            AnchoredSystemPathBuf::default(),
+            vec!["crate".to_string()],
+            Vec::new(),
+            resolved(vec![PackageResolution::new("crate", Vec::new())]),
+        );
+        assert!(matches!(
+            ExternalResolutionGeneration::build(&repository(), vec![spoofed_builtin]),
+            Err(ExternalResolutionError::InvalidBuiltinDomain { .. })
+        ));
+
+        let incomplete = ExternalResolutionDomain::new(
+            ExternalResolutionDomainId::new("custom"),
+            ToolchainId::JAVASCRIPT,
+            AnchoredSystemPathBuf::default(),
+            vec!["app".to_string()],
+            Vec::new(),
+            resolved(Vec::new()),
+        );
+        assert!(matches!(
+            ExternalResolutionGeneration::build(&repository(), vec![incomplete]),
+            Err(ExternalResolutionError::IncompleteDomain { .. })
         ));
 
         let unknown = ExternalResolutionDomain::new(
+            CARGO_RESOLUTION_DOMAIN.clone(),
             ToolchainId::RUST,
             AnchoredSystemPathBuf::default(),
+            vec!["missing".to_string()],
             Vec::new(),
             resolved(vec![PackageResolution::new("missing", Vec::new())]),
         );

--- a/crates/turborepo-repository/src/package_graph/javascript.rs
+++ b/crates/turborepo-repository/src/package_graph/javascript.rs
@@ -14,8 +14,8 @@ use crate::{
     external_resolution::{
         ExternalDeclarations, ExternalPackageIdentity, ExternalResolutionChanges,
         ExternalResolutionData, ExternalResolutionDomain, ExternalResolutionGeneration,
-        PackageResolution, ResolutionCompleteness, ResolutionFingerprint,
-        ResolutionUnavailableReason, compare_resolution_data,
+        JAVASCRIPT_RESOLUTION_DOMAIN, PackageResolution, ResolutionCompleteness,
+        ResolutionFingerprint, ResolutionUnavailableReason, compare_resolution_data,
     },
     knowledge::{RelationshipKnowledge, RepositoryKnowledge},
     package_json::DependencyKind,
@@ -31,31 +31,8 @@ pub(super) struct ResolutionSnapshot {
     pub warning: Option<String>,
 }
 
-fn scope_directory_and_toolchain<'a>(
-    knowledge: &'a RepositoryKnowledge,
-    name: &PackageName,
-) -> Option<(&'a AnchoredSystemPath, &'a ToolchainId)> {
-    match name {
-        PackageName::Root => knowledge
-            .root_javascript_scope()
-            .map(|scope| (knowledge.repository_directory(), scope.toolchain())),
-        PackageName::Other(name) => knowledge
-            .scope(name)
-            .map(|scope| (scope.directory(), scope.toolchain())),
-    }
-}
-
 fn resolution_packages(knowledge: &RepositoryKnowledge) -> Vec<(&str, &AnchoredSystemPath)> {
-    let mut packages = Vec::new();
-    if knowledge.root_javascript_scope().is_some() {
-        packages.push((ROOT_PKG_NAME, knowledge.repository_directory()));
-    }
-    packages.extend(
-        knowledge
-            .scopes()
-            .filter(|scope| scope.toolchain() == &ToolchainId::JAVASCRIPT)
-            .map(|scope| (scope.identity(), scope.directory())),
-    );
+    let mut packages = knowledge.package_json_packages().collect::<Vec<_>>();
     packages.sort_unstable_by_key(|(identity, _)| *identity);
     packages
 }
@@ -64,7 +41,12 @@ pub(super) fn external_dependencies(
     knowledge: &RepositoryKnowledge,
     relationships: &RelationshipKnowledge,
 ) -> HashMap<String, BTreeMap<String, String>> {
-    let mut by_source: BTreeMap<String, BTreeMap<String, String>> = resolution_packages(knowledge)
+    let packages = resolution_packages(knowledge);
+    let directories = packages
+        .iter()
+        .map(|(identity, directory)| ((*identity).to_string(), *directory))
+        .collect::<HashMap<_, _>>();
+    let mut by_source: BTreeMap<String, BTreeMap<String, String>> = packages
         .into_iter()
         .map(|(identity, _)| (identity.to_string(), BTreeMap::new()))
         .collect();
@@ -83,10 +65,8 @@ pub(super) fn external_dependencies(
     by_source
         .into_iter()
         .filter_map(|(identity, dependencies)| {
-            let name = PackageName::from(identity.as_str());
-            let (directory, toolchain) = scope_directory_and_toolchain(knowledge, &name)?;
-            (toolchain == &ToolchainId::JAVASCRIPT)
-                .then(|| (directory.to_unix().to_string(), dependencies))
+            let directory = directories.get(&identity)?;
+            Some((directory.to_unix().to_string(), dependencies))
         })
         .collect()
 }
@@ -100,9 +80,15 @@ pub(super) fn unavailable_resolution(
     warning: Option<String>,
     closure_hasher: Option<&ClosureHasher>,
 ) -> Result<ResolutionSnapshot, String> {
+    let members = resolution_packages(knowledge)
+        .into_iter()
+        .map(|(identity, _)| identity.to_string())
+        .collect::<Vec<_>>();
     domains.push(ExternalResolutionDomain::new(
+        JAVASCRIPT_RESOLUTION_DOMAIN.clone(),
         ToolchainId::JAVASCRIPT,
         AnchoredSystemPathBuf::default(),
+        members,
         [definition_source],
         ExternalResolutionData::Unavailable(ResolutionUnavailableReason::new(code, message)),
     ));
@@ -162,9 +148,15 @@ pub(super) fn resolve_dependencies(
         })
         .collect::<Vec<_>>();
     let fingerprint = ResolutionFingerprint::from_packages(&packages);
+    let members = packages
+        .iter()
+        .map(|package| package.package().to_string())
+        .collect::<Vec<_>>();
     domains.push(ExternalResolutionDomain::new(
+        JAVASCRIPT_RESOLUTION_DOMAIN.clone(),
         ToolchainId::JAVASCRIPT,
         AnchoredSystemPathBuf::default(),
+        members,
         [definition_source],
         ExternalResolutionData::Resolved {
             completeness: ResolutionCompleteness::Complete,
@@ -185,9 +177,7 @@ fn resolution_data(
     generation: &ExternalResolutionGeneration,
 ) -> Result<&ExternalResolutionData, ChangedPackagesError> {
     generation
-        .domains()
-        .iter()
-        .find(|domain| domain.toolchain() == &ToolchainId::JAVASCRIPT)
+        .domain(&JAVASCRIPT_RESOLUTION_DOMAIN)
         .map(ExternalResolutionDomain::data)
         .ok_or(ChangedPackagesError::ResolutionUnavailable)
 }

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -19,8 +19,8 @@ use crate::{
     discovery::LocalPackageDiscoveryBuilder,
     external_resolution::{
         ExternalDeclarations, ExternalPackageIdentity, ExternalResolutionData,
-        ExternalResolutionGeneration, ExternalResolutionStatus, PackageExternalDeclarations,
-        PackageResolutionState,
+        ExternalResolutionDomainId, ExternalResolutionGeneration, ExternalResolutionStatus,
+        JAVASCRIPT_RESOLUTION_DOMAIN, PackageExternalDeclarations, PackageResolutionState,
     },
     knowledge::{RelationshipKnowledge, RepositoryKnowledge},
     package_json::PackageJson,
@@ -48,6 +48,7 @@ pub const ROOT_PKG_NAME: &str = "//";
 struct ExternalResolutionKnowledge {
     status: ExternalResolutionStatus,
     generation: Option<Arc<ExternalResolutionGeneration>>,
+    claims: HashMap<String, ExternalResolutionDomainId>,
 }
 
 impl ExternalResolutionKnowledge {
@@ -55,13 +56,26 @@ impl ExternalResolutionKnowledge {
         Self {
             status: ExternalResolutionStatus::Complete,
             generation: None,
+            claims: HashMap::new(),
         }
     }
 
     fn complete(generation: Arc<ExternalResolutionGeneration>) -> Self {
+        let claims = generation
+            .domains()
+            .iter()
+            .flat_map(|domain| {
+                domain
+                    .members()
+                    .iter()
+                    .cloned()
+                    .map(|member| (member, domain.id().clone()))
+            })
+            .collect();
         Self {
             status: ExternalResolutionStatus::Complete,
             generation: Some(generation),
+            claims,
         }
     }
 }
@@ -1094,17 +1108,12 @@ impl PackageGraph {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         self.package_task_contexts()
             .map(|context| {
-                let state = match context.toolchain() {
+                let state = match resolution.claims.get(context.package().as_str()) {
                     None => PackageResolutionState::NotApplicable,
-                    Some(toolchain) => resolution
+                    Some(domain_id) => resolution
                         .generation
                         .as_deref()
-                        .and_then(|generation| {
-                            generation
-                                .domains()
-                                .iter()
-                                .find(|domain| domain.toolchain() == toolchain)
-                        })
+                        .and_then(|generation| generation.domain(domain_id))
                         .map_or(PackageResolutionState::Missing, |domain| {
                             match domain.data() {
                                 ExternalResolutionData::Resolved {
@@ -1503,10 +1512,7 @@ impl PackageGraph {
             }
             return Some(paths);
         };
-        let domain = generation
-            .domains()
-            .iter()
-            .find(|domain| domain.toolchain() == &crate::toolchain::ToolchainId::JAVASCRIPT)?;
+        let domain = generation.domain(&JAVASCRIPT_RESOLUTION_DOMAIN)?;
         match domain.data() {
             ExternalResolutionData::Resolved { .. } => None,
             ExternalResolutionData::Unavailable(_) => {
@@ -1545,7 +1551,7 @@ impl PackageGraph {
         let mut seen = HashSet::new();
         let mut identities = Vec::new();
         for domain in generation.domains() {
-            if domain.toolchain() != &crate::toolchain::ToolchainId::JAVASCRIPT {
+            if domain.id() != &JAVASCRIPT_RESOLUTION_DOMAIN {
                 continue;
             }
             let ExternalResolutionData::Resolved { packages, .. } = domain.data() else {
@@ -3084,10 +3090,15 @@ version = "0.1.0"
                 .expect("mixed repository should retain external resolution knowledge");
             assert_eq!(resolution.domains().len(), 2);
             let cargo_domain = resolution
-                .domains()
-                .iter()
-                .find(|domain| domain.toolchain() == &crate::toolchain::ToolchainId::RUST)
+                .domain(&crate::external_resolution::CARGO_RESOLUTION_DOMAIN)
                 .expect("Cargo should contribute one resolution domain");
+            assert_eq!(
+                resolution
+                    .domain(&crate::external_resolution::JAVASCRIPT_RESOLUTION_DOMAIN)
+                    .unwrap()
+                    .id(),
+                &crate::external_resolution::JAVASCRIPT_RESOLUTION_DOMAIN
+            );
             assert_eq!(cargo_domain.definition_sources()[0].as_str(), "Cargo.lock");
             let crate::external_resolution::ExternalResolutionData::Resolved {
                 completeness,
@@ -3149,13 +3160,23 @@ version = "0.1.0"
             .expect("pure Cargo repository should retain external resolution knowledge");
         assert_eq!(resolution.domains().len(), 1);
         assert_eq!(
-            resolution.domains()[0].toolchain(),
-            &crate::toolchain::ToolchainId::RUST
+            resolution.domains()[0].id(),
+            &crate::external_resolution::CARGO_RESOLUTION_DOMAIN
         );
+        let states = pkg_graph.package_resolution_states();
+        assert_eq!(states["//"], PackageResolutionState::NotApplicable);
+        // This fixture has no closure hasher, so the claimed package fails
+        // closed as Missing rather than being normalized to NotApplicable.
+        assert_eq!(states["app"], PackageResolutionState::Missing);
         assert!(
             pkg_graph.relationship_projections.get().is_none(),
             "relationship projections must remain lazy for current consumers"
         );
+
+        pkg_graph.remove_external_resolution_for_test();
+        let missing_states = pkg_graph.package_resolution_states();
+        assert_eq!(missing_states["//"], PackageResolutionState::NotApplicable);
+        assert_eq!(missing_states["app"], PackageResolutionState::Missing);
 
         assert_eq!(
             pkg_graph

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -158,7 +158,13 @@ Represents the workspace structure and package dependencies:
   `rustc -vV` identity directly through its external-resolution domain. Cargo
   keeps missing, stale, or invalid lockfile and compiler identity failures
   fatal. Core validates the combined domains and retains exact opaque
-  identities, definition sources, completeness, and stable fingerprints. A
+  identities, definition sources, completeness, and stable fingerprints.
+  Open resolution-domain IDs select behavior after construction independently
+  of retained `ToolchainId` provenance, and each domain explicitly claims its
+  package members. Built-in JavaScript and Cargo IDs are reserved to their
+  canonical producers and repository roots. Core rejects duplicate IDs, package
+  ownership, unknown members, resolution rows outside declared membership, and
+  complete domains without exactly one row per member. A
   single resolution owner tracks lifecycle status. Task hashing and run/task
   summaries (including OpenTelemetry external-input attributes) consume the
   same stored byte-compatible package resolution fingerprint and preserve
@@ -275,8 +281,8 @@ JavaScript reports only the repository root for its authoritative package-manage
 command family; if discovery reports a different family than an explicitly
 resolved manager, the response is rejected. Pnpm versions and Yarn/Berry share
 their respective canonical families. Cargo reports the current workspace root.
-Resolution domains are validated against these authoritative roots during
-generation construction.
+External-resolution generation validates domain roots against these authoritative
+workspace roots before publishing terminal knowledge.
 
 The package graph intentionally allows cyclic dependencies between packages —
 this aligns with how npm, pnpm, and yarn handle cyclic workspace deps. Cycle


### PR DESCRIPTION
## Intent

Separate external-resolution behavior from contributor provenance.

## Changes

- Add open external-resolution domain IDs with reserved JavaScript and Cargo domains.
- Give each immutable domain explicit, exclusive package membership while retaining producer provenance.
- Validate domain IDs, canonical built-in producers/roots, package ownership, unknown members, and complete member-row equality.
- Route package resolution states through retained domain claims instead of `ToolchainId`.
- Select JavaScript lockfile comparison, global fallback, and N-API identities by domain ID.
- Project JavaScript members from authoritative package.json scopes and Cargo members from resolution rows.
- Document the domain contract in architecture and crate docs.

## Testing

- `cargo test -p turborepo-repository` (392 passed)
- `cargo clippy -p turborepo-repository --all-targets -- -D warnings`
- Pre-push `format` and `check:toml` hooks

Advances TURBO-5798.