### PR TITLE
refactor: Own resolution fingerprints in repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8648,6 +8648,7 @@ dependencies = [
  "hex",
  "test-case",
  "turbopath",
+ "turborepo-lockfile-hash",
  "turborepo-lockfiles",
  "turborepo-types",
  "xxhash-rust",
@@ -8787,6 +8788,17 @@ dependencies = [
  "wax",
  "webbrowser",
  "which 4.4.0",
+]
+
+[[package]]
+name = "turborepo-lockfile-hash"
+version = "0.1.0"
+dependencies = [
+ "capnp",
+ "capnpc",
+ "hex",
+ "thiserror 2.0.18",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -9042,7 +9054,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
- "sha2",
  "tempfile",
  "test-case",
  "thiserror 2.0.18",
@@ -9052,6 +9063,7 @@ dependencies = [
  "turbopath",
  "turborepo-errors",
  "turborepo-graph-utils",
+ "turborepo-lockfile-hash",
  "turborepo-lockfiles",
  "turborepo-rayon-compat",
  "wax",
@@ -9300,7 +9312,6 @@ dependencies = [
  "turborepo-env",
  "turborepo-frameworks",
  "turborepo-hash",
- "turborepo-lockfiles",
  "turborepo-repository",
  "turborepo-run-summary",
  "turborepo-scm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ turborepo-frameworks = { path = "crates/turborepo-frameworks" }
 turborepo-fs = { path = "crates/turborepo-fs" }
 turborepo-gitignore = { path = "crates/turborepo-gitignore" }
 turborepo-hash = { path = "crates/turborepo-hash" }
+turborepo-lockfile-hash = { path = "crates/turborepo-lockfile-hash" }
 turborepo-json-rewrite = { path = "crates/turborepo-json-rewrite" }
 turborepo-lib = { path = "crates/turborepo-lib", default-features = false }
 turborepo-lsp = { path = "crates/turborepo-lsp", default-features = false }

--- a/crates/turborepo-hash/Cargo.toml
+++ b/crates/turborepo-hash/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 capnp = "0.24"
 hex = "0.4.3"
 turbopath = { workspace = true }
+turborepo-lockfile-hash = { workspace = true }
 turborepo-lockfiles = { workspace = true }
 turborepo-types = { workspace = true }
 xxhash-rust = { version = "0.8", features = ["xxh64"] }

--- a/crates/turborepo-hash/README.md
+++ b/crates/turborepo-hash/README.md
@@ -4,6 +4,10 @@
 
 Hashing utilities for Turborepo cache keys. Uses Cap'n Proto for deterministic cross-platform serialization, then applies xxHash64 for fast hashing.
 
+Lockfile-package canonical serialization and hashing live in the cycle-free
+`turborepo-lockfile-hash` crate. This crate retains the existing owned and
+borrowed compatibility wrappers and delegates them to that primitive.
+
 ## Architecture
 
 ```

--- a/crates/turborepo-hash/src/lib.rs
+++ b/crates/turborepo-hash/src/lib.rs
@@ -125,6 +125,7 @@ pub enum Error {
     Canonicalize(capnp::Error),
     ReadTaskOutputs(capnp::Error),
     SetTaskOutputs(capnp::Error),
+    Lockfile(turborepo_lockfile_hash::Error),
 }
 
 impl fmt::Display for Error {
@@ -140,6 +141,7 @@ impl fmt::Display for Error {
                 write!(f, "unable to read Cap'n Proto task outputs: {err}")
             }
             Self::SetTaskOutputs(err) => write!(f, "unable to set Cap'n Proto task outputs: {err}"),
+            Self::Lockfile(err) => write!(f, "unable to hash lockfile packages: {err}"),
         }
     }
 }
@@ -151,6 +153,7 @@ impl std::error::Error for Error {
             | Self::Canonicalize(err)
             | Self::ReadTaskOutputs(err)
             | Self::SetTaskOutputs(err) => Some(err),
+            Self::Lockfile(err) => Some(err),
         }
     }
 }
@@ -212,54 +215,24 @@ impl From<HashableTaskOutputs> for Builder<HeapAllocator> {
 impl HashableMessage for LockFilePackages {
     fn into_builder(self) -> Result<Builder<HeapAllocator>, Error> {
         let LockFilePackages(packages) = self;
-        let mut message = ::capnp::message::TypedBuilder::<
-            proto_capnp::lock_file_packages::Owned,
-            HeapAllocator,
-        >::new_default();
-        let mut builder = message.init_root();
-
-        {
-            let mut packages_builder = builder.reborrow().init_packages(packages.len() as u32);
-            for (i, turborepo_lockfiles::Package { key, version }) in packages.iter().enumerate() {
-                let mut package = packages_builder.reborrow().get(i as u32);
-                package.set_key(key);
-                package.set_version(version);
-                // we don't track this in rust, set it to true
-                package.set_found(true);
-            }
-        }
-
-        canonical_builder::<proto_capnp::lock_file_packages::Owned>(
-            builder.total_size(),
-            builder.reborrow_as_reader(),
+        turborepo_lockfile_hash::canonical_builder(
+            packages
+                .iter()
+                .map(|package| (package.key.as_str(), package.version.as_str())),
         )
+        .map_err(Error::Lockfile)
     }
 }
 
 impl HashableMessage for LockFilePackagesRef<'_> {
     fn into_builder(self) -> Result<Builder<HeapAllocator>, Error> {
         let LockFilePackagesRef(packages) = self;
-        let mut message = ::capnp::message::TypedBuilder::<
-            proto_capnp::lock_file_packages::Owned,
-            HeapAllocator,
-        >::new_default();
-        let mut builder = message.init_root();
-
-        {
-            let mut packages_builder = builder.reborrow().init_packages(packages.len() as u32);
-            for (i, pkg) in packages.iter().enumerate() {
-                let mut package = packages_builder.reborrow().get(i as u32);
-                package.set_key(&pkg.key);
-                package.set_version(&pkg.version);
-                // we don't track this in rust, set it to true
-                package.set_found(true);
-            }
-        }
-
-        canonical_builder::<proto_capnp::lock_file_packages::Owned>(
-            builder.total_size(),
-            builder.reborrow_as_reader(),
+        turborepo_lockfile_hash::canonical_builder(
+            packages
+                .into_iter()
+                .map(|package| (package.key.as_str(), package.version.as_str())),
         )
+        .map_err(Error::Lockfile)
     }
 }
 

--- a/crates/turborepo-hash/src/proto.capnp
+++ b/crates/turborepo-hash/src/proto.capnp
@@ -56,16 +56,6 @@ struct GlobalHashable {
   }
 }
 
-struct LockFilePackages {
-  packages @0 :List(Package);
-}
-
-struct Package {
-  key @0 :Text;
-  version @1 :Text;
-  found @2 :Bool;
-}
-
 struct FileHashes {
   fileHashes @0 :List(Entry);
 

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -566,10 +566,7 @@ impl RunBuilder {
             let mut builder =
                 PackageGraph::builder_optional(&self.repo_root, root_package_json.clone())
                     .with_single_package_mode(self.opts.run_opts.single_package)
-                    .with_allow_no_package_manager(self.opts.repo_opts.allow_no_package_manager)
-                    .with_closure_hasher(std::sync::Arc::new(
-                        turborepo_task_hash::hash_sorted_closures,
-                    ));
+                    .with_allow_no_package_manager(self.opts.repo_opts.allow_no_package_manager);
             if cargo_enabled(&self.opts.future_flags) {
                 builder = builder.with_cargo();
             }

--- a/crates/turborepo-lockfile-hash/Cargo.toml
+++ b/crates/turborepo-lockfile-hash/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "turborepo-lockfile-hash"
+version = "0.1.0"
+edition = { workspace = true }
+license = "MIT"
+
+[lints]
+workspace = true
+
+[dependencies]
+capnp = "0.24"
+hex = "0.4.3"
+thiserror = { workspace = true }
+xxhash-rust = { version = "0.8", features = ["xxh64"] }
+
+[build-dependencies]
+capnpc = "0.24"

--- a/crates/turborepo-lockfile-hash/README.md
+++ b/crates/turborepo-lockfile-hash/README.md
@@ -1,0 +1,17 @@
+# turborepo-lockfile-hash
+
+## Purpose
+
+Cycle-free, byte-compatible hashing for normalized lockfile package closures.
+
+## Architecture
+
+The crate preserves the historical Cap'n Proto layout and xxHash64 output used
+by Turborepo task hashes. Repository knowledge uses it to install package
+resolution fingerprints during generation construction. `turborepo-hash`
+delegates its compatibility wrappers to the same primitive.
+
+Input order is preserved and affects the resulting 16-character lowercase
+hexadecimal hash. Repository generation supplies lexicographic `(key, version)`
+ordering; `turborepo-hash` compatibility wrappers intentionally preserve their
+supplied order.

--- a/crates/turborepo-lockfile-hash/build.rs
+++ b/crates/turborepo-lockfile-hash/build.rs
@@ -1,0 +1,17 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let result = capnpc::CompilerCommand::new()
+        .file("./src/proto.capnp")
+        .run();
+
+    if std::env::var("RUSTC_WRAPPER")
+        .unwrap_or_default()
+        .ends_with("rust-analyzer")
+        && result.is_err()
+    {
+        println!("cargo:warning=capnpc failed, but continuing with rust-analyzer");
+        return Ok(());
+    }
+
+    result?;
+    Ok(())
+}

--- a/crates/turborepo-lockfile-hash/src/lib.rs
+++ b/crates/turborepo-lockfile-hash/src/lib.rs
@@ -1,0 +1,96 @@
+//! Byte-compatible hashing for normalized lockfile package closures.
+
+// Generated Cap'n Proto setters use infallible unwraps.
+#![allow(clippy::unwrap_used)]
+
+use capnp::{
+    message::{Builder, HeapAllocator},
+    traits::{Owned, SetterInput},
+};
+
+#[allow(dead_code)]
+mod proto_capnp {
+    include!(concat!(env!("OUT_DIR"), "/src/proto_capnp.rs"));
+}
+
+/// Failures while constructing the canonical Cap'n Proto message.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Cap'n Proto could not calculate the source message size.
+    #[error("failed to calculate message size")]
+    MessageSize(#[source] capnp::Error),
+    /// Cap'n Proto could not write the canonical single-segment message.
+    #[error("failed to canonicalize lockfile packages")]
+    Canonicalize(#[source] capnp::Error),
+}
+
+/// Serializes `(key, version)` pairs in the supplied order.
+/// Repository callers provide lexicographic `(key, version)` ordering;
+/// compatibility wrappers intentionally preserve their supplied order.
+pub fn canonical_builder<'a>(
+    packages: impl ExactSizeIterator<Item = (&'a str, &'a str)>,
+) -> Result<Builder<HeapAllocator>, Error> {
+    let mut message = ::capnp::message::TypedBuilder::<
+        proto_capnp::lock_file_packages::Owned,
+        HeapAllocator,
+    >::new_default();
+    let mut builder = message.init_root();
+
+    {
+        let mut packages_builder = builder.reborrow().init_packages(packages.len() as u32);
+        for (index, (key, version)) in packages.enumerate() {
+            let mut output = packages_builder.reborrow().get(index as u32);
+            output.set_key(key);
+            output.set_version(version);
+            output.set_found(true);
+        }
+    }
+
+    canonicalize::<proto_capnp::lock_file_packages::Owned>(
+        builder.total_size(),
+        builder.reborrow_as_reader(),
+    )
+}
+
+/// Returns the byte-compatible xxHash64 fingerprint as 16 lowercase hex chars.
+/// Input order is preserved. Repository callers provide lexicographic
+/// `(key, version)` ordering; compatibility wrappers preserve supplied order.
+pub fn hash<'a>(
+    packages: impl ExactSizeIterator<Item = (&'a str, &'a str)>,
+) -> Result<String, Error> {
+    let message = canonical_builder(packages)?;
+    debug_assert_eq!(message.get_segments_for_output().len(), 1);
+    let bytes = message.get_segments_for_output()[0];
+    Ok(hex::encode(
+        xxhash_rust::xxh64::xxh64(bytes, 0).to_be_bytes(),
+    ))
+}
+
+fn canonicalize<T: Owned>(
+    size: capnp::Result<capnp::MessageSize>,
+    value: impl SetterInput<T>,
+) -> Result<Builder<HeapAllocator>, Error> {
+    let size = size.map_err(Error::MessageSize)?.word_count + 1;
+    let mut canonical = Builder::new(HeapAllocator::default().first_segment_words(size as u32));
+    canonical
+        .set_root_canonical::<T>(value)
+        .map_err(Error::Canonicalize)?;
+    Ok(canonical)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::hash;
+
+    #[test]
+    fn preserves_byte_compatible_fingerprints() {
+        let empty = Vec::<(&str, &str)>::new();
+        assert_eq!(hash(empty.into_iter()).unwrap(), "459c029558afe716");
+
+        let one = [("key", "version")];
+        assert_eq!(hash(one.into_iter()).unwrap(), "1b266409f3ae154e");
+
+        let multiple = [("key", "version"), ("zey", "version")];
+        assert_eq!(hash(multiple.into_iter()).unwrap(), "6c0185544234b6dc");
+    }
+}

--- a/crates/turborepo-lockfile-hash/src/proto.capnp
+++ b/crates/turborepo-lockfile-hash/src/proto.capnp
@@ -1,0 +1,11 @@
+@0xe1dde60149aeb063;
+
+struct LockFilePackages {
+  packages @0 :List(Package);
+}
+
+struct Package {
+  key @0 :Text;
+  version @1 :Text;
+  found @2 :Bool;
+}

--- a/crates/turborepo-repository/Cargo.toml
+++ b/crates/turborepo-repository/Cargo.toml
@@ -26,7 +26,6 @@ rust-ini = "0.20.0"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }
-sha2 = { workspace = true }
 thiserror = { workspace = true }
 tokio.workspace = true
 toml_edit = { workspace = true }
@@ -34,6 +33,7 @@ tracing.workspace = true
 turbopath = { workspace = true }
 turborepo-errors = { workspace = true }
 turborepo-graph-utils = { path = "../turborepo-graph-utils" }
+turborepo-lockfile-hash = { workspace = true }
 turborepo-lockfiles = { workspace = true }
 turborepo-rayon-compat = { workspace = true }
 wax = { workspace = true }

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -45,7 +45,7 @@ use crate::{
     change_knowledge::ChangeObservation,
     external_resolution::{
         ExternalPackageIdentity, ExternalResolutionData, ExternalResolutionDomain,
-        PackageResolution, ResolutionCompleteness, ResolutionFingerprint,
+        PackageResolution, ResolutionCompleteness,
     },
     package_json::{DependencyKind, PackageJson},
     prune_knowledge::{PruneDomain, PrunePlan},
@@ -1577,7 +1577,6 @@ impl RepositoryContributor for CargoContributor {
                 );
             }
 
-            let fingerprint = ResolutionFingerprint::from_packages(&resolutions);
             let members = resolutions
                 .iter()
                 .map(|resolution| resolution.package().to_string())
@@ -1592,7 +1591,6 @@ impl RepositoryContributor for CargoContributor {
                     .map_err(|error| toolchain::Error::Failed(Box::new(error)))?],
                 ExternalResolutionData::Resolved {
                     completeness: ResolutionCompleteness::Complete,
-                    fingerprint,
                     packages: resolutions,
                 },
             );
@@ -3531,15 +3529,20 @@ release: 1.96.0-nightly\n",
         assert_eq!(resolutions[0].definition_sources()[0].as_str(), CARGO_LOCK);
         let ExternalResolutionData::Resolved {
             completeness,
-            fingerprint,
             packages: resolution_packages,
         } = resolutions[0].data()
         else {
             panic!("Cargo resolution must be complete")
         };
         assert_eq!(completeness, &ResolutionCompleteness::Complete);
-        assert!(!fingerprint.as_str().is_empty());
         assert_eq!(resolution_packages.len(), 4);
+        // Producers supply normalized identities; generation construction owns
+        // byte-compatible package fingerprints.
+        assert!(
+            resolution_packages
+                .iter()
+                .all(|package| package.fingerprint().is_none())
+        );
         assert!(resolution_packages.iter().all(|package| {
             package
                 .identities()

--- a/crates/turborepo-repository/src/external_resolution.rs
+++ b/crates/turborepo-repository/src/external_resolution.rs
@@ -7,7 +7,6 @@ use std::{
     ops::Range,
 };
 
-use sha2::{Digest, Sha256};
 use turbopath::{AnchoredSystemPath, AnchoredSystemPathBuf};
 
 use crate::{
@@ -264,7 +263,7 @@ impl ResolutionUnavailableReason {
     }
 }
 
-/// Stable producer-supplied identity for one resolved domain generation.
+/// Generation-owned, byte-compatible fingerprint for one package resolution.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolutionFingerprint(String);
 
@@ -275,27 +274,6 @@ impl ResolutionFingerprint {
 
     pub fn as_str(&self) -> &str {
         &self.0
-    }
-
-    pub(crate) fn from_packages(packages: &[PackageResolution]) -> Self {
-        fn update(hasher: &mut Sha256, value: &str) {
-            hasher.update((value.len() as u64).to_le_bytes());
-            hasher.update(value.as_bytes());
-        }
-
-        let mut packages: Vec<_> = packages.iter().collect();
-        packages.sort_unstable_by_key(|package| package.package());
-        let mut hasher = Sha256::new();
-        for package in packages {
-            update(&mut hasher, package.package());
-            let mut identities: Vec<_> = package.identities().iter().collect();
-            identities.sort_unstable();
-            for identity in identities {
-                update(&mut hasher, identity.key());
-                update(&mut hasher, identity.version());
-            }
-        }
-        Self::new(format!("{:x}", hasher.finalize()))
     }
 }
 
@@ -347,7 +325,6 @@ impl PackageResolution {
 pub enum ExternalResolutionData {
     Resolved {
         completeness: ResolutionCompleteness,
-        fingerprint: ResolutionFingerprint,
         packages: Vec<PackageResolution>,
     },
     Unavailable(ResolutionUnavailableReason),
@@ -477,10 +454,6 @@ impl ExternalResolutionDomain {
     pub fn data(&self) -> &ExternalResolutionData {
         &self.data
     }
-
-    pub(crate) fn data_mut(&mut self) -> &mut ExternalResolutionData {
-        &mut self.data
-    }
 }
 
 /// Lifecycle state for resolution production, kept separate from terminal
@@ -511,6 +484,15 @@ impl ExternalResolutionGeneration {
                 for package in packages.iter_mut() {
                     package.identities.sort();
                     package.identities.dedup();
+                    package.set_fingerprint(ResolutionFingerprint::new(
+                        turborepo_lockfile_hash::hash(
+                            package
+                                .identities
+                                .iter()
+                                .map(|identity| (identity.key(), identity.version())),
+                        )
+                        .map_err(ExternalResolutionError::Fingerprint)?,
+                    ));
                 }
                 packages.sort_by(|left, right| left.package.cmp(&right.package));
             }
@@ -635,8 +617,10 @@ impl ExternalResolutionGeneration {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 pub(crate) enum ExternalResolutionError {
+    #[error("failed to fingerprint normalized package resolution")]
+    Fingerprint(#[source] turborepo_lockfile_hash::Error),
     #[error("external resolution domain {id} was contributed more than once")]
     DuplicateDomain { id: ExternalResolutionDomainId },
     #[error("external resolution domain {id} has unknown root {root}")]
@@ -813,7 +797,6 @@ mod tests {
     fn resolved(packages: Vec<PackageResolution>) -> ExternalResolutionData {
         ExternalResolutionData::Resolved {
             completeness: ResolutionCompleteness::Complete,
-            fingerprint: ResolutionFingerprint::new("fingerprint"),
             packages,
         }
     }

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -21,10 +21,7 @@ use crate::{
         self, CachingPackageDiscovery, LocalPackageDiscoveryBuilder, PackageDiscovery,
         PackageDiscoveryBuilder,
     },
-    external_resolution::{
-        ExternalResolutionData, ExternalResolutionDomain, ExternalResolutionGeneration,
-        ResolutionFingerprint,
-    },
+    external_resolution::{ExternalResolutionDomain, ExternalResolutionGeneration},
     knowledge::{
         PackageScopeObservation, RelationshipGroup, RelationshipKnowledge, RepositoryKnowledge,
         ScopeKind, WorkspaceRootObservation,
@@ -50,7 +47,6 @@ pub struct PackageGraphBuilder<'a, T> {
     lockfile: Option<Box<dyn Lockfile>>,
     package_discovery: T,
     package_manager: Option<PackageManager>,
-    closure_hasher: Option<ClosureHasher>,
     /// Toolchains registered in addition to JavaScript (e.g. Cargo when
     /// `futureFlags.experimentalCargoWorkspaces` is enabled). Their packages
     /// are discovered alongside JavaScript packages; name collisions across
@@ -266,7 +262,6 @@ impl<'a> PackageGraphBuilder<'a, LocalPackageDiscoveryBuilder> {
             package_jsons: None,
             lockfile: None,
             package_manager: None,
-            closure_hasher: None,
             extra_contributors: Vec::new(),
         }
     }
@@ -296,13 +291,6 @@ impl<'a, P> PackageGraphBuilder<'a, P> {
         package_jsons: Option<HashMap<AbsoluteSystemPathBuf, PackageJson>>,
     ) -> Self {
         self.package_jsons = package_jsons;
-        self
-    }
-
-    /// Provide the byte-compatible hasher used to fingerprint normalized
-    /// package resolutions once, alongside closure production.
-    pub fn with_closure_hasher(mut self, hasher: ClosureHasher) -> Self {
-        self.closure_hasher = Some(hasher);
         self
     }
 
@@ -340,7 +328,6 @@ impl<'a, P> PackageGraphBuilder<'a, P> {
             lockfile: self.lockfile,
             package_discovery: discovery,
             package_manager: self.package_manager,
-            closure_hasher: self.closure_hasher,
             extra_contributors: self.extra_contributors,
         }
     }
@@ -420,7 +407,6 @@ struct BuildState<'a, S, T> {
     lockfile: Option<Box<dyn Lockfile>>,
     package_manager: Option<PackageManager>,
     package_jsons: Option<HashMap<AbsoluteSystemPathBuf, PackageJson>>,
-    closure_hasher: Option<ClosureHasher>,
     state: std::marker::PhantomData<S>,
     /// The JavaScript contributor, kept typed. Package-manager resolution for
     /// dependency splitting and lockfile handling reaches through this —
@@ -643,7 +629,6 @@ where
         let PackageGraphBuilder {
             repo_root,
             root_package_json,
-            closure_hasher,
             is_single_package: single,
 
             package_jsons,
@@ -706,7 +691,6 @@ where
             package_manager: None,
             package_jsons,
             root_package_json,
-            closure_hasher,
             state: std::marker::PhantomData,
             javascript,
             extra_contributors: additional_contributors,
@@ -878,7 +862,6 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             package_manager,
             javascript,
             extra_contributors,
-            closure_hasher,
             ..
         } = self;
         Ok(BuildState {
@@ -897,7 +880,6 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             package_manager,
             javascript,
             extra_contributors,
-            closure_hasher,
             package_jsons: None,
             state: std::marker::PhantomData,
         })
@@ -1215,7 +1197,6 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
             root_package_json,
             javascript,
             extra_contributors,
-            closure_hasher,
             ..
         } = self;
         Ok(BuildState {
@@ -1233,55 +1214,11 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
             root_package_json,
             lockfile,
             package_manager,
-            closure_hasher,
             package_jsons: None,
             state: std::marker::PhantomData,
             javascript,
             extra_contributors,
         })
-    }
-}
-
-/// Computes byte-compatible fingerprints from normalized package identities.
-pub type ClosureHasher = Arc<
-    dyn Fn(&HashMap<String, Vec<Arc<turborepo_lockfiles::Package>>>) -> HashMap<String, String>
-        + Send
-        + Sync,
->;
-
-pub(super) fn apply_resolution_fingerprints(
-    domains: &mut [ExternalResolutionDomain],
-    hasher: Option<&ClosureHasher>,
-) {
-    let Some(hasher) = hasher else {
-        return;
-    };
-    for domain in domains {
-        let ExternalResolutionData::Resolved { packages, .. } = domain.data_mut() else {
-            continue;
-        };
-        let identities = packages
-            .iter()
-            .map(|package| {
-                let identities = package
-                    .identities()
-                    .iter()
-                    .map(|identity| {
-                        Arc::new(turborepo_lockfiles::Package::new(
-                            identity.key(),
-                            identity.version(),
-                        ))
-                    })
-                    .collect();
-                (package.package().to_string(), identities)
-            })
-            .collect();
-        let fingerprints = hasher(&identities);
-        for package in packages {
-            if let Some(fingerprint) = fingerprints.get(package.package()) {
-                package.set_fingerprint(ResolutionFingerprint::new(fingerprint));
-            }
-        }
     }
 }
 
@@ -1347,7 +1284,6 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
                                 external_dependencies,
                                 false,
                                 definition_source,
-                                self.closure_hasher.as_ref(),
                             )
                         })
                         .map_err(|message| build_failure(Error::ExternalResolution(message)))?;
@@ -1366,7 +1302,6 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
                             "declarations-unavailable",
                             error.to_string(),
                             None,
-                            self.closure_hasher.as_ref(),
                         )
                         .map_err(|message| build_failure(Error::ExternalResolution(message)))?;
                         external_resolution =
@@ -1381,16 +1316,11 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
                     "lockfile-unavailable",
                     "JavaScript lockfile could not be read or parsed".to_string(),
                     None,
-                    self.closure_hasher.as_ref(),
                 )
                 .map_err(|message| build_failure(Error::ExternalResolution(message)))?;
                 external_resolution = ExternalResolutionKnowledge::complete(snapshot.generation);
             }
         } else if !native_external_resolutions.is_empty() {
-            apply_resolution_fingerprints(
-                &mut native_external_resolutions,
-                self.closure_hasher.as_ref(),
-            );
             let generation =
                 ExternalResolutionGeneration::build(&knowledge, native_external_resolutions)
                     .map_err(|error| build_failure(Error::ExternalResolution(error.to_string())))?;

--- a/crates/turborepo-repository/src/package_graph/javascript.rs
+++ b/crates/turborepo-repository/src/package_graph/javascript.rs
@@ -6,16 +6,13 @@ use std::{
 use turbopath::{AnchoredSystemPath, AnchoredSystemPathBuf};
 use turborepo_lockfiles::Lockfile;
 
-use super::{
-    ExternalDependencyChange, PackageGraph, PackageName, ROOT_PKG_NAME, WorkspacePackage,
-    builder::{ClosureHasher, apply_resolution_fingerprints},
-};
+use super::{ExternalDependencyChange, PackageGraph, PackageName, ROOT_PKG_NAME, WorkspacePackage};
 use crate::{
     external_resolution::{
         ExternalDeclarations, ExternalPackageIdentity, ExternalResolutionChanges,
         ExternalResolutionData, ExternalResolutionDomain, ExternalResolutionGeneration,
         JAVASCRIPT_RESOLUTION_DOMAIN, PackageResolution, ResolutionCompleteness,
-        ResolutionFingerprint, ResolutionUnavailableReason, compare_resolution_data,
+        ResolutionUnavailableReason, compare_resolution_data,
     },
     knowledge::{RelationshipKnowledge, RepositoryKnowledge},
     package_json::DependencyKind,
@@ -78,7 +75,6 @@ pub(super) fn unavailable_resolution(
     code: &str,
     message: String,
     warning: Option<String>,
-    closure_hasher: Option<&ClosureHasher>,
 ) -> Result<ResolutionSnapshot, String> {
     let members = resolution_packages(knowledge)
         .into_iter()
@@ -92,7 +88,6 @@ pub(super) fn unavailable_resolution(
         [definition_source],
         ExternalResolutionData::Unavailable(ResolutionUnavailableReason::new(code, message)),
     ));
-    apply_resolution_fingerprints(&mut domains, closure_hasher);
     let generation = ExternalResolutionGeneration::build(knowledge, domains)
         .map_err(|error| error.to_string())?;
     Ok(ResolutionSnapshot {
@@ -108,7 +103,6 @@ pub(super) fn resolve_dependencies(
     external_dependencies: HashMap<String, BTreeMap<String, String>>,
     ignore_missing_packages: bool,
     definition_source: AnchoredSystemPathBuf,
-    closure_hasher: Option<&ClosureHasher>,
 ) -> Result<ResolutionSnapshot, String> {
     let closures = match turborepo_lockfiles::all_transitive_closures_sorted(
         lockfile,
@@ -125,7 +119,6 @@ pub(super) fn resolve_dependencies(
                 "closure-unavailable",
                 message.clone(),
                 Some(message),
-                closure_hasher,
             );
         }
     };
@@ -147,7 +140,6 @@ pub(super) fn resolve_dependencies(
             PackageResolution::new(identity, exact_identities)
         })
         .collect::<Vec<_>>();
-    let fingerprint = ResolutionFingerprint::from_packages(&packages);
     let members = packages
         .iter()
         .map(|package| package.package().to_string())
@@ -160,11 +152,9 @@ pub(super) fn resolve_dependencies(
         [definition_source],
         ExternalResolutionData::Resolved {
             completeness: ResolutionCompleteness::Complete,
-            fingerprint,
             packages,
         },
     ));
-    apply_resolution_fingerprints(&mut domains, closure_hasher);
     let generation = ExternalResolutionGeneration::build(knowledge, domains)
         .map_err(|error| error.to_string())?;
     Ok(ResolutionSnapshot {
@@ -223,7 +213,6 @@ impl PackageGraph {
             external_dependencies(&self.knowledge, &self.relationship_knowledge),
             true,
             definition_source,
-            None,
         )
         .map_err(ChangedPackagesError::Resolution)?;
         let current_resolution = self

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -2380,7 +2380,6 @@ mod test {
         );
         let crate::external_resolution::ExternalResolutionData::Resolved {
             completeness,
-            fingerprint,
             packages,
         } = resolved_domain.data()
         else {
@@ -2390,10 +2389,10 @@ mod test {
             completeness,
             &crate::external_resolution::ResolutionCompleteness::Complete
         );
-        assert!(!fingerprint.as_str().is_empty());
         assert_eq!(packages.len(), 1);
         assert_eq!(packages[0].package(), ROOT_PKG_NAME);
         assert!(packages[0].identities().is_empty());
+        assert!(packages[0].fingerprint().is_some());
         assert!(
             resolved
                 .external_package_identities_for_packages([&PackageName::Root])
@@ -2922,7 +2921,7 @@ version = "0.1.0"
         // Several iterations: the closure-attribution regression this guards
         // was decided by HashMap iteration order, roughly a coin flip per
         // process/build.
-        let mut expected_cargo_fingerprint = None;
+        let mut expected_cargo_fingerprints = None;
         for iteration in 0..8 {
             let _defer_resolution = iteration % 2 == 1;
             let mut pkg_graph = PackageGraph::builder(
@@ -3102,7 +3101,6 @@ version = "0.1.0"
             assert_eq!(cargo_domain.definition_sources()[0].as_str(), "Cargo.lock");
             let crate::external_resolution::ExternalResolutionData::Resolved {
                 completeness,
-                fingerprint,
                 packages,
             } = cargo_domain.data()
             else {
@@ -3112,10 +3110,14 @@ version = "0.1.0"
                 completeness,
                 &crate::external_resolution::ResolutionCompleteness::Complete
             );
-            if let Some(expected) = &expected_cargo_fingerprint {
-                assert_eq!(fingerprint, expected);
+            let fingerprints = packages
+                .iter()
+                .map(|package| package.fingerprint().unwrap().clone())
+                .collect::<Vec<_>>();
+            if let Some(expected) = &expected_cargo_fingerprints {
+                assert_eq!(&fingerprints, expected);
             } else {
-                expected_cargo_fingerprint = Some(fingerprint.clone());
+                expected_cargo_fingerprints = Some(fingerprints);
             }
             assert_eq!(packages.len(), 4);
             for package in packages {
@@ -3165,9 +3167,10 @@ version = "0.1.0"
         );
         let states = pkg_graph.package_resolution_states();
         assert_eq!(states["//"], PackageResolutionState::NotApplicable);
-        // This fixture has no closure hasher, so the claimed package fails
-        // closed as Missing rather than being normalized to NotApplicable.
-        assert_eq!(states["app"], PackageResolutionState::Missing);
+        assert!(matches!(
+            states["app"],
+            PackageResolutionState::Resolved { .. }
+        ));
         assert!(
             pkg_graph.relationship_projections.get().is_none(),
             "relationship projections must remain lazy for current consumers"

--- a/crates/turborepo-task-hash/Cargo.toml
+++ b/crates/turborepo-task-hash/Cargo.toml
@@ -21,7 +21,6 @@ turborepo-engine = { path = "../turborepo-engine" }
 turborepo-env = { workspace = true }
 turborepo-frameworks = { workspace = true }
 turborepo-hash = { workspace = true }
-turborepo-lockfiles = { workspace = true }
 turborepo-repository = { path = "../turborepo-repository" }
 turborepo-run-summary = { workspace = true }
 turborepo-scm = { workspace = true }

--- a/crates/turborepo-task-hash/src/lib.rs
+++ b/crates/turborepo-task-hash/src/lib.rs
@@ -29,7 +29,7 @@ use turborepo_env::{
     WildcardMapCache,
 };
 use turborepo_frameworks::{Framework, Slug as FrameworkSlug, infer_framework};
-use turborepo_hash::{FileHashes, LockFilePackagesRef, TaskHashable, TurboHash};
+use turborepo_hash::{FileHashes, TaskHashable, TurboHash};
 use turborepo_repository::package_graph::{PackageGraph, PackageName, PackageTaskContext};
 use turborepo_scm::{RepoGitIndex, SCM};
 use turborepo_task_id::TaskId;
@@ -801,19 +801,6 @@ pub fn deferred_task_hash_message(inputs: &TaskInputs) -> &'static str {
     }
 }
 
-/// Produce byte-compatible fingerprints once from normalized resolution sets.
-pub fn hash_sorted_closures(
-    closures: &HashMap<String, Vec<Arc<turborepo_lockfiles::Package>>>,
-) -> HashMap<String, String> {
-    closures
-        .par_iter()
-        .map(|(package, closure)| {
-            let identities = closure.iter().map(|identity| &**identity).collect();
-            (package.clone(), LockFilePackagesRef(identities).hash())
-        })
-        .collect()
-}
-
 pub fn get_internal_deps_hash(
     scm: &SCM,
     root: &AbsoluteSystemPath,
@@ -1132,7 +1119,6 @@ mod test {
             .unwrap();
 
         PackageGraph::builder(repo_root, PackageJson::from_value(root_json).unwrap())
-            .with_closure_hasher(Arc::new(hash_sorted_closures))
             .build()
             .await
             .unwrap()
@@ -1173,7 +1159,6 @@ mod test {
 
         PackageGraph::builder_optional(repo_root, None)
             .with_cargo()
-            .with_closure_hasher(Arc::new(hash_sorted_closures))
             .build()
             .await
             .unwrap()

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -159,6 +159,8 @@ Represents the workspace structure and package dependencies:
   keeps missing, stale, or invalid lockfile and compiler identity failures
   fatal. Core validates the combined domains and retains exact opaque
   identities, definition sources, completeness, and stable fingerprints.
+  Repository generation owns byte-compatible per-package fingerprinting through
+  the cycle-free `turborepo-lockfile-hash` primitive; callers cannot omit it.
   Open resolution-domain IDs select behavior after construction independently
   of retained `ToolchainId` provenance, and each domain explicitly claims its
   package members. Built-in JavaScript and Cargo IDs are reserved to their


### PR DESCRIPTION
## Intent

Make complete external-resolution generations self-contained and remove the retained fingerprint callback.

## Changes

- Compute every package resolution fingerprint during normalized generation construction.
- Remove `ClosureHasher`, `with_closure_hasher`, `apply_resolution_fingerprints`, and `hash_sorted_closures`.
- Extract the historical lockfile-package Cap'n Proto layout and xxHash64 primitive into cycle-free `turborepo-lockfile-hash`.
- Delegate existing `turborepo-hash` compatibility wrappers to the same single schema and implementation.
- Remove the unused producer-level aggregate fingerprint so package fingerprint ownership is unambiguous.
- Preserve exact historical fingerprint bytes and typed error chains.

## Testing

- `cargo test -p turborepo-lockfile-hash -p turborepo-hash -p turborepo-repository -p turborepo-task-hash`
  - 1 lockfile primitive test
  - 25 hash tests
  - 393 repository tests
  - 18 task-hash tests
- `cargo clippy -p turborepo-lockfile-hash -p turborepo-hash -p turborepo-repository -p turborepo-task-hash -p turborepo-lib --all-targets -- -D warnings`
- Pre-push `format` and `check:toml` hooks

Advances TURBO-5799.