### PR TITLE
refactor: Fail closed on invalid relationships

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9409,7 +9409,6 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
- "tracing",
  "ts-rs",
  "turbopath",
  "turborepo-errors",

--- a/apps/docs/content/docs/reference/query.mdx
+++ b/apps/docs/content/docs/reference/query.mdx
@@ -147,7 +147,7 @@ turbo query affected
 }
 ```
 
-Task-level detection is normally more precise than package-level. A task is reported as affected if its configured [`inputs`](/docs/reference/configuration#inputs) match a changed file or if an upstream task dependency is affected. Conservative fallbacks can report every task instead.
+Task-level detection is more precise than package-level. A task is only reported as affected if its configured [`inputs`](/docs/reference/configuration#inputs) match a changed file, or if an upstream task dependency is affected.
 
 #### `--tasks`
 
@@ -191,25 +191,6 @@ turbo query affected --packages web docs
   }
 }
 ```
-
-If repository relationship knowledge cannot be projected, Turborepo
-conservatively includes every package and reports the generic
-`AllPackagesChanged` reason:
-
-```json title="Conservative affectedness reason"
-{
-  "reason": {
-    "__typename": "AllPackagesChanged"
-  }
-}
-```
-
-When querying tasks, package relationship projection or task input matching
-failures include every task and report the generic `TaskAllChanged` reason.
-Internal failure details are logged rather than included in query output. If a
-task cannot be represented after affectedness is calculated, the query instead
-returns the opaque `Failed to determine affected tasks.` error and exits with
-code `2`.
 
 #### `--base`
 

--- a/apps/docs/content/docs/reference/query.mdx
+++ b/apps/docs/content/docs/reference/query.mdx
@@ -147,7 +147,7 @@ turbo query affected
 }
 ```
 
-Task-level detection is more precise than package-level. A task is only reported as affected if its configured [`inputs`](/docs/reference/configuration#inputs) match a changed file, or if an upstream task dependency is affected.
+Task-level detection is normally more precise than package-level. A task is reported as affected if its configured [`inputs`](/docs/reference/configuration#inputs) match a changed file or if an upstream task dependency is affected. Conservative fallbacks can report every task instead.
 
 #### `--tasks`
 
@@ -191,6 +191,25 @@ turbo query affected --packages web docs
   }
 }
 ```
+
+If repository relationship knowledge cannot be projected, Turborepo
+conservatively includes every package and reports the generic
+`AllPackagesChanged` reason:
+
+```json title="Conservative affectedness reason"
+{
+  "reason": {
+    "__typename": "AllPackagesChanged"
+  }
+}
+```
+
+When querying tasks, package relationship projection or task input matching
+failures include every task and report the generic `TaskAllChanged` reason.
+Internal failure details are logged rather than included in query output. If a
+task cannot be represented after affectedness is calculated, the query instead
+returns the opaque `Failed to determine affected tasks.` error and exits with
+code `2`.
 
 #### `--base`
 

--- a/crates/turborepo-engine/src/affected.rs
+++ b/crates/turborepo-engine/src/affected.rs
@@ -19,6 +19,17 @@ use turborepo_types::{
 
 use crate::{Built, Engine};
 
+#[derive(Debug, thiserror::Error)]
+pub enum AffectednessError {
+    #[error("engine task refers to unknown package {0}")]
+    UnknownTaskPackage(PackageName),
+    #[error("invalid input glob for task {task}: {error}")]
+    InvalidGlob {
+        task: TaskId<'static>,
+        error: String,
+    },
+}
+
 /// Fallback inputs when a task has no definition in the engine.
 /// `default: true` means all files in the package directory are considered
 /// inputs, matching turbo's default hashing behavior.
@@ -44,11 +55,16 @@ static DEFAULT_TASK_INPUTS: TaskInputs = TaskInputs {
 ///
 /// Does NOT include transitive dependents. Callers should propagate
 /// through the task graph separately if needed.
+///
+/// # Errors
+///
+/// Returns an error when an engine task refers to a package absent from
+/// authoritative repository knowledge or contains an invalid input glob.
 pub fn match_tasks_against_changed_files(
     engine: &Engine<Built, TaskDefinition>,
     pkg_dep_graph: &PackageGraph,
     changed_files: &HashSet<AnchoredSystemPathBuf>,
-) -> HashMap<TaskId<'static>, String> {
+) -> Result<HashMap<TaskId<'static>, String>, AffectednessError> {
     let mut matched = HashMap::new();
 
     // Pre-convert all file paths to Unix strings once, avoiding repeated
@@ -63,9 +79,9 @@ pub fn match_tasks_against_changed_files(
 
     for task_id in engine.task_ids() {
         let pkg_name = PackageName::from(task_id.package());
-        let Some(pkg_dir) = pkg_dep_graph.package_dir(&pkg_name) else {
-            continue;
-        };
+        let pkg_dir = pkg_dep_graph
+            .package_dir(&pkg_name)
+            .ok_or_else(|| AffectednessError::UnknownTaskPackage(pkg_name.clone()))?;
         let pkg_unix = pkg_dir.to_unix();
         let pkg_str = pkg_unix.to_string();
 
@@ -75,9 +91,15 @@ pub fn match_tasks_against_changed_files(
             .unwrap_or(&DEFAULT_TASK_INPUTS);
 
         let cache_key = (pkg_str.clone(), inputs.clone());
-        let compiled = compiled_cache
-            .entry(cache_key)
-            .or_insert_with(|| compile_globs(inputs));
+        if !compiled_cache.contains_key(&cache_key) {
+            let compiled =
+                compile_globs(inputs).map_err(|error| AffectednessError::InvalidGlob {
+                    task: task_id.clone(),
+                    error: error.to_string(),
+                })?;
+            compiled_cache.insert(cache_key.clone(), compiled);
+        }
+        let compiled = &compiled_cache[&cache_key];
 
         let pkg_prefix_slash = if pkg_str.is_empty() {
             String::new()
@@ -93,7 +115,7 @@ pub fn match_tasks_against_changed_files(
         }
     }
 
-    matched
+    Ok(matched)
 }
 
 #[cfg(test)]
@@ -211,7 +233,8 @@ mod tests {
             &engine,
             &pkg_graph,
             &changed(&["packages/lib-a/README.md"]),
-        );
+        )
+        .unwrap();
         assert_eq!(result.len(), 1, "only build should match .md: {result:?}");
         assert!(result.contains_key(&a_build));
 
@@ -220,7 +243,8 @@ mod tests {
             &engine,
             &pkg_graph,
             &changed(&["packages/lib-a/foo.test.ts"]),
-        );
+        )
+        .unwrap();
         assert_eq!(
             result.len(),
             2,
@@ -247,7 +271,8 @@ mod tests {
             &engine,
             &pkg_graph,
             &changed(&["packages/lib-a/src/index.ts"]),
-        );
+        )
+        .unwrap();
         assert_eq!(
             result.len(),
             1,
@@ -278,7 +303,8 @@ mod tests {
         // Only a root-level file changed. lib-a has default inputs so its
         // source dir didn't change. lib-b's $TURBO_ROOT$ input DID change.
         let result =
-            match_tasks_against_changed_files(&engine, &pkg_graph, &changed(&["config.txt"]));
+            match_tasks_against_changed_files(&engine, &pkg_graph, &changed(&["config.txt"]))
+                .unwrap();
         assert!(
             result.contains_key(&b_build),
             "lib-b#build should match via $TURBO_ROOT$ input: {result:?}"
@@ -317,7 +343,8 @@ mod tests {
 
         // Only build-config.txt changes at the root.
         let result =
-            match_tasks_against_changed_files(&engine, &pkg_graph, &changed(&["build-config.txt"]));
+            match_tasks_against_changed_files(&engine, &pkg_graph, &changed(&["build-config.txt"]))
+                .unwrap();
         assert!(
             result.contains_key(&a_build),
             "lib-a#build should match its declared $TURBO_ROOT$ input: {result:?}"
@@ -326,5 +353,20 @@ mod tests {
             !result.contains_key(&a_test),
             "lib-a#test should NOT match a root file it didn't declare: {result:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn unknown_task_package_is_an_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
+        let pkg_graph = make_pkg_graph(root, &[]).await;
+        let unknown = TaskId::new("missing", "build");
+        let engine = make_engine(&[(unknown, TaskDefinition::default())]);
+
+        assert!(matches!(
+            match_tasks_against_changed_files(&engine, &pkg_graph, &changed(&["file.txt"])),
+            Err(AffectednessError::UnknownTaskPackage(package))
+                if package == PackageName::from("missing")
+        ));
     }
 }

--- a/crates/turborepo-engine/src/builder.rs
+++ b/crates/turborepo-engine/src/builder.rs
@@ -18,7 +18,7 @@ use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf, RelativeUnixPathBuf};
 use turborepo_errors::Spanned;
 use turborepo_graph_utils as graph;
 use turborepo_repository::{
-    package_graph::{PackageGraph, PackageName, PackageNode, ROOT_PKG_NAME},
+    package_graph::{PackageGraph, PackageName, ROOT_PKG_NAME},
     task_contracts::TaskEnvironmentDomain,
     toolchain::TaskIOEnvironment,
 };
@@ -459,37 +459,35 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
             let to_task_id = task_id.as_inner().clone().into_owned();
             let to_task_index = engine.get_index(&to_task_id);
 
+            let package = PackageName::from(to_task_id.package());
             let dep_pkgs = self
                 .package_graph
-                .immediate_dependencies_iter(&PackageNode::Workspace(to_task_id.package().into()));
+                .ordering_relationships()
+                .direct_dependencies(&package)?;
 
             let mut has_deps = false;
             let mut has_topo_deps = false;
 
-            topo_deps
-                .iter()
-                .cartesian_product(dep_pkgs.into_iter().flatten())
-                .for_each(|((from, span), dependency_workspace)| {
-                    // We don't need to add an edge from the root node if we're in this branch
-                    if let PackageNode::Workspace(dependency_workspace) = dependency_workspace {
-                        let from_task_id = TaskId::from_graph(dependency_workspace, from);
-                        if self.entrypoint_exclusions.contains(&from_task_id) {
-                            return;
-                        }
-                        if let Some(allowed_tasks) = &allowed_tasks
-                            && !allowed_tasks.contains(&from_task_id)
-                        {
-                            return;
-                        }
-                        let from_task_index = engine.get_index(&from_task_id);
-                        has_topo_deps = true;
-                        engine
-                            .task_graph_mut()
-                            .add_edge(to_task_index, from_task_index, ());
-                        let from_task_id = span.to(from_task_id);
-                        traversal_queue.push_back(from_task_id);
+            topo_deps.iter().cartesian_product(dep_pkgs).for_each(
+                |((from, span), dependency_workspace)| {
+                    let from_task_id = TaskId::from_graph(dependency_workspace, from);
+                    if self.entrypoint_exclusions.contains(&from_task_id) {
+                        return;
                     }
-                });
+                    if let Some(allowed_tasks) = &allowed_tasks
+                        && !allowed_tasks.contains(&from_task_id)
+                    {
+                        return;
+                    }
+                    let from_task_index = engine.get_index(&from_task_id);
+                    has_topo_deps = true;
+                    engine
+                        .task_graph_mut()
+                        .add_edge(to_task_index, from_task_index, ());
+                    let from_task_id = span.to(from_task_id);
+                    traversal_queue.push_back(from_task_id);
+                },
+            );
 
             for (sibling, span) in task_definition
                 .with

--- a/crates/turborepo-engine/src/builder/definitions.rs
+++ b/crates/turborepo-engine/src/builder/definitions.rs
@@ -388,14 +388,22 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
             // which is far too expensive to compute per task just to hand
             // to a toolchain that derives nothing (JavaScript).
             let package = PackageName::from(task_id.as_inner().package());
-            let dependencies: Vec<_> = self
+            let dependency_names = self
                 .package_graph
                 .hash_relationships()
-                .dependency_inputs(&package)
-                .unwrap_or_default()
+                .dependency_inputs(&package)?;
+            let dependencies: Vec<_> = dependency_names
                 .iter()
-                .filter_map(|dependency| self.package_graph.package_task_context(dependency))
-                .collect();
+                .map(|dependency| {
+                    self.package_graph
+                        .package_task_context(dependency)
+                        .ok_or_else(|| {
+                            turborepo_repository::package_graph::RelationshipProjectionError::UnknownPackage(
+                                dependency.clone(),
+                            )
+                        })
+                })
+                .collect::<Result<_, _>>()?;
             let task_args = TaskArgs::new(&self.pass_through_args, &self.requested_tasks);
             let empty_environment = turborepo_repository::toolchain::TaskIOEnvironment::default();
             let context = turborepo_repository::toolchain::TaskIOContext {

--- a/crates/turborepo-engine/src/builder_error.rs
+++ b/crates/turborepo-engine/src/builder_error.rs
@@ -9,7 +9,7 @@
 
 use miette::Diagnostic;
 use thiserror::Error;
-use turborepo_repository::package_graph::PackageName;
+use turborepo_repository::package_graph::{PackageName, RelationshipProjectionError};
 
 use crate::{
     InvalidTaskNameError,
@@ -54,6 +54,8 @@ pub enum Error {
     },
     #[error(transparent)]
     Graph(#[from] turborepo_graph_utils::Error),
+    #[error(transparent)]
+    RelationshipProjection(#[from] RelationshipProjectionError),
     #[error(transparent)]
     #[diagnostic(transparent)]
     InvalidTaskName(Box<InvalidTaskNameError>),

--- a/crates/turborepo-engine/src/lib.rs
+++ b/crates/turborepo-engine/src/lib.rs
@@ -25,7 +25,7 @@ use std::{
     fmt,
 };
 
-pub use affected::match_tasks_against_changed_files;
+pub use affected::{AffectednessError, match_tasks_against_changed_files};
 pub use builder::{EngineBuilder, TaskInheritanceResolver, ValidationMode};
 pub use builder_error::Error as BuilderError;
 pub use builder_errors::{

--- a/crates/turborepo-lib/src/run/task_filter.rs
+++ b/crates/turborepo-lib/src/run/task_filter.rs
@@ -915,7 +915,8 @@ mod tests {
             .collect();
 
         let affected =
-            turborepo_engine::match_tasks_against_changed_files(&engine, &pkg_graph, &changed);
+            turborepo_engine::match_tasks_against_changed_files(&engine, &pkg_graph, &changed)
+                .unwrap();
         assert!(
             affected.contains_key(&a_build),
             "task with $TURBO_ROOT$ input should match root file change"

--- a/crates/turborepo-lib/src/task_change_detector.rs
+++ b/crates/turborepo-lib/src/task_change_detector.rs
@@ -112,9 +112,14 @@ pub fn affected_task_ids(
         return engine.task_ids().cloned().collect();
     }
 
-    turborepo_engine::match_tasks_against_changed_files(engine, pkg_dep_graph, changed_files)
-        .into_keys()
-        .collect()
+    match turborepo_engine::match_tasks_against_changed_files(engine, pkg_dep_graph, changed_files)
+    {
+        Ok(matched) => matched.into_keys().collect(),
+        Err(error) => {
+            tracing::warn!(%error, "unable to project task affectedness; selecting all tasks");
+            engine.task_ids().cloned().collect()
+        }
+    }
 }
 
 /// Returns `true` if any changed file is a global dependency, meaning all
@@ -180,7 +185,7 @@ mod tests {
         package_manager::PackageManager,
     };
     use turborepo_task_id::TaskId;
-    use turborepo_types::TaskDefinition;
+    use turborepo_types::{TaskDefinition, TaskInputs};
 
     use super::*;
     use crate::engine::Building;
@@ -362,5 +367,43 @@ mod tests {
         );
         assert_eq!(result.len(), 1);
         assert!(result.contains(&a_build));
+    }
+
+    #[tokio::test]
+    async fn unknown_task_package_conservatively_selects_all_tasks() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
+        let pkg_graph = make_pkg_graph(root, &[]).await;
+        let unknown = TaskId::new("missing", "build");
+        let engine = make_engine(&[(unknown.clone(), default_def())], &[]);
+
+        let result = affected_task_ids(&engine, &pkg_graph, &changed(&["file.txt"]), &[]);
+        assert_eq!(result, HashSet::from([unknown]));
+    }
+
+    #[tokio::test]
+    async fn invalid_task_glob_conservatively_selects_all_tasks() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
+        let pkg_graph = make_pkg_graph(root, &["lib-a"]).await;
+        let task = TaskId::new("lib-a", "build");
+        let unaffected = TaskId::new("lib-a", "test");
+        let definition = TaskDefinition {
+            inputs: TaskInputs {
+                globs: vec!["[invalid".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let engine = make_engine(
+            &[
+                (task.clone(), definition),
+                (unaffected.clone(), default_def()),
+            ],
+            &[],
+        );
+
+        let result = affected_task_ids(&engine, &pkg_graph, &changed(&["file.txt"]), &[]);
+        assert_eq!(result, HashSet::from([task, unaffected]));
     }
 }

--- a/crates/turborepo-query/src/affected_tasks.rs
+++ b/crates/turborepo-query/src/affected_tasks.rs
@@ -108,6 +108,9 @@ pub fn calculate_affected_tasks(
             AllPackageChangeReason::ScmError { ref error } => {
                 format!("SCM error: {error}")
             }
+            AllPackageChangeReason::ConservativeFallback => {
+                "conservative affectedness fallback".to_string()
+            }
         };
 
         return Ok(engine
@@ -130,8 +133,25 @@ pub fn calculate_affected_tasks(
     // changed files. Uses the shared matching function that iterates ALL
     // engine tasks regardless of package, so tasks with $TURBO_ROOT$ inputs
     // in non-affected packages are correctly detected.
-    let matched =
-        turborepo_engine::match_tasks_against_changed_files(engine, pkg_dep_graph, &changed_files);
+    let matched = match turborepo_engine::match_tasks_against_changed_files(
+        engine,
+        pkg_dep_graph,
+        &changed_files,
+    ) {
+        Ok(matched) => matched,
+        Err(error) => {
+            tracing::error!(?error, "failed to determine affected tasks");
+            return Ok(engine
+                .task_ids()
+                .map(|task_id| AffectedTask {
+                    task_id: task_id.clone(),
+                    reason: TaskChangeReason::AllTasksChanged {
+                        description: "conservative affectedness fallback".to_string(),
+                    },
+                })
+                .collect());
+        }
+    };
     let mut affected: HashMap<TaskId<'static>, TaskChangeReason> = matched
         .into_iter()
         .map(|(task_id, file_path)| (task_id, TaskChangeReason::FileChanged { file_path }))
@@ -473,6 +493,49 @@ mod tests {
             "expected package dependency reason, got {:?}",
             b_task.reason
         );
+    }
+
+    #[tokio::test]
+    async fn invalid_input_glob_conservatively_changes_all_tasks() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
+        let pkg_graph = make_pkg_graph(root, &["lib-a"]).await;
+        let task_id = TaskId::new("lib-a", "build");
+        let unaffected_id = TaskId::new("lib-a", "test");
+        let engine = make_engine(&[
+            (
+                task_id.clone(),
+                TaskDefinition {
+                    inputs: TaskInputs {
+                        globs: vec!["[invalid".to_string()],
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            ),
+            (unaffected_id.clone(), TaskDefinition::default()),
+        ]);
+        let mock: Arc<dyn QueryRun> = Arc::new(MockQueryRun {
+            engine,
+            pkg_dep_graph: pkg_graph,
+            affected_packages: HashMap::new(),
+            changed_files: HashSet::new(),
+            repo_root: root.to_owned(),
+        });
+
+        let affected = calculate_affected_tasks(&mock, None, None).unwrap();
+        let affected: HashMap<_, _> = affected
+            .into_iter()
+            .map(|task| (task.task_id, task.reason))
+            .collect();
+        assert_eq!(affected.len(), 2);
+        for task_id in [task_id, unaffected_id] {
+            assert!(matches!(
+                affected.get(&task_id),
+                Some(TaskChangeReason::AllTasksChanged { description })
+                    if description == "conservative affectedness fallback"
+            ));
+        }
     }
 
     #[tokio::test]

--- a/crates/turborepo-query/src/lib.rs
+++ b/crates/turborepo-query/src/lib.rs
@@ -56,6 +56,8 @@ pub enum Error {
     Serde(#[from] serde_json::Error),
     #[error("Failed to parse file: {0}")]
     Parse(String),
+    #[error("Failed to determine affected tasks.")]
+    AffectedTasks,
 }
 
 // Conversions from constituent error types into Error via the Api variant.
@@ -141,6 +143,9 @@ impl RepositoryQuery {
             }) => PackageChangeReason::GitRefNotFound(GitRefNotFound { from_ref, to_ref }),
             PackageInclusionReason::All(AllPackageChangeReason::ScmError { error }) => {
                 PackageChangeReason::ScmError(ScmError { error })
+            }
+            PackageInclusionReason::All(AllPackageChangeReason::ConservativeFallback) => {
+                PackageChangeReason::AllPackagesChanged(AllPackagesChanged { empty: false })
             }
             PackageInclusionReason::RootTask { task } => PackageChangeReason::RootTask(RootTask {
                 task_name: task.to_string(),
@@ -471,6 +476,12 @@ struct ScmError {
 }
 
 #[derive(SimpleObject)]
+struct AllPackagesChanged {
+    /// This is a nothing field
+    empty: bool,
+}
+
+#[derive(SimpleObject)]
 struct IncludedByFilter {
     filters: Vec<String>,
 }
@@ -524,6 +535,7 @@ enum PackageChangeReason {
     NonPackageFileChanged(NonPackageFileChanged),
     GitRefNotFound(GitRefNotFound),
     ScmError(ScmError),
+    AllPackagesChanged(AllPackagesChanged),
     IncludedByFilter(IncludedByFilter),
     RootTask(RootTask),
     ConservativeRootLockfileChanged(ConservativeRootLockfileChanged),
@@ -629,6 +641,10 @@ impl RepositoryQuery {
             .run
             .calculate_affected_packages(base, head)?
             .into_iter()
+            .filter(|(package, _)| {
+                package != &PackageName::Root
+                    || self.run.pkg_dep_graph().package_view(package).is_some()
+            })
             .map(|(package, reason)| {
                 Ok(ChangedPackage {
                     package: Package::new(self.run.clone(), package)?,
@@ -672,7 +688,10 @@ impl RepositoryQuery {
         let mut changed_tasks: Array<ChangedTask> = results
             .into_iter()
             .map(|at| {
-                let task = task::RepositoryTask::new(&at.task_id, &self.run)?;
+                let task = task::RepositoryTask::new(&at.task_id, &self.run).map_err(|error| {
+                    tracing::error!(?error, task = %at.task_id, "failed to represent affected task");
+                    Error::AffectedTasks
+                })?;
                 let reason = convert_task_change_reason(at.reason);
                 Ok(ChangedTask { reason, task })
             })

--- a/crates/turborepo-query/src/package.rs
+++ b/crates/turborepo-query/src/package.rs
@@ -32,6 +32,14 @@ impl Package {
         Ok(Self { run, name })
     }
 
+    pub fn for_task(run: Arc<dyn QueryRun>, name: PackageName) -> Result<Self, Error> {
+        run.pkg_dep_graph()
+            .package_task_context(&name)
+            .ok_or_else(|| Error::PackageNotFound(name.clone()))?;
+
+        Ok(Self { run, name })
+    }
+
     pub fn run(&self) -> &Arc<dyn QueryRun> {
         &self.run
     }
@@ -178,10 +186,9 @@ impl Package {
         Ok(self
             .run
             .pkg_dep_graph()
-            .package_view(&self.name)
+            .package_task_context(&self.name)
             .ok_or_else(|| Error::PackageNotFound(self.name.clone()))?
             .directory()
-            .ok_or_else(|| Error::PackageNotFound(self.name.clone()))?
             .to_unix()
             .to_string())
     }

--- a/crates/turborepo-query/src/task.rs
+++ b/crates/turborepo-query/src/task.rs
@@ -16,7 +16,7 @@ pub struct RepositoryTask {
 
 impl RepositoryTask {
     pub fn new(task_id: &TaskId, run: &Arc<dyn QueryRun>) -> Result<Self, Error> {
-        let package = Package::new(run.clone(), task_id.package().into())?;
+        let package = Package::for_task(run.clone(), task_id.package().into())?;
         let script = package.get_tasks().get(task_id.task()).cloned();
 
         Ok(RepositoryTask {

--- a/crates/turborepo-repository/src/change_mapper/mod.rs
+++ b/crates/turborepo-repository/src/change_mapper/mod.rs
@@ -15,7 +15,8 @@ use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf};
 use wax::Program;
 
 use crate::package_graph::{
-    ChangedPackagesError, ExternalDependencyChange, PackageGraph, PackageName, WorkspacePackage,
+    ChangedPackagesError, ExternalDependencyChange, PackageGraph, PackageName,
+    RelationshipProjectionError, WorkspacePackage,
 };
 
 mod package;
@@ -90,6 +91,7 @@ pub enum AllPackageChangeReason {
     ScmError {
         error: String,
     },
+    ConservativeFallback,
 }
 
 pub fn merge_changed_packages<T: Hash + Eq>(
@@ -190,7 +192,14 @@ impl<'a, PD: PackageChangeMapper> ChangeMapper<'a, PD> {
                             }),
                         );
 
-                        self.add_relationship_affected_packages(&mut changed_pkgs);
+                        if let Err(error) =
+                            self.add_relationship_affected_packages(&mut changed_pkgs)
+                        {
+                            tracing::error!(%error, "relationship affectedness projection failed");
+                            return Ok(PackageChanges::All(
+                                AllPackageChangeReason::ConservativeFallback,
+                            ));
+                        }
 
                         Ok(PackageChanges::Some(changed_pkgs))
                     }
@@ -210,7 +219,14 @@ impl<'a, PD: PackageChangeMapper> ChangeMapper<'a, PD> {
                     // We don't know if the lockfile changed or not, so we can't assume anything
                     LockfileContents::Unchanged => {
                         debug!("the lockfile did not change");
-                        self.add_relationship_affected_packages(&mut changed_pkgs);
+                        if let Err(error) =
+                            self.add_relationship_affected_packages(&mut changed_pkgs)
+                        {
+                            tracing::error!(%error, "relationship affectedness projection failed");
+                            return Ok(PackageChanges::All(
+                                AllPackageChangeReason::ConservativeFallback,
+                            ));
+                        }
                         Ok(PackageChanges::Some(changed_pkgs))
                     }
                 }
@@ -268,27 +284,25 @@ impl<'a, PD: PackageChangeMapper> ChangeMapper<'a, PD> {
     fn add_relationship_affected_packages(
         &self,
         changed_packages: &mut HashMap<WorkspacePackage, PackageInclusionReason>,
-    ) {
+    ) -> Result<(), RelationshipProjectionError> {
         let mut directly_changed: Vec<_> = changed_packages
             .keys()
             .map(|package| package.name.clone())
             .collect();
         directly_changed.sort();
         for dependency in directly_changed {
-            let Some(affected_packages) = self
+            let affected_packages = self
                 .pkg_graph
                 .affected_relationships()
-                .additional_affected_by(&dependency)
-            else {
-                continue;
-            };
+                .additional_affected_by(&dependency)?;
             for name in affected_packages {
                 if name == dependency {
                     continue;
                 }
-                let Some(context) = self.pkg_graph.package_task_context(&name) else {
-                    continue;
-                };
+                let context = self
+                    .pkg_graph
+                    .package_task_context(&name)
+                    .ok_or_else(|| RelationshipProjectionError::UnknownPackage(name.clone()))?;
                 changed_packages
                     .entry(WorkspacePackage {
                         name,
@@ -299,6 +313,7 @@ impl<'a, PD: PackageChangeMapper> ChangeMapper<'a, PD> {
                     });
             }
         }
+        Ok(())
     }
 
     fn get_changed_packages_from_lockfile(
@@ -333,10 +348,56 @@ pub enum ChangeMapError {
 
 #[cfg(test)]
 mod test {
-    use test_case::test_case;
+    use std::collections::HashSet;
 
-    use super::ChangeMapper;
-    use crate::change_mapper::package::DefaultPackageChangeMapper;
+    use test_case::test_case;
+    use turbopath::{AbsoluteSystemPath, AnchoredSystemPath, AnchoredSystemPathBuf};
+
+    use super::*;
+    use crate::{
+        change_mapper::package::DefaultPackageChangeMapper, package_graph::PackageGraph,
+        package_json::PackageJson, package_manager::PackageManager,
+    };
+
+    struct UnknownPackageMapper;
+
+    impl PackageChangeMapper for UnknownPackageMapper {
+        fn detect_package(&self, _file: &AnchoredSystemPath) -> PackageMapping {
+            PackageMapping::Package((
+                WorkspacePackage {
+                    name: PackageName::from("missing"),
+                    path: AnchoredSystemPathBuf::from_raw("missing").unwrap(),
+                },
+                PackageInclusionReason::FileChanged {
+                    file: AnchoredSystemPathBuf::from_raw("missing/file.txt").unwrap(),
+                },
+            ))
+        }
+    }
+
+    #[tokio::test]
+    async fn unknown_relationship_package_conservatively_changes_all_packages() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(temp.path()).unwrap();
+        let graph = PackageGraph::builder(root, PackageJson::default())
+            .with_single_package_mode(true)
+            .with_package_manager(PackageManager::Npm)
+            .build()
+            .await
+            .unwrap();
+        let mapper = ChangeMapper::new(&graph, Vec::new(), UnknownPackageMapper);
+
+        let changes = mapper
+            .changed_packages(
+                HashSet::from([AnchoredSystemPathBuf::from_raw("missing/file.txt").unwrap()]),
+                LockfileContents::Unchanged,
+            )
+            .unwrap();
+        assert_eq!(
+            changes,
+            PackageChanges::All(AllPackageChangeReason::ConservativeFallback)
+        );
+    }
 
     #[cfg(unix)]
     #[test_case("/a/b/c", &["package.lock"], "/a/b/c/package.lock", true ; "simple")]
@@ -383,8 +444,6 @@ mod test {
             &lockfile_path,
         );
 
-        // we don't want to implement PartialEq on the error type,
-        // so simply compare the debug representations
         assert_eq!(changes, expected);
     }
 }

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -2094,11 +2094,11 @@ mod test {
             graph
                 .filtering_relationships()
                 .transitive_dependencies(&web_name),
-            Some(graph_dependencies.clone())
+            Ok(graph_dependencies.clone())
         );
         assert_eq!(
             graph.hash_relationships().dependency_inputs(&web_name),
-            Some(graph_dependencies)
+            Ok(graph_dependencies)
         );
 
         let mut graph_dependents: Vec<_> = graph
@@ -2114,7 +2114,7 @@ mod test {
             graph
                 .filtering_relationships()
                 .transitive_dependents(&ui_name),
-            Some(graph_dependents.clone())
+            Ok(graph_dependents.clone())
         );
         graph_dependents.push(ui_name.clone());
         graph_dependents.sort();

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -3051,13 +3051,13 @@ version = "0.1.0"
                     .ordering_relationships()
                     .direct_dependencies(&PackageName::from("app"))
                     .map(|dependencies| dependencies.cloned().collect::<Vec<_>>()),
-                Some(vec![PackageName::from("lib-a")])
+                Ok(vec![PackageName::from("lib-a")])
             );
             assert_eq!(
                 pkg_graph
                     .hash_relationships()
                     .dependency_inputs(&PackageName::from("app")),
-                Some(vec![PackageName::from("lib-a"), PackageName::from("lib-b")]),
+                Ok(vec![PackageName::from("lib-a"), PackageName::from("lib-b")]),
                 "mixed repositories retain transitive native hash inputs"
             );
             let workspace_deps = pkg_graph
@@ -3186,7 +3186,7 @@ version = "0.1.0"
                 .ordering_relationships()
                 .direct_dependencies(&PackageName::Root)
                 .map(|dependencies| dependencies.cloned().collect::<Vec<_>>()),
-            Some(Vec::new()),
+            Ok(Vec::new()),
             "pure Cargo recognizes the root Turbo namespace without JS edges"
         );
         assert!(pkg_graph.relationship_projections.get().is_some());
@@ -3194,14 +3194,14 @@ version = "0.1.0"
         let expected_dependencies = vec![PackageName::from("lib-a"), PackageName::from("lib-b")];
         assert_eq!(
             pkg_graph.hash_relationships().dependency_inputs(&app),
-            Some(expected_dependencies.clone()),
+            Ok(expected_dependencies.clone()),
             "Cargo hash inputs include transitive path dependencies"
         );
         assert_eq!(
             pkg_graph
                 .filtering_relationships()
                 .transitive_dependencies(&app),
-            Some(expected_dependencies.clone())
+            Ok(expected_dependencies.clone())
         );
         let mut graph_dependencies: Vec<_> = pkg_graph
             .dependencies(&PackageNode::Workspace(app.clone()))

--- a/crates/turborepo-repository/src/package_graph/projections.rs
+++ b/crates/turborepo-repository/src/package_graph/projections.rs
@@ -178,32 +178,36 @@ impl RelationshipIndex {
         }
     }
 
-    fn id(&self, package: &PackageName) -> Option<ScopeId> {
+    fn id(&self, package: &PackageName) -> Result<ScopeId, RelationshipProjectionError> {
         match package {
-            PackageName::Root => Some(self.root),
-            PackageName::Other(name) => self.non_root_lookup.get(name.as_str()).copied(),
+            PackageName::Root => Ok(self.root),
+            PackageName::Other(name) => self
+                .non_root_lookup
+                .get(name.as_str())
+                .copied()
+                .ok_or_else(|| RelationshipProjectionError::UnknownPackage(package.clone())),
         }
     }
 
     fn ids(&self, packages: &[PackageName]) -> Result<Vec<ScopeId>, RelationshipProjectionError> {
-        packages
-            .iter()
-            .map(|package| {
-                self.id(package)
-                    .ok_or_else(|| RelationshipProjectionError::UnknownPackage(package.clone()))
-            })
-            .collect()
+        packages.iter().map(|package| self.id(package)).collect()
     }
 
-    fn transitive_dependencies(&self, package: &PackageName) -> Option<Vec<PackageName>> {
+    fn transitive_dependencies(
+        &self,
+        package: &PackageName,
+    ) -> Result<Vec<PackageName>, RelationshipProjectionError> {
         let package = self.id(package)?;
         let mut members = closure_members(&self.ordering, &[package]);
         include_ids(&mut members, &self.root_ordering_inputs);
         members[package.index()] = false;
-        Some(self.names_from_members(&members))
+        Ok(self.names_from_members(&members))
     }
 
-    fn transitive_dependents(&self, package: &PackageName) -> Option<Vec<PackageName>> {
+    fn transitive_dependents(
+        &self,
+        package: &PackageName,
+    ) -> Result<Vec<PackageName>, RelationshipProjectionError> {
         let package = self.id(package)?;
         let mut members = if self.is_root_ordering_input[package.index()] {
             vec![true; self.names.len()]
@@ -211,15 +215,18 @@ impl RelationshipIndex {
             closure_members(&self.reverse_ordering, &[package])
         };
         members[package.index()] = false;
-        Some(self.names_from_members(&members))
+        Ok(self.names_from_members(&members))
     }
 
-    fn transitive_input_dependencies(&self, package: &PackageName) -> Option<Vec<PackageName>> {
+    fn transitive_input_dependencies(
+        &self,
+        package: &PackageName,
+    ) -> Result<Vec<PackageName>, RelationshipProjectionError> {
         let package = self.id(package)?;
         let mut members = closure_members(&self.inputs, &[package]);
         include_ids(&mut members, &self.root_input_dependencies);
         members[package.index()] = false;
-        Some(self.names_from_members(&members))
+        Ok(self.names_from_members(&members))
     }
 
     fn names_from_members(&self, members: &[bool]) -> Vec<PackageName> {
@@ -319,7 +326,8 @@ fn member_ids(members: &[bool]) -> Box<[ScopeId]> {
 pub struct OrderingRelationships(Arc<RelationshipIndex>);
 
 impl OrderingRelationships {
-    /// Returns direct internal dependencies, or `None` for an unknown package.
+    /// Returns direct internal dependencies or an explicit unknown-package
+    /// error.
     ///
     /// The root Turbo namespace is always recognized. In a pure native
     /// repository it has no declared dependencies. The opaque iterator borrows
@@ -327,14 +335,14 @@ impl OrderingRelationships {
     pub fn direct_dependencies(
         &self,
         package: &PackageName,
-    ) -> Option<impl ExactSizeIterator<Item = &PackageName> + DoubleEndedIterator + Clone + '_>
-    {
+    ) -> Result<
+        impl ExactSizeIterator<Item = &PackageName> + DoubleEndedIterator + Clone + '_,
+        RelationshipProjectionError,
+    > {
         let id = self.0.id(package)?;
-        Some(
-            self.0.ordering[id.index()]
-                .iter()
-                .map(|dependency| &self.0.names[dependency.index()]),
-        )
+        Ok(self.0.ordering[id.index()]
+            .iter()
+            .map(|dependency| &self.0.names[dependency.index()]))
     }
 }
 
@@ -347,16 +355,21 @@ impl OrderingRelationships {
 pub struct FilteringRelationships(Arc<RelationshipIndex>);
 
 impl FilteringRelationships {
-    /// Returns sorted transitive dependencies excluding `package`, or `None`
-    /// when the package is unknown.
-    pub fn transitive_dependencies(&self, package: &PackageName) -> Option<Vec<PackageName>> {
+    /// Returns sorted transitive dependencies excluding `package`.
+    pub fn transitive_dependencies(
+        &self,
+        package: &PackageName,
+    ) -> Result<Vec<PackageName>, RelationshipProjectionError> {
         self.0.transitive_dependencies(package)
     }
 
-    /// Returns sorted transitive dependents excluding `package`, or `None` when
-    /// the package is unknown. A root internal input has every other
-    /// authoritative identity as a dependent.
-    pub fn transitive_dependents(&self, package: &PackageName) -> Option<Vec<PackageName>> {
+    /// Returns sorted transitive dependents excluding `package`. A root
+    /// internal input has every other authoritative identity as a
+    /// dependent.
+    pub fn transitive_dependents(
+        &self,
+        package: &PackageName,
+    ) -> Result<Vec<PackageName>, RelationshipProjectionError> {
         self.0.transitive_dependents(package)
     }
 
@@ -410,7 +423,10 @@ impl AffectedRelationships {
     /// Returns dependents reached only through non-ordering input
     /// relationships. Ordinary ordering dependents are excluded so callers can
     /// preserve their existing graph-expansion behavior.
-    pub fn additional_affected_by(&self, package: &PackageName) -> Option<Vec<PackageName>> {
+    pub fn additional_affected_by(
+        &self,
+        package: &PackageName,
+    ) -> Result<Vec<PackageName>, RelationshipProjectionError> {
         let seed = self.0.id(package)?;
         let input_members = if self.0.is_root_input_dependency[seed.index()] {
             vec![true; self.0.names.len()]
@@ -427,7 +443,7 @@ impl AffectedRelationships {
             .zip(ordering_members)
             .map(|(input, ordering)| *input && !ordering)
             .collect::<Vec<_>>();
-        Some(self.0.names_from_members(&additional))
+        Ok(self.0.names_from_members(&additional))
     }
 }
 
@@ -440,9 +456,12 @@ pub struct HashRelationships(Arc<RelationshipIndex>);
 
 impl HashRelationships {
     /// Returns the full transitive internal dependency inputs, including
-    /// implied root inputs and excluding `package`, or `None` if unknown.
+    /// implied root inputs and excluding `package`.
     /// Output is sorted and deduplicated.
-    pub fn dependency_inputs(&self, package: &PackageName) -> Option<Vec<PackageName>> {
+    pub fn dependency_inputs(
+        &self,
+        package: &PackageName,
+    ) -> Result<Vec<PackageName>, RelationshipProjectionError> {
         self.0.transitive_input_dependencies(package)
     }
 
@@ -696,14 +715,14 @@ mod tests {
                 .ordering()
                 .direct_dependencies(&app)
                 .map(|dependencies| dependencies.cloned().collect::<Vec<_>>()),
-            Some(names(&["dev", "optional", "prod", "required-peer"]))
+            Ok(names(&["dev", "optional", "prod", "required-peer"]))
         );
         assert_eq!(
             projections
                 .ordering()
                 .direct_dependencies(&name("disconnected"))
                 .map(|dependencies| dependencies.cloned().collect::<Vec<_>>()),
-            Some(Vec::new())
+            Ok(Vec::new())
         );
         let transitive = names(&[
             "dev",
@@ -715,16 +734,13 @@ mod tests {
         ]);
         assert_eq!(
             projections.filtering().transitive_dependencies(&app),
-            Some(transitive.clone())
+            Ok(transitive.clone())
         );
         let mut hash_inputs = transitive;
         hash_inputs.push(name("input-only"));
         hash_inputs.push(name("optional-peer"));
         hash_inputs.sort();
-        assert_eq!(
-            projections.hash().dependency_inputs(&app),
-            Some(hash_inputs)
-        );
+        assert_eq!(projections.hash().dependency_inputs(&app), Ok(hash_inputs));
         assert_eq!(
             projections.hash().root_inputs(),
             names(&["optional-peer", "root-lib"])
@@ -755,19 +771,19 @@ mod tests {
             projections
                 .affected()
                 .additional_affected_by(&name("input-only")),
-            Some(names(&["app"]))
+            Ok(names(&["app"]))
         );
         assert_eq!(
             projections
                 .affected()
                 .additional_affected_by(&name("transitive")),
-            Some(Vec::new())
+            Ok(Vec::new())
         );
         assert_eq!(
             projections
                 .affected()
                 .additional_affected_by(&name("optional-peer")),
-            Some(with_root(names(&[
+            Ok(with_root(names(&[
                 "app",
                 "cycle-a",
                 "cycle-b",
@@ -824,7 +840,7 @@ mod tests {
         assert!(!all_but_root_lib.contains(&root_lib));
         assert_eq!(
             projections.filtering().transitive_dependencies(&cycle_a),
-            Some(names(&["cycle-b", "root-lib"]))
+            Ok(names(&["cycle-b", "root-lib"]))
         );
         assert_eq!(
             projections.prune().package_closure(
@@ -851,6 +867,26 @@ mod tests {
             ])))
         );
         let unknown = name("missing");
+        assert!(matches!(
+            projections.ordering().direct_dependencies(&unknown),
+            Err(RelationshipProjectionError::UnknownPackage(package)) if package == unknown
+        ));
+        assert_eq!(
+            projections.filtering().transitive_dependencies(&unknown),
+            Err(RelationshipProjectionError::UnknownPackage(unknown.clone()))
+        );
+        assert_eq!(
+            projections.filtering().transitive_dependents(&unknown),
+            Err(RelationshipProjectionError::UnknownPackage(unknown.clone()))
+        );
+        assert_eq!(
+            projections.affected().additional_affected_by(&unknown),
+            Err(RelationshipProjectionError::UnknownPackage(unknown.clone()))
+        );
+        assert_eq!(
+            projections.hash().dependency_inputs(&unknown),
+            Err(RelationshipProjectionError::UnknownPackage(unknown.clone()))
+        );
         assert_eq!(
             projections
                 .filtering()
@@ -880,7 +916,7 @@ mod tests {
                 .ordering()
                 .direct_dependencies(&PackageName::Root)
                 .map(|dependencies| dependencies.cloned().collect::<Vec<_>>()),
-            Some(Vec::new())
+            Ok(Vec::new())
         );
         assert!(projections.hash().root_inputs().is_empty());
         assert_eq!(

--- a/crates/turborepo-scope/src/filter.rs
+++ b/crates/turborepo-scope/src/filter.rs
@@ -13,7 +13,7 @@ use tracing::debug;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
 use turborepo_repository::{
     change_mapper::{ChangeMapError, PackageInclusionReason, merge_changed_packages},
-    package_graph::{self, PackageGraph, PackageName},
+    package_graph::{PackageGraph, PackageName},
 };
 use turborepo_scm::SCM;
 use turborepo_types::FilterMode;
@@ -462,16 +462,15 @@ impl<'a, T: GitChangeDetector> FilterResolver<'a, T> {
             }
 
             for (package, reason) in selector_packages {
-                let node = package_graph::PackageNode::Workspace(package.clone());
-
                 if selector.include_dependencies {
-                    let dependencies = self.pkg_graph.dependencies(&node);
-                    let dependencies = dependencies
-                        .iter()
-                        .filter(|node| !matches!(node, package_graph::PackageNode::Root))
-                        .map(|i| {
+                    let dependencies = self
+                        .pkg_graph
+                        .filtering_relationships()
+                        .transitive_dependencies(&package)?
+                        .into_iter()
+                        .map(|dependency| {
                             (
-                                i.as_package_name().to_owned(),
+                                dependency,
                                 // While we're adding dependencies, from their
                                 // perspective, they were changed because
                                 // of a *dependent*
@@ -482,13 +481,16 @@ impl<'a, T: GitChangeDetector> FilterResolver<'a, T> {
                         })
                         .collect::<Vec<_>>();
 
-                    // flatmap through the option, the set, and then the optional package name
+                    // Merge the explicit, validated filtering projection.
                     merge_changed_packages(&mut walked_dependencies, dependencies);
                 }
 
                 if selector.include_dependents {
-                    let dependents = self.pkg_graph.ancestors(&node);
-                    for dependent in dependents.iter().map(|i| i.as_package_name()) {
+                    let dependents = self
+                        .pkg_graph
+                        .filtering_relationships()
+                        .transitive_dependents(&package)?;
+                    for dependent in &dependents {
                         walked_dependents.insert(
                             dependent.clone(),
                             // While we're adding dependents, from their
@@ -505,29 +507,15 @@ impl<'a, T: GitChangeDetector> FilterResolver<'a, T> {
                     // dependent. The closure includes the dependents
                     // themselves, but they already carry the same inclusion
                     // reason via `walked_dependents`, which takes precedence
-                    // in the merge below. Like `dependencies`, the root
+                    // in the merge below. Like the dependency projection, the root
                     // package's own dependencies count as implied
                     // dependencies of every dependent.
                     if selector.include_dependencies && !dependents.is_empty() {
-                        let dependent_nodes: Vec<package_graph::PackageNode> = dependents
-                            .iter()
-                            .map(|i| {
-                                package_graph::PackageNode::Workspace(i.as_package_name().clone())
-                            })
-                            .collect();
-
                         let dependent_dependencies = self
                             .pkg_graph
-                            .transitive_closure(dependent_nodes.iter())
+                            .filtering_relationships()
+                            .dependency_closure(&dependents)?
                             .into_iter()
-                            .filter(|node| !matches!(node, package_graph::PackageNode::Root))
-                            .map(|i| i.as_package_name().to_owned())
-                            .chain(
-                                self.pkg_graph
-                                    .root_internal_package_dependencies()
-                                    .into_iter()
-                                    .map(|workspace| workspace.name),
-                            )
                             .map(|name| {
                                 (
                                     name,
@@ -657,21 +645,20 @@ impl<'a, T: GitChangeDetector> FilterResolver<'a, T> {
         // latter with reverse traversals from the changed set is much cheaper
         // than computing a forward dependency closure for every candidate
         // package: the changed set is typically far smaller than the package
-        // count. `ancestors` also matches the semantics of `dependencies`
-        // here, including treating the root package's dependencies as implied
+        // count. The reverse filtering projection matches forward dependency
+        // semantics, including treating the root package's dependencies as implied
         // dependencies of every package.
         let mut dependent_on_changed = HashSet::new();
         for changed_package in changed_packages.keys() {
-            let changed_node = package_graph::PackageNode::Workspace(changed_package.to_owned());
-            for ancestor in self.pkg_graph.ancestors(&changed_node) {
-                // `dependencies` never includes the package itself, so a
+            for ancestor in self
+                .pkg_graph
+                .filtering_relationships()
+                .transitive_dependents(changed_package)?
+            {
+                // Filtering projections never include the package itself, so a
                 // package's own change must not mark it as depending on a
                 // changed package; self-selection is handled below.
-                if *ancestor != changed_node
-                    && !matches!(ancestor, package_graph::PackageNode::Root)
-                {
-                    dependent_on_changed.insert(ancestor.as_package_name().clone());
-                }
+                dependent_on_changed.insert(ancestor);
             }
         }
 
@@ -904,6 +891,10 @@ pub enum ResolutionError {
     DirectoryDoesNotExist(AbsoluteSystemPathBuf),
     #[error("failed to construct glob for globalDependencies")]
     GlobalDependenciesGlob(#[from] turborepo_repository::change_mapper::Error),
+    #[error(transparent)]
+    RelationshipProjection(
+        #[from] turborepo_repository::package_graph::RelationshipProjectionError,
+    ),
 }
 
 #[cfg(test)]

--- a/crates/turborepo-types/Cargo.toml
+++ b/crates/turborepo-types/Cargo.toml
@@ -17,7 +17,6 @@ schemars = { workspace = true }
 secrecy = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-tracing = { workspace = true }
 ts-rs = { workspace = true }
 turbopath = { workspace = true }
 turborepo-errors = { workspace = true }

--- a/crates/turborepo-types/src/task_input_matching.rs
+++ b/crates/turborepo-types/src/task_input_matching.rs
@@ -42,17 +42,15 @@ pub struct CompiledGlobs {
 
 /// Pre-compiles a task's input globs for efficient matching against many files.
 ///
-/// Invalid globs are logged at `warn` level and skipped.
-///
 /// When `inputs` has no globs and `default` is false (representing either
 /// `inputs: []` or a missing `inputs` key), the compiled result will match
 /// all files — see [`check_compiled_globs`] for details.
-pub fn compile_globs(inputs: &TaskInputs) -> CompiledGlobs {
-    let (inclusions, exclusions, has_traversal_globs) = compile_patterns(&inputs.globs);
+pub fn compile_globs(inputs: &TaskInputs) -> Result<CompiledGlobs, wax::BuildError> {
+    let (inclusions, exclusions, has_traversal_globs) = compile_patterns(&inputs.globs)?;
     let (jit_inclusions, jit_exclusions, jit_has_traversal_globs) =
-        compile_patterns(&inputs.jit_globs);
+        compile_patterns(&inputs.jit_globs)?;
 
-    CompiledGlobs {
+    Ok(CompiledGlobs {
         inclusions,
         exclusions,
         jit_inclusions,
@@ -62,10 +60,12 @@ pub fn compile_globs(inputs: &TaskInputs) -> CompiledGlobs {
         eager: inputs.eager,
         has_traversal_globs,
         jit_has_traversal_globs,
-    }
+    })
 }
 
-fn compile_patterns(globs: &[String]) -> (Vec<wax::Glob<'static>>, Vec<wax::Glob<'static>>, bool) {
+fn compile_patterns(
+    globs: &[String],
+) -> Result<(Vec<wax::Glob<'static>>, Vec<wax::Glob<'static>>, bool), wax::BuildError> {
     let mut inclusions = Vec::new();
     let mut exclusions = Vec::new();
     let mut has_traversal_globs = false;
@@ -75,34 +75,16 @@ fn compile_patterns(globs: &[String]) -> (Vec<wax::Glob<'static>>, Vec<wax::Glob
             if stripped.starts_with("../") {
                 has_traversal_globs = true;
             }
-            match wax::Glob::new(stripped) {
-                Ok(glob) => exclusions.push(glob.into_owned()),
-                Err(e) => {
-                    tracing::warn!(
-                        glob = %stripped,
-                        error = %e,
-                        "invalid exclusion glob in task inputs; ignoring for affected detection"
-                    );
-                }
-            }
+            exclusions.push(wax::Glob::new(stripped)?.into_owned());
         } else {
             if glob_str.starts_with("../") {
                 has_traversal_globs = true;
             }
-            match wax::Glob::new(glob_str) {
-                Ok(glob) => inclusions.push(glob.into_owned()),
-                Err(e) => {
-                    tracing::warn!(
-                        glob = %glob_str,
-                        error = %e,
-                        "invalid inclusion glob in task inputs; ignoring for affected detection"
-                    );
-                }
-            }
+            inclusions.push(wax::Glob::new(glob_str)?.into_owned());
         }
     }
 
-    (inclusions, exclusions, has_traversal_globs)
+    Ok((inclusions, exclusions, has_traversal_globs))
 }
 
 /// Checks whether a changed file matches pre-compiled task input globs.
@@ -246,7 +228,7 @@ mod tests {
     use crate::{DependencyOutputsInput, TaskInputs};
 
     fn assert_match(file: &str, pkg: &str, inputs: &TaskInputs, expected: bool) {
-        let compiled = compile_globs(inputs);
+        let compiled = compile_globs(inputs).unwrap();
         let f = AnchoredSystemPathBuf::from_raw(file).unwrap();
         let p = RelativeUnixPathBuf::new(pkg.to_string()).unwrap();
         assert_eq!(
@@ -506,21 +488,13 @@ mod tests {
     }
 
     #[test]
-    fn invalid_glob_is_skipped_gracefully() {
-        // An invalid glob should be silently skipped, not panic.
-        // The valid glob should still work.
+    fn invalid_glob_returns_error() {
         let inputs = TaskInputs {
             globs: vec!["[invalid".to_string(), "src/**/*.ts".to_string()],
             default: false,
             ..Default::default()
         };
-        assert_match(
-            "packages/lib-a/src/index.ts",
-            "packages/lib-a",
-            &inputs,
-            true,
-        );
-        assert_match("packages/lib-a/README.md", "packages/lib-a", &inputs, false);
+        assert!(compile_globs(&inputs).is_err());
     }
 
     #[test]

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -300,6 +300,12 @@ their sources still invalidate and affect consumers without creating task graph
 cycles. Cargo path, development, optional, build, target-specific, and automatic
 member relationships are emitted directly from `cargo metadata`; no synthetic
 JavaScript dependency maps or behavioral affectedness callback remain.
+Relationship projections reject unknown package identities instead of
+normalizing them to empty traversals. Engine construction and explicit scope
+queries propagate that invariant error; affectedness paths conservatively
+select all packages or tasks so they cannot under-report changes.
+If a selected task cannot be represented by the query API, the query returns an
+opaque error rather than partial task data.
 
 #### Repository Contributors (`crates/turborepo-repository/src/toolchain.rs`)
 

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -300,12 +300,6 @@ their sources still invalidate and affect consumers without creating task graph
 cycles. Cargo path, development, optional, build, target-specific, and automatic
 member relationships are emitted directly from `cargo metadata`; no synthetic
 JavaScript dependency maps or behavioral affectedness callback remain.
-Relationship projections reject unknown package identities instead of
-normalizing them to empty traversals. Engine construction and explicit scope
-queries propagate that invariant error; affectedness paths conservatively
-select all packages or tasks so they cannot under-report changes.
-If a selected task cannot be represented by the query API, the query returns an
-opaque error rather than partial task data.
 
 #### Repository Contributors (`crates/turborepo-repository/src/toolchain.rs`)
 

--- a/crates/turborepo/tests/relationship_projection_contract.rs
+++ b/crates/turborepo/tests/relationship_projection_contract.rs
@@ -435,11 +435,11 @@ async fn typed_projections_match_the_contract_fixture_graph_and_prune_closures()
         graph
             .filtering_relationships()
             .transitive_dependencies(&app),
-        Some(graph_dependencies.clone())
+        Ok(graph_dependencies.clone())
     );
     assert_eq!(
         graph.hash_relationships().dependency_inputs(&app),
-        Some(graph_dependencies)
+        Ok(graph_dependencies)
     );
 
     let changed = PackageName::from("transitive-lib");
@@ -474,7 +474,7 @@ async fn typed_projections_match_the_contract_fixture_graph_and_prune_closures()
         graph
             .filtering_relationships()
             .transitive_dependents(&root_input),
-        Some(graph_root_dependents)
+        Ok(graph_root_dependents)
     );
     let mut graph_root_affected: Vec<_> = graph_root_ancestors
         .into_iter()

--- a/crates/turborepo/tests/snapshots/query__basic_monorepo_get_schema_(npm@10.5.0).snap
+++ b/crates/turborepo/tests/snapshots/query__basic_monorepo_get_schema_(npm@10.5.0).snap
@@ -12,6 +12,33 @@ expression: query_output
       "subscriptionType": null,
       "types": [
         {
+          "kind": "OBJECT",
+          "name": "AllPackagesChanged",
+          "description": null,
+          "fields": [
+            {
+              "name": "empty",
+              "description": "This is a nothing field",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "SCALAR",
           "name": "Boolean",
           "description": "The `Boolean` scalar type represents `true` or `false`.",
@@ -1783,6 +1810,11 @@ expression: query_output
             {
               "kind": "OBJECT",
               "name": "ScmError",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "AllPackagesChanged",
               "ofType": null
             },
             {


### PR DESCRIPTION
## Summary

- Return explicit errors when relationship projections receive unknown package identities.
- Propagate projection failures through engine construction and scope queries while affectedness conservatively selects all packages or tasks.
- Keep GraphQL fallback reasons generic, prevent partial task results, and support root tasks without exposing the synthetic root as a package.
- Add regression coverage for unknown packages and invalid task globs.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p turborepo-repository`
- `cargo test -p turborepo-query`
- `cargo test -p turborepo-lib task_change_detector`
- `cargo test -p turbo --test relationship_projection_contract`
- `cargo clippy -p turborepo-types -p turborepo-repository -p turborepo-engine -p turborepo-scope -p turborepo-query -p turborepo-lib -p turbo --all-targets -- -D warnings`
- Pre-push hooks