### PR TITLE
refactor: Resolve MFE package ownership from graph

### DIFF
--- a/crates/turborepo-lib/src/cli/error.rs
+++ b/crates/turborepo-lib/src/cli/error.rs
@@ -145,7 +145,7 @@ mod tests {
         assert!(matches!(cli_err, Error::GetMfePort(_)));
         assert_eq!(
             cli_err.to_string(),
-            "No package.json found in current directory"
+            "Current directory does not belong to a named JavaScript package"
         );
 
         // Test NoPackageName error

--- a/crates/turborepo-lib/src/commands/get_mfe_port.rs
+++ b/crates/turborepo-lib/src/commands/get_mfe_port.rs
@@ -1,23 +1,23 @@
-use std::{io, io::ErrorKind};
+use std::io;
 
 use thiserror::Error;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 use turborepo_microfrontends::TurborepoMfeConfig;
-use turborepo_repository::{
-    cargo::CARGO_TOML,
-    package_graph::{PackageGraph, PackageGraphNodeKind, PackageName, PackageNode},
-    package_json::PackageJson,
+use turborepo_repository::package_graph::{
+    PackageGraph, PackageGraphNodeKind, PackageName, PackageNode,
 };
 
 use crate::{
-    commands::CommandBase, microfrontends::MicrofrontendsConfigs, run::builder::cargo_enabled,
+    commands::CommandBase,
+    microfrontends::MicrofrontendsConfigs,
+    run::builder::{cargo_enabled, load_root_package_json},
 };
 
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("Failed to get current working directory: {0}")]
     Cwd(#[from] turbopath::PathError),
-    #[error("No package.json found in current directory")]
+    #[error("Current directory does not belong to a named JavaScript package")]
     NoPackageJson,
     #[error("package.json is missing the 'name' field")]
     NoPackageName,
@@ -52,19 +52,8 @@ async fn get_port_for_current_package(base: &CommandBase) -> Result<u16, Error> 
 
 async fn build_package_graph(base: &CommandBase) -> Result<PackageGraph, Error> {
     let repo_root = &base.repo_root;
-    let root_package_json_path = repo_root.join_component("package.json");
     let cargo_enabled = cargo_enabled(&base.opts().future_flags);
-    let root_package_json = match PackageJson::load(&root_package_json_path) {
-        Ok(package_json) => Some(package_json),
-        Err(turborepo_repository::package_json::Error::Io(io))
-            if io.kind() == ErrorKind::NotFound
-                && cargo_enabled
-                && repo_root.join_component(CARGO_TOML).exists() =>
-        {
-            None
-        }
-        Err(error) => return Err(error.into()),
-    };
+    let root_package_json = load_root_package_json(repo_root, cargo_enabled)?;
 
     let mut builder = PackageGraph::builder_optional(repo_root, root_package_json)
         .with_single_package_mode(base.opts().run_opts.single_package)
@@ -119,28 +108,10 @@ fn package_for_directory(
     }
 }
 
-fn check_exact_cwd_manifest(
-    repo_root: &AbsoluteSystemPath,
-    cwd: &AbsoluteSystemPath,
-) -> Result<(), Error> {
-    let Ok(relative) = repo_root.anchor(cwd) else {
-        return Err(Error::NoPackageJson);
-    };
-    let manifest = cwd.join_component("package.json");
-    if manifest.exists() || relative.as_str().is_empty() {
-        let package_json = PackageJson::load(&manifest).map_err(|_| Error::NoPackageJson)?;
-        if package_json.name.is_none() {
-            return Err(Error::NoPackageName);
-        }
-    }
-    Ok(())
-}
-
 async fn get_port_for_current_package_at(
     base: &CommandBase,
     cwd: &AbsoluteSystemPath,
 ) -> Result<u16, Error> {
-    check_exact_cwd_manifest(&base.repo_root, cwd)?;
     let package_graph = build_package_graph(base).await?;
     let package_name = package_for_directory(&package_graph, &base.repo_root, cwd)?;
     get_port_from_graph(base, &package_graph, &package_name)
@@ -526,26 +497,85 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_exact_unnamed_and_malformed_workspace_errors_precede_graph_identity() {
-        for (manifest, expected_unnamed) in [(r#"{}"#, true), ("{", false)] {
-            let tmp = TempDir::new().unwrap();
-            let repo_root = setup_test_repo(&tmp);
-            let app = repo_root.join_components(&["apps", "web"]);
-            app.create_dir_all().unwrap();
-            app.join_component("package.json")
-                .create_with_contents(manifest)
-                .unwrap();
-            let base = create_command_base(repo_root);
+    async fn test_unnamed_workspace_has_no_authoritative_owner() {
+        let tmp = TempDir::new().unwrap();
+        let repo_root = setup_test_repo(&tmp);
+        let app = repo_root.join_components(&["apps", "web"]);
+        app.create_dir_all().unwrap();
+        app.join_component("package.json")
+            .create_with_contents(r#"{}"#)
+            .unwrap();
+        let base = create_command_base(repo_root);
 
-            let error = get_port_for_current_package_at(&base, &app)
-                .await
-                .unwrap_err();
-            assert!(if expected_unnamed {
-                matches!(error, Error::NoPackageName)
-            } else {
-                matches!(error, Error::NoPackageJson)
-            });
-        }
+        assert!(matches!(
+            get_port_for_current_package_at(&base, &app).await,
+            Err(Error::NoPackageJson)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_malformed_registered_workspace_returns_package_graph_error() {
+        let tmp = TempDir::new().unwrap();
+        let repo_root = setup_test_repo(&tmp);
+        let app = repo_root.join_components(&["apps", "web"]);
+        app.create_dir_all().unwrap();
+        app.join_component("package.json")
+            .create_with_contents("{")
+            .unwrap();
+        let base = create_command_base(repo_root);
+
+        assert!(matches!(
+            get_port_for_current_package_at(&base, &app).await,
+            Err(Error::PackageGraph(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_unnamed_root_returns_no_package_name() {
+        let tmp = TempDir::new().unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(tmp.path().to_path_buf()).unwrap();
+        repo_root
+            .join_component("package.json")
+            .create_with_contents(r#"{"packageManager":"pnpm@9.0.0","workspaces":["apps/*"]}"#)
+            .unwrap();
+        repo_root
+            .join_component("pnpm-workspace.yaml")
+            .create_with_contents("packages:\n  - 'apps/*'\n")
+            .unwrap();
+        let base = create_command_base(repo_root.clone());
+
+        assert!(matches!(
+            get_port_for_current_package_at(&base, &repo_root).await,
+            Err(Error::NoPackageName)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_unregistered_nested_manifest_does_not_override_graph_owner() {
+        let tmp = TempDir::new().unwrap();
+        let repo_root = setup_test_repo(&tmp);
+        let shell = repo_root.join_components(&["apps", "shell"]);
+        let src = shell.join_component("src");
+        src.create_dir_all().unwrap();
+        shell
+            .join_component("package.json")
+            .create_with_contents(r#"{"name":"shell"}"#)
+            .unwrap();
+        src.join_component("package.json")
+            .create_with_contents("{")
+            .unwrap();
+        shell
+            .join_component("microfrontends.json")
+            .create_with_contents(
+                r#"{"version":"1","applications":{"shell":{"development":{"local":3010}}}}"#,
+            )
+            .unwrap();
+        let base = create_command_base(repo_root);
+
+        assert_eq!(
+            get_port_for_current_package_at(&base, &src).await.unwrap(),
+            3010
+        );
     }
 
     #[tokio::test]
@@ -696,7 +726,7 @@ mod tests {
         let err = Error::NoPackageJson;
         assert_eq!(
             err.to_string(),
-            "No package.json found in current directory"
+            "Current directory does not belong to a named JavaScript package"
         );
 
         let err = Error::NoPackageName;


### PR DESCRIPTION
## Summary

- Remove `get_mfe_port`'s direct current-directory `package.json` read and native-manifest probing.
- Reuse the shared root manifest loader and resolve package ownership exclusively from repository graph knowledge.
- Preserve root, nested workspace, Cargo, and mixed-repository ownership behavior while surfacing accurate graph and ownership errors.
- Add coverage proving unregistered nested manifests cannot override the authoritative package owner.

## Tracking

Part of TURBO-5799, specifically the final verification requirement to remove direct native-manifest reads.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p turborepo-lib get_mfe_port`
- `cargo clippy -p turborepo-lib --all-targets -- -D warnings`
- Pre-push hooks