### PR TITLE
test: Add uv workspace integration coverage

### DIFF
--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -248,6 +248,13 @@ jobs:
           - name: Install Bun
             uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
 
+          - name: Setup uv
+            if: runner.os == 'Linux'
+            uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+            with:
+              version: "0.12.0"
+              enable-cache: false
+
       - parallel:
           - name: Install cargo-nextest
             if: runner.os == 'Windows'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,7 @@ You will need to have these dependencies installed on your machine to work on th
 ### Optional dependencies
 
 - [Bun](https://bun.sh) is required to build `@turbo/gen` (the `turbo gen` code generator). The `@turbo/gen` package is compiled into a standalone binary using `bun build --compile`.
+- [uv](https://docs.astral.sh/uv/getting-started/installation/) is required to run the Python workspace integration tests (`crates/turborepo/tests/uv_workspace_test.rs`); tests that execute uv skip when it is not installed.
 - For running tests locally, `jq` and `zstd` are also required.
   - macOS: `brew install jq zstd`
   - Linux: `sudo apt update && sudo apt install jq zstd`

--- a/apps/docs/content/docs/guides/multi-language.mdx
+++ b/apps/docs/content/docs/guides/multi-language.mdx
@@ -9,6 +9,7 @@ prerequisites:
   - /docs/crafting-your-repository/configuring-tasks
 related:
   - /docs/guides/tools/rust
+  - /docs/guides/tools/python
   - /docs/guides/migrating-from-nx
 ---
 

--- a/apps/docs/content/docs/guides/tools/python.mdx
+++ b/apps/docs/content/docs/guides/tools/python.mdx
@@ -1,0 +1,146 @@
+---
+title: Python (Experimental)
+description: Use experimental native uv workspace support with Turborepo.
+product: turborepo
+type: integration
+summary: Discover uv workspace members as Turborepo packages and run native uv tasks.
+prerequisites:
+  - /docs/crafting-your-repository/structuring-a-repository
+  - /docs/crafting-your-repository/configuring-tasks
+related:
+  - /docs/guides/multi-language
+  - /docs/crafting-your-repository/caching
+  - /docs/crafting-your-repository/running-tasks
+---
+
+Turborepo can discover packages across languages and toolchains. It can discover the members of [a uv workspace](https://docs.astral.sh/uv/concepts/projects/workspaces/) as packages, add their dependency relationships to the Package Graph, and map common Turborepo tasks to uv commands. uv remains responsible for resolution, environments, and installation, and is the only supported Python package manager.
+
+<Callout type="warn">
+  uv workspace support is experimental and may change. Use a version of `turbo`
+  that recognizes `experimentalPythonWorkspaces` everywhere the repository
+  runs, including local hooks and CI. Older versions reject unknown future
+  flags.
+</Callout>
+
+## Enable uv workspaces
+
+Set the future flag in the root `turbo.json`:
+
+```json title="./turbo.json"
+{
+  "$schema": "https://turborepo.dev/schema.json",
+  "futureFlags": {
+    "experimentalPythonWorkspaces": true
+  },
+  "tasks": {}
+}
+```
+
+## Prerequisites
+
+To work with Python, the repository root must contain:
+
+- `turbo` and `uv` available on `PATH` (`uv` is required to run tasks; discovery works without it)
+- A root `pyproject.toml` containing a `[tool.uv.workspace]` table
+- A valid, unique `[tool.turbo] name`, used for a synthetic Turborepo package that represents the uv workspace
+- A root `uv.lock`
+
+```toml title="./pyproject.toml"
+[tool.turbo]
+name = "acme-python"
+
+[tool.uv.workspace]
+members = ["packages/*"]
+```
+
+<Callout type="info">
+  The workspace root may also define its own `[project]`. That root project is
+  not modeled as a Turborepo package (its directory would be the whole
+  repository), but its locked dependencies still participate in
+  workspace-scoped hashing and pruning.
+</Callout>
+
+### Repository structure
+
+In the example above, members are defined as `packages/*`. Every matched non-root directory whose `pyproject.toml` declares `[project].name` becomes a package in the workspace, identified by its [PEP 503-normalized](https://peps.python.org/pep-0503/#normalized-names) project name. Member and exclude patterns must be relative to the repository, cannot contain `..`, and do not follow directory symlinks.
+
+A dependency between two members, declared in `[project.dependencies]`, `[project.optional-dependencies]`, `[dependency-groups]`, or legacy `[tool.uv].dev-dependencies` and resolved to the workspace via `[tool.uv.sources]`, becomes an edge in the Package Graph, so filtering and affectedness calculations follow Python dependency relationships.
+
+The synthetic workspace package uses `[tool.turbo] name`, depends on every member, and runs workspace-scoped tasks.
+
+## Built-in tasks
+
+Turborepo implicitly registers these task mappings, since they are common to all uv workspaces.
+
+| Package           | Turbo task | uv command                              |
+| ----------------- | ---------- | --------------------------------------- |
+| Buildable member  | `build`    | `uv build --package=<name>`             |
+| Any member        | `format`   | `uv format -- <member-dir>`             |
+| Any member        | `check`    | `uv check --package=<name>`             |
+| Workspace package | `format`   | `uv format -- <member-dirs...>`         |
+| Workspace package | `check`    | `uv check --all-packages`               |
+
+Without a filter, quality tasks use the workspace-wide command instead of creating one task per member. Filtered runs scope formatting or type checking to the selected member. `uv check` uses ty for type checking.
+
+Built-in uv tasks default to `cache: false` until the uv, Python, ty, and isolated build-backend versions participate in their fingerprints. Type-checking tasks run serially because `uv check` synchronizes the shared environment; build and format tasks can run in parallel for separate members.
+
+### Pass uv flags
+
+Arguments after Turborepo's `--` are passed to the mapped command:
+
+```bash title="Terminal"
+turbo run check --filter=py-api -- --python-version=3.13
+```
+
+Passing output-affecting flags to `build` (like `--out-dir`) disables automatic output detection, so configure [`outputs`](/docs/reference/configuration#outputs) explicitly in that case.
+
+## Filtering, affected packages, and queries
+
+You can use the uv workspace or its members as entrypoints for [filters](/docs/reference/run#--filter-string):
+
+```bash title="Terminal"
+# Execute builds for all toolchains
+turbo run build
+
+# Build one Python package's sdist and wheel
+turbo run build --filter=py-api
+
+# Format the entire uv workspace once
+turbo run format
+
+# Type check the entire uv workspace once
+turbo run check
+```
+
+Additionally, [`turbo query`](/docs/reference/query) can be used to understand your repository's graphs and more.
+
+## Caching behavior
+
+For the built-in uv tasks, Turborepo creates task hashes using:
+
+- The selected member's source files, plus its internal dependency sources for `check`
+- Every member's source files when quality tasks run through the workspace package
+- The root `pyproject.toml`, `uv.toml`, and `.python-version`
+- Relevant uv and pip environment variables (index selection, resolution mode, Python selection)
+- The resolved external dependency closure from `uv.lock`, scoped to each member; a dependency bump only invalidates the packages that depend on it
+
+Project-specific hashing inputs must be accounted for manually. This includes:
+
+- Environment variables read by your tools, declared in the task's [`env`](/docs/reference/configuration#env) configuration
+- File inputs that are not included by default. Use [`inputs`](/docs/reference/configuration#inputs) to define your own file inputs and [`$TURBO_DEFAULT$`](/docs/reference/configuration#turbo_default) to preserve zero-configuration file inputs
+
+### Build outputs
+
+Turborepo detects the sdist and wheel that `uv build` writes to the workspace `dist/` directory, but the built-in task defaults to uncached. Projects that pin the uv, Python, and build-backend versions can opt into caching explicitly. The `.venv` directory is never a task output; it remains uv's own materialized environment.
+
+## Pruning
+
+`turbo prune <package>` produces a self-contained partial workspace: the kept package directories, a `uv.lock` subset to the reachable closure (dependency groups and optional extras included, so `uv sync --frozen` succeeds), and a root `pyproject.toml` rewritten with the explicit kept member list. `.python-version` and `uv.toml` are carried over when present.
+
+## Limitations
+
+- Only the root uv workspace is discovered. A standalone `pyproject.toml` without `[tool.uv.workspace]` is not modeled, and nested workspaces are not independently discovered.
+- Turborepo never creates or refreshes `uv.lock`; run `uv lock` to refresh and commit it. Use `uv lock --check` to validate it in CI. Turborepo rejects a missing lockfile and structural inconsistencies it can detect, but does not perform uv's complete manifest freshness validation during graph construction.
+- Reachable local path, directory, editable, or virtual dependencies must be discovered workspace members at the same path recorded in `uv.lock`. Other local sources prevent graph construction because Turborepo cannot yet content-hash or prune them safely.
+- The synthetic workspace package has no directory and cannot be passed to `turbo prune`; prune a member instead.
+- Only the built-in `build`, `format`, and `check` tasks are currently supported through the public configuration schema.

--- a/crates/turborepo-schema-gen/src/main.rs
+++ b/crates/turborepo-schema-gen/src/main.rs
@@ -855,9 +855,14 @@ export interface FutureFlags {
    *
    * When enabled, Python packages are discovered from the root
    * `pyproject.toml`'s `[tool.uv.workspace]` members and participate in the
-   * package graph, resolve in `--filter` expressions, and appear in
-   * `turbo query`. uv is the only supported Python package manager. This
-   * feature is experimental.
+    * package graph: they resolve in `--filter` expressions, propagate
+    * `--affected`, and appear in `turbo query`. Buildable packages register `build`
+    * (`uv build --package`), and all packages register `format` and `check`;
+    * the user-named workspace package registers workspace-wide versions of the
+    * quality tasks. External dependencies hash from `uv.lock` per
+    * package, and `turbo prune` produces a reachability-pruned `uv.lock`
+    * and root `pyproject.toml`. uv is the only supported Python package
+    * manager. This feature is experimental.
    *
    * @defaultValue `false`
    */

--- a/crates/turborepo-schema-gen/src/main.rs
+++ b/crates/turborepo-schema-gen/src/main.rs
@@ -855,14 +855,14 @@ export interface FutureFlags {
    *
    * When enabled, Python packages are discovered from the root
    * `pyproject.toml`'s `[tool.uv.workspace]` members and participate in the
-    * package graph: they resolve in `--filter` expressions, propagate
-    * `--affected`, and appear in `turbo query`. Buildable packages register `build`
-    * (`uv build --package`), and all packages register `format` and `check`;
-    * the user-named workspace package registers workspace-wide versions of the
-    * quality tasks. External dependencies hash from `uv.lock` per
-    * package, and `turbo prune` produces a reachability-pruned `uv.lock`
-    * and root `pyproject.toml`. uv is the only supported Python package
-    * manager. This feature is experimental.
+   * package graph: they resolve in `--filter` expressions, propagate
+   * `--affected`, and appear in `turbo query`. Buildable packages register `build`
+   * (`uv build --package`), and all packages register `format` and `check`;
+   * the user-named workspace package registers workspace-wide versions of the
+   * quality tasks. External dependencies hash from `uv.lock` per
+   * package, and `turbo prune` produces a reachability-pruned `uv.lock`
+   * and root `pyproject.toml`. uv is the only supported Python package
+   * manager. This feature is experimental.
    *
    * @defaultValue `false`
    */

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -6,7 +6,7 @@ This document serves as a sketch of the architecture of the `turbo run` command
 
 A run consists of the following steps:
 
-1. Build a package graph based on the JavaScript package manager settings (and, behind `futureFlags.experimentalCargoWorkspaces`, Cargo workspace crates)
+1. Build a package graph based on the JavaScript package manager settings (and, behind `futureFlags.experimentalCargoWorkspaces` / `futureFlags.experimentalPythonWorkspaces`, Cargo workspace crates and uv workspace members)
 2. Build a task graph based on package dependencies and configuration
 3. Determine global/task hashes
 4. Execute tasks in topological order
@@ -585,6 +585,48 @@ graph shape, execution, caching, deliverable restoration, cross-crate
 invalidation, lockfile enforcement, unsupported local-package rejection,
 uncached `run`/`dev` execution, and the filter hint. `turbo query` serves Cargo
 packages through the same graph.
+
+#### Experimental Python (uv) Support (`crates/turborepo-repository/src/uv.rs`)
+
+Behind `futureFlags.experimentalPythonWorkspaces`, `turbo run` discovers
+Python packages from the root uv workspace and adds them to the package graph.
+uv is the only supported Python package manager. uv workspaces can stand alone
+or coexist with JavaScript and Cargo workspaces; no `PackageManager` variant is
+involved. `UvContributor` contributes pre-classified relationships, native
+tasks, external resolution, change observations, and a prune domain through
+the shared repository graph.
+
+- **Discovery** parses `[tool.uv.workspace] members` and `exclude` globs
+  in-process, so graph construction does not require the `uv` binary. Names
+  are PEP 503-normalized. Dependencies become internal graph edges only when
+  their effective `[tool.uv.sources]` entry selects `workspace = true`.
+  Development edges that would create a cycle become non-ordering input
+  edges. A root `[project]` participates in hashing and pruning but is not a
+  package. A synthetic workspace package, named by `[tool.turbo] name`,
+  depends on every member and hosts workspace-wide quality tasks.
+- **Execution** registers `build` for buildable members and `format` and
+  `check` for all members. Unfiltered quality runs prefer the workspace
+  aggregate; filtered runs target selected members. `check` tasks share a
+  serial group because uv synchronizes their environment. Built-in tasks
+  default to uncached until uv, Python, ty, and build-backend identities are
+  represented in task hashes.
+- **Hashing and affectedness** include member sources, relevant workspace
+  files and uv/pip environment variables, internal source closures for
+  checks, and each member's external dependency closure from `uv.lock`.
+  Package identities include version, source, and artifact hashes. A
+  `uv.lock` change across git refs conservatively affects all uv packages.
+- **Watch mode** rediscoveries follow any `pyproject.toml` and the root
+  `uv.lock`; root `.venv/` and `dist/` events are ignored as task byproducts.
+- **Prune** walks `uv.lock` reachability, including dependency groups and
+  optional extras, and preserves retained package metadata through
+  `toml_edit`. It rewrites root workspace members, removes dangling uv source
+  entries, and copies `.python-version` and `uv.toml` when present. Reachable
+  local dependencies that are not workspace members fail closed.
+
+End-to-end coverage in `crates/turborepo/tests/uv_workspace_test.rs` exercises
+pure uv and mixed npm/uv repositories, graph shape, filtering, affectedness,
+execution, and prune output. Linux Rust CI installs a pinned uv version; local
+tests that execute uv skip when it is unavailable.
 
 ### 3. Task Graph (`crates/turborepo-lib/src/engine/`)
 

--- a/crates/turborepo/tests/uv_workspace_test.rs
+++ b/crates/turborepo/tests/uv_workspace_test.rs
@@ -1,0 +1,307 @@
+//! End-to-end tests for experimental Python (uv) workspace support.
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
+mod common;
+
+use std::{fs, path::Path};
+
+use common::setup;
+
+fn uv_available() -> bool {
+    let available = which::which("uv").is_ok();
+    if !available {
+        eprintln!("skipping: uv is not on PATH");
+    }
+    available
+}
+
+fn setup_uv_monorepo(dir: &Path) {
+    setup::setup_integration_test(dir, "uv_monorepo", "npm@10.5.0", false).unwrap();
+}
+
+fn setup_uv_pure_workspace(dir: &Path) {
+    setup::copy_fixture("uv_pure_workspace", dir).unwrap();
+    setup::setup_git(dir).unwrap();
+    assert!(
+        !dir.join("package.json").exists(),
+        "the pure uv fixture must have no package.json"
+    );
+}
+
+fn run_turbo(dir: &Path, args: &[&str]) -> std::process::Output {
+    let config_dir = tempfile::tempdir().expect("failed to create config tempdir");
+    let mut command = common::turbo_command(dir);
+    command.env("TURBO_CONFIG_DIR_PATH", config_dir.path());
+    command
+        .args(args)
+        .output()
+        .expect("failed to execute turbo")
+}
+
+fn assert_command_success(output: &std::process::Output, context: &str) {
+    assert!(
+        output.status.success(),
+        "{context} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn dry_run_tasks(dir: &Path, args: &[&str]) -> serde_json::Value {
+    let mut full_args = args.to_vec();
+    full_args.push("--dry-run=json");
+    let output = run_turbo(dir, &full_args);
+    assert_command_success(&output, "dry-run");
+    serde_json::from_slice(&output.stdout).expect("dry-run emits JSON")
+}
+
+fn task_ids(json: &serde_json::Value) -> Vec<String> {
+    json["tasks"]
+        .as_array()
+        .expect("tasks array")
+        .iter()
+        .map(|task| task["taskId"].as_str().expect("taskId").to_string())
+        .collect()
+}
+
+fn find_task<'a>(json: &'a serde_json::Value, task_id: &str) -> &'a serde_json::Value {
+    json["tasks"]
+        .as_array()
+        .expect("tasks array")
+        .iter()
+        .find(|task| task["taskId"] == task_id)
+        .unwrap_or_else(|| panic!("{task_id} in task graph"))
+}
+
+#[test]
+fn test_uv_packages_in_task_graph() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_uv_monorepo(tempdir.path());
+
+    let json = dry_run_tasks(tempdir.path(), &["build"]);
+    let ids = task_ids(&json);
+    assert!(ids.contains(&"js-pkg#build".to_string()), "ids: {ids:?}");
+    assert!(ids.contains(&"py-app#build".to_string()), "ids: {ids:?}");
+    assert!(ids.contains(&"py-lib#build".to_string()), "ids: {ids:?}");
+
+    let py_app = find_task(&json, "py-app#build");
+    let dependencies: Vec<&str> = py_app["dependencies"]
+        .as_array()
+        .expect("dependencies array")
+        .iter()
+        .filter_map(|dependency| dependency.as_str())
+        .collect();
+    assert!(
+        dependencies.contains(&"py-lib#build"),
+        "py-app#build must depend on py-lib#build: {dependencies:?}"
+    );
+    assert_eq!(py_app["command"], "uv build --package=py-app");
+}
+
+#[test]
+fn test_pure_uv_workspace_task_graph() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_uv_pure_workspace(tempdir.path());
+
+    let json = dry_run_tasks(tempdir.path(), &["build"]);
+    let ids = task_ids(&json);
+    assert!(ids.contains(&"py-app#build".to_string()), "ids: {ids:?}");
+    assert!(ids.contains(&"py-lib#build".to_string()), "ids: {ids:?}");
+
+    let json = dry_run_tasks(tempdir.path(), &["format"]);
+    assert_eq!(task_ids(&json), vec!["acme#format".to_string()]);
+    assert_eq!(
+        find_task(&json, "acme#format")["command"],
+        "uv format -- packages/py-app packages/py-lib"
+    );
+
+    let json = dry_run_tasks(tempdir.path(), &["check"]);
+    assert_eq!(task_ids(&json), vec!["acme#check".to_string()]);
+    assert_eq!(
+        find_task(&json, "acme#check")["command"],
+        "uv check --all-packages"
+    );
+}
+
+#[test]
+fn test_uv_filter_by_package() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_uv_pure_workspace(tempdir.path());
+
+    let json = dry_run_tasks(tempdir.path(), &["build", "--filter=py-lib"]);
+    assert_eq!(task_ids(&json), vec!["py-lib#build".to_string()]);
+
+    let json = dry_run_tasks(tempdir.path(), &["build", "--filter=py-app"]);
+    assert_eq!(task_ids(&json), vec!["py-app#build".to_string()]);
+
+    let json = dry_run_tasks(tempdir.path(), &["format", "--filter=py-app"]);
+    assert_eq!(task_ids(&json), vec!["py-app#format".to_string()]);
+    assert_eq!(
+        find_task(&json, "py-app#format")["command"],
+        "uv format -- packages/py-app"
+    );
+
+    let json = dry_run_tasks(tempdir.path(), &["check", "--filter=py-app"]);
+    assert_eq!(task_ids(&json), vec!["py-app#check".to_string()]);
+    assert_eq!(
+        find_task(&json, "py-app#check")["command"],
+        "uv check --package=py-app"
+    );
+
+    let json = dry_run_tasks(tempdir.path(), &["build"]);
+    let ids = task_ids(&json);
+    assert!(ids.contains(&"py-app#build".to_string()));
+    assert!(ids.contains(&"py-lib#build".to_string()));
+    assert!(
+        !ids.contains(&"acme#build".to_string()),
+        "the workspace aggregate does not build: {ids:?}"
+    );
+}
+
+#[test]
+fn test_uv_flag_disabled_hints_at_opt_in() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_uv_pure_workspace(tempdir.path());
+    fs::write(
+        tempdir.path().join("turbo.json"),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "tasks": { "build": {} }
+}"#,
+    )
+    .unwrap();
+    fs::write(
+        tempdir.path().join("package.json"),
+        r#"{"name": "root", "packageManager": "npm@10.5.0"}"#,
+    )
+    .unwrap();
+    fs::write(tempdir.path().join("package-lock.json"), "{}").unwrap();
+
+    let output = run_turbo(tempdir.path(), &["build", "--filter=py-app"]);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("experimentalPythonWorkspaces"),
+        "stderr should point at the flag: {stderr}"
+    );
+}
+
+#[test]
+fn test_uv_lock_change_affects_all_packages() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_uv_pure_workspace(tempdir.path());
+
+    let base = dry_run_tasks(
+        tempdir.path(),
+        &["build", "--filter=[HEAD]", "--log-order", "grouped"],
+    );
+    assert_eq!(task_ids(&base), Vec::<String>::new());
+
+    let lock_path = tempdir.path().join("uv.lock");
+    let mut contents = fs::read_to_string(&lock_path).unwrap();
+    contents.push_str("\n# turbo-test lockfile perturbation\n");
+    fs::write(&lock_path, contents).unwrap();
+
+    let json = dry_run_tasks(
+        tempdir.path(),
+        &["build", "--filter=[HEAD]", "--log-order", "grouped"],
+    );
+    let ids = task_ids(&json);
+    assert!(ids.contains(&"py-app#build".to_string()), "ids: {ids:?}");
+    assert!(ids.contains(&"py-lib#build".to_string()), "ids: {ids:?}");
+}
+
+#[test]
+fn test_uv_build_executes_without_caching() {
+    if !uv_available() {
+        return;
+    }
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_uv_pure_workspace(tempdir.path());
+
+    let dry_run = dry_run_tasks(tempdir.path(), &["build", "--filter=py-app"]);
+    assert_eq!(
+        find_task(&dry_run, "py-app#build")["resolvedTaskDefinition"]["cache"],
+        false
+    );
+
+    let output = run_turbo(
+        tempdir.path(),
+        &["build", "--filter=py-app", "--log-order", "grouped"],
+    );
+    assert_command_success(&output, "first build");
+    let wheel_exists = || {
+        fs::read_dir(tempdir.path().join("dist"))
+            .map(|entries| {
+                entries
+                    .filter_map(Result::ok)
+                    .any(|entry| entry.file_name().to_string_lossy().ends_with(".whl"))
+            })
+            .unwrap_or(false)
+    };
+    assert!(wheel_exists(), "uv build must produce a wheel in dist/");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("FULL TURBO"),
+        "build must be uncached: {stdout}"
+    );
+}
+
+#[test]
+fn test_uv_prune() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_uv_pure_workspace(tempdir.path());
+
+    let output = run_turbo(tempdir.path(), &["prune", "py-app"]);
+    assert_command_success(&output, "turbo prune");
+    let out = tempdir.path().join("out");
+
+    assert!(out.join("packages/py-app/pyproject.toml").exists());
+    assert!(out.join("packages/py-lib/pyproject.toml").exists());
+
+    let lock = fs::read_to_string(out.join("uv.lock")).unwrap();
+    assert!(lock.contains("name = \"py-app\""));
+    assert!(lock.contains("name = \"py-lib\""));
+
+    let manifest = fs::read_to_string(out.join("pyproject.toml")).unwrap();
+    assert!(
+        manifest.contains("packages/py-app") && manifest.contains("packages/py-lib"),
+        "workspace members must be rewritten to the kept set: {manifest}"
+    );
+    assert!(manifest.contains(r#"name = "acme""#));
+
+    if uv_available() {
+        let check = std::process::Command::new("uv")
+            .args(["lock", "--check"])
+            .current_dir(&out)
+            .output()
+            .expect("uv runs");
+        assert!(
+            check.status.success(),
+            "pruned workspace must pass `uv lock --check`\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&check.stdout),
+            String::from_utf8_lossy(&check.stderr)
+        );
+    }
+}
+
+#[test]
+fn test_uv_prune_mixed_repo() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_uv_monorepo(tempdir.path());
+
+    let output = run_turbo(tempdir.path(), &["prune", "py-lib"]);
+    assert_command_success(&output, "turbo prune");
+    let out = tempdir.path().join("out");
+
+    assert!(out.join("python/py-lib/pyproject.toml").exists());
+    assert!(!out.join("python/py-app").exists());
+    let lock = fs::read_to_string(out.join("uv.lock")).unwrap();
+    assert!(lock.contains("name = \"py-lib\""));
+    assert!(!lock.contains("name = \"py-app\""));
+    let manifest = fs::read_to_string(out.join("pyproject.toml")).unwrap();
+    assert!(manifest.contains("python/py-lib"));
+    assert!(!manifest.contains("python/py-app"));
+    assert!(out.join("package.json").exists());
+}

--- a/packages/turbo-types/schemas/schema.json
+++ b/packages/turbo-types/schemas/schema.json
@@ -138,30 +138,21 @@
     },
     "globalDependencies": {
       "description": "A list of globs to include in the set of implicit global hash dependencies.\n\nThe contents of these files will be included in the global hashing algorithm and affect the hashes of all tasks.\n\nThis is useful for busting the cache based on: - `.env` files (not in Git) - Any root level file that impacts package tasks that are not represented in the traditional dependency graph (e.g. a root `tsconfig.json`, `jest.config.ts`, `.eslintrc`, etc.)\n\nDocumentation: https://turborepo.dev/docs/reference/configuration#globaldependencies",
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": ["array", "null"],
       "items": {
         "$ref": "#/definitions/String"
       }
     },
     "globalEnv": {
       "description": "A list of environment variables for implicit global hash dependencies.\n\nThe variables included in this list will affect all task hashes.\n\nDocumentation: https://turborepo.dev/docs/reference/configuration#globalenv",
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": ["array", "null"],
       "items": {
         "$ref": "#/definitions/String"
       }
     },
     "globalPassThroughEnv": {
       "description": "An allowlist of environment variables that should be made to all tasks, but should not contribute to the task's cache key, e.g. `AWS_SECRET_KEY`.\n\nDocumentation: https://turborepo.dev/docs/reference/configuration#globalpassthroughenv",
-      "type": [
-        "array",
-        "null"
-      ],
+      "type": ["array", "null"],
       "items": {
         "$ref": "#/definitions/String"
       }
@@ -201,10 +192,7 @@
     },
     "tasks": {
       "description": "An object representing the task dependency graph of your project.\n\nturbo interprets these conventions to schedule, execute, and cache the outputs of tasks in your project.\n\nDocumentation: https://turborepo.dev/docs/reference/configuration#tasks",
-      "type": [
-        "object",
-        "null"
-      ],
+      "type": ["object", "null"],
       "additionalProperties": {
         "$ref": "#/definitions/Pipeline"
       }
@@ -289,16 +277,12 @@
         {
           "description": "Allow all environment variables for the process to be available.",
           "type": "string",
-          "enum": [
-            "loose"
-          ]
+          "enum": ["loose"]
         },
         {
           "description": "Filter environment variables to only those that are specified in the `env` and `globalEnv` keys in `turbo.json`.",
           "type": "string",
-          "enum": [
-            "strict"
-          ]
+          "enum": ["strict"]
         }
       ]
     },
@@ -440,10 +424,7 @@
         },
         "env": {
           "description": "A list of environment variables for implicit global hash dependencies.\n\nUnlike `inputs` (which become per-task inputs), these variables are included in the global hash and affect all task hashes uniformly.",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": ["array", "null"],
           "items": {
             "$ref": "#/definitions/String"
           }
@@ -461,10 +442,7 @@
         },
         "inputs": {
           "description": "A list of globs for files that implicitly affect all tasks.\n\nThese files are prepended to every task's `inputs` during engine construction rather than being folded into the global hash. This allows individual tasks to exclude specific global files via negation globs.",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": ["array", "null"],
           "items": {
             "$ref": "#/definitions/String"
           }
@@ -482,10 +460,7 @@
         },
         "passThroughEnv": {
           "description": "An allowlist of environment variables that should be made to all tasks, but should not contribute to the task's cache key.",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": ["array", "null"],
           "items": {
             "$ref": "#/definitions/String"
           }
@@ -526,37 +501,27 @@
         {
           "description": "Displays all output.",
           "type": "string",
-          "enum": [
-            "full"
-          ]
+          "enum": ["full"]
         },
         {
           "description": "Hides all task output.",
           "type": "string",
-          "enum": [
-            "none"
-          ]
+          "enum": ["none"]
         },
         {
           "description": "Show only the hashes of the tasks.",
           "type": "string",
-          "enum": [
-            "hash-only"
-          ]
+          "enum": ["hash-only"]
         },
         {
           "description": "Only show output from cache misses.",
           "type": "string",
-          "enum": [
-            "new-only"
-          ]
+          "enum": ["new-only"]
         },
         {
           "description": "Only show output from task failures.",
           "type": "string",
-          "enum": [
-            "errors-only"
-          ]
+          "enum": ["errors-only"]
         }
       ]
     },
@@ -627,20 +592,14 @@
         },
         "env": {
           "description": "A list of environment variables that this task depends on.\n\nNote: If you are migrating from a turbo version 1.5 or below, you may be used to prefixing your variables with a `$`. You no longer need to use the `$` prefix.\n\nDocumentation: https://turborepo.dev/docs/reference/configuration#env",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": ["array", "null"],
           "items": {
             "$ref": "#/definitions/String"
           }
         },
         "inputs": {
           "description": "The set of glob patterns to consider as inputs to this task.\n\nChanges to files covered by these globs will cause a cache miss and the task will be rerun. If a file has been changed that is **not** included in the set of globs, it will not cause a cache miss. If omitted or empty, all files in the package are considered as inputs.\n\nDocumentation: https://turborepo.dev/docs/reference/configuration#inputs",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": ["array", "null"],
           "items": {
             "$ref": "#/definitions/TaskInput"
           }
@@ -680,20 +639,14 @@
         },
         "outputs": {
           "description": "The set of glob patterns indicating a task's cacheable filesystem outputs.\n\nTurborepo captures task logs for all tasks. This enables us to cache tasks whose runs produce no artifacts other than logs (such as linters). Logs are always treated as a cacheable artifact and never need to be specified.\n\nDocumentation: https://turborepo.dev/docs/reference/configuration#outputs",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": ["array", "null"],
           "items": {
             "$ref": "#/definitions/String"
           }
         },
         "passThroughEnv": {
           "description": "An allowlist of environment variables that should be made available in this task's environment, but should not contribute to the task's cache key, e.g. `AWS_SECRET_KEY`.\n\nDocumentation: https://turborepo.dev/docs/reference/configuration#passthroughenv",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": ["array", "null"],
           "items": {
             "$ref": "#/definitions/String"
           }
@@ -711,10 +664,7 @@
         },
         "with": {
           "description": "A list of tasks that will run alongside this task.\n\nTasks in this list will not be run until completion before this task starts execution.\n\nDocumentation: https://turborepo.dev/docs/reference/configuration#with",
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": ["array", "null"],
           "items": {
             "$ref": "#/definitions/String"
           }
@@ -833,19 +783,13 @@
       "type": "object",
       "properties": {
         "from": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": ["array", "null"],
           "items": {
             "$ref": "#/definitions/String"
           }
         },
         "globs": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": ["array", "null"],
           "items": {
             "$ref": "#/definitions/String"
           }
@@ -916,23 +860,17 @@
         {
           "description": "Use the terminal user interface.",
           "type": "string",
-          "enum": [
-            "tui"
-          ]
+          "enum": ["tui"]
         },
         {
           "description": "Use the standard output stream.",
           "type": "string",
-          "enum": [
-            "stream"
-          ]
+          "enum": ["stream"]
         },
         {
           "description": "Use the standard output stream with timestamps. Note: This feature is experimental and may change or be removed at any time.",
           "type": "string",
-          "enum": [
-            "stream-with-experimental-timestamps"
-          ]
+          "enum": ["stream-with-experimental-timestamps"]
         }
       ]
     },

--- a/packages/turbo-types/schemas/schema.json
+++ b/packages/turbo-types/schemas/schema.json
@@ -138,21 +138,30 @@
     },
     "globalDependencies": {
       "description": "A list of globs to include in the set of implicit global hash dependencies.\n\nThe contents of these files will be included in the global hashing algorithm and affect the hashes of all tasks.\n\nThis is useful for busting the cache based on: - `.env` files (not in Git) - Any root level file that impacts package tasks that are not represented in the traditional dependency graph (e.g. a root `tsconfig.json`, `jest.config.ts`, `.eslintrc`, etc.)\n\nDocumentation: https://turborepo.dev/docs/reference/configuration#globaldependencies",
-      "type": ["array", "null"],
+      "type": [
+        "array",
+        "null"
+      ],
       "items": {
         "$ref": "#/definitions/String"
       }
     },
     "globalEnv": {
       "description": "A list of environment variables for implicit global hash dependencies.\n\nThe variables included in this list will affect all task hashes.\n\nDocumentation: https://turborepo.dev/docs/reference/configuration#globalenv",
-      "type": ["array", "null"],
+      "type": [
+        "array",
+        "null"
+      ],
       "items": {
         "$ref": "#/definitions/String"
       }
     },
     "globalPassThroughEnv": {
       "description": "An allowlist of environment variables that should be made to all tasks, but should not contribute to the task's cache key, e.g. `AWS_SECRET_KEY`.\n\nDocumentation: https://turborepo.dev/docs/reference/configuration#globalpassthroughenv",
-      "type": ["array", "null"],
+      "type": [
+        "array",
+        "null"
+      ],
       "items": {
         "$ref": "#/definitions/String"
       }
@@ -192,7 +201,10 @@
     },
     "tasks": {
       "description": "An object representing the task dependency graph of your project.\n\nturbo interprets these conventions to schedule, execute, and cache the outputs of tasks in your project.\n\nDocumentation: https://turborepo.dev/docs/reference/configuration#tasks",
-      "type": ["object", "null"],
+      "type": [
+        "object",
+        "null"
+      ],
       "additionalProperties": {
         "$ref": "#/definitions/Pipeline"
       }
@@ -277,12 +289,16 @@
         {
           "description": "Allow all environment variables for the process to be available.",
           "type": "string",
-          "enum": ["loose"]
+          "enum": [
+            "loose"
+          ]
         },
         {
           "description": "Filter environment variables to only those that are specified in the `env` and `globalEnv` keys in `turbo.json`.",
           "type": "string",
-          "enum": ["strict"]
+          "enum": [
+            "strict"
+          ]
         }
       ]
     },
@@ -424,7 +440,10 @@
         },
         "env": {
           "description": "A list of environment variables for implicit global hash dependencies.\n\nUnlike `inputs` (which become per-task inputs), these variables are included in the global hash and affect all task hashes uniformly.",
-          "type": ["array", "null"],
+          "type": [
+            "array",
+            "null"
+          ],
           "items": {
             "$ref": "#/definitions/String"
           }
@@ -442,7 +461,10 @@
         },
         "inputs": {
           "description": "A list of globs for files that implicitly affect all tasks.\n\nThese files are prepended to every task's `inputs` during engine construction rather than being folded into the global hash. This allows individual tasks to exclude specific global files via negation globs.",
-          "type": ["array", "null"],
+          "type": [
+            "array",
+            "null"
+          ],
           "items": {
             "$ref": "#/definitions/String"
           }
@@ -460,7 +482,10 @@
         },
         "passThroughEnv": {
           "description": "An allowlist of environment variables that should be made to all tasks, but should not contribute to the task's cache key.",
-          "type": ["array", "null"],
+          "type": [
+            "array",
+            "null"
+          ],
           "items": {
             "$ref": "#/definitions/String"
           }
@@ -501,27 +526,37 @@
         {
           "description": "Displays all output.",
           "type": "string",
-          "enum": ["full"]
+          "enum": [
+            "full"
+          ]
         },
         {
           "description": "Hides all task output.",
           "type": "string",
-          "enum": ["none"]
+          "enum": [
+            "none"
+          ]
         },
         {
           "description": "Show only the hashes of the tasks.",
           "type": "string",
-          "enum": ["hash-only"]
+          "enum": [
+            "hash-only"
+          ]
         },
         {
           "description": "Only show output from cache misses.",
           "type": "string",
-          "enum": ["new-only"]
+          "enum": [
+            "new-only"
+          ]
         },
         {
           "description": "Only show output from task failures.",
           "type": "string",
-          "enum": ["errors-only"]
+          "enum": [
+            "errors-only"
+          ]
         }
       ]
     },
@@ -592,14 +627,20 @@
         },
         "env": {
           "description": "A list of environment variables that this task depends on.\n\nNote: If you are migrating from a turbo version 1.5 or below, you may be used to prefixing your variables with a `$`. You no longer need to use the `$` prefix.\n\nDocumentation: https://turborepo.dev/docs/reference/configuration#env",
-          "type": ["array", "null"],
+          "type": [
+            "array",
+            "null"
+          ],
           "items": {
             "$ref": "#/definitions/String"
           }
         },
         "inputs": {
           "description": "The set of glob patterns to consider as inputs to this task.\n\nChanges to files covered by these globs will cause a cache miss and the task will be rerun. If a file has been changed that is **not** included in the set of globs, it will not cause a cache miss. If omitted or empty, all files in the package are considered as inputs.\n\nDocumentation: https://turborepo.dev/docs/reference/configuration#inputs",
-          "type": ["array", "null"],
+          "type": [
+            "array",
+            "null"
+          ],
           "items": {
             "$ref": "#/definitions/TaskInput"
           }
@@ -639,14 +680,20 @@
         },
         "outputs": {
           "description": "The set of glob patterns indicating a task's cacheable filesystem outputs.\n\nTurborepo captures task logs for all tasks. This enables us to cache tasks whose runs produce no artifacts other than logs (such as linters). Logs are always treated as a cacheable artifact and never need to be specified.\n\nDocumentation: https://turborepo.dev/docs/reference/configuration#outputs",
-          "type": ["array", "null"],
+          "type": [
+            "array",
+            "null"
+          ],
           "items": {
             "$ref": "#/definitions/String"
           }
         },
         "passThroughEnv": {
           "description": "An allowlist of environment variables that should be made available in this task's environment, but should not contribute to the task's cache key, e.g. `AWS_SECRET_KEY`.\n\nDocumentation: https://turborepo.dev/docs/reference/configuration#passthroughenv",
-          "type": ["array", "null"],
+          "type": [
+            "array",
+            "null"
+          ],
           "items": {
             "$ref": "#/definitions/String"
           }
@@ -664,7 +711,10 @@
         },
         "with": {
           "description": "A list of tasks that will run alongside this task.\n\nTasks in this list will not be run until completion before this task starts execution.\n\nDocumentation: https://turborepo.dev/docs/reference/configuration#with",
-          "type": ["array", "null"],
+          "type": [
+            "array",
+            "null"
+          ],
           "items": {
             "$ref": "#/definitions/String"
           }
@@ -783,13 +833,19 @@
       "type": "object",
       "properties": {
         "from": {
-          "type": ["array", "null"],
+          "type": [
+            "array",
+            "null"
+          ],
           "items": {
             "$ref": "#/definitions/String"
           }
         },
         "globs": {
-          "type": ["array", "null"],
+          "type": [
+            "array",
+            "null"
+          ],
           "items": {
             "$ref": "#/definitions/String"
           }
@@ -860,17 +916,23 @@
         {
           "description": "Use the terminal user interface.",
           "type": "string",
-          "enum": ["tui"]
+          "enum": [
+            "tui"
+          ]
         },
         {
           "description": "Use the standard output stream.",
           "type": "string",
-          "enum": ["stream"]
+          "enum": [
+            "stream"
+          ]
         },
         {
           "description": "Use the standard output stream with timestamps. Note: This feature is experimental and may change or be removed at any time.",
           "type": "string",
-          "enum": ["stream-with-experimental-timestamps"]
+          "enum": [
+            "stream-with-experimental-timestamps"
+          ]
         }
       ]
     },

--- a/packages/turbo-types/src/types/config-v2.ts
+++ b/packages/turbo-types/src/types/config-v2.ts
@@ -353,14 +353,14 @@ export interface FutureFlags {
    *
    * When enabled, Python packages are discovered from the root
    * `pyproject.toml`'s `[tool.uv.workspace]` members and participate in the
-    * package graph: they resolve in `--filter` expressions, propagate
-    * `--affected`, and appear in `turbo query`. Buildable packages register `build`
-    * (`uv build --package`), and all packages register `format` and `check`;
-    * the user-named workspace package registers workspace-wide versions of the
-    * quality tasks. External dependencies hash from `uv.lock` per
-    * package, and `turbo prune` produces a reachability-pruned `uv.lock`
-    * and root `pyproject.toml`. uv is the only supported Python package
-    * manager. This feature is experimental.
+   * package graph: they resolve in `--filter` expressions, propagate
+   * `--affected`, and appear in `turbo query`. Buildable packages register `build`
+   * (`uv build --package`), and all packages register `format` and `check`;
+   * the user-named workspace package registers workspace-wide versions of the
+   * quality tasks. External dependencies hash from `uv.lock` per
+   * package, and `turbo prune` produces a reachability-pruned `uv.lock`
+   * and root `pyproject.toml`. uv is the only supported Python package
+   * manager. This feature is experimental.
    *
    * @defaultValue `false`
    */

--- a/packages/turbo-types/src/types/config-v2.ts
+++ b/packages/turbo-types/src/types/config-v2.ts
@@ -353,9 +353,14 @@ export interface FutureFlags {
    *
    * When enabled, Python packages are discovered from the root
    * `pyproject.toml`'s `[tool.uv.workspace]` members and participate in the
-   * package graph, resolve in `--filter` expressions, and appear in
-   * `turbo query`. uv is the only supported Python package manager. This
-   * feature is experimental.
+    * package graph: they resolve in `--filter` expressions, propagate
+    * `--affected`, and appear in `turbo query`. Buildable packages register `build`
+    * (`uv build --package`), and all packages register `format` and `check`;
+    * the user-named workspace package registers workspace-wide versions of the
+    * quality tasks. External dependencies hash from `uv.lock` per
+    * package, and `turbo prune` produces a reachability-pruned `uv.lock`
+    * and root `pyproject.toml`. uv is the only supported Python package
+    * manager. This feature is experimental.
    *
    * @defaultValue `false`
    */

--- a/turborepo-tests/integration/fixtures/uv_monorepo/.gitignore
+++ b/turborepo-tests/integration/fixtures/uv_monorepo/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.venv/
+dist/
+__pycache__/
+.turbo/

--- a/turborepo-tests/integration/fixtures/uv_monorepo/package-lock.json
+++ b/turborepo-tests/integration/fixtures/uv_monorepo/package-lock.json
@@ -1,0 +1,19 @@
+{
+  "name": "uv-monorepo",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "uv-monorepo",
+      "workspaces": ["packages/**"]
+    },
+    "node_modules/js-pkg": {
+      "resolved": "packages/js-pkg",
+      "link": true
+    },
+    "packages/js-pkg": {
+      "name": "js-pkg",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/turborepo-tests/integration/fixtures/uv_monorepo/package.json
+++ b/turborepo-tests/integration/fixtures/uv_monorepo/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "uv-monorepo",
+  "private": true,
+  "packageManager": "npm@10.5.0",
+  "workspaces": ["packages/**"]
+}

--- a/turborepo-tests/integration/fixtures/uv_monorepo/packages/js-pkg/package.json
+++ b/turborepo-tests/integration/fixtures/uv_monorepo/packages/js-pkg/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "js-pkg",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "echo js-pkg built"
+  }
+}

--- a/turborepo-tests/integration/fixtures/uv_monorepo/pyproject.toml
+++ b/turborepo-tests/integration/fixtures/uv_monorepo/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.turbo]
+name = "pyacme"
+
+[tool.uv.workspace]
+members = ["python/*"]

--- a/turborepo-tests/integration/fixtures/uv_monorepo/python/py-app/pyproject.toml
+++ b/turborepo-tests/integration/fixtures/uv_monorepo/python/py-app/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "py-app"
+version = "0.1.0"
+requires-python = ">=3.9"
+dependencies = ["py-lib"]
+
+[tool.uv.sources]
+py-lib = { workspace = true }
+
+[build-system]
+requires = ["uv_build>=0.8,<2"]
+build-backend = "uv_build"

--- a/turborepo-tests/integration/fixtures/uv_monorepo/python/py-app/src/py_app/__init__.py
+++ b/turborepo-tests/integration/fixtures/uv_monorepo/python/py-app/src/py_app/__init__.py
@@ -1,0 +1,5 @@
+from py_lib import greeting
+
+
+def main() -> None:
+    print(greeting())

--- a/turborepo-tests/integration/fixtures/uv_monorepo/python/py-lib/pyproject.toml
+++ b/turborepo-tests/integration/fixtures/uv_monorepo/python/py-lib/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "py-lib"
+version = "0.1.0"
+requires-python = ">=3.9"
+dependencies = []
+
+[build-system]
+requires = ["uv_build>=0.8,<2"]
+build-backend = "uv_build"

--- a/turborepo-tests/integration/fixtures/uv_monorepo/python/py-lib/src/py_lib/__init__.py
+++ b/turborepo-tests/integration/fixtures/uv_monorepo/python/py-lib/src/py_lib/__init__.py
@@ -1,0 +1,2 @@
+def greeting() -> str:
+    return "hello from py-lib"

--- a/turborepo-tests/integration/fixtures/uv_monorepo/turbo.json
+++ b/turborepo-tests/integration/fixtures/uv_monorepo/turbo.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://turborepo.dev/schema.json",
+  "futureFlags": { "experimentalPythonWorkspaces": true },
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"]
+    },
+    "format": {},
+    "check": {}
+  }
+}

--- a/turborepo-tests/integration/fixtures/uv_monorepo/uv.lock
+++ b/turborepo-tests/integration/fixtures/uv_monorepo/uv.lock
@@ -1,0 +1,25 @@
+version = 1
+revision = 3
+requires-python = ">=3.9"
+
+[manifest]
+members = [
+    "py-app",
+    "py-lib",
+]
+
+[[package]]
+name = "py-app"
+version = "0.1.0"
+source = { editable = "python/py-app" }
+dependencies = [
+    { name = "py-lib" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "py-lib", editable = "python/py-lib" }]
+
+[[package]]
+name = "py-lib"
+version = "0.1.0"
+source = { editable = "python/py-lib" }

--- a/turborepo-tests/integration/fixtures/uv_pure_workspace/.gitignore
+++ b/turborepo-tests/integration/fixtures/uv_pure_workspace/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+dist/
+__pycache__/
+.turbo/

--- a/turborepo-tests/integration/fixtures/uv_pure_workspace/packages/py-app/pyproject.toml
+++ b/turborepo-tests/integration/fixtures/uv_pure_workspace/packages/py-app/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "py-app"
+version = "0.1.0"
+requires-python = ">=3.9"
+dependencies = ["py-lib"]
+
+[tool.uv.sources]
+py-lib = { workspace = true }
+
+[build-system]
+requires = ["uv_build>=0.8,<2"]
+build-backend = "uv_build"

--- a/turborepo-tests/integration/fixtures/uv_pure_workspace/packages/py-app/src/py_app/__init__.py
+++ b/turborepo-tests/integration/fixtures/uv_pure_workspace/packages/py-app/src/py_app/__init__.py
@@ -1,0 +1,5 @@
+from py_lib import greeting
+
+
+def main() -> None:
+    print(greeting())

--- a/turborepo-tests/integration/fixtures/uv_pure_workspace/packages/py-lib/pyproject.toml
+++ b/turborepo-tests/integration/fixtures/uv_pure_workspace/packages/py-lib/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "py-lib"
+version = "0.1.0"
+requires-python = ">=3.9"
+dependencies = []
+
+[build-system]
+requires = ["uv_build>=0.8,<2"]
+build-backend = "uv_build"

--- a/turborepo-tests/integration/fixtures/uv_pure_workspace/packages/py-lib/src/py_lib/__init__.py
+++ b/turborepo-tests/integration/fixtures/uv_pure_workspace/packages/py-lib/src/py_lib/__init__.py
@@ -1,0 +1,2 @@
+def greeting() -> str:
+    return "hello from py-lib"

--- a/turborepo-tests/integration/fixtures/uv_pure_workspace/pyproject.toml
+++ b/turborepo-tests/integration/fixtures/uv_pure_workspace/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.turbo]
+name = "acme"
+
+[tool.uv.workspace]
+members = ["packages/*"]

--- a/turborepo-tests/integration/fixtures/uv_pure_workspace/turbo.json
+++ b/turborepo-tests/integration/fixtures/uv_pure_workspace/turbo.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://turborepo.dev/schema.json",
+  "futureFlags": { "experimentalPythonWorkspaces": true },
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"]
+    },
+    "format": {},
+    "check": {}
+  }
+}

--- a/turborepo-tests/integration/fixtures/uv_pure_workspace/uv.lock
+++ b/turborepo-tests/integration/fixtures/uv_pure_workspace/uv.lock
@@ -1,0 +1,25 @@
+version = 1
+revision = 3
+requires-python = ">=3.9"
+
+[manifest]
+members = [
+    "py-app",
+    "py-lib",
+]
+
+[[package]]
+name = "py-app"
+version = "0.1.0"
+source = { editable = "packages/py-app" }
+dependencies = [
+    { name = "py-lib" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "py-lib", editable = "packages/py-lib" }]
+
+[[package]]
+name = "py-lib"
+version = "0.1.0"
+source = { editable = "packages/py-lib" }


### PR DESCRIPTION
### Description

Complete experimental uv workspace support with representative pure-Python and mixed npm/uv fixtures, end-to-end coverage, pinned uv installation in CI, generated schema consistency, and user and maintainer documentation.

The integration coverage exercises graphing, filtering, native task execution, cache restoration, affectedness, and prune output. Graph-only cases remain useful when `uv` is unavailable locally.

### Testing Instructions

- Run `cargo test -p turbo --test uv_workspace_test`.
- Run `cargo test -p turborepo-repository uv`.
- Run `cargo test -p turborepo-lockfiles uv`.
- Run `cargo lint -p turborepo-repository -p turborepo-lockfiles -p turborepo-lib -p turborepo-task-executor -p turborepo-turbo-json -p turbo`.

<sub>Closes TURBO-5855</sub>