### PR TITLE
refactor: Remove retained package payloads

### DIFF
--- a/crates/turborepo-frameworks/src/lib.rs
+++ b/crates/turborepo-frameworks/src/lib.rs
@@ -152,7 +152,6 @@ mod tests {
     use test_case::test_case;
     use turborepo_repository::{
         external_resolution::{ExternalDeclaration, PackageExternalDeclarations},
-        package_graph::PackageInfo,
         package_json::PackageJson,
     };
 
@@ -175,76 +174,63 @@ mod tests {
         )
     }
 
-    #[test_case(PackageInfo::default(), None, true; "empty dependencies")]
+    #[test_case(PackageJson::default(), None, true; "empty dependencies")]
     #[test_case(
-        PackageInfo {
-            package_json: PackageJson {
+        PackageJson {
                 dependencies: deps(&[("blitz", "*")]),
                 ..Default::default()
-            },
         },
         Some(get_framework_by_slug("blitzjs")),
         true;
         "blitz"
     )]
     #[test_case(
-        PackageInfo {
-            package_json: PackageJson {
+        PackageJson {
                 dependencies: deps(&[("blitz", "*"), ("next", "*")]),
                 ..Default::default()
-            },
         },
         Some(get_framework_by_slug("blitzjs")),
         true;
         "Order is preserved (returns blitz, not next)"
     )]
     #[test_case(
-        PackageInfo {
-            package_json: PackageJson {
+        PackageJson {
                 dependencies: deps(&[("next", "*")]),
                 ..Default::default()
-            },
         },
         Some(get_framework_by_slug("nextjs")),
         true;
         "Finds next without blitz"
     )]
     #[test_case(
-        PackageInfo {
-            package_json: PackageJson {
+        PackageJson {
                 dependencies: deps(&[("solid-js", "*"), ("solid-start", "*")]),
                 ..Default::default()
-            },
         },
         Some(get_framework_by_slug("solidstart")),
         true;
         "match all strategy works (solid)"
     )]
     #[test_case(
-        PackageInfo {
-            package_json: PackageJson {
+        PackageJson {
                 dependencies: deps(&[("nuxt", "*")]),
                 ..Default::default()
-            },
         },
         Some(get_framework_by_slug("nuxtjs")),
         true;
         "match some strategy works (nuxt)"
     )]
     #[test_case(
-        PackageInfo {
-            package_json: PackageJson {
+        PackageJson {
                 dependencies: deps(&[("react-scripts", "*")]),
                 ..Default::default()
-            },
         },
         Some(get_framework_by_slug("create-react-app")),
         true;
         "match some strategy works (create-react-app)"
     )]
     #[test_case(
-        PackageInfo {
-              package_json: PackageJson {
+        PackageJson {
                             dependencies: Some(
                 vec![("next", "*")]
                     .into_iter()
@@ -252,15 +238,13 @@ mod tests {
                     .collect()
               ),
                             ..Default::default()
-              },
         },
         Some(get_framework_by_slug("nextjs")),
         false;
         "Finds next in non-monorepo"
     )]
     #[test_case(
-        PackageInfo {
-              package_json: PackageJson {
+        PackageJson {
                             dev_dependencies: Some(
                 vec![("vite", "*")]
                     .into_iter()
@@ -268,88 +252,77 @@ mod tests {
                     .collect()
               ),
                             ..Default::default()
-              },
         },
         Some(get_framework_by_slug("vite")),
         false;
         "Finds vite in devDependencies in non-monorepo"
     )]
-    #[test_case(PackageInfo::default(), None, false; "empty dependencies in non-monorepo")]
+    #[test_case(PackageJson::default(), None, false; "empty dependencies in non-monorepo")]
     #[test_case(
-        PackageInfo {
-                package_json: PackageJson {
+        PackageJson {
                                 dev_dependencies: deps(&[("vite", "*")]),
                                 ..Default::default()
-                },
         },
         None,
         true;
         "devDependencies in package_json ignored in monorepo mode"
     )]
     #[test_case(
-        PackageInfo {
-                package_json: PackageJson {
+        PackageJson {
                                 dependencies: deps(&[("solid-js", "*")]),
                 dev_dependencies: deps(&[("solid-start", "*")]),
                                 ..Default::default()
-                },
         },
         Some(get_framework_by_slug("solidstart")),
         false;
         "Strategy::All matches deps split across dependencies and devDependencies"
     )]
     #[test_case(
-        PackageInfo {
-                package_json: PackageJson {
+        PackageJson {
                                 dev_dependencies: deps(&[("react-scripts", "*")]),
                                 ..Default::default()
-                },
         },
         Some(get_framework_by_slug("create-react-app")),
         false;
         "Strategy::Some matches devDependency in non-monorepo"
     )]
     fn test_infer_framework(
-        workspace_info: PackageInfo,
+        workspace_info: PackageJson,
         expected: Option<&Framework>,
         is_monorepo: bool,
     ) {
-        let declarations = if is_monorepo {
-            workspace_info
-                .package_json
-                .dependencies
-                .iter()
-                .flatten()
-                .map(|(name, specifier)| {
-                    ExternalDeclaration::new(
-                        "workspace",
-                        name,
-                        name,
-                        specifier,
-                        DependencyKind::Production,
+        let declarations =
+            if is_monorepo {
+                workspace_info
+                    .dependencies
+                    .iter()
+                    .flatten()
+                    .map(|(name, specifier)| {
+                        ExternalDeclaration::new(
+                            "workspace",
+                            name,
+                            name,
+                            specifier,
+                            DependencyKind::Production,
+                        )
+                    })
+                    .collect::<Vec<_>>()
+            } else {
+                workspace_info
+                    .dependencies
+                    .iter()
+                    .flatten()
+                    .map(|(name, specifier)| (name, specifier, DependencyKind::Production))
+                    .chain(
+                        workspace_info.dev_dependencies.iter().flatten().map(
+                            |(name, specifier)| (name, specifier, DependencyKind::Development),
+                        ),
                     )
-                })
-                .collect::<Vec<_>>()
-        } else {
-            workspace_info
-                .package_json
-                .dependencies
-                .iter()
-                .flatten()
-                .map(|(name, specifier)| (name, specifier, DependencyKind::Production))
-                .chain(
-                    workspace_info
-                        .package_json
-                        .dev_dependencies
-                        .iter()
-                        .flatten()
-                        .map(|(name, specifier)| (name, specifier, DependencyKind::Development)),
-                )
-                .map(|(name, specifier, kind)| {
-                    ExternalDeclaration::new("workspace", name, name, specifier, kind)
-                })
-                .collect::<Vec<_>>()
-        };
+                    .map(|(name, specifier, kind)| {
+                        ExternalDeclaration::new("workspace", name, name, specifier, kind)
+                    })
+                    .collect::<Vec<_>>()
+            };
         let framework = infer_framework(
             PackageExternalDeclarations::new(&declarations, "workspace"),
             is_monorepo,

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -357,10 +357,7 @@ pub async fn prune(
     // Distinct JavaScript rendering + materialization: core already selected
     // closures and laid out packages. Format rewriting lives entirely in
     // `render_javascript_prune`; orchestration only writes the artifacts.
-    if let (Some(package_manager), Some(root_package_json)) = (
-        prune.package_graph.package_manager(),
-        prune.package_graph.root_package_json(),
-    ) {
+    if let Some(package_manager) = prune.package_graph.package_manager() {
         let original_lockfile = prune
             .package_graph
             .lockfile()
@@ -369,10 +366,11 @@ pub async fn prune(
             .package_graph
             .package_definition_path(&PackageName::Root)
             .ok_or_else(|| Error::MissingPackageDefinition(PackageName::Root))?;
+        let root_package_json = PackageJson::load(&prune.root.resolve(root_definition))?;
         let original_root_contents = prune.root.resolve(root_definition).read_to_string()?;
         let rendered = render_javascript_prune(JavaScriptPruneRenderInput {
             package_manager,
-            root_package_json,
+            root_package_json: &root_package_json,
             original_lockfile,
             workspace_paths: &workspace_paths,
             lockfile_keys: &lockfile_keys,
@@ -862,7 +860,7 @@ impl<'a> Prune<'a> {
         let definition_name = package_json_path
             .file_name()
             .ok_or(Error::WorkspaceAtFilesystemRoot)?;
-        // Load from the authoritative definition path — not PackageInfo.
+        // Load from the authoritative definition path, not retained graph data.
         let workspace_package_json =
             PackageJson::load(&package_json_path).map_err(|error| match error {
                 turborepo_repository::package_json::Error::Io(io)
@@ -1509,7 +1507,7 @@ mod tests {
         full_directory.create_dir_all().unwrap();
         json_directory.create_dir_all().unwrap();
         let scope = vec!["web".to_string()];
-        let mut prune = Prune {
+        let prune = Prune {
             package_graph,
             root: root.clone(),
             out_directory,
@@ -1555,12 +1553,8 @@ mod tests {
             .exists());
         assert!(!prune.full_directory.join_component("stale").exists());
 
-        // Closure/copy no longer require PackageInfo; definition-path IO is
-        // the fail-closed source for package.json during workspace copy.
-        assert!(prune
-            .package_graph
-            .remove_package_info_for_test(&web)
-            .is_some());
+        // Definition-path IO is the fail-closed source for package.json during
+        // workspace copy.
         assert!(prune.internal_dependencies().is_ok());
         let context = prune.package_context(&web).unwrap();
         let definition_path = prune.package_definition_path(&context).unwrap();

--- a/crates/turborepo-lib/src/devtools.rs
+++ b/crates/turborepo-lib/src/devtools.rs
@@ -111,8 +111,7 @@ impl ProperTaskGraphBuilder {
             ),
         };
 
-        // Collect authoritative execution scopes, including aggregates. The
-        // compatibility PackageInfo map can contain a synthetic Cargo root.
+        // Collect authoritative execution scopes, including aggregates.
         let workspaces: Vec<PackageName> = pkg_graph
             .package_scope_directories()
             .map(|(name, _)| name)

--- a/crates/turborepo-lib/src/microfrontends.rs
+++ b/crates/turborepo-lib/src/microfrontends.rs
@@ -373,7 +373,7 @@ fn microfrontend_packages(
 }
 
 /// Whether a package declares a dependency on `@vercel/microfrontends`, using
-/// relationship knowledge rather than `PackageInfo` / PackageJson.
+/// relationship knowledge rather than package manifests.
 fn has_mfe_dependency(package_graph: &PackageGraph, package: &PackageName) -> bool {
     package_graph.has_dependency_declaration(package, MICROFRONTENDS_PACKAGE)
 }

--- a/crates/turborepo-repository/README.md
+++ b/crates/turborepo-repository/README.md
@@ -20,7 +20,6 @@ Repository root
 Key types:
 - `PackageGraph` - Graph of workspace packages and their dependencies
 - `RepositoryKnowledge` - Immutable authority for package and aggregate identities, paths, kinds, and toolchain provenance
-- `PackageInfo` - Temporary JavaScript-shaped manifest compatibility payload; not package identity or path authority
 - `PackageManager` - Abstraction over npm/pnpm/yarn/bun
 - `ExternalResolutionDomain` - Immutable domain identity, membership, and resolution data
 

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -2354,7 +2354,6 @@ struct MetadataTarget {
 #[cfg(test)]
 mod test {
     use turbopath::{AbsoluteSystemPathBuf, IntoUnix};
-    use turborepo_errors::Spanned;
 
     use super::*;
 
@@ -3777,22 +3776,12 @@ release: 1.96.0-nightly\n",
         assert!(prune_domains.is_empty());
     }
 
-    fn package_info(name: &str) -> crate::package_graph::PackageInfo {
-        crate::package_graph::PackageInfo {
-            package_json: PackageJson {
-                name: Some(Spanned::new(name.to_string())),
-                ..Default::default()
-            },
-        }
-    }
-
     #[rustfmt::skip]
     fn task_context<'a>(
         _toolchain: &CargoContributor,
         root: &'a AbsoluteSystemPath,
         name: &str,
         directory: &'a str,
-        package: Option<&'a crate::package_graph::PackageInfo>,
     ) -> crate::package_graph::PackageTaskContext<'a> {
         let kind = if directory.is_empty() {
             crate::package_graph::PackageTaskContextKind::Aggregate
@@ -3835,7 +3824,6 @@ release: 1.96.0-nightly\n",
             name.into(),
             root,
             turbopath::AnchoredSystemPath::new(directory).unwrap(),
-            package,
             kind,
             Some(&ToolchainId::RUST),
             native_tasks,
@@ -3898,10 +3886,9 @@ release: 1.96.0-nightly\n",
             })
             .collect();
 
-        let stale_package = package_info("stale-name");
-        let app_context = task_context(&toolchain, &root, "app", "crates/app", Some(&stale_package));
-        let lib_a_context = task_context(&toolchain, &root, "lib-a", "crates/lib-a", None);
-        let workspace_context = task_context(&toolchain, &root, "fixture-ws", "", Some(&stale_package));
+        let app_context = task_context(&toolchain, &root, "app", "crates/app");
+        let lib_a_context = task_context(&toolchain, &root, "lib-a", "crates/lib-a");
+        let workspace_context = task_context(&toolchain, &root, "fixture-ws", "");
 
         // Entrypoint build: scoped to the crate, serialized on the cargo
         // group, run from the workspace root.
@@ -4025,16 +4012,8 @@ release: 1.96.0-nightly\n",
         let toolchain = CargoContributor::new(root.clone());
         toolchain.discover_packages().await.unwrap();
 
-        let stale_package = package_info("stale-name");
-        let lib_a_context = task_context(
-            &toolchain,
-            &root,
-            "lib-a",
-            "crates/lib-a",
-            Some(&stale_package),
-        );
-        let workspace_context =
-            task_context(&toolchain, &root, "fixture-ws", "", Some(&stale_package));
+        let lib_a_context = task_context(&toolchain, &root, "lib-a", "crates/lib-a");
+        let workspace_context = task_context(&toolchain, &root, "fixture-ws", "");
 
         // An override applies to any crate and any task. cwd is the package's
         // directory, and an argv still invoking cargo keeps the serial group
@@ -4086,20 +4065,15 @@ release: 1.96.0-nightly\n",
         let library_contract = &contracts["lib-a"];
         let workspace_contract = &contracts["fixture-ws"];
 
-        let app = package_info("app");
-        let lib_a = package_info("lib-a");
-        let test_util = package_info("lib-a-test-util");
-        let workspace = package_info("fixture-ws");
-        let app_ctx = task_context(&toolchain, &root, "app", "crates/app", Some(&app));
-        let lib_ctx = task_context(&toolchain, &root, "lib-a", "crates/lib-a", Some(&lib_a));
+        let app_ctx = task_context(&toolchain, &root, "app", "crates/app");
+        let lib_ctx = task_context(&toolchain, &root, "lib-a", "crates/lib-a");
         let test_util_ctx = task_context(
             &toolchain,
             &root,
             "lib-a-test-util",
             "crates/lib-a-test-util",
-            Some(&test_util),
         );
-        let workspace_ctx = task_context(&toolchain, &root, "fixture-ws", "", Some(&workspace));
+        let workspace_ctx = task_context(&toolchain, &root, "fixture-ws", "");
         let environment = toolchain::TaskIOEnvironment::default();
         let context = toolchain::TaskIOContext {
             task_args: None,
@@ -4159,7 +4133,6 @@ release: 1.96.0-nightly\n",
                 "custom-dep".into(),
                 &root,
                 turbopath::AnchoredSystemPath::new("crates/custom-dep").unwrap(),
-                None,
                 crate::package_graph::PackageTaskContextKind::Package,
                 Some(&custom_toolchain),
                 None,
@@ -4180,7 +4153,6 @@ release: 1.96.0-nightly\n",
                 "rust-by-id-only".into(),
                 &root,
                 turbopath::AnchoredSystemPath::new("crates/rust-by-id-only").unwrap(),
-                None,
                 crate::package_graph::PackageTaskContextKind::Package,
                 Some(&ToolchainId::RUST),
                 None,
@@ -4216,7 +4188,6 @@ release: 1.96.0-nightly\n",
                 "generated-scope".into(),
                 &root,
                 turbopath::AnchoredSystemPath::new("generated/scope").unwrap(),
-                None,
                 crate::package_graph::PackageTaskContextKind::Package,
                 Some(&custom_toolchain),
                 None,

--- a/crates/turborepo-repository/src/knowledge.rs
+++ b/crates/turborepo-repository/src/knowledge.rs
@@ -1,9 +1,8 @@
 //! Immutable, parser-neutral facts observed about a repository.
 //!
 //! This module deliberately contains no package manifests or native metadata.
-//! Parsers contribute normalized facts here; compatibility payloads remain
-//! inputs for classification, lockfile resolution and hash state, and task
-//! construction.
+//! Parsers contribute normalized facts here; descriptors remain transient
+//! inputs to repository construction.
 
 use std::collections::HashMap;
 

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -12,7 +12,7 @@ use turbopath::{
 use turborepo_lockfiles::Lockfile;
 
 use super::{
-    ExternalResolutionKnowledge, PackageGraph, PackageInfo, PackageName, PackageNode,
+    ExternalResolutionKnowledge, PackageGraph, PackageName, PackageNode,
     dep_splitter::{DependencySplitter, WorkspacePathIndex},
     javascript,
 };
@@ -80,10 +80,10 @@ pub enum Error {
         path: AbsoluteSystemPathBuf,
         repository_root: AbsoluteSystemPathBuf,
     },
-    #[error("missing compatibility payload for discovered scope {name}")]
-    MissingCompatibilityPayload { name: String },
-    #[error("compatibility payload {name} has no authoritative discovered scope")]
-    UnexpectedCompatibilityPayload { name: String },
+    #[error("missing construction descriptor for discovered scope {name}")]
+    MissingDescriptor { name: String },
+    #[error("construction descriptor {name} has no authoritative discovered scope")]
+    UnexpectedDescriptor { name: String },
     #[error("repository package knowledge was not constructed")]
     MissingRepositoryKnowledge,
     #[error("repository relationship knowledge was not constructed")]
@@ -420,7 +420,7 @@ struct BuildState<'a, S, T> {
 }
 
 struct PackageGraphAssembler {
-    package_payloads: HashMap<PackageName, PackageInfo>,
+    package_jsons: HashMap<PackageName, PackageJson>,
     workspace_graph: Graph<PackageNode, DependencyKind>,
     root_node_index: NodeIndex,
     root_workspace_index: NodeIndex,
@@ -428,7 +428,6 @@ struct PackageGraphAssembler {
 }
 
 struct PackageGraphAssembly {
-    package_payloads: HashMap<PackageName, PackageInfo>,
     workspace_graph: Graph<PackageNode, DependencyKind>,
     root_node_index: NodeIndex,
     root_workspace_index: NodeIndex,
@@ -437,16 +436,16 @@ struct PackageGraphAssembly {
 
 struct ObservedPackage {
     scope: PackageScopeObservation,
-    compatibility: Option<(String, PackageInfo)>,
+    descriptor: Option<(String, PackageJson)>,
     native_relationships: Option<(String, Vec<Relationship>)>,
     native_tasks: Option<crate::native_tasks::NativeTaskObservation>,
 }
 
 impl PackageGraphAssembler {
-    fn new(root_package_info: Option<PackageInfo>) -> Self {
-        let mut package_payloads = HashMap::new();
-        if let Some(root_package_info) = root_package_info {
-            package_payloads.insert(PackageName::Root, root_package_info);
+    fn new(root_package_json: Option<PackageJson>) -> Self {
+        let mut package_jsons = HashMap::new();
+        if let Some(root_package_json) = root_package_json {
+            package_jsons.insert(PackageName::Root, root_package_json);
         }
 
         let mut workspace_graph = Graph::new();
@@ -464,7 +463,7 @@ impl PackageGraphAssembler {
         node_lookup.insert(root_workspace, root_workspace_index);
 
         Self {
-            package_payloads,
+            package_jsons,
             workspace_graph,
             root_node_index,
             root_workspace_index,
@@ -473,13 +472,13 @@ impl PackageGraphAssembler {
     }
 
     fn reserve(&mut self, additional: usize) {
-        self.package_payloads.reserve(additional);
+        self.package_jsons.reserve(additional);
         self.node_lookup.reserve(additional);
     }
 
-    fn add_scope(&mut self, name: PackageName, info: Option<PackageInfo>) {
-        if let Some(info) = info {
-            self.package_payloads.insert(name.clone(), info);
+    fn add_scope(&mut self, name: PackageName, descriptor: Option<PackageJson>) {
+        if let Some(descriptor) = descriptor {
+            self.package_jsons.insert(name.clone(), descriptor);
         }
         let node = PackageNode::Workspace(name);
         let idx = self.workspace_graph.add_node(node.clone());
@@ -489,35 +488,39 @@ impl PackageGraphAssembler {
     fn add_knowledge(
         &mut self,
         knowledge: &RepositoryKnowledge,
-        compatibility: Vec<(String, PackageInfo)>,
+        descriptors: Vec<(String, PackageJson)>,
     ) -> Result<(), Error> {
-        let mut compatibility: HashMap<_, _> = compatibility.into_iter().collect();
+        let mut descriptors: HashMap<_, _> = descriptors.into_iter().collect();
         self.reserve(knowledge.packages().count() + knowledge.aggregate_scopes().count());
 
         for package in knowledge.packages() {
             let name = package.identity();
             self.add_scope(
                 PackageName::Other(name.to_string()),
-                Some(compatibility.remove(name).ok_or_else(|| {
-                    Error::MissingCompatibilityPayload {
-                        name: name.to_string(),
-                    }
-                })?),
+                Some(
+                    descriptors
+                        .remove(name)
+                        .ok_or_else(|| Error::MissingDescriptor {
+                            name: name.to_string(),
+                        })?,
+                ),
             );
         }
         for aggregate in knowledge.aggregate_scopes() {
             let name = aggregate.identity();
             self.add_scope(
                 PackageName::Other(name.to_string()),
-                Some(compatibility.remove(name).ok_or_else(|| {
-                    Error::MissingCompatibilityPayload {
-                        name: name.to_string(),
-                    }
-                })?),
+                Some(
+                    descriptors
+                        .remove(name)
+                        .ok_or_else(|| Error::MissingDescriptor {
+                            name: name.to_string(),
+                        })?,
+                ),
             );
         }
-        if let Some(name) = compatibility.keys().next() {
-            return Err(Error::UnexpectedCompatibilityPayload { name: name.clone() });
+        if let Some(name) = descriptors.keys().next() {
+            return Err(Error::UnexpectedDescriptor { name: name.clone() });
         }
         Ok(())
     }
@@ -529,8 +532,8 @@ impl PackageGraphAssembler {
         for group in relationships.groups() {
             let identity = group.source();
             let name = package_name_from_identity(identity);
-            if !self.package_payloads.contains_key(&name) {
-                return Err(Error::MissingCompatibilityPayload {
+            if !self.package_jsons.contains_key(&name) {
+                return Err(Error::MissingDescriptor {
                     name: identity.to_string(),
                 });
             }
@@ -569,7 +572,7 @@ impl PackageGraphAssembler {
                 .node_lookup
                 .get(&PackageNode::Workspace(name.clone()))
                 .copied()
-                .ok_or_else(|| Error::MissingCompatibilityPayload {
+                .ok_or_else(|| Error::MissingDescriptor {
                     name: identity.to_string(),
                 })?;
             if internal.is_empty() {
@@ -598,7 +601,6 @@ impl PackageGraphAssembler {
 
     fn finish(self) -> PackageGraphAssembly {
         PackageGraphAssembly {
-            package_payloads: self.package_payloads,
             workspace_graph: self.workspace_graph,
             root_node_index: self.root_node_index,
             root_workspace_index: self.root_workspace_index,
@@ -642,10 +644,7 @@ where
         // constructed nor queried for a package manager. The graph is built
         // entirely from the extra contributors (Cargo).
         let no_javascript = root_package_json.is_none();
-        let root_package_info = root_package_json
-            .clone()
-            .map(|package_json| PackageInfo { package_json });
-        let assembler = PackageGraphAssembler::new(root_package_info);
+        let assembler = PackageGraphAssembler::new(root_package_json.clone());
 
         // The discovery strategy is shared (via the JavaScript contributor)
         // between package discovery and package-manager resolution; the
@@ -715,8 +714,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             task_contract,
         } = package.into_parts();
         // Producer-resolved external identities are contributed to the
-        // resolution generation separately; PackageInfo no longer carries
-        // closure/hash compatibility projections.
+        // resolution generation separately.
         let task_contract =
             task_contract.unwrap_or_else(crate::task_contracts::ScopeTaskContract::empty);
         if let Some(contract_toolchain) = task_contract.toolchain()
@@ -740,7 +738,6 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             }
             (None, _) => None,
         };
-        let entry = PackageInfo { package_json: json };
         let observation = PackageScopeObservation {
             identity: name.clone(),
             name_source,
@@ -752,8 +749,8 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             },
         };
         let native_relationships = name.clone().zip(native_relationships);
-        let compatibility = name.map(|name| (name, entry));
-        if compatibility.is_none() {
+        let descriptor = name.map(|name| (name, json));
+        if descriptor.is_none() {
             tracing::debug!(
                 "ignoring package definition at {} since it has no name",
                 manifest_path
@@ -761,7 +758,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
         }
         Ok(ObservedPackage {
             scope: observation,
-            compatibility,
+            descriptor,
             native_relationships,
             native_tasks: native_task_observation,
         })
@@ -809,12 +806,12 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
 
         let _span = tracing::info_span!("add_packages").entered();
         let mut observations = Vec::with_capacity(discovered.len());
-        let mut compatibility = Vec::with_capacity(discovered.len());
+        let mut descriptors = Vec::with_capacity(discovered.len());
         for (toolchain, package) in discovered {
             let observed = self.observe_package(toolchain, package)?;
             observations.push(observed.scope);
-            if let Some(projection) = observed.compatibility {
-                compatibility.push(projection);
+            if let Some(descriptor) = observed.descriptor {
+                descriptors.push(descriptor);
             }
             if let Some((source, relationships)) = observed.native_relationships {
                 self.native_relationships.insert(source, relationships);
@@ -843,7 +840,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
                 "observed native workspace root"
             );
         }
-        self.assembler.add_knowledge(&knowledge, compatibility)?;
+        self.assembler.add_knowledge(&knowledge, descriptors)?;
         self.knowledge = Some(knowledge);
 
         let Self {
@@ -951,7 +948,6 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             relationship_groups,
         )?);
         let PackageGraphAssembly {
-            package_payloads,
             workspace_graph,
             root_node_index,
             root_workspace_index,
@@ -1022,7 +1018,6 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             root_workspace_index,
             node_lookup,
             root_package_json,
-            package_payloads,
             lockfile: lockfile.map(Arc::from),
             package_manager,
             knowledge,
@@ -1052,7 +1047,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
             .ok_or(Error::MissingRepositoryKnowledge)?;
         let path_index = WorkspacePathIndex::from_knowledge(knowledge);
         // Compute once — for pnpm/Berry this reads a config file from disk.
-        // Without hoisting, classifying each compatibility descriptor would
+        // Without hoisting, classifying each JavaScript descriptor would
         // redundantly read the same file. Cargo supplies classified internal
         // relationships, so its empty descriptors never reach this fallback.
         let link_workspace_packages =
@@ -1086,21 +1081,21 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
                         None => {
                             let name = package_name_from_identity(identity);
                             let entry =
-                                self.assembler.package_payloads.get(&name).ok_or_else(|| {
-                                    Error::MissingCompatibilityPayload {
+                                self.assembler.package_jsons.get(&name).ok_or_else(|| {
+                                    Error::MissingDescriptor {
                                         name: identity.to_string(),
                                     }
                                 })?;
                             let definition_path = scope_definition_path(knowledge, &name)
-                                .ok_or_else(|| Error::MissingCompatibilityPayload {
+                                .ok_or_else(|| Error::MissingDescriptor {
                                     name: identity.to_string(),
                                 })?;
                             Relationships::classify(
                                 self.repo_root,
                                 definition_path,
-                                &self.assembler.package_payloads,
+                                &self.assembler.package_jsons,
                                 link_workspace_packages,
-                                entry.package_json.dependencies_with_kind(),
+                                entry.dependencies_with_kind(),
                                 &path_index,
                                 catalogs.as_ref(),
                             )
@@ -1343,7 +1338,6 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             Box::new(Error::MissingRelationshipKnowledge),
         ))?;
         let PackageGraphAssembly {
-            package_payloads,
             workspace_graph,
             root_node_index,
             root_workspace_index,
@@ -1422,7 +1416,6 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             root_workspace_index,
             node_lookup,
             root_package_json,
-            package_payloads,
             package_manager,
             lockfile: arc_lockfile,
             knowledge,
@@ -1446,7 +1439,7 @@ impl Relationships {
     fn classify<'a, I: IntoIterator<Item = (&'a String, &'a String, DependencyKind)>>(
         repo_root: &AbsoluteSystemPath,
         workspace_json_path: &AnchoredSystemPath,
-        workspaces: &HashMap<PackageName, PackageInfo>,
+        workspaces: &HashMap<PackageName, PackageJson>,
         link_workspace_packages: bool,
         dependencies: I,
         path_index: &WorkspacePathIndex<'_>,

--- a/crates/turborepo-repository/src/package_graph/dep_splitter.rs
+++ b/crates/turborepo-repository/src/package_graph/dep_splitter.rs
@@ -5,8 +5,10 @@ use turbopath::{
     RelativeUnixPathBuf,
 };
 
-use super::{PackageInfo, PackageName};
-use crate::{knowledge::RepositoryKnowledge, package_manager::pnpm::PnpmCatalogs};
+use super::PackageName;
+use crate::{
+    knowledge::RepositoryKnowledge, package_json::PackageJson, package_manager::pnpm::PnpmCatalogs,
+};
 
 /// Reverse index from package path to package name, built once and shared
 /// across all `DependencySplitter` instances.
@@ -18,7 +20,7 @@ pub struct WorkspacePathIndex<'a>(HashMap<&'a AnchoredSystemPath, PackageName>);
 
 impl<'a> WorkspacePathIndex<'a> {
     /// Builds the production index from authoritative package definitions
-    /// rather than compatibility `PackageInfo` fields or contributor identity.
+    /// rather than transient descriptors or contributor identity.
     pub(crate) fn from_knowledge(knowledge: &'a RepositoryKnowledge) -> Self {
         Self(
             knowledge
@@ -32,7 +34,7 @@ impl<'a> WorkspacePathIndex<'a> {
 pub struct DependencySplitter<'a> {
     repo_root: &'a AbsoluteSystemPath,
     workspace_dir: &'a AbsoluteSystemPath,
-    workspaces: &'a HashMap<PackageName, PackageInfo>,
+    workspaces: &'a HashMap<PackageName, PackageJson>,
     path_index: &'a WorkspacePathIndex<'a>,
     link_workspace_packages: bool,
     catalogs: Option<&'a PnpmCatalogs>,
@@ -42,7 +44,7 @@ impl<'a> DependencySplitter<'a> {
     pub fn new(
         repo_root: &'a AbsoluteSystemPath,
         workspace_dir: &'a AbsoluteSystemPath,
-        workspaces: &'a HashMap<PackageName, PackageInfo>,
+        workspaces: &'a HashMap<PackageName, PackageJson>,
         link_workspace_packages: bool,
         path_index: &'a WorkspacePathIndex<'a>,
         catalogs: Option<&'a PnpmCatalogs>,
@@ -82,7 +84,7 @@ impl<'a> DependencySplitter<'a> {
         let is_internal = DependencyVersion::new(version).matches_workspace_package(
             // This is the current Go behavior, in the future we might not want to paper over a
             // missing version
-            info.package_json.version.as_deref().unwrap_or_default(),
+            info.version.as_deref().unwrap_or_default(),
             self.workspace_dir,
             self.repo_root,
         );
@@ -97,7 +99,7 @@ impl<'a> DependencySplitter<'a> {
     fn find_package(
         &self,
         specifier: WorkspacePackageSpecifier,
-    ) -> Option<(PackageName, &PackageInfo)> {
+    ) -> Option<(PackageName, &PackageJson)> {
         match specifier {
             WorkspacePackageSpecifier::Alias(name) => {
                 // TODO implement borrowing for workspaces to allow for zero copy queries
@@ -124,7 +126,7 @@ impl<'a> DependencySplitter<'a> {
         }
     }
 
-    fn workspace(&self, path: &AnchoredSystemPath) -> Option<(&PackageName, &PackageInfo)> {
+    fn workspace(&self, path: &AnchoredSystemPath) -> Option<(&PackageName, &PackageJson)> {
         let name = self.path_index.0.get(path)?;
         let info = self.workspaces.get(name)?;
         Some((name, info))
@@ -400,38 +402,30 @@ mod test {
             let mut map = HashMap::new();
             map.insert(
                 PackageName::Other("@scope/foo".to_string()),
-                PackageInfo {
-                    package_json: PackageJson {
-                        version: Some(package_version.to_string()),
-                        ..Default::default()
-                    },
+                PackageJson {
+                    version: Some(package_version.to_string()),
+                    ..Default::default()
                 },
             );
             map.insert(
                 PackageName::Other("bar".to_string()),
-                PackageInfo {
-                    package_json: PackageJson {
-                        version: Some("1.0.0".to_string()),
-                        ..Default::default()
-                    },
+                PackageJson {
+                    version: Some("1.0.0".to_string()),
+                    ..Default::default()
                 },
             );
             map.insert(
                 PackageName::Other("baz".to_string()),
-                PackageInfo {
-                    package_json: PackageJson {
-                        version: Some("1.0.0".to_string()),
-                        ..Default::default()
-                    },
+                PackageJson {
+                    version: Some("1.0.0".to_string()),
+                    ..Default::default()
                 },
             );
             map.insert(
                 PackageName::Other("buffer".to_string()),
-                PackageInfo {
-                    package_json: PackageJson {
-                        version: Some("6.0.3".to_string()),
-                        ..Default::default()
-                    },
+                PackageJson {
+                    version: Some("6.0.3".to_string()),
+                    ..Default::default()
                 },
             );
             map
@@ -512,11 +506,9 @@ mod test {
             let mut map = HashMap::new();
             map.insert(
                 PackageName::Other("pkg-b".to_string()),
-                PackageInfo {
-                    package_json: PackageJson {
-                        version: Some("1.0.0".to_string()),
-                        ..Default::default()
-                    },
+                PackageJson {
+                    version: Some("1.0.0".to_string()),
+                    ..Default::default()
                 },
             );
             map
@@ -550,11 +542,9 @@ mod test {
             let mut map = HashMap::new();
             map.insert(
                 PackageName::Other("pkg-b".to_string()),
-                PackageInfo {
-                    package_json: PackageJson {
-                        version: Some("1.0.0".to_string()),
-                        ..Default::default()
-                    },
+                PackageJson {
+                    version: Some("1.0.0".to_string()),
+                    ..Default::default()
                 },
             );
             map
@@ -588,11 +578,9 @@ mod test {
             let mut map = HashMap::new();
             map.insert(
                 PackageName::Other("pkg-b".to_string()),
-                PackageInfo {
-                    package_json: PackageJson {
-                        version: Some("1.2.3".to_string()),
-                        ..Default::default()
-                    },
+                PackageJson {
+                    version: Some("1.2.3".to_string()),
+                    ..Default::default()
                 },
             );
             map
@@ -651,11 +639,9 @@ mod test {
             let mut map = HashMap::new();
             map.insert(
                 PackageName::Other("pkg-b".to_string()),
-                PackageInfo {
-                    package_json: PackageJson {
-                        version: Some("1.0.0".to_string()),
-                        ..Default::default()
-                    },
+                PackageJson {
+                    version: Some("1.0.0".to_string()),
+                    ..Default::default()
                 },
             );
             map
@@ -686,11 +672,9 @@ mod test {
             let mut map = HashMap::new();
             map.insert(
                 PackageName::Other("pkg-b".to_string()),
-                PackageInfo {
-                    package_json: PackageJson {
-                        version: Some("1.0.0".to_string()),
-                        ..Default::default()
-                    },
+                PackageJson {
+                    version: Some("1.0.0".to_string()),
+                    ..Default::default()
                 },
             );
             map

--- a/crates/turborepo-repository/src/package_graph/javascript.rs
+++ b/crates/turborepo-repository/src/package_graph/javascript.rs
@@ -21,8 +21,7 @@ use crate::{
 };
 
 /// One JavaScript resolution snapshot. Both production paths create this
-/// exact generation-backed shape; compatibility projections onto `PackageInfo`
-/// have been deleted.
+/// exact generation-backed shape.
 pub(super) struct ResolutionSnapshot {
     pub generation: Arc<ExternalResolutionGeneration>,
     pub warning: Option<String>,
@@ -181,7 +180,8 @@ impl PackageGraph {
             .package_manager()
             .ok_or(ChangedPackagesError::NoLockfile)?;
         let root_package_json = self
-            .root_package_json()
+            .root_package_json
+            .as_ref()
             .ok_or(ChangedPackagesError::NoLockfile)?;
         let yarnrc = matches!(package_manager, PackageManager::Berry)
             .then(|| crate::package_manager::yarnrc::YarnRc::from_file(self.repo_root()))

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -87,7 +87,7 @@ pub struct PackageGraph {
     root_workspace_index: NodeIndex,
     #[allow(dead_code)]
     node_lookup: HashMap<PackageNode, petgraph::graph::NodeIndex>,
-    package_payloads: HashMap<PackageName, PackageInfo>,
+    /// Immutable root package-manager configuration captured at construction.
     root_package_json: Option<PackageJson>,
     package_manager: Option<PackageManager>,
     lockfile: Option<Arc<dyn Lockfile>>,
@@ -103,8 +103,7 @@ pub struct PackageGraph {
     /// from construction.
     external_resolution: Mutex<ExternalResolutionKnowledge>,
     /// Lazy reverse index from exact external identities to internal
-    /// dependents. Built once from the resolution generation, not from
-    /// `PackageInfo` compatibility payloads.
+    /// dependents. Built once from the resolution generation.
     external_dep_to_internal_dependents: OnceLock<ExternalDependencyIndex>,
     /// Lazily computed internal dependencies of the root package. They are
     /// implied dependencies of every package, so per-package operations like
@@ -142,21 +141,6 @@ impl WorkspacePackage {
             path: AnchoredSystemPathBuf::default(),
         }
     }
-}
-
-/// Compatibility data retained for descriptor relationship classification
-/// and task consumers.
-///
-/// Package identity, directory ownership, definition source, provenance, and
-/// external-resolution state are authoritative in repository knowledge, not in
-/// this projection.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct PackageInfo {
-    /// A temporary compatibility descriptor for relationship classification
-    /// and tasks.
-    /// Its native `name` may be retained for later payload semantics, but must
-    /// never be used as package identity or to derive paths or provenance.
-    pub package_json: PackageJson,
 }
 
 // PackageName refers to a real package's name or the root package.
@@ -213,11 +197,11 @@ pub enum PackageGraphNodeKind {
     GraphSentinel,
 }
 
-/// Compatibility-payload-independent facts about a package graph node.
+/// Manifest-independent facts about a package graph node.
 ///
 /// Paths and provenance come from the graph's immutable repository knowledge,
-/// not from the [`PackageInfo`] compatibility projection. The graph sentinel
-/// has no directory, native definition, or toolchain provenance.
+/// The graph sentinel has no directory, native definition, or toolchain
+/// provenance.
 #[derive(Debug, Clone, Copy)]
 pub struct PackageGraphNodeView<'a> {
     kind: PackageGraphNodeKind,
@@ -230,8 +214,8 @@ pub struct PackageGraphNodeView<'a> {
 /// Identity-bearing execution context for a Turbo task namespace.
 ///
 /// Only [`PackageGraph::package_task_context`] can construct this value, so
-/// its identity, authoritative directory, and optional compatibility payload
-/// cannot be assembled from unrelated graph entries. The root Turbo namespace
+/// its identity and authoritative directory cannot be assembled from unrelated
+/// graph entries. The root Turbo namespace
 /// exists at the repository directory even when the repository has no root
 /// JavaScript scope (for example, a pure Cargo workspace).
 #[derive(Debug, Clone)]
@@ -240,13 +224,11 @@ pub struct PackageTaskContext<'a> {
     repository_root: &'a AbsoluteSystemPath,
     directory: &'a AnchoredSystemPath,
     definition_path: Option<&'a AnchoredSystemPath>,
-    package_info: Option<&'a PackageInfo>,
     external_declarations: &'a ExternalDeclarations,
     native_tasks: &'a crate::native_tasks::ScopeNativeTasks,
     task_contract: crate::task_contracts::ScopeTaskContract,
     kind: PackageTaskContextKind,
     toolchain: Option<&'a crate::toolchain::ToolchainId>,
-    requires_compatibility_payload: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -266,8 +248,8 @@ pub enum TaskEntrypointPreference {
 impl<'a> PackageTaskContext<'a> {
     #[cfg(test)]
     #[rustfmt::skip]
-    pub(crate) fn new_for_test(package: PackageName, repository_root: &'a AbsoluteSystemPath, directory: &'a AnchoredSystemPath, package_info: Option<&'a PackageInfo>, kind: PackageTaskContextKind, toolchain: Option<&'a crate::toolchain::ToolchainId>) -> Self {
-        Self::new_for_test_with_native_tasks(package, repository_root, directory, package_info, kind, toolchain, None, None)
+    pub(crate) fn new_for_test(package: PackageName, repository_root: &'a AbsoluteSystemPath, directory: &'a AnchoredSystemPath, kind: PackageTaskContextKind, toolchain: Option<&'a crate::toolchain::ToolchainId>) -> Self {
+        Self::new_for_test_with_native_tasks(package, repository_root, directory, kind, toolchain, None, None)
     }
 
     #[cfg(test)]
@@ -275,7 +257,6 @@ impl<'a> PackageTaskContext<'a> {
         package: PackageName,
         repository_root: &'a AbsoluteSystemPath,
         directory: &'a AnchoredSystemPath,
-        package_info: Option<&'a PackageInfo>,
         kind: PackageTaskContextKind,
         toolchain: Option<&'a crate::toolchain::ToolchainId>,
         native_tasks: Option<Vec<crate::native_tasks::NativeTask>>,
@@ -293,24 +274,9 @@ impl<'a> PackageTaskContext<'a> {
                 crate::native_tasks::ScopeNativeTasks::Available(tasks.into_boxed_slice())
             };
             Box::leak(Box::new(scope)) as &'static _
-        } else if let Some(info) = package_info {
-            let observation = crate::native_tasks::observation_from_package_json(
-                package.as_str(),
-                &info.package_json,
-            );
-            let scope = if observation.tasks.is_empty() {
-                crate::native_tasks::ScopeNativeTasks::Empty
-            } else {
-                crate::native_tasks::ScopeNativeTasks::Available(
-                    observation.tasks.into_boxed_slice(),
-                )
-            };
-            Box::leak(Box::new(scope)) as &'static _
         } else {
             &UNKNOWN_NATIVE_TASKS
         };
-        let requires_compatibility_payload = package != PackageName::Root
-            || toolchain == Some(&crate::toolchain::ToolchainId::JAVASCRIPT);
         let task_contract =
             task_contract.unwrap_or_else(crate::task_contracts::ScopeTaskContract::empty);
         Self {
@@ -318,13 +284,11 @@ impl<'a> PackageTaskContext<'a> {
             repository_root,
             directory,
             definition_path: None,
-            package_info,
             external_declarations,
             native_tasks,
             task_contract,
             kind,
             toolchain,
-            requires_compatibility_payload,
         }
     }
 
@@ -351,10 +315,6 @@ impl<'a> PackageTaskContext<'a> {
         )
     }
 
-    pub fn package_info(&self) -> Option<&'a PackageInfo> {
-        self.package_info
-    }
-
     pub fn external_declarations(&self) -> PackageExternalDeclarations<'_> {
         self.external_declarations
             .for_package(self.package.as_str())
@@ -374,10 +334,6 @@ impl<'a> PackageTaskContext<'a> {
 
     pub fn toolchain(&self) -> Option<&'a crate::toolchain::ToolchainId> {
         self.toolchain
-    }
-
-    pub fn requires_compatibility_payload(&self) -> bool {
-        self.requires_compatibility_payload
     }
 }
 
@@ -884,7 +840,7 @@ impl PackageGraph {
         }
     }
 
-    /// Looks up manifest-independent facts for a compatibility package
+    /// Looks up manifest-independent facts for a package
     /// identity. Unlike [`Self::package_dir`], this returns `None` for the
     /// synthetic root workspace when no root JavaScript scope exists.
     pub fn package_view(&self, package: &PackageName) -> Option<PackageGraphNodeView<'_>> {
@@ -918,41 +874,36 @@ impl PackageGraph {
 
     /// Resolves the complete context for tasks in `package`.
     ///
-    /// Non-root identities must exist in repository knowledge. Compatibility
-    /// payload is associated when present, but is not authoritative and is not
-    /// required to construct a context. The root identity denotes Turbo's root
-    /// task namespace and is always anchored at the repository directory.
+    /// Non-root identities must exist in repository knowledge. The root
+    /// identity denotes Turbo's root task namespace and is always anchored at
+    /// the repository directory.
     pub fn package_task_context(&self, package: &PackageName) -> Option<PackageTaskContext<'_>> {
-        let (package, directory, definition_path, kind, toolchain, requires_compatibility_payload) =
-            match package {
-                PackageName::Root => {
-                    let scope = self.knowledge.root_javascript_scope();
-                    (
-                        PackageName::Root,
-                        self.knowledge.repository_directory(),
-                        scope.map(|scope| scope.definition_path()),
-                        PackageTaskContextKind::Root,
-                        scope.map(|scope| scope.toolchain()),
-                        scope.is_some(),
-                    )
-                }
-                PackageName::Other(name) => {
-                    let scope = self.knowledge.scope(name)?;
-                    let kind = match scope.kind() {
-                        crate::knowledge::ScopeKind::Package => PackageTaskContextKind::Package,
-                        crate::knowledge::ScopeKind::Aggregate => PackageTaskContextKind::Aggregate,
-                    };
-                    (
-                        PackageName::Other(scope.identity().to_owned()),
-                        scope.directory(),
-                        Some(scope.definition_path()),
-                        kind,
-                        Some(scope.toolchain()),
-                        true,
-                    )
-                }
-            };
-        let package_info = self.package_payloads.get(&package);
+        let (package, directory, definition_path, kind, toolchain) = match package {
+            PackageName::Root => {
+                let scope = self.knowledge.root_javascript_scope();
+                (
+                    PackageName::Root,
+                    self.knowledge.repository_directory(),
+                    scope.map(|scope| scope.definition_path()),
+                    PackageTaskContextKind::Root,
+                    scope.map(|scope| scope.toolchain()),
+                )
+            }
+            PackageName::Other(name) => {
+                let scope = self.knowledge.scope(name)?;
+                let kind = match scope.kind() {
+                    crate::knowledge::ScopeKind::Package => PackageTaskContextKind::Package,
+                    crate::knowledge::ScopeKind::Aggregate => PackageTaskContextKind::Aggregate,
+                };
+                (
+                    PackageName::Other(scope.identity().to_owned()),
+                    scope.directory(),
+                    Some(scope.definition_path()),
+                    kind,
+                    Some(scope.toolchain()),
+                )
+            }
+        };
         let native_tasks = self.native_task_knowledge.for_scope(package.as_str());
         let task_contract = self.task_contract_knowledge.for_scope(package.as_str());
 
@@ -961,13 +912,11 @@ impl PackageGraph {
             repository_root: self.knowledge.repository_root(),
             directory,
             definition_path,
-            package_info,
             external_declarations: self.external_declaration_view(),
             native_tasks,
             task_contract,
             kind,
             toolchain,
-            requires_compatibility_payload,
         })
     }
 
@@ -975,8 +924,7 @@ impl PackageGraph {
     ///
     /// The root namespace is always first and present exactly once, including
     /// in repositories without a root JavaScript scope. All other identities
-    /// follow authoritative repository observation order; compatibility
-    /// payload entries cannot add or remove namespaces from this iterator.
+    /// follow authoritative repository observation order.
     pub fn package_task_contexts(&self) -> impl Iterator<Item = PackageTaskContext<'_>> + '_ {
         std::iter::once(PackageName::Root)
             .chain(
@@ -988,26 +936,6 @@ impl PackageGraph {
                 Some(context) => context,
                 None => unreachable!("authoritative package name must resolve to a task context"),
             })
-    }
-
-    /// Test hook for exercising knowledge-backed consumers without a
-    /// compatibility projection.
-    #[cfg(any(test, feature = "test-util"))]
-    pub fn remove_package_info_for_test(&mut self, package: &PackageName) -> Option<PackageInfo> {
-        self.package_payloads.remove(package)
-    }
-
-    #[cfg(any(test, feature = "test-util"))]
-    pub fn set_compatibility_manifest_name_for_test(
-        &mut self,
-        package: &PackageName,
-        compatibility_manifest_name: Option<String>,
-    ) -> bool {
-        let Some(payload) = self.package_payloads.get_mut(package) else {
-            return false;
-        };
-        payload.package_json.name = compatibility_manifest_name.map(turborepo_errors::Spanned::new);
-        true
     }
 
     /// Iterates the structural graph sentinel followed by every authoritative
@@ -1160,11 +1088,6 @@ impl PackageGraph {
             .generation = None;
     }
 
-    pub fn package_json(&self, package: &PackageName) -> Option<&PackageJson> {
-        let entry = self.package_payloads.get(package)?;
-        Some(&entry.package_json)
-    }
-
     pub fn package_dir(&self, package: &PackageName) -> Option<&AnchoredSystemPath> {
         match package {
             // Compatibility: the synthetic root workspace has historically
@@ -1173,10 +1096,6 @@ impl PackageGraph {
             PackageName::Root => Some(self.knowledge.repository_directory()),
             PackageName::Other(_) => self.package_view(package)?.directory(),
         }
-    }
-
-    pub fn package_info(&self, package: &PackageName) -> Option<&PackageInfo> {
-        self.package_payloads.get(package)
     }
 
     fn package_dir_for_node(&self, node: &PackageNode) -> Option<&AnchoredSystemPath> {
@@ -1207,10 +1126,6 @@ impl PackageGraph {
             .edges_connecting(*from_index, *to_index)
             .next()
             .map(|edge| *edge.weight())
-    }
-
-    pub fn root_package_json(&self) -> Option<&PackageJson> {
-        self.root_package_json.as_ref()
     }
 
     /// Gets all the nodes that directly depend on this one, that is to say
@@ -1935,8 +1850,7 @@ mod test {
                 );
             }
 
-            let missing = PackageName::from("b");
-            assert!(dep_graph.remove_package_info_for_test(&missing).is_some());
+            let changed = PackageName::from("b");
             assert_eq!(
                 dep_graph
                     .changed_packages_from_lockfile(previous.as_ref())
@@ -1944,7 +1858,7 @@ mod test {
                     .into_iter()
                     .map(|change| change.package.name)
                     .collect::<Vec<_>>(),
-                vec![missing]
+                vec![changed]
             );
 
             dep_graph.remove_external_resolution_for_test();
@@ -2924,7 +2838,7 @@ version = "0.1.0"
         let mut expected_cargo_fingerprints = None;
         for iteration in 0..8 {
             let _defer_resolution = iteration % 2 == 1;
-            let mut pkg_graph = PackageGraph::builder(
+            let pkg_graph = PackageGraph::builder(
                 &root,
                 PackageJson::from_value(json!({ "name": "root", "dependencies": { "a": "1" } }))
                     .unwrap(),
@@ -2945,23 +2859,16 @@ version = "0.1.0"
             .unwrap();
 
             assert!(pkg_graph.validate().is_ok());
-            assert!(pkg_graph.package_task_contexts().all(|context| {
-                context.requires_compatibility_payload() && context.package_info().is_some()
-            }));
+            assert!(
+                pkg_graph
+                    .package_task_contexts()
+                    .all(|context| { pkg_graph.package_task_context(context.package()).is_some() })
+            );
 
             let app_name = PackageName::from("app");
-            assert!(pkg_graph.set_compatibility_manifest_name_for_test(
-                &app_name,
-                Some("stale-payload-name".into())
-            ));
             assert_eq!(
                 pkg_graph.package_task_context(&app_name).unwrap().package(),
                 &app_name
-            );
-            assert!(
-                pkg_graph
-                    .package_task_context(&PackageName::from("stale-payload-name"))
-                    .is_none()
             );
 
             // All packages are present with knowledge-backed provenance.
@@ -2973,7 +2880,6 @@ version = "0.1.0"
                 pkg_graph.package_toolchain(&PackageName::from("js-pkg")),
                 Some(&crate::toolchain::ToolchainId::JAVASCRIPT)
             );
-            let _workspace_pkg = pkg_graph.package_info(&PackageName::from("acme")).unwrap();
             assert_eq!(
                 pkg_graph.package_toolchain(&PackageName::from("acme")),
                 Some(&crate::toolchain::ToolchainId::RUST)
@@ -3144,7 +3050,7 @@ version = "0.1.0"
 
     /// A pure Cargo workspace has no root package.json and no JavaScript
     /// package manager: the graph is built entirely from the Cargo toolchain,
-    /// and both `package_manager()` and `root_package_json()` report `None`.
+    /// and `package_manager()` reports `None`.
     #[tokio::test(flavor = "multi_thread")]
     async fn test_pure_cargo_workspace_has_no_javascript() {
         let (_tmp, root) = canonical_tempdir();
@@ -3244,8 +3150,7 @@ version = "0.1.0"
         );
         assert_eq!(root_context.kind(), PackageTaskContextKind::Root);
         assert_eq!(root_context.toolchain(), None);
-        assert!(root_context.package_info().is_none());
-        assert!(pkg_graph.package_info(&PackageName::Root).is_none());
+        assert!(!root_context.is_package_json_scope());
         assert_eq!(pkg_graph.package_definition_path(&PackageName::Root), None);
         assert_eq!(pkg_graph.package_toolchain(&PackageName::Root), None);
         assert!(
@@ -3282,15 +3187,12 @@ version = "0.1.0"
             "existing workspace-scoped Cargo behavior is represented as an aggregate"
         );
 
-        // No JavaScript project: no package manager, no root manifest.
+        // No JavaScript project: no package manager or root JavaScript scope.
         assert!(
             pkg_graph.package_manager().is_none(),
             "a pure Cargo workspace has no JavaScript package manager"
         );
-        assert!(
-            pkg_graph.root_package_json().is_none(),
-            "a pure Cargo workspace has no root package.json"
-        );
+        assert!(!pkg_graph.has_root_javascript_scope());
 
         // The Cargo crates and workspace aggregate populate the graph.
         assert_eq!(
@@ -3338,12 +3240,6 @@ version = "0.1.0"
             "app should depend on lib-a, got {app_deps:?}"
         );
 
-        assert!(
-            pkg_graph
-                .remove_package_info_for_test(&PackageName::Root)
-                .is_none()
-        );
-        assert!(pkg_graph.remove_package_info_for_test(&app_name).is_some());
         let contexts = pkg_graph.package_task_contexts().collect::<Vec<_>>();
         assert_eq!(
             contexts.first().map(|context| context.package()),
@@ -3372,27 +3268,11 @@ version = "0.1.0"
             assert_eq!(enumerated.directory(), point.directory());
             assert_eq!(enumerated.kind(), point.kind());
             assert_eq!(enumerated.toolchain(), point.toolchain());
-            assert_eq!(
-                enumerated.requires_compatibility_payload(),
-                point.requires_compatibility_payload()
-            );
-            assert_eq!(
-                enumerated.package_info().map(std::ptr::from_ref),
-                point.package_info().map(std::ptr::from_ref)
-            );
         }
-        assert!(
-            contexts
-                .iter()
-                .find(|context| context.package() == &app_name)
-                .is_some_and(|context| context.package_info().is_none()),
-            "removing compatibility payload must not remove the package namespace"
-        );
-        let root_without_payload = pkg_graph
+        let root_context = pkg_graph
             .package_task_context(&PackageName::Root)
-            .expect("root context is independent of compatibility payload");
-        assert!(root_without_payload.package_info().is_none());
-        assert_eq!(root_without_payload.repository_root(), root.as_ref());
+            .expect("root Turbo namespace always has a context");
+        assert_eq!(root_context.repository_root(), root.as_ref());
     }
 
     /// A crate and a JS package sharing a name is a hard error, like any

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -91,15 +91,13 @@ impl fmt::Display for ToolchainId {
     }
 }
 
-/// Compatibility output from native package discovery.
+/// Output from native package discovery.
 ///
 /// Identity and source facts feed [`crate::knowledge::RepositoryKnowledge`].
-/// `descriptor` remains temporary compatibility input for relationship
-/// classification and JavaScript construction paths. JavaScript packages retain
-/// their parsed manifest; native producers can contribute normalized
-/// relationships and tasks separately without synthesizing JavaScript
-/// dependency maps. Cargo still supplies an empty descriptor only because graph
-/// assembly currently requires a compatibility payload for every scope.
+/// `descriptor` remains transient construction input for relationship
+/// classification and JavaScript construction paths. Native producers can
+/// contribute normalized relationships and tasks separately without
+/// synthesizing JavaScript dependency maps.
 #[derive(Debug, Clone)]
 pub struct DiscoveredPackage {
     /// Real user-facing identity, extracted by the native producer. `None`
@@ -110,7 +108,7 @@ pub struct DiscoveredPackage {
     name_source: Option<Spanned<()>>,
     /// Whether this is a real package or an execution-only aggregate scope.
     scope_kind: DiscoveredScopeKind,
-    /// Temporary relationship/task compatibility data; never identity or path
+    /// Transient relationship/task construction data; never identity or path
     /// authority.
     descriptor: PackageJson,
     /// Absolute path to the package's native manifest (`package.json`,
@@ -726,7 +724,6 @@ mod tests {
             crate::package_graph::PackageName::Root,
             &root,
             directory,
-            None,
             crate::package_graph::PackageTaskContextKind::Root,
             None,
         );
@@ -869,21 +866,23 @@ mod tests {
         let repo_root_buf =
             AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
         let repo_root = repo_root_buf.as_ref() as &AbsoluteSystemPath;
-        let package = crate::package_graph::PackageInfo {
-            package_json: PackageJson::from_value(serde_json::json!({
+        let package_directory = turbopath::AnchoredSystemPath::new("apps/web").unwrap();
+        let tasks = crate::native_tasks::observation_from_package_json(
+            "web",
+            &PackageJson::from_value(serde_json::json!({
                 "name": "stale-web",
                 "scripts": { "build": "next build", "empty": "" }
             }))
             .unwrap(),
-        };
-        let package_directory = turbopath::AnchoredSystemPath::new("apps/web").unwrap();
-        let context = crate::package_graph::PackageTaskContext::new_for_test(
+        );
+        let context = crate::package_graph::PackageTaskContext::new_for_test_with_native_tasks(
             "web".into(),
             repo_root,
             package_directory,
-            Some(&package),
             crate::package_graph::PackageTaskContextKind::Package,
             Some(&ToolchainId::JAVASCRIPT),
+            Some(tasks.tasks),
+            None,
         );
 
         let command = crate::native_tasks::resolve_task_command(

--- a/crates/turborepo-run-cache/src/lib.rs
+++ b/crates/turborepo-run-cache/src/lib.rs
@@ -1076,11 +1076,11 @@ mod test {
     }
 
     #[tokio::test]
-    async fn task_cache_uses_context_and_ignores_missing_payload() {
+    async fn task_cache_uses_authoritative_context() {
         let tmp = tempdir().unwrap();
         let repo_root =
             AbsoluteSystemPathBuf::new(tmp.path().to_string_lossy().to_string()).unwrap();
-        let mut graph = javascript_graph(&repo_root, "packages").await;
+        let graph = javascript_graph(&repo_root, "packages").await;
         let cache = run_cache(&repo_root);
         let definition = TaskDefinition {
             incremental: Some(vec![IncrementalPartition {
@@ -1144,7 +1144,6 @@ mod test {
             Err(super::Error::TaskPackageMismatch { .. })
         ));
 
-        graph.remove_package_info_for_test(&PackageName::from("app"));
         assert!(
             cache
                 .task_cache(
@@ -1166,9 +1165,7 @@ mod test {
             .unwrap()
             .to_realpath()
             .unwrap();
-        let mut graph = cargo_graph(&repo_root).await;
-        graph.remove_package_info_for_test(&PackageName::Root);
-        graph.remove_package_info_for_test(&PackageName::from("cargo-workspace"));
+        let graph = cargo_graph(&repo_root).await;
         let cache = run_cache(&repo_root);
         let definition = TaskDefinition {
             outputs: TaskOutputs {

--- a/crates/turborepo-run-summary/src/task_factory.rs
+++ b/crates/turborepo-run-summary/src/task_factory.rs
@@ -234,8 +234,7 @@ where
     ///
     /// Prefer the per-run cache produced for hashing. When that cache is absent
     /// (tests or callers that did not precompute), read package resolution
-    /// knowledge directly. Never rehash closures or read
-    /// `PackageInfo::external_deps_hash`.
+    /// knowledge directly. Never rehash closures.
     fn hash_of_external_dependencies(&self, task_id: &TaskId) -> Result<String, Error> {
         let package = PackageName::from(task_id.package());
         if let Some(hashes) = self.external_deps_hashes {
@@ -448,10 +447,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn summary_uses_knowledge_when_package_payload_is_missing() {
-        let (_tempdir, mut graph) = summary_graph().await;
+    async fn summary_uses_authoritative_package_context() {
+        let (_tempdir, graph) = summary_graph().await;
         let app = PackageName::from("app");
-        assert!(graph.remove_package_info_for_test(&app).is_some());
         let task_id = TaskId::new("app", "build").into_owned();
         let engine = TestEngine {
             definitions: HashMap::from([(task_id.clone(), TaskDefinition::default())]),

--- a/crates/turborepo-task-executor/src/command.rs
+++ b/crates/turborepo-task-executor/src/command.rs
@@ -994,7 +994,7 @@ mod tests {
         let (_tempdir, repo_root, package_dir) = create_test_repo();
         let inherited_env = inherited_env_name();
         write_custom_proxy_package(&package_dir, inherited_env);
-        let mut package_graph = package_graph(
+        let package_graph = package_graph(
             &repo_root,
             &package_dir,
             PackageJson {
@@ -1006,7 +1006,6 @@ mod tests {
             },
         )
         .await;
-        package_graph.remove_package_info_for_test(&PackageName::from("web"));
         let cmd = proxy_command(&package_graph, &filtered_environment());
         assert!(
             cmd.label()
@@ -1069,10 +1068,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_microfrontend_proxy_does_not_require_package_info_payload() {
+    async fn test_microfrontend_proxy_uses_declaration_knowledge() {
         let (_tempdir, repo_root, package_dir) = create_test_repo();
         write_microfrontends_binary(&package_dir, inherited_env_name());
-        let mut graph = package_graph(
+        let graph = package_graph(
             &repo_root,
             &package_dir,
             PackageJson {
@@ -1084,7 +1083,6 @@ mod tests {
             },
         )
         .await;
-        graph.remove_package_info_for_test(&PackageName::from("web"));
         let mfe_config = MockMfeConfig("configs/microfrontends.json");
         let tasks = [TaskId::new("docs", "dev"), TaskId::new("web", "proxy")];
         let command_provider = MicroFrontendProxyProvider::new(&graph, tasks.iter(), &mfe_config);
@@ -1152,11 +1150,9 @@ mod tests {
             custom_graph
                 .package_task_context(&PackageName::Root)
                 .unwrap()
-                .package_info()
-                .unwrap()
-                .package_json
-                .scripts
-                .contains_key("proxy")
+                .native_tasks()
+                .get("proxy")
+                .is_some()
         );
         let custom = proxy_command_result(&custom_graph, &environment, &config, "//")
             .unwrap()

--- a/crates/turborepo-task-executor/src/lib.rs
+++ b/crates/turborepo-task-executor/src/lib.rs
@@ -38,8 +38,7 @@ use turbopath::AbsoluteSystemPathBuf;
 use turborepo_task_id::TaskId;
 use turborepo_types::{ContinueMode, EnvMode, ResolvedLogOrder, ResolvedLogPrefix, UIMode};
 pub use visitor::{
-    EngineExecutor, EngineMessage, EngineProvider, TaskCallback, TaskHashProvider,
-    command_invokes_turbo,
+    EngineExecutor, EngineMessage, EngineProvider, TaskCallback, command_invokes_turbo,
 };
 
 /// Configuration for task execution.

--- a/crates/turborepo-task-executor/src/visitor.rs
+++ b/crates/turborepo-task-executor/src/visitor.rs
@@ -5,12 +5,8 @@
 //! but these abstractions allow for decoupling and testing.
 
 use tokio::sync::mpsc;
-use turborepo_repository::package_graph::PackageInfo;
 use turborepo_task_id::TaskId;
-use turborepo_telemetry::events::task::PackageTaskEventBuilder;
-use turborepo_types::{EnvMode, StopExecution, TaskDefinition};
-
-use crate::HashTrackerProvider;
+use turborepo_types::{StopExecution, TaskDefinition};
 
 /// Trait for providing task execution messages from the engine.
 pub trait EngineProvider: Send + Sync {
@@ -25,29 +21,6 @@ pub trait EngineProvider: Send + Sync {
 
     /// Returns the dependencies for a given task ID.
     fn dependencies(&self, task_id: &TaskId) -> Option<Vec<TaskId<'static>>>;
-}
-
-/// Trait for providing task hashing functionality.
-pub trait TaskHashProvider: Send {
-    /// The error type for hash calculation.
-    type Error: std::error::Error + Send;
-
-    /// The hash tracker type returned by this provider.
-    type HashTracker: HashTrackerProvider;
-
-    /// Calculate the hash for a task.
-    fn calculate_task_hash(
-        &self,
-        task_id: &TaskId,
-        task_definition: &TaskDefinition,
-        env_mode: EnvMode,
-        workspace_info: &PackageInfo,
-        dependency_set: Vec<TaskId<'static>>,
-        telemetry: PackageTaskEventBuilder,
-    ) -> Result<String, Self::Error>;
-
-    /// Get the hash tracker.
-    fn task_hash_tracker(&self) -> Self::HashTracker;
 }
 
 /// Callback for task completion.

--- a/crates/turborepo-task-hash/src/lib.rs
+++ b/crates/turborepo-task-hash/src/lib.rs
@@ -1292,17 +1292,15 @@ mod test {
     }
 
     #[tokio::test]
-    async fn task_hash_uses_resolution_knowledge_without_compatibility_payload() {
+    async fn task_hash_uses_resolution_knowledge() {
         let tmp = tempdir().unwrap();
         let repo_root =
             AbsoluteSystemPathBuf::new(tmp.path().to_string_lossy().to_string()).unwrap();
-        let mut graph = javascript_graph(&repo_root).await;
+        let graph = javascript_graph(&repo_root).await;
         let package = PackageName::from("app");
-        assert!(graph.remove_package_info_for_test(&package).is_some());
         let context = graph
             .package_task_context(&package)
-            .expect("knowledge scope remains authoritative");
-        assert!(context.package_info().is_none());
+            .expect("authoritative scope has a task context");
 
         let task_id = TaskId::new("app", "build");
         let definition = TaskDefinition::default();
@@ -1476,7 +1474,7 @@ mod test {
             !graph
                 .package_task_context(&PackageName::Root)
                 .unwrap()
-                .requires_compatibility_payload()
+                .is_package_json_scope()
         );
         let task_id = TaskId::new("//", "build");
         let tasks = [TaskNode::Task(task_id.clone())];

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -173,7 +173,7 @@ Represents the workspace structure and package dependencies:
   explicit unavailable states without closure fallback hashing. Query external
   package listing, human names, and internal-dependent reverse indexes read
   the same resolution generation (including a lazy compact reverse index)
-  rather than `PackageInfo` closures or live lockfile human-name callbacks.
+  rather than retained manifest payloads or live lockfile human-name callbacks.
   N-API JavaScript lockfile package listing uses the JavaScript domain of that
   generation. The JavaScript
   adapter owns package-manager configuration, previous-lockfile parsing, and
@@ -187,11 +187,11 @@ Represents the workspace structure and package dependencies:
   Global hashing consumes the same root resolution fingerprint as task hashing
   and, when JavaScript resolution is unavailable, hashes resolution definition
   sources plus the root package.json instead of reading the singleton lockfile
-  object.   Phase 3 deletion removed `PackageInfo` closure/hash compatibility
-  fields and deferred resolution installation; readiness belongs to repository
+  object. Phase 3 deletion removed closure/hash compatibility fields and
+  deferred resolution installation; readiness belongs to repository
   construction. External declaration consumers (frameworks, boundaries, task
   hashing) read the authoritative `ExternalDeclarations` projection built from
-  relationship knowledge rather than raw manifests or PackageInfo maps. MFE
+  relationship knowledge rather than raw manifests. MFE
   enablement checks exact declaration names in the same relationship generation
   so internal workspace declarations and alias-key behavior remain unchanged.
   MFE configuration discovery, directory ownership, and proxy execution accept
@@ -209,42 +209,38 @@ Represents the workspace structure and package dependencies:
 
 `RepositoryKnowledge` is the crate-private authority for package identity,
 paths, scope kind, and provenance during node assembly, and the resulting
-`PackageGraph` retains that exact immutable generation. Phase 1 of the payload
-deletion is complete: `PackageInfo` carries no identity, definition path,
-directory, or toolchain provenance; the graph exposes no payload-map identity
-enumeration. Consumers enumerate and resolve authoritative contexts/views, then
-look up an optional payload only for the remaining relationship and task data.
-The retained native `PackageJson.name` is non-authoritative payload data: no
-consumer may derive package identity, path, or provenance from it.
-Compatibility payloads still provide JavaScript relationship-classification
-inputs, lockfile resolution and hash state, and task construction data. Cargo
-no longer synthesizes JavaScript dependency maps, but retains empty
-`PackageJson` descriptors until task compatibility payloads are removed.
+`PackageGraph` retains that exact immutable generation. `PackageGraph` and
+`PackageTaskContext` retain no manifest compatibility payloads. Consumers use
+authoritative contexts, views, and immutable knowledge catalogs. A
+`DiscoveredPackage` descriptor remains transient construction input for
+JavaScript relationship classification and native-task observation; it is not
+retained in the completed graph. Its `PackageJson.name` is non-authoritative:
+no consumer may derive package identity, path, or provenance from it.
 Native manifest objects do not enter repository knowledge. Repository knowledge
 may retain bounded diagnostic provenance for an authoritative fact, such as an
 authored JavaScript package name's source text and span. Native definition paths
 must remain within the repository, including after resolving existing symlinks.
 
-The remaining payload deletion phases are explicit:
+Retained graph and task-context payload deletion is complete. Discovery
+descriptor deletion remains pending:
 
-- **Phase 2:** Move script and version reads behind task queries; normalized
-  relationship knowledge now owns graph assembly, while JavaScript declarations
-  remain a temporary classification input.
-- **Phase 3:** Complete. External resolution lives in the immutable generation; query, prune, hashing, and summaries consume it. `PackageInfo` no longer carries `unresolved_external_dependencies`, `transitive_dependencies`, or `external_deps_hash`, and deferred closure installation is gone.
+- **Phase 2:** Complete for scripts. Native task knowledge owns script queries;
+  JavaScript descriptors and package versions remain transient relationship
+  classification input and are dropped before the graph is published.
+- **Phase 3:** Complete. External resolution lives in the immutable generation; query, prune, hashing, and summaries consume it, and deferred closure installation is gone.
 - **Phase 4 (complete):** Native task/command knowledge is an immutable catalog produced at repository construction. JavaScript scripts and Cargo verb tables contribute observations; engine, turbo-json, executor, query, devtools, LSP, and summary consumers read the catalog. Behavioral task-command callbacks have been deleted; only the JavaScript contributor and the LSP unsaved-source adapter parse scripts.
 - **Phase 5 (complete for JavaScript and Cargo):** Task-contract knowledge catalogs are produced for every scope. Engine composition, task hashing, entrypoint selection, derived I/O, startup-environment projection, and execution-only compile-cache decoration consume explicit contract capabilities without live toolchain or provenance-ID dispatch.
 - **Phase 6 (complete for JavaScript and Cargo):** Change knowledge is produced at repository construction. Cargo discovery contributes `Cargo.toml` rediscovery names, the `Cargo.lock` resolution/rediscovery path, and the effective in-repository target-directory ignore prefix. `PackageGraph::active_watch_spec` is now a projection of only the immutable facts retained by that graph generation; it never calls live toolchains. Before the first generation is published, the watcher conservatively retains all in-repository events, closing the subscription/bootstrap race without mutable toolchain callbacks. Single-package generations retain no inactive Cargo facts.
 - **Phase 7 (complete):** JavaScript prune rendering is a distinct pure step (`render_javascript_prune`) producing typed artifacts; `commands/prune.rs` selects closures, performs path-safe layout, and materializes those artifacts without inline lockfile/manifest/patch format interpretation. Cargo discovery captures an immutable, generation-owned prune domain containing lockfile, root-manifest, package-directory, and post-write finalization authority. Scope contracts select JavaScript layout or an explicit native prune domain without branching on ecosystem provenance. Cargo lock pruning, extra-member selection, manifest rewriting, root/config file planning, and final lockfile canonicalization run through that graph-owned domain. Golden inventories cover standard and Docker layouts.
-- **Phase 8 (audit complete for owned consumers):** Query/devtools/summary/run/engine/watch/prune task and resolution views consume knowledge catalogs. Remaining `PackageJson` / `PackageInfo` reads are construction entry points, LSP unsaved-buffer adapters, and package-manager detection. Boundary tag diagnostics consume optional authored-name provenance from repository knowledge only when the authored name matches the authoritative identity.
+- **Phase 8 (complete for retained payloads):** Query/devtools/summary/run/engine/watch/prune task and resolution views consume knowledge catalogs. Remaining `PackageJson` use is limited to construction inputs and narrowly scoped operational reads that have not yet moved into knowledge, including root package-manager configuration, prune rendering, and LSP unsaved-buffer adaptation. Boundary tag diagnostics consume optional authored-name provenance from repository knowledge only when the authored name matches the authoritative identity.
 
 Task hashing, run-cache path construction, and run-summary task directories use
 a graph-created `PackageTaskContext` that binds identity, repository root,
-directory, kind, and an optional compatibility payload. Repository-wide task
+directory, kind, task knowledge, and contract knowledge. Repository-wide task
 namespace and external-dependency-hash enumeration is root-first, then follows
-repository observation order; scripts and dependency closures are joined only
-as compatibility payloads. Pure Cargo retains the root Turbo namespace without
-synthesizing an empty root payload; consumers reject contexts from another
-repository, and required missing payloads fail closed.
+repository observation order. Pure Cargo retains the root Turbo namespace
+without synthesizing a JavaScript scope, and consumers reject contexts from
+another repository.
 
 Repository-facing commands use the same optional-root construction policy as
 `turbo run`: a missing root `package.json` is accepted only when Cargo support


### PR DESCRIPTION
## Summary

- Remove `PackageInfo` and retained package manifest payloads from `PackageGraph` and task contexts.
- Keep JavaScript manifests transient during relationship classification, then drop them before publishing the graph.
- Migrate workspace version matching and framework fixtures to direct construction inputs.
- Delete the unused `TaskHashProvider` API and payload mutation test hooks.
- Preserve an immutable root package-manager snapshot for previous-lockfile comparison.

## Tracking

Part of TURBO-5799, specifically the compatibility payload deletion gate. Discovery descriptor deletion remains a separate follow-up.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p turborepo-repository`
- Affected consumer crate test suites
- `cargo test -p turborepo-lib`
- `cargo clippy -p turborepo-repository -p turborepo-lib -p turborepo-task-executor -p turborepo-task-hash -p turborepo-run-cache -p turborepo-run-summary -p turborepo-frameworks --all-targets -- -D warnings`
- Pre-push hooks