### PR TITLE
feat: Run native uv tasks

### DIFF
--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -3862,6 +3862,7 @@ release: 1.96.0-nightly\n",
                 None,
                 None,
                 cargo_binary.as_deref(),
+                None,
                 pass_through_args,
                 override_command,
             )

--- a/crates/turborepo-repository/src/native_tasks.rs
+++ b/crates/turborepo-repository/src/native_tasks.rs
@@ -7,6 +7,7 @@ use std::{
     ffi::OsString,
 };
 
+use turbopath::AbsoluteSystemPathBuf;
 use turborepo_errors::Spanned;
 
 use crate::{
@@ -39,6 +40,15 @@ pub enum NativeCommandTemplate {
         locked: bool,
         serial_group: Option<String>,
         pass_through_uses_separator: bool,
+    },
+    /// `uv <subcommand> <args>` with uv serial grouping. None of the
+    /// registered subcommands forwards trailing args to another tool, so
+    /// pass-through args attach directly as uv flags.
+    Uv {
+        subcommand: String,
+        /// Fixed arguments, e.g. `--package=<name>` or `--all-packages`.
+        args: Vec<String>,
+        serial_group: Option<String>,
     },
 }
 
@@ -120,6 +130,31 @@ impl NativeTask {
             cwd_policy: WorkingDirectoryPolicy::RepositoryRoot,
         }
     }
+
+    /// Construct a uv-synthesized native task (not package-authored).
+    pub fn uv(
+        name: impl Into<String>,
+        display: String,
+        subcommand: impl Into<String>,
+        args: Vec<String>,
+        serial_group: Option<String>,
+    ) -> Self {
+        let name = name.into();
+        Self {
+            name: name.clone(),
+            authored: false,
+            registered: true,
+            executable: true,
+            display: Some(display),
+            script: None,
+            command: Some(NativeCommandTemplate::Uv {
+                subcommand: subcommand.into(),
+                args,
+                serial_group,
+            }),
+            cwd_policy: WorkingDirectoryPolicy::RepositoryRoot,
+        }
+    }
 }
 
 /// Observation state for one authoritative scope's native tasks.
@@ -180,13 +215,24 @@ impl ScopeNativeTasks {
     /// command family. This also applies to override-only task names that have
     /// no catalog entry.
     pub fn override_serial_group(&self, override_command: &[String]) -> Option<String> {
-        let invokes_cargo = override_command.first().map(String::as_str) == Some("cargo");
-        (invokes_cargo
+        let program = override_command.first().map(String::as_str);
+        if program == Some("cargo")
             && self
                 .tasks()
                 .iter()
-                .any(|task| matches!(task.command(), Some(NativeCommandTemplate::Cargo { .. }))))
-        .then(|| "cargo".to_string())
+                .any(|task| matches!(task.command(), Some(NativeCommandTemplate::Cargo { .. })))
+        {
+            return Some("cargo".to_string());
+        }
+        if program == Some("uv")
+            && self
+                .tasks()
+                .iter()
+                .any(|task| matches!(task.command(), Some(NativeCommandTemplate::Uv { .. })))
+        {
+            return Some("uv".to_string());
+        }
+        None
     }
 }
 
@@ -320,6 +366,7 @@ pub fn resolve_task_command(
     package_manager: Option<&PackageManager>,
     package_manager_binary: Option<&std::path::Path>,
     cargo_binary: Option<&std::path::Path>,
+    uv_binary: Option<&std::path::Path>,
     pass_through_args: Option<&[String]>,
     override_command: Option<&[String]>,
 ) -> Result<Option<TaskCommand>, ResolveNativeCommandError> {
@@ -398,7 +445,44 @@ pub fn resolve_task_command(
                 serial_group: serial_group.clone(),
             }))
         }
+        NativeCommandTemplate::Uv {
+            subcommand,
+            args: fixed_args,
+            serial_group,
+        } => resolve_uv_task_command(
+            uv_binary,
+            cwd,
+            subcommand,
+            fixed_args,
+            serial_group.clone(),
+            pass_through_args,
+        )
+        .map(Some),
     }
+}
+
+fn resolve_uv_task_command(
+    uv_binary: Option<&std::path::Path>,
+    cwd: AbsoluteSystemPathBuf,
+    subcommand: &str,
+    fixed_args: &[String],
+    serial_group: Option<String>,
+    pass_through_args: Option<&[String]>,
+) -> Result<TaskCommand, ResolveNativeCommandError> {
+    let uv_binary = uv_binary.ok_or(ResolveNativeCommandError::MissingUvBinary)?;
+    let mut args: Vec<OsString> = std::iter::once(subcommand)
+        .chain(fixed_args.iter().map(String::as_str))
+        .map(OsString::from)
+        .collect();
+    if let Some(pass_through_args) = pass_through_args {
+        args.extend(pass_through_args.iter().map(OsString::from));
+    }
+    Ok(TaskCommand {
+        program: uv_binary.as_os_str().to_owned(),
+        args,
+        cwd,
+        serial_group,
+    })
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -409,6 +493,11 @@ pub enum ResolveNativeCommandError {
     MissingPackageManagerBinary,
     #[error("Cargo binary is not available for native task resolution")]
     MissingCargoBinary,
+    #[error(
+        "The `uv` binary is required to run Python tasks but was not found on PATH. Install uv: \
+         https://docs.astral.sh/uv/getting-started/installation/"
+    )]
+    MissingUvBinary,
 }
 
 #[cfg(test)]
@@ -521,5 +610,43 @@ mod tests {
                 .script_names()
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn uv_command_resolution_preserves_argument_order_and_group() {
+        let root =
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+        let binary = std::path::Path::new(if cfg!(windows) {
+            r"C:\bin\uv.exe"
+        } else {
+            "/bin/uv"
+        });
+        let pass_through = ["--frozen".to_string()];
+        let command = resolve_uv_task_command(
+            Some(binary),
+            root.clone(),
+            "sync",
+            &["--package=app".to_string()],
+            Some("uv".to_string()),
+            Some(&pass_through),
+        )
+        .unwrap();
+        assert_eq!(command.program, binary.as_os_str());
+        assert_eq!(
+            command.args,
+            ["sync", "--package=app", "--frozen"].map(OsString::from)
+        );
+        assert_eq!(command.cwd, root);
+        assert_eq!(command.serial_group.as_deref(), Some("uv"));
+    }
+
+    #[test]
+    fn uv_command_resolution_requires_binary() {
+        let root =
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+        assert!(matches!(
+            resolve_uv_task_command(None, root, "build", &[], None, None),
+            Err(ResolveNativeCommandError::MissingUvBinary)
+        ));
     }
 }

--- a/crates/turborepo-repository/src/task_contracts.rs
+++ b/crates/turborepo-repository/src/task_contracts.rs
@@ -61,6 +61,7 @@ impl TaskEnvironmentRequirement {
 pub enum CommandMapTarget {
     JavaScript,
     Rust,
+    Python,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -86,9 +87,15 @@ impl CommandMapTarget {
     fn matches(self, key: &str) -> bool {
         matches!(
             (self, key),
-            (Self::JavaScript, "javascript") | (Self::Rust, "rust")
+            (Self::JavaScript, "javascript") | (Self::Rust, "rust") | (Self::Python, "python")
         )
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DynamicTaskContract {
+    Cargo(crate::cargo::CargoTaskContract),
+    Python(crate::uv::UvTaskContract),
 }
 
 /// Per-scope task-contract observation produced at repository construction.
@@ -107,7 +114,7 @@ pub struct ScopeTaskContract {
     entrypoint_domain: Option<TaskEntrypointDomain>,
     prune_package_mode: Option<PrunePackageMode>,
     dependency_source_inputs: DependencySourceInputs,
-    cargo: Option<crate::cargo::CargoTaskContract>,
+    dynamic: Option<DynamicTaskContract>,
     static_defaults: BTreeMap<String, TaskDefaults>,
     static_io: BTreeMap<String, crate::toolchain::DerivedTaskIO>,
     static_entrypoints: BTreeMap<String, TaskEntrypoint>,
@@ -125,7 +132,7 @@ impl ScopeTaskContract {
             entrypoint_domain: None,
             prune_package_mode: Some(PrunePackageMode::JavaScript),
             dependency_source_inputs: DependencySourceInputs::Exclude,
-            cargo: None,
+            dynamic: None,
             static_defaults: BTreeMap::new(),
             static_io: BTreeMap::new(),
             static_entrypoints: BTreeMap::new(),
@@ -143,7 +150,7 @@ impl ScopeTaskContract {
             entrypoint_domain: None,
             prune_package_mode: None,
             dependency_source_inputs: DependencySourceInputs::Unknown,
-            cargo: None,
+            dynamic: None,
             static_defaults: BTreeMap::new(),
             static_io: BTreeMap::new(),
             static_entrypoints: BTreeMap::new(),
@@ -166,7 +173,28 @@ impl ScopeTaskContract {
                 crate::prune_knowledge::CARGO_PRUNE_DOMAIN.clone(),
             )),
             dependency_source_inputs,
-            cargo: Some(contract),
+            dynamic: Some(DynamicTaskContract::Cargo(contract)),
+            static_defaults: BTreeMap::new(),
+            static_io: BTreeMap::new(),
+            static_entrypoints: BTreeMap::new(),
+        }
+    }
+
+    pub(crate) fn python(contract: crate::uv::UvTaskContract) -> Self {
+        let dependency_source_inputs = contract.dependency_source_inputs();
+        Self {
+            derives_io: true,
+            defaults: TaskDefaults::default(),
+            environment: Some(TaskEnvironmentRequirement::new(
+                TaskEnvironmentDomain(Cow::Borrowed("uv-task-io")),
+                crate::uv::HASHED_ENV_VARS.to_vec(),
+            )),
+            toolchain: Some(ToolchainId::PYTHON),
+            command_map_target: Some(CommandMapTarget::Python),
+            entrypoint_domain: Some(TaskEntrypointDomain(Cow::Borrowed("uv"))),
+            prune_package_mode: Some(PrunePackageMode::NativeCopy),
+            dependency_source_inputs,
+            dynamic: Some(DynamicTaskContract::Python(contract)),
             static_defaults: BTreeMap::new(),
             static_io: BTreeMap::new(),
             static_entrypoints: BTreeMap::new(),
@@ -189,7 +217,7 @@ impl ScopeTaskContract {
             entrypoint_domain: None,
             prune_package_mode: Some(PrunePackageMode::NativeCopy),
             dependency_source_inputs: DependencySourceInputs::Unknown,
-            cargo: None,
+            dynamic: None,
             static_defaults: defaults,
             static_io: io,
             static_entrypoints: BTreeMap::new(),
@@ -255,23 +283,24 @@ impl ScopeTaskContract {
     }
 
     pub fn defaults_for_task(&self, task: &str) -> TaskDefaults {
-        self.cargo.as_ref().map_or_else(
-            || {
-                self.static_defaults
-                    .get(task)
-                    .cloned()
-                    .unwrap_or_else(|| self.defaults.clone())
-            },
-            |cargo| cargo.task_defaults(task),
-        )
+        if let Some(dynamic) = self.dynamic.as_ref() {
+            return match dynamic {
+                DynamicTaskContract::Cargo(contract) => contract.task_defaults(task),
+                DynamicTaskContract::Python(contract) => contract.task_defaults(task),
+            };
+        }
+        self.static_defaults
+            .get(task)
+            .cloned()
+            .unwrap_or_else(|| self.defaults.clone())
     }
 
     pub fn derives_task_io(&self, task: &str) -> bool {
         self.static_io.contains_key(task)
-            || self
-                .cargo
-                .as_ref()
-                .is_some_and(|cargo| cargo.derives_task_io(task))
+            || self.dynamic.as_ref().is_some_and(|dynamic| match dynamic {
+                DynamicTaskContract::Cargo(contract) => contract.derives_task_io(task),
+                DynamicTaskContract::Python(contract) => contract.derives_task_io(task),
+            })
     }
 
     pub fn derived_task_io(
@@ -286,21 +315,34 @@ impl ScopeTaskContract {
         if let Some(io) = self.static_io.get(task) {
             return Some(io.clone());
         }
-        self.cargo.as_ref()?.derived_task_io(
-            package,
-            task,
-            path_to_root,
-            dependencies,
-            wants_automatic_inputs,
-            context,
-        )
+        match self.dynamic.as_ref()? {
+            DynamicTaskContract::Cargo(contract) => contract.derived_task_io(
+                package,
+                task,
+                path_to_root,
+                dependencies,
+                wants_automatic_inputs,
+                context,
+            ),
+            DynamicTaskContract::Python(contract) => contract.derived_task_io(
+                package,
+                task,
+                path_to_root,
+                dependencies,
+                wants_automatic_inputs,
+                context,
+            ),
+        }
     }
 
     pub fn task_entrypoint(&self, task: &str) -> Option<TaskEntrypoint> {
         self.static_entrypoints
             .get(task)
             .copied()
-            .or_else(|| self.cargo.as_ref()?.task_entrypoint(task))
+            .or_else(|| match self.dynamic.as_ref()? {
+                DynamicTaskContract::Cargo(contract) => contract.task_entrypoint(task),
+                DynamicTaskContract::Python(contract) => contract.task_entrypoint(task),
+            })
     }
 
     pub fn task_entrypoint_domain(&self) -> Option<&TaskEntrypointDomain> {
@@ -324,9 +366,12 @@ impl ScopeTaskContract {
         endpoint: &crate::toolchain::CompileCacheEndpoint,
         task_env: &std::collections::HashMap<String, String>,
     ) -> Vec<(String, String)> {
-        self.cargo.as_ref().map_or_else(Vec::new, |cargo| {
-            cargo.compile_cache_env(endpoint, task_env)
-        })
+        match self.dynamic.as_ref() {
+            Some(DynamicTaskContract::Cargo(contract)) => {
+                contract.compile_cache_env(endpoint, task_env)
+            }
+            _ => Vec::new(),
+        }
     }
 }
 

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -900,6 +900,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .unwrap()
         .expect("script exists, command resolves");

--- a/crates/turborepo-repository/src/uv.rs
+++ b/crates/turborepo-repository/src/uv.rs
@@ -14,15 +14,23 @@
 //! machines that only orchestrate. The `uv` binary is required only to
 //! execute tasks.
 //!
-//! A synthetic package anchored at the root `pyproject.toml` and depending on
-//! every member represents the workspace itself. Its name is declared by the
-//! user in the root manifest; using Turborepo with Python requires naming the
-//! workspace:
+//! Buildable packages register `build` (`uv build --package=<name>`), and all
+//! packages register `format` and `check`. A synthetic package
+//! anchored at the root `pyproject.toml` and depending on every member
+//! represents the workspace itself; it registers workspace-wide versions of the
+//! same quality tasks. Every other task comes from normal task definitions (via
+//! the `command` map's `python` key). The
+//! workspace package's name is declared by the user in the root manifest —
+//! using Turborepo with Python requires naming the workspace:
 //!
 //! ```toml
 //! [tool.turbo]
 //! name = "acme"
 //! ```
+//!
+//! External dependencies hash from `uv.lock` per member (see
+//! [`external_closures`]), scoped to each member's transitive closure, so a
+//! dependency bump only invalidates the packages that depend on it.
 //!
 //! Support is experimental and gated behind
 //! `futureFlags.experimentalPythonWorkspaces`.
@@ -35,7 +43,7 @@ use std::{
 };
 
 use serde::Deserialize;
-use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
+use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
 
 use crate::{
     package_json::PackageJson,
@@ -106,7 +114,7 @@ pub enum Error {
     #[error("uv workspace glob exceeds the maximum length of {0} bytes")]
     WorkspaceGlobTooLong(usize),
     #[error(transparent)]
-    Path(#[from] turbopath::PathError),
+    ResolutionPath(#[from] turbopath::PathError),
 }
 
 /// Normalize a Python package name per PEP 503: lowercase, with runs of
@@ -133,6 +141,10 @@ pub fn normalize_name(name: &str) -> String {
 /// The distribution-name form of a normalized package name: `-` becomes
 /// `_`, matching the file names `uv build` writes to the dist directory
 /// (PEP 625 / the wheel file name convention).
+fn dist_name(normalized_name: &str) -> String {
+    normalized_name.replace('-', "_")
+}
+
 /// Extract the package name from a PEP 508 dependency string: the leading
 /// identifier before any extras (`[...]`), version specifier, URL (`@`),
 /// or environment marker (`;`). Returns `None` for strings that do not
@@ -660,6 +672,423 @@ fn connect_packages(
 }
 
 // ---------------------------------------------------------------------------
+// Native tasks
+// ---------------------------------------------------------------------------
+
+/// How a Python-toolchain package participates in task execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UvPackageKind {
+    /// A buildable workspace member.
+    Package,
+    /// A workspace member uv cannot build as a distribution. It receives the
+    /// quality tasks but no built-in build task.
+    VirtualPackage,
+    /// The user-named workspace aggregate hosting workspace-scoped quality
+    /// tasks.
+    Workspace,
+}
+
+const PACKAGE_TASKS: &[(&str, &str)] =
+    &[("build", "build"), ("format", "format"), ("check", "check")];
+const QUALITY_TASKS: &[(&str, &str)] = &[("format", "format"), ("check", "check")];
+
+/// The uv subcommand a task resolves to for a package, given its
+/// [`UvPackageKind`]. `None` means the task is a no-op for this package
+/// (like a missing package.json script).
+pub fn task_subcommand(kind: UvPackageKind, task: &str) -> Option<&'static str> {
+    let tasks = match kind {
+        UvPackageKind::Package => PACKAGE_TASKS,
+        UvPackageKind::VirtualPackage | UvPackageKind::Workspace => QUALITY_TASKS,
+    };
+    tasks
+        .iter()
+        .find_map(|(name, subcommand)| (*name == task).then_some(*subcommand))
+}
+
+fn registered_tasks(kind: UvPackageKind) -> impl Iterator<Item = &'static str> {
+    match kind {
+        UvPackageKind::Package => PACKAGE_TASKS,
+        UvPackageKind::VirtualPackage | UvPackageKind::Workspace => QUALITY_TASKS,
+    }
+    .iter()
+    .map(|(task, _)| *task)
+}
+
+/// The fixed arguments the subcommand takes for this package, derived from
+/// the same tables as registration so display and execution cannot drift.
+fn task_arguments(
+    kind: UvPackageKind,
+    task: &str,
+    package: &str,
+    package_directory: &str,
+    workspace_directories: &[String],
+) -> Vec<String> {
+    match (kind, task) {
+        (UvPackageKind::Package, "build") => vec![format!("--package={package}")],
+        (UvPackageKind::Package | UvPackageKind::VirtualPackage, "format") => {
+            vec!["--".to_string(), package_directory.to_string()]
+        }
+        (UvPackageKind::Package | UvPackageKind::VirtualPackage, "check") => {
+            vec![format!("--package={package}")]
+        }
+        (UvPackageKind::Workspace, "format") => std::iter::once("--".to_string())
+            .chain(workspace_directories.iter().cloned())
+            .collect(),
+        (UvPackageKind::Workspace, "check") => vec!["--all-packages".to_string()],
+        (UvPackageKind::Workspace, _) => Vec::new(),
+        _ => Vec::new(),
+    }
+}
+
+/// The display string for a uv task's command.
+pub fn display_command(
+    kind: UvPackageKind,
+    task: &str,
+    package: &str,
+    package_directory: &str,
+    workspace_directories: &[String],
+) -> Option<String> {
+    let subcommand = task_subcommand(kind, task)?;
+    let mut display = format!("uv {subcommand}");
+    for argument in task_arguments(
+        kind,
+        task,
+        package,
+        package_directory,
+        workspace_directories,
+    ) {
+        display.push(' ');
+        display.push_str(&argument);
+    }
+    Some(display)
+}
+
+/// Build native-task facts for a Python package from its verb tables.
+pub fn native_tasks_for_package(
+    kind: UvPackageKind,
+    package: &str,
+    package_directory: &str,
+    workspace_directories: &[String],
+) -> Vec<crate::native_tasks::NativeTask> {
+    use crate::native_tasks::NativeTask;
+
+    registered_tasks(kind)
+        .filter_map(|task| {
+            let subcommand = task_subcommand(kind, task)?;
+            let display = display_command(
+                kind,
+                task,
+                package,
+                package_directory,
+                workspace_directories,
+            )?;
+            Some(NativeTask::uv(
+                task,
+                display,
+                subcommand,
+                task_arguments(
+                    kind,
+                    task,
+                    package,
+                    package_directory,
+                    workspace_directories,
+                ),
+                (task == "check").then(|| "uv".to_string()),
+            ))
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Task contract
+// ---------------------------------------------------------------------------
+
+/// Standard uv and pip environment variables that can change what a uv
+/// invocation resolves, installs, or builds. Credentials and purely
+/// cosmetic settings are deliberately excluded.
+pub const HASHED_ENV_VARS: &[&str] = &[
+    "APPDATA",
+    "HOME",
+    "UV_BUILD_CONSTRAINT",
+    "UV_COMPILE_BYTECODE",
+    "UV_CONFIG_FILE",
+    "UV_CONSTRAINT",
+    "UV_DEFAULT_INDEX",
+    "UV_EXCLUDE",
+    "UV_EXCLUDE_NEWER",
+    "UV_INDEX",
+    "UV_INDEX_STRATEGY",
+    "UV_INDEX_URL",
+    "UV_EXTRA_INDEX_URL",
+    "UV_FIND_LINKS",
+    "UV_FORK_STRATEGY",
+    "UV_GIT_LFS",
+    "UV_INSECURE_HOST",
+    "UV_LINK_MODE",
+    "UV_MANAGED_PYTHON",
+    "UV_NO_BUILD_ISOLATION",
+    "UV_NO_BUILD_ISOLATION_PACKAGE",
+    "UV_PYTHON",
+    "UV_PYTHON_DOWNLOADS",
+    "UV_PYTHON_PREFERENCE",
+    "UV_PROJECT",
+    "UV_PROJECT_ENVIRONMENT",
+    "UV_NO_BINARY",
+    "UV_NO_BINARY_PACKAGE",
+    "UV_NO_BUILD",
+    "UV_NO_BUILD_PACKAGE",
+    "UV_NO_CONFIG",
+    "UV_NO_EDITABLE",
+    "UV_NO_MANAGED_PYTHON",
+    "UV_NO_SOURCES_PACKAGE",
+    "UV_NO_SYSTEM_CONFIG",
+    "UV_NO_SOURCES",
+    "UV_OFFLINE",
+    "UV_OVERRIDE",
+    "UV_RESOLUTION",
+    "UV_PRERELEASE",
+    "UV_SYSTEM_CERTS",
+    "UV_WORKING_DIR",
+    "XDG_CONFIG_HOME",
+    "PIP_INDEX_URL",
+    "PIP_EXTRA_INDEX_URL",
+];
+
+const UV_PATH_ENV_VARS: &[&str] = &[
+    "UV_BUILD_CONSTRAINT",
+    "UV_CONFIG_FILE",
+    "UV_CONSTRAINT",
+    "UV_EXCLUDE",
+    "UV_OVERRIDE",
+    "UV_PROJECT",
+    "UV_WORKING_DIR",
+];
+
+fn has_untracked_uv_path_env(environment: &toolchain::TaskIOEnvironment) -> bool {
+    UV_PATH_ENV_VARS
+        .iter()
+        .any(|name| environment.get(name).is_some())
+}
+
+fn has_untracked_uv_configuration(environment: &toolchain::TaskIOEnvironment) -> bool {
+    if has_untracked_uv_path_env(environment) {
+        return true;
+    }
+    if environment.get("UV_NO_CONFIG").is_some_and(|value| {
+        !matches!(
+            value.to_ascii_lowercase().as_str(),
+            "" | "0" | "false" | "no"
+        )
+    }) {
+        return false;
+    }
+    let mut paths = Vec::new();
+    if let Some(config_home) = environment.get("XDG_CONFIG_HOME") {
+        paths.push(std::path::PathBuf::from(config_home).join("uv/uv.toml"));
+    } else if let Some(home) = environment.get("HOME") {
+        paths.push(std::path::PathBuf::from(home).join(".config/uv/uv.toml"));
+    }
+    if let Some(app_data) = environment.get("APPDATA") {
+        paths.push(std::path::PathBuf::from(app_data).join("uv/uv.toml"));
+    }
+    if let Some(program_data) = std::env::var_os("PROGRAMDATA") {
+        paths.push(std::path::PathBuf::from(program_data).join("uv/uv.toml"));
+    }
+    #[cfg(unix)]
+    paths.push(std::path::PathBuf::from("/etc/uv/uv.toml"));
+
+    paths.into_iter().any(|path| path.is_file())
+}
+
+/// Input globs whose changes should invalidate a Python task's cache: the
+/// workspace root manifest (workspace membership, sources, and
+/// requires-python live there), uv's optional configuration file, and the
+/// pinned interpreter version — expressed relative to the task's package
+/// directory via `prefix` (the path from the package to the repo root;
+/// empty for the workspace package). Globs that don't match anything (e.g.
+/// a missing `.python-version`) simply contribute nothing.
+///
+/// uv.lock is deliberately absent: locked dependencies participate in each
+/// package task's external-dependency hash, scoped to that package's
+/// transitive closure (see [`external_closures`]), so a dependency bump
+/// only invalidates the packages that actually depend on it.
+pub fn hash_input_globs(prefix: &str) -> Vec<String> {
+    [PYPROJECT_TOML, "uv.toml", ".python-version"]
+        .iter()
+        .map(|rel| join_prefix(prefix, rel))
+        .collect()
+}
+
+fn join_prefix(prefix: &str, rel: &str) -> String {
+    if prefix.is_empty() {
+        rel.to_string()
+    } else {
+        format!("{prefix}/{rel}")
+    }
+}
+
+/// uv-specific details captured in immutable task-contract knowledge.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UvTaskContract {
+    kind: UvPackageKind,
+    /// The package's distribution file-name stem (normalized name with `_`
+    /// separators), used to derive `uv build` output globs. Empty for the
+    /// workspace aggregate.
+    dist_name: String,
+    /// Repository-relative member directories for workspace-wide quality
+    /// tasks. Empty for member packages.
+    workspace_directories: Vec<String>,
+}
+
+impl UvTaskContract {
+    fn new(kind: UvPackageKind, package_name: &str) -> Self {
+        Self {
+            kind,
+            dist_name: match kind {
+                UvPackageKind::Package | UvPackageKind::VirtualPackage => dist_name(package_name),
+                UvPackageKind::Workspace => String::new(),
+            },
+            workspace_directories: Vec::new(),
+        }
+    }
+
+    fn workspace(package_name: &str, workspace_directories: Vec<String>) -> Self {
+        Self {
+            workspace_directories,
+            ..Self::new(UvPackageKind::Workspace, package_name)
+        }
+    }
+
+    pub(crate) fn task_defaults(&self, task: &str) -> toolchain::TaskDefaults {
+        // uv, Python, ty, and isolated build-backend versions are not
+        // yet part of the task fingerprint, so built-in uv commands fail
+        // closed on cache.
+        let cache = task_subcommand(self.kind, task).map(|_| false);
+        toolchain::TaskDefaults { cache }
+    }
+
+    /// Classifies Python package sources for dependent derived-input
+    /// closures. Workspace aggregates have no package source directory to
+    /// include.
+    pub(crate) fn dependency_source_inputs(&self) -> crate::task_contracts::DependencySourceInputs {
+        match self.kind {
+            UvPackageKind::Package | UvPackageKind::VirtualPackage => {
+                crate::task_contracts::DependencySourceInputs::Include
+            }
+            UvPackageKind::Workspace => crate::task_contracts::DependencySourceInputs::Exclude,
+        }
+    }
+
+    pub(crate) fn derives_task_io(&self, task: &str) -> bool {
+        registered_tasks(self.kind).any(|registered| registered == task)
+    }
+
+    pub(crate) fn task_entrypoint(
+        &self,
+        task: &str,
+    ) -> Option<crate::task_contracts::TaskEntrypoint> {
+        if task_subcommand(self.kind, task).is_some() {
+            return Some(match self.kind {
+                // Unfiltered quality tasks use the workspace-scoped command
+                // only; per-package commands are for filtered runs.
+                UvPackageKind::Workspace => crate::task_contracts::TaskEntrypoint::PreferredOnly,
+                UvPackageKind::Package | UvPackageKind::VirtualPackage => {
+                    crate::task_contracts::TaskEntrypoint::Candidate
+                }
+            });
+        }
+        match (self.kind, task) {
+            (UvPackageKind::Workspace | UvPackageKind::VirtualPackage, "build") => {
+                Some(crate::task_contracts::TaskEntrypoint::Excluded)
+            }
+            _ => None,
+        }
+    }
+
+    pub(crate) fn derived_task_io(
+        &self,
+        _package: &crate::package_graph::PackageTaskContext<'_>,
+        task: &str,
+        path_to_root: &str,
+        dependencies: &[crate::package_graph::PackageTaskContext<'_>],
+        wants_automatic_inputs: bool,
+        context: &toolchain::TaskIOContext<'_>,
+    ) -> Option<toolchain::DerivedTaskIO> {
+        let subcommand = task_subcommand(self.kind, task)?;
+        let mut io = toolchain::DerivedTaskIO {
+            input_globs: hash_input_globs(path_to_root),
+            env: HASHED_ENV_VARS.iter().map(|var| var.to_string()).collect(),
+            ..Default::default()
+        };
+        // These variables point at files whose contents affect uv. Until the
+        // paths can be resolved against the repository safely, fail closed
+        // instead of restoring an artifact hashed only by the path string.
+        if has_untracked_uv_configuration(context.environment) {
+            io.input_safety = toolchain::DerivedInputSafety::Untracked;
+        }
+        match self.kind {
+            UvPackageKind::Package | UvPackageKind::VirtualPackage => {
+                if wants_automatic_inputs {
+                    io.package_default_inputs = Some(true);
+                    if task == "check" {
+                        let mut globs: Vec<String> = dependencies
+                            .iter()
+                            .filter(|dependency| {
+                                dependency.task_contract().dependency_source_inputs()
+                                    == crate::task_contracts::DependencySourceInputs::Include
+                            })
+                            .flat_map(|dependency| {
+                                let directory = join_prefix(
+                                    path_to_root,
+                                    dependency.directory().to_unix().as_str(),
+                                );
+                                [format!("{directory}/**"), format!("!{directory}/.turbo/**")]
+                            })
+                            .collect();
+                        globs.sort();
+                        globs.dedup();
+                        io.input_globs.extend(globs);
+                    }
+                }
+                if subcommand == "build" {
+                    // `uv build` writes `<dist_name>-<version>*` sdists and
+                    // wheels into the workspace root's dist directory. Extra
+                    // task args can relocate the output (`--out-dir`), so
+                    // outputs resolve only for the bare invocation.
+                    io.outputs = if context.task_args.is_some_and(|args| !args.is_empty()) {
+                        toolchain::DerivedOutputs::Unavailable
+                    } else {
+                        toolchain::DerivedOutputs::Resolved(vec![join_prefix(
+                            path_to_root,
+                            &format!("dist/{}-*", self.dist_name),
+                        )])
+                    };
+                }
+            }
+            UvPackageKind::Workspace => {
+                if wants_automatic_inputs {
+                    // The aggregate is anchored at the repository root;
+                    // default-hashing the entire repository would be wrong.
+                    io.package_default_inputs = Some(false);
+                    let mut globs: Vec<String> = self
+                        .workspace_directories
+                        .iter()
+                        .flat_map(|directory| {
+                            let directory = join_prefix(path_to_root, directory);
+                            [format!("{directory}/**"), format!("!{directory}/.turbo/**")]
+                        })
+                        .collect();
+                    globs.sort();
+                    globs.dedup();
+                    io.input_globs.extend(globs);
+                }
+            }
+        }
+        Some(io)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // The contributor
 // ---------------------------------------------------------------------------
 
@@ -709,9 +1138,38 @@ impl RepositoryContributor for UvContributor {
                 .name
                 .ok_or_else(|| toolchain::Error::Failed(Box::new(Error::MissingWorkspaceName)))?;
 
+            let package_directories: HashMap<String, String> = packages
+                .iter()
+                .map(|package| {
+                    let directory = package.manifest_path.parent().ok_or_else(|| {
+                        Error::InvalidMemberManifestPath(package.manifest_path.to_string())
+                    })?;
+                    let directory = AnchoredSystemPathBuf::new(&self.repo_root, directory)?;
+                    Ok((package.name.clone(), directory.to_unix().to_string()))
+                })
+                .collect::<Result<_, Error>>()
+                .map_err(|error| toolchain::Error::Failed(Box::new(error)))?;
+            let mut workspace_directories: Vec<String> = packages
+                .iter()
+                .filter_map(|package| package_directories.get(&package.name).cloned())
+                .collect();
+            workspace_directories.sort();
+            workspace_directories.dedup();
+
             let mut package_names = Vec::with_capacity(packages.len());
             let mut discovered = Vec::with_capacity(packages.len() + 1);
             for package in packages {
+                let kind = if package.buildable {
+                    UvPackageKind::Package
+                } else {
+                    UvPackageKind::VirtualPackage
+                };
+                let package_directory = package_directories
+                    .get(&package.name)
+                    .map_or(".", String::as_str);
+                let native_tasks =
+                    native_tasks_for_package(kind, &package.name, package_directory, &[]);
+                let task_contract = UvTaskContract::new(kind, &package.name);
                 package_names.push(package.name.clone());
                 discovered.push(
                     DiscoveredPackage::package(
@@ -719,10 +1177,22 @@ impl RepositoryContributor for UvContributor {
                         PackageJson::default(),
                         package.manifest_path,
                     )
-                    .with_native_relationships(package.relationships),
+                    .with_native_relationships(package.relationships)
+                    .with_native_tasks(native_tasks)
+                    .with_task_contract(
+                        crate::task_contracts::ScopeTaskContract::python(task_contract),
+                    ),
                 );
             }
 
+            let workspace_native_tasks = native_tasks_for_package(
+                UvPackageKind::Workspace,
+                &workspace_name,
+                ".",
+                &workspace_directories,
+            );
+            let workspace_task_contract =
+                UvTaskContract::workspace(&workspace_name, workspace_directories);
             package_names.sort();
             let workspace_relationships = package_names
                 .into_iter()
@@ -734,7 +1204,11 @@ impl RepositoryContributor for UvContributor {
                     PackageJson::default(),
                     self.repo_root.join_component(PYPROJECT_TOML),
                 )
-                .with_native_relationships(workspace_relationships),
+                .with_native_relationships(workspace_relationships)
+                .with_native_tasks(workspace_native_tasks)
+                .with_task_contract(
+                    crate::task_contracts::ScopeTaskContract::python(workspace_task_contract),
+                ),
             );
 
             Ok(DiscoveredPackages::new(discovered, workspace_roots))
@@ -753,6 +1227,12 @@ mod test {
         assert_eq!(normalize_name("a.b--c__d"), "a-b-c-d");
         assert_eq!(normalize_name("already-normal"), "already-normal");
         assert_eq!(normalize_name(""), "");
+    }
+
+    #[test]
+    fn test_dist_name() {
+        assert_eq!(dist_name("py-app"), "py_app");
+        assert_eq!(dist_name("single"), "single");
     }
 
     #[test]
@@ -1083,6 +1563,43 @@ overridden = { index = "private" }
     }
 
     #[test]
+    fn test_uv_path_environment_disables_automatic_inputs() {
+        let environment = toolchain::TaskIOEnvironment::new(HashMap::from([(
+            "UV_CONFIG_FILE".to_string(),
+            "/outside/uv.toml".to_string(),
+        )]));
+        assert!(has_untracked_uv_configuration(&environment));
+        assert!(!has_untracked_uv_configuration(
+            &toolchain::TaskIOEnvironment::default()
+        ));
+    }
+
+    #[test]
+    fn test_no_config_does_not_hide_other_path_inputs() {
+        let environment = toolchain::TaskIOEnvironment::new(HashMap::from([
+            ("UV_NO_CONFIG".to_string(), "true".to_string()),
+            (
+                "UV_BUILD_CONSTRAINT".to_string(),
+                "/outside/constraints.txt".to_string(),
+            ),
+        ]));
+        assert!(has_untracked_uv_configuration(&environment));
+    }
+
+    #[test]
+    fn test_user_uv_config_disables_automatic_inputs() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let config_dir = tempdir.path().join("uv");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::write(config_dir.join("uv.toml"), "offline = true\n").unwrap();
+        let environment = toolchain::TaskIOEnvironment::new(HashMap::from([(
+            "XDG_CONFIG_HOME".to_string(),
+            tempdir.path().to_string_lossy().to_string(),
+        )]));
+        assert!(has_untracked_uv_configuration(&environment));
+    }
+
+    #[test]
     fn test_missing_workspace_table_discovers_nothing() {
         let tempdir = tempfile::tempdir().unwrap();
         let root = AbsoluteSystemPathBuf::try_from(tempdir.path()).unwrap();
@@ -1145,5 +1662,96 @@ overridden = { index = "private" }
             .unwrap();
         let error = discover_workspace(&root).unwrap_err();
         assert!(matches!(error, Error::InvalidWorkspaceName { .. }));
+    }
+
+    #[test]
+    fn test_task_tables() {
+        assert_eq!(
+            task_subcommand(UvPackageKind::Package, "build"),
+            Some("build")
+        );
+        assert_eq!(
+            task_subcommand(UvPackageKind::Package, "format"),
+            Some("format")
+        );
+        assert_eq!(task_subcommand(UvPackageKind::Package, "lock"), None);
+        assert_eq!(task_subcommand(UvPackageKind::Package, "test"), None);
+        assert_eq!(
+            task_subcommand(UvPackageKind::VirtualPackage, "format"),
+            Some("format")
+        );
+        assert_eq!(
+            task_subcommand(UvPackageKind::VirtualPackage, "build"),
+            None
+        );
+        assert_eq!(
+            task_subcommand(UvPackageKind::Workspace, "check"),
+            Some("check")
+        );
+        assert_eq!(task_subcommand(UvPackageKind::Workspace, "lock"), None);
+        assert_eq!(task_subcommand(UvPackageKind::Workspace, "build"), None);
+
+        assert_eq!(
+            display_command(
+                UvPackageKind::Package,
+                "build",
+                "py-app",
+                "packages/py-app",
+                &[]
+            )
+            .as_deref(),
+            Some("uv build --package=py-app")
+        );
+        assert_eq!(
+            display_command(
+                UvPackageKind::Package,
+                "format",
+                "py-app",
+                "packages/py-app",
+                &[]
+            )
+            .as_deref(),
+            Some("uv format -- packages/py-app")
+        );
+        assert_eq!(
+            display_command(
+                UvPackageKind::Workspace,
+                "format",
+                "acme",
+                ".",
+                &["packages/py-app".to_string(), "packages/py-lib".to_string()]
+            )
+            .as_deref(),
+            Some("uv format -- packages/py-app packages/py-lib")
+        );
+        assert_eq!(
+            display_command(UvPackageKind::Workspace, "check", "acme", ".", &[]).as_deref(),
+            Some("uv check --all-packages")
+        );
+
+        let tasks =
+            native_tasks_for_package(UvPackageKind::Package, "py-app", "packages/py-app", &[]);
+        assert_eq!(tasks.len(), 3);
+        assert!(
+            tasks
+                .iter()
+                .all(|task| task.registered() && task.executable())
+        );
+    }
+
+    #[test]
+    fn test_derived_outputs_for_build() {
+        let contract = UvTaskContract::new(UvPackageKind::Package, "py-app");
+        assert!(contract.derives_task_io("build"));
+        assert!(contract.derives_task_io("format"));
+        assert!(contract.derives_task_io("check"));
+        assert!(!contract.derives_task_io("test"));
+        assert_eq!(contract.task_defaults("check").cache, Some(false));
+        assert_eq!(contract.task_defaults("build").cache, Some(false));
+        assert_eq!(contract.dist_name, "py_app");
+
+        let virtual_contract = UvTaskContract::new(UvPackageKind::VirtualPackage, "py-app");
+        assert!(!virtual_contract.derives_task_io("build"));
+        assert!(virtual_contract.derives_task_io("check"));
     }
 }

--- a/crates/turborepo-task-executor/src/command.rs
+++ b/crates/turborepo-task-executor/src/command.rs
@@ -152,10 +152,11 @@ pub enum CommandProviderError {
 /// Command provider that resolves commands through the native-task catalog.
 ///
 /// The catalog owns native command templates (JavaScript: package-manager
-/// `run <script>`; Cargo: `cargo <verb>` scoped to crate/workspace). This
-/// provider adapts the resolved [`TaskCommand`] data into a process command
-/// and applies concerns that are not native-task-specific: the task
-/// environment, stdin policy, and microfrontends proxy decorations.
+/// `run <script>`; Cargo: `cargo <verb>` scoped to crate/workspace; uv:
+/// `uv <verb>` scoped to package/workspace). This provider adapts the
+/// resolved [`TaskCommand`] data into a process command and applies concerns
+/// that are not native-task-specific: the task environment, stdin policy,
+/// and microfrontends proxy decorations.
 #[derive(Debug)]
 pub struct ToolchainCommandProvider<'a, M = crate::NoMfeConfig> {
     package_graph: &'a PackageGraph,
@@ -172,6 +173,8 @@ pub struct ToolchainCommandProvider<'a, M = crate::NoMfeConfig> {
     package_manager_binary: std::sync::OnceLock<Result<std::path::PathBuf, which::Error>>,
     /// Lazily resolved cargo binary path for Cargo framing.
     cargo_binary: std::sync::OnceLock<Result<std::path::PathBuf, which::Error>>,
+    /// Lazily resolved uv binary path for Python framing.
+    uv_binary: std::sync::OnceLock<Result<std::path::PathBuf, which::Error>>,
 }
 
 impl<'a, M: MfeConfigProvider> ToolchainCommandProvider<'a, M> {
@@ -190,6 +193,7 @@ impl<'a, M: MfeConfigProvider> ToolchainCommandProvider<'a, M> {
             command_overrides,
             package_manager_binary: std::sync::OnceLock::new(),
             cargo_binary: std::sync::OnceLock::new(),
+            uv_binary: std::sync::OnceLock::new(),
         }
     }
 
@@ -208,6 +212,13 @@ impl<'a, M: MfeConfigProvider> ToolchainCommandProvider<'a, M> {
 
     fn cargo_binary(&self) -> Result<Option<&std::path::Path>, CommandProviderError> {
         match self.cargo_binary.get_or_init(|| which::which("cargo")) {
+            Ok(path) => Ok(Some(path.as_path())),
+            Err(_) => Ok(None),
+        }
+    }
+
+    fn uv_binary(&self) -> Result<Option<&std::path::Path>, CommandProviderError> {
+        match self.uv_binary.get_or_init(|| which::which("uv")) {
             Ok(path) => Ok(Some(path.as_path())),
             Err(_) => Ok(None),
         }
@@ -252,15 +263,16 @@ impl<'a, M: MfeConfigProvider, E: From<CommandProviderError>> CommandProvider<E>
         };
 
         let spec = if let Some(native_task) = package_context.native_tasks().get(task_id.task()) {
-            let (package_manager_binary, cargo_binary) = if override_command.is_some() {
-                (None, None)
+            let (package_manager_binary, cargo_binary, uv_binary) = if override_command.is_some() {
+                (None, None, None)
             } else {
                 match native_task.command() {
                     Some(NativeCommandTemplate::JavaScriptPackageManagerRun { .. }) => {
-                        (self.package_manager_binary()?, None)
+                        (self.package_manager_binary()?, None, None)
                     }
-                    Some(NativeCommandTemplate::Cargo { .. }) => (None, self.cargo_binary()?),
-                    None => (None, None),
+                    Some(NativeCommandTemplate::Cargo { .. }) => (None, self.cargo_binary()?, None),
+                    Some(NativeCommandTemplate::Uv { .. }) => (None, None, self.uv_binary()?),
+                    None => (None, None, None),
                 }
             };
             turborepo_repository::native_tasks::resolve_task_command(
@@ -269,6 +281,7 @@ impl<'a, M: MfeConfigProvider, E: From<CommandProviderError>> CommandProvider<E>
                 self.package_graph.package_manager(),
                 package_manager_binary,
                 cargo_binary,
+                uv_binary,
                 self.task_args.args_for_task(task_id),
                 override_command,
             )

--- a/crates/turborepo-turbo-json/src/error.rs
+++ b/crates/turborepo-turbo-json/src/error.rs
@@ -314,11 +314,10 @@ pub enum Error {
         text: NamedSource<String>,
     },
 
-    #[error(
-        "The {key:?} toolchain in `command` requires `futureFlags.experimentalCargoWorkspaces`."
-    )]
+    #[error("The {key:?} toolchain in `command` requires `futureFlags.{flag}`.")]
     TaskCommandToolchainRequiresFlag {
         key: String,
+        flag: &'static str,
         #[label("toolchain is not enabled")]
         span: Option<SourceSpan>,
         #[source_code]

--- a/crates/turborepo-turbo-json/src/processed.rs
+++ b/crates/turborepo-turbo-json/src/processed.rs
@@ -563,7 +563,7 @@ pub struct ProcessedIncrementalPartition {
 /// The canonical toolchain ids accepted as `command` map keys, alongside
 /// their accepted aliases. Kept as literals: this crate sits below the
 /// toolchain registry, and these ids are stable public API.
-const KNOWN_TOOLCHAINS: [&str; 2] = ["javascript", "rust"];
+const KNOWN_TOOLCHAINS: [&str; 3] = ["javascript", "rust", "python"];
 const TOOLCHAIN_ALIASES: [(&str, &str); 1] = [("typescript", "javascript")];
 
 /// A task `command` after alias resolution and validation: the argv the
@@ -633,6 +633,8 @@ impl ProcessedCommand {
             let (span, text) = key.span_and_text("turbo.json");
             let hint = if raw_key == "cargo" {
                 r#"Rust crates are the "rust" toolchain."#.to_string()
+            } else if raw_key == "uv" {
+                r#"Python packages are the "python" toolchain."#.to_string()
             } else {
                 format!(
                     "Known toolchains: {}.",
@@ -650,10 +652,20 @@ impl ProcessedCommand {
                 text,
             });
         }
-        if canonical == "rust" && !future_flags.experimental_cargo_workspaces {
+        let missing_flag = match canonical {
+            "rust" if !future_flags.experimental_cargo_workspaces => {
+                Some("experimentalCargoWorkspaces")
+            }
+            "python" if !future_flags.experimental_python_workspaces => {
+                Some("experimentalPythonWorkspaces")
+            }
+            _ => None,
+        };
+        if let Some(flag) = missing_flag {
             let (span, text) = key.span_and_text("turbo.json");
             return Err(Error::TaskCommandToolchainRequiresFlag {
                 key: raw_key.to_string(),
+                flag,
                 span,
                 text,
             });


### PR DESCRIPTION
### Description

Register package-scoped uv `build`, `format`, and `check` tasks and add `python` as an `experimentalTaskCommand` toolchain key. The task contracts handle workspace scoping, serialized shared-environment commands, safe output derivation, and uncached defaults.

This layer does not add uv lockfile hashing, watch behavior, or pruning.

### Testing Instructions

- Run `cargo test -p turborepo-repository uv`.
- Run `cargo check -p turborepo-task-executor -p turborepo-turbo-json`.

<sub>Closes TURBO-5851</sub>