### PR TITLE
feat: Prune uv workspaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8828,6 +8828,7 @@ dependencies = [
  "test-case",
  "thiserror 2.0.18",
  "toml 0.9.12+spec-1.1.0",
+ "toml_edit 0.22.15",
  "tracing",
  "turbopath",
  "turborepo-errors",

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -520,29 +520,13 @@ impl<'a> Prune<'a> {
             return Err(Error::NoWorkspaceSpecified);
         }
 
-        let cargo_enabled = crate::run::builder::cargo_enabled(&base.opts().future_flags);
-        let root_package_json_path = base.repo_root.join_component("package.json");
-        let root_package_json = match PackageJson::load(&root_package_json_path) {
-            Ok(package_json) => Some(package_json),
-            Err(turborepo_repository::package_json::Error::Io(error))
-                if error.kind() == ErrorKind::NotFound
-                    && cargo_enabled
-                    && base
-                        .repo_root
-                        .join_component(turborepo_repository::cargo::CARGO_TOML)
-                        .exists() =>
-            {
-                None
-            }
-            Err(error) => return Err(error.into()),
-        };
+        let features =
+            crate::repository_graph::RepositoryGraphFeatures::new(&base.opts().future_flags);
+        let root_package_json = features.load_root_package_json(&base.repo_root)?;
 
-        let mut graph_builder = PackageGraph::builder_optional(&base.repo_root, root_package_json)
+        let graph_builder = PackageGraph::builder_optional(&base.repo_root, root_package_json)
             .with_allow_no_package_manager(allow_missing_package_manager);
-        if cargo_enabled {
-            graph_builder = graph_builder.with_cargo();
-        }
-        let package_graph = graph_builder.build().await?;
+        let package_graph = features.configure(graph_builder).build().await?;
 
         let out_directory = AbsoluteSystemPathBuf::from_unknown(&base.repo_root, output_dir);
 

--- a/crates/turborepo-lockfiles/Cargo.toml
+++ b/crates/turborepo-lockfiles/Cargo.toml
@@ -30,6 +30,7 @@ serde_json = "1.0.86"
 serde_yaml_ng = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
+toml_edit = { workspace = true }
 tracing.workspace = true
 turbopath = { path = "../turborepo-paths" }
 turborepo-errors = { workspace = true }

--- a/crates/turborepo-lockfiles/src/lib.rs
+++ b/crates/turborepo-lockfiles/src/lib.rs
@@ -42,7 +42,7 @@ use rayon::prelude::*;
 use rustc_hash::{FxBuildHasher, FxHashSet};
 use serde::Serialize;
 use turbopath::RelativeUnixPathBuf;
-pub use uv::{Error as UvLockError, uv_external_closures};
+pub use uv::{Error as UvLockError, PrunedUvLock, uv_external_closures, uv_prune_lock};
 pub use yarn1::{Yarn1Lockfile, yarn_subgraph};
 
 // The closure walk visits every edge of every workspace's dependency closure,

--- a/crates/turborepo-lockfiles/src/uv.rs
+++ b/crates/turborepo-lockfiles/src/uv.rs
@@ -1,10 +1,11 @@
-//! uv.lock parsing for external-dependency hashing.
+//! uv.lock parsing for external-dependency hashing and prune.
 //!
 //! Like the Cargo module (and unlike the JS lockfile implementations), this
 //! module does not implement the [`crate::Lockfile`] trait: uv owns
 //! resolution, subgraph pruning, and installation, so Turborepo only needs
 //! two things from uv.lock — the set of external packages in each workspace
-//! member's transitive dependency closure.
+//! member's transitive dependency closure, and a reachability-pruned
+//! lockfile for `turbo prune`.
 //!
 //! uv.lock is a flat list of `[[package]]` entries. Workspace members carry
 //! a local project source (`{ editable = "…" }`, or `{ virtual = "…" }` for
@@ -31,6 +32,8 @@ use crate::Package;
 pub enum Error {
     #[error("Unable to parse uv.lock: {0}")]
     Parse(#[from] Box<toml::de::Error>),
+    #[error("Unable to parse uv.lock: {0}")]
+    ParseDocument(#[from] Box<toml_edit::TomlError>),
     #[error(
         "uv.lock has unsupported schema version {version}. This version of Turborepo supports \
          uv.lock version 1; a newer Turborepo release may be required."
@@ -43,6 +46,8 @@ pub enum Error {
          commit the result."
     )]
     MissingMember(String),
+    #[error("uv.lock is malformed: the [[package]] entries are not a valid array of tables.")]
+    MalformedPackageArray,
     #[error(
         "uv.lock contains reachable local dependency {name:?} at {source_description:?}, but only \
          uv workspace members are supported. Add it to [tool.uv.workspace] or replace it with a \
@@ -227,6 +232,79 @@ pub fn uv_external_closures(
         })
         .collect();
     Ok(closures)
+}
+
+/// The result of pruning a uv.lock to a set of root members.
+#[derive(Debug)]
+pub struct PrunedUvLock {
+    /// Every workspace member in the pruned closure, sorted.
+    pub members: Vec<String>,
+    /// The pruned lockfile, preserving retained package metadata.
+    pub lockfile: String,
+}
+
+/// Prune a uv.lock to the transitive closure of the given root members.
+pub fn uv_prune_lock(
+    contents: &str,
+    roots: &[String],
+    workspace_paths: &HashMap<String, String>,
+) -> Result<PrunedUvLock, Error> {
+    let lock = parse_lock(contents)?;
+    let index = LockIndex::new(&lock)?;
+
+    let mut starts = Vec::with_capacity(roots.len());
+    for root in roots {
+        starts.push(
+            index
+                .member(root, workspace_paths)
+                .ok_or_else(|| Error::MissingMember(root.clone()))?,
+        );
+    }
+    let kept = index.reachable(&starts);
+
+    for &idx in &kept {
+        reject_non_workspace_local(&lock.package[idx], workspace_paths)?;
+    }
+
+    let mut members: Vec<String> = kept
+        .iter()
+        .filter(|&&idx| package_matches_workspace(&lock.package[idx], workspace_paths))
+        .map(|&idx| lock.package[idx].name.clone())
+        .collect();
+    members.sort();
+    members.dedup();
+
+    // Rewrite instead of re-serializing so artifact and metadata tables that
+    // uv validates against manifests survive unchanged.
+    let mut document: toml_edit::DocumentMut = contents.parse().map_err(Box::new)?;
+    let packages = document
+        .get_mut("package")
+        .and_then(|item| item.as_array_of_tables_mut())
+        .ok_or(Error::MalformedPackageArray)?;
+    if packages.len() != lock.package.len() {
+        return Err(Error::MalformedPackageArray);
+    }
+    let mut position = 0;
+    packages.retain(|_| {
+        let keep = kept.contains(&position);
+        position += 1;
+        keep
+    });
+
+    if let Some(manifest_members) = document
+        .get_mut("manifest")
+        .and_then(|item| item.as_table_like_mut())
+        .and_then(|manifest| manifest.get_mut("members"))
+        .and_then(|item| item.as_array_mut())
+    {
+        let members: HashSet<&str> = members.iter().map(String::as_str).collect();
+        manifest_members.retain(|entry| entry.as_str().is_some_and(|name| members.contains(name)));
+    }
+
+    Ok(PrunedUvLock {
+        members,
+        lockfile: document.to_string(),
+    })
 }
 
 fn reject_non_workspace_local(
@@ -419,6 +497,18 @@ impl<'a> LockIndex<'a> {
             return Err(Error::UnknownDependency(display(dependency)));
         }
         Ok(candidates)
+    }
+
+    fn reachable(&self, starts: &[usize]) -> HashSet<usize> {
+        let mut visited = HashSet::new();
+        let mut stack = starts.to_vec();
+        while let Some(idx) = stack.pop() {
+            if !visited.insert(idx) {
+                continue;
+            }
+            stack.extend(self.adjacency[idx].iter().copied());
+        }
+        visited
     }
 }
 
@@ -771,6 +861,8 @@ source = { directory = "vendor/local-lib" }
         let allowed = HashMap::from([("app".to_string(), "packages/app".to_string())]);
         let error = uv_external_closures(lock, &members, &allowed).unwrap_err();
         assert!(matches!(error, Error::UnsupportedLocalDependency { .. }));
+        let error = uv_prune_lock(lock, &members, &allowed).unwrap_err();
+        assert!(matches!(error, Error::UnsupportedLocalDependency { .. }));
     }
 
     #[test]
@@ -826,5 +918,103 @@ source = { registry = "https://pypi.org/simple" }
             names(&closures["app"]),
             vec!["dep@1.0.0 registry+https://pypi.org/simple"]
         );
+    }
+
+    #[test]
+    fn test_prune_does_not_treat_external_same_name_as_member() {
+        let lock = r#"
+version = 1
+
+[manifest]
+members = ["app", "shared"]
+
+[[package]]
+name = "app"
+source = { editable = "packages/app" }
+dependencies = [
+    { name = "shared", version = "2.0.0", source = { registry = "https://pypi.org/simple" } },
+]
+
+[[package]]
+name = "shared"
+source = { editable = "packages/shared" }
+
+[[package]]
+name = "shared"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+"#;
+        let paths = HashMap::from([
+            ("app".to_string(), "packages/app".to_string()),
+            ("shared".to_string(), "packages/shared".to_string()),
+        ]);
+        let pruned = uv_prune_lock(lock, &["app".to_string()], &paths).unwrap();
+        assert_eq!(pruned.members, vec!["app"]);
+        assert!(pruned.lockfile.contains("version = \"2.0.0\""));
+    }
+
+    #[test]
+    fn test_prune_lock_keeps_reachable_closure() {
+        let pruned = uv_prune_lock(LOCK, &["py-lib".to_string()], &workspace_paths(LOCK)).unwrap();
+        assert_eq!(pruned.members, vec!["py-lib"]);
+        assert!(pruned.lockfile.contains("name = \"py-lib\""));
+        assert!(pruned.lockfile.contains("name = \"six\""));
+        assert!(!pruned.lockfile.contains("name = \"py-app\""));
+        assert!(!pruned.lockfile.contains("name = \"click\""));
+        assert!(!pruned.lockfile.contains("name = \"root-project\""));
+        assert!(!pruned.lockfile.contains("\"py-app\","));
+        assert!(pruned.lockfile.contains("requires-python = \">=3.11\""));
+        let closures = uv_external_closures(
+            &pruned.lockfile,
+            &["py-lib".to_string()],
+            &workspace_paths(LOCK),
+        )
+        .unwrap();
+        assert_eq!(
+            names(&closures["py-lib"]),
+            vec!["six@1.17.0 registry+https://pypi.org/simple sha256:51x"]
+        );
+    }
+
+    #[test]
+    fn test_prune_lock_preserves_metadata_tables_verbatim() {
+        let pruned = uv_prune_lock(LOCK, &["py-app".to_string()], &workspace_paths(LOCK)).unwrap();
+        assert!(pruned.lockfile.contains("[package.metadata]"));
+        assert!(
+            pruned
+                .lockfile
+                .contains(r#"{ name = "py-lib", editable = "packages/py-lib" }"#)
+        );
+        assert!(pruned.lockfile.contains("hash = \"sha256:c11c4wheel\""));
+    }
+
+    #[test]
+    fn test_prune_lock_retains_group_reachable_members() {
+        let pruned = uv_prune_lock(LOCK, &["py-app".to_string()], &workspace_paths(LOCK)).unwrap();
+        assert_eq!(pruned.members, vec!["py-app", "py-lib"]);
+        assert!(pruned.lockfile.contains("name = \"pytest\""));
+        assert!(pruned.lockfile.contains("name = \"colorama\""));
+        assert!(!pruned.lockfile.contains("name = \"ruff\""));
+    }
+
+    #[test]
+    fn test_prune_lock_stale_root_errors() {
+        let error =
+            uv_prune_lock(LOCK, &["not-in-lock".to_string()], &workspace_paths(LOCK)).unwrap_err();
+        assert!(matches!(error, Error::MissingMember(_)));
+    }
+
+    #[test]
+    fn test_prune_forked_lock_keeps_exact_forks() {
+        let pruned = uv_prune_lock(
+            FORKED_LOCK,
+            &["fork-lib".to_string()],
+            &workspace_paths(FORKED_LOCK),
+        )
+        .unwrap();
+        assert_eq!(pruned.members, vec!["fork-lib"]);
+        assert!(pruned.lockfile.contains("version = \"4.8.0\""));
+        assert!(pruned.lockfile.contains("version = \"4.16.0\""));
+        assert!(pruned.lockfile.contains("resolution-markers"));
     }
 }

--- a/crates/turborepo-repository/src/prune_knowledge.rs
+++ b/crates/turborepo-repository/src/prune_knowledge.rs
@@ -22,6 +22,8 @@ impl std::fmt::Display for PruneDomainId {
 
 pub const CARGO_PRUNE_DOMAIN: PruneDomainId = PruneDomainId(Cow::Borrowed("cargo"));
 
+pub const PYTHON_PRUNE_DOMAIN: PruneDomainId = PruneDomainId(Cow::Borrowed("python"));
+
 /// A toolchain's contribution to a pruned repository.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct PrunePlan {

--- a/crates/turborepo-repository/src/task_contracts.rs
+++ b/crates/turborepo-repository/src/task_contracts.rs
@@ -192,7 +192,9 @@ impl ScopeTaskContract {
             toolchain: Some(ToolchainId::PYTHON),
             command_map_target: Some(CommandMapTarget::Python),
             entrypoint_domain: Some(TaskEntrypointDomain(Cow::Borrowed("uv"))),
-            prune_package_mode: Some(PrunePackageMode::NativeCopy),
+            prune_package_mode: Some(PrunePackageMode::NativeDomain(
+                crate::prune_knowledge::PYTHON_PRUNE_DOMAIN.clone(),
+            )),
             dependency_source_inputs,
             dynamic: Some(DynamicTaskContract::Python(contract)),
             static_defaults: BTreeMap::new(),

--- a/crates/turborepo-repository/src/uv.rs
+++ b/crates/turborepo-repository/src/uv.rs
@@ -52,6 +52,7 @@ use crate::{
         PackageResolution, ResolutionCompleteness,
     },
     package_json::PackageJson,
+    prune_knowledge::{PruneDomain, PrunePlan},
     relationships::{DependencyKind, Relationship},
     toolchain::{
         self, DiscoverPackagesFuture, DiscoveredPackage, DiscoveredPackages, RepositoryContributor,
@@ -79,6 +80,10 @@ pub enum Error {
         #[source]
         source: Box<toml::de::Error>,
     },
+    #[error("failed to parse root pyproject.toml: {0}")]
+    ManifestEdit(#[from] Box<toml_edit::TomlError>),
+    #[error("root pyproject.toml has no [tool.uv.workspace] table")]
+    NotAWorkspace,
     #[error(
         "The uv workspace has no name.\n\nTurborepo needs a name for the workspace's tasks \
          (`<name>#check`), filters (`--filter=<name>`), and configuration. Add one to the root \
@@ -1148,6 +1153,169 @@ fn package_resolution(
     )
 }
 
+// ---------------------------------------------------------------------------
+// Prune
+// ---------------------------------------------------------------------------
+
+/// Rewrite the workspace root manifest for a pruned repository.
+pub fn prune_root_manifest(
+    contents: &str,
+    kept_dirs: &[String],
+    kept_names: &HashSet<String>,
+) -> Result<String, Error> {
+    let mut document: toml_edit::DocumentMut = contents.parse().map_err(Box::new)?;
+    let normalized_kept: HashSet<String> = kept_dirs.iter().map(|dir| normalize_dir(dir)).collect();
+
+    let uv = document
+        .get_mut("tool")
+        .and_then(|item| item.as_table_like_mut())
+        .and_then(|tool| tool.get_mut("uv"))
+        .and_then(|item| item.as_table_like_mut())
+        .ok_or(Error::NotAWorkspace)?;
+
+    {
+        let workspace = uv
+            .get_mut("workspace")
+            .and_then(|item| item.as_table_like_mut())
+            .ok_or(Error::NotAWorkspace)?;
+        let mut members = toml_edit::Array::new();
+        let mut sorted_dirs = kept_dirs.to_vec();
+        sorted_dirs.sort();
+        sorted_dirs.dedup();
+        for dir in &sorted_dirs {
+            members.push(dir.as_str());
+        }
+        workspace.insert("members", toml_edit::value(members));
+        workspace.remove("exclude");
+    }
+
+    if let Some(sources) = uv
+        .get_mut("sources")
+        .and_then(|item| item.as_table_like_mut())
+    {
+        let removed: Vec<String> = sources
+            .iter()
+            .filter(|(name, value)| {
+                let workspace_target = value
+                    .get("workspace")
+                    .and_then(|workspace| workspace.as_bool())
+                    .unwrap_or(false);
+                if workspace_target {
+                    return !kept_names.contains(&normalize_name(name));
+                }
+                value
+                    .get("path")
+                    .and_then(|path| path.as_str())
+                    .is_some_and(|path| !normalized_kept.contains(&normalize_dir(path)))
+            })
+            .map(|(name, _)| name.to_string())
+            .collect();
+        for name in removed {
+            sources.remove(&name);
+        }
+    }
+
+    Ok(document.to_string())
+}
+
+fn normalize_dir(dir: &str) -> String {
+    dir.replace('\\', "/")
+        .trim_start_matches("./")
+        .trim_end_matches('/')
+        .to_string()
+}
+
+#[derive(Debug)]
+struct UvPruneKnowledge {
+    domain: crate::prune_knowledge::PruneDomainId,
+    lockfile: String,
+    root_manifest: String,
+    package_directories: HashMap<String, String>,
+    root_project_name: Option<String>,
+}
+
+impl UvPruneKnowledge {
+    fn discover(
+        repo_root: &AbsoluteSystemPath,
+        package_directories: HashMap<String, String>,
+        root_project_name: Option<String>,
+        lockfile: String,
+    ) -> Result<Self, Error> {
+        let root_manifest = repo_root
+            .join_component(PYPROJECT_TOML)
+            .read_to_string()
+            .map_err(|source| Error::ManifestRead {
+                path: repo_root.join_component(PYPROJECT_TOML).to_string(),
+                source,
+            })?;
+        Ok(Self {
+            domain: crate::prune_knowledge::PYTHON_PRUNE_DOMAIN.clone(),
+            lockfile,
+            root_manifest,
+            package_directories,
+            root_project_name,
+        })
+    }
+}
+
+impl PruneDomain for UvPruneKnowledge {
+    fn id(&self) -> &crate::prune_knowledge::PruneDomainId {
+        &self.domain
+    }
+
+    fn plan(
+        &self,
+        kept_packages: &[String],
+    ) -> Result<Option<PrunePlan>, crate::prune_knowledge::Error> {
+        if kept_packages.is_empty() {
+            return Ok(None);
+        }
+        let failed = |error: Error| crate::prune_knowledge::Error::Failed(Box::new(error));
+        let mut roots = kept_packages.to_vec();
+        if let Some(root_project) = &self.root_project_name {
+            roots.push(root_project.clone());
+        }
+        let pruned_lock =
+            turborepo_lockfiles::uv_prune_lock(&self.lockfile, &roots, &self.package_directories)
+                .map_err(|error| failed(Error::Lockfile(error)))?;
+
+        let mut kept_dirs = Vec::with_capacity(pruned_lock.members.len());
+        let mut kept_names = HashSet::with_capacity(pruned_lock.members.len());
+        let mut extra_packages = Vec::new();
+        let requested_packages: HashSet<&str> = kept_packages.iter().map(String::as_str).collect();
+        for member in &pruned_lock.members {
+            if self.root_project_name.as_deref() == Some(member.as_str()) {
+                kept_names.insert(member.clone());
+                continue;
+            }
+            let Some(directory) = self.package_directories.get(member) else {
+                tracing::warn!(
+                    "uv.lock member {member} is not a discovered workspace package; skipping"
+                );
+                continue;
+            };
+            kept_dirs.push(directory.clone());
+            kept_names.insert(member.clone());
+            if !requested_packages.contains(member.as_str()) {
+                extra_packages.push(member.clone());
+            }
+        }
+        let pruned_manifest =
+            prune_root_manifest(&self.root_manifest, &kept_dirs, &kept_names).map_err(failed)?;
+        Ok(Some(PrunePlan {
+            extra_packages,
+            root_files: vec![
+                (UV_LOCK.to_string(), pruned_lock.lockfile),
+                (PYPROJECT_TOML.to_string(), pruned_manifest),
+            ],
+            copy_paths: [".python-version", "uv.toml"]
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+        }))
+    }
+}
+
 fn uv_change_observation() -> ChangeObservation {
     ChangeObservation::new()
         .with_rediscovery_file_name(PYPROJECT_TOML)
@@ -1229,6 +1397,13 @@ impl RepositoryContributor for UvContributor {
                 .collect();
             workspace_directories.sort();
             workspace_directories.dedup();
+            let prune_domain = UvPruneKnowledge::discover(
+                &self.repo_root,
+                package_directories.clone(),
+                workspace.root_project_name.clone(),
+                lockfile.clone(),
+            )
+            .map_err(|error| toolchain::Error::Failed(Box::new(error)))?;
 
             // Each package contributes its already-classified native
             // internal relationships directly. External dependencies (locked
@@ -1345,7 +1520,8 @@ impl RepositoryContributor for UvContributor {
             );
             Ok(DiscoveredPackages::new(discovered, workspace_roots)
                 .with_external_resolution(resolution)
-                .with_change_observation(change_observation))
+                .with_change_observation(change_observation)
+                .with_prune_domain(Arc::new(prune_domain)))
         })
     }
 }
@@ -1887,5 +2063,44 @@ overridden = { index = "private" }
         let virtual_contract = UvTaskContract::new(UvPackageKind::VirtualPackage, "py-app");
         assert!(!virtual_contract.derives_task_io("build"));
         assert!(virtual_contract.derives_task_io("check"));
+    }
+
+    #[test]
+    fn test_prune_root_manifest() {
+        let manifest = r#"
+[project]
+name = "root-project"
+version = "0.1.0"
+dependencies = ["py-app"]
+
+[tool.turbo]
+name = "acme"
+
+[tool.uv.workspace]
+members = ["packages/*"]
+exclude = ["packages/skipped"]
+
+[tool.uv.sources]
+py-app = { workspace = true }
+gone = { workspace = true }
+local = { path = "packages/gone-dir" }
+"#;
+        let kept_names: HashSet<String> = ["py-app".to_string(), "root-project".to_string()].into();
+        let pruned =
+            prune_root_manifest(manifest, &["packages/py-app".to_string()], &kept_names).unwrap();
+        assert!(pruned.contains(r#"members = ["packages/py-app"]"#));
+        assert!(!pruned.contains("exclude"));
+        assert!(pruned.contains("py-app = { workspace = true }"));
+        assert!(!pruned.contains("gone"));
+        assert!(!pruned.contains("local"));
+        assert!(pruned.contains("name = \"root-project\""));
+        assert!(pruned.contains("name = \"acme\""));
+    }
+
+    #[test]
+    fn test_prune_root_manifest_requires_workspace() {
+        let error =
+            prune_root_manifest("[project]\nname = \"x\"\n", &[], &HashSet::new()).unwrap_err();
+        assert!(matches!(error, Error::NotAWorkspace));
     }
 }


### PR DESCRIPTION
### Description

Add uv-aware pruning for pure Python and mixed JavaScript/Python repositories. Pruning keeps the reachable workspace and external dependency closure, rewrites root workspace members and `[tool.uv.sources]`, preserves lockfile fidelity, and carries required uv/Python configuration into the output without invoking `uv`.

### Testing Instructions

- Run `cargo test -p turborepo-lockfiles uv`.
- Run `cargo test -p turborepo-repository uv`.
- When `uv` is installed, verify pruned output with `uv lock --check`.

<sub>Closes TURBO-5854</sub>