### PR TITLE
fix: Make Windows Cap'n Proto cache relocatable

### DIFF
--- a/.github/actions/setup-capnproto/action.yml
+++ b/.github/actions/setup-capnproto/action.yml
@@ -51,8 +51,8 @@ runs:
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       id: cache-capnp-windows
       with:
-        path: C:\capnproto
-        key: ${{ runner.os }}-${{ github.head_ref || github.ref_name }}-capnproto-1.1.0-v2
+        path: .capnproto
+        key: ${{ runner.os }}-${{ github.head_ref || github.ref_name }}-capnproto-1.1.0-v3
 
     - name: "Setup capnproto for Windows"
       if: runner.os == 'Windows' && (steps.cache-capnp-windows.outcome == 'skipped' || steps.cache-capnp-windows.outputs.cache-hit != 'true')
@@ -68,19 +68,19 @@ runs:
           Write-Error "capnproto checksum mismatch. Expected $expectedHash, got $actualHash"
           exit 1
         }
-        Expand-Archive -Path $zip -DestinationPath "C:\capnproto" -Force
+        Expand-Archive -Path $zip -DestinationPath "$env:GITHUB_WORKSPACE\.capnproto" -Force
         Remove-Item $zip
 
     - name: "Add capnproto to PATH (Windows)"
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
-        $toolsDir = "C:\capnproto\capnproto-tools-win32-1.1.0"
+        $toolsDir = "$env:GITHUB_WORKSPACE\.capnproto\capnproto-tools-win32-1.1.0"
         if (Test-Path "$toolsDir\capnp.exe") {
           Write-Host "Adding $toolsDir to PATH"
           echo "$toolsDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         } else {
           Write-Error "capnp.exe not found at expected path: $toolsDir"
-          Get-ChildItem -Path "C:\capnproto" -Recurse | Select-Object FullName
+          Get-ChildItem -Path "$env:GITHUB_WORKSPACE\.capnproto" -Recurse | Select-Object FullName
           exit 1
         }


### PR DESCRIPTION
## Summary

- Store the Windows Cap’n Proto installation relative to `GITHUB_WORKSPACE` instead of the absolute `C:\capnproto` path.
- Allow caches created on `C:`-backed runners to restore on `D:`-backed release runners.
- Bump the Windows cache generation to avoid the existing non-relocatable entries.

## Testing

- `git diff --check`