### PR TITLE
fix: Accept semver ranges in devEngines.packageManager.version

### DIFF
--- a/packages/turbo-workspaces/__tests__/utils.test.ts
+++ b/packages/turbo-workspaces/__tests__/utils.test.ts
@@ -64,7 +64,11 @@ describe("utils", () => {
       ["pnpm", "9.12.3"],
       ["yarn", "4.5.0+sha224.abc"],
       ["bun", "1.1.0"],
-      ["nub", "0.1.0"]
+      ["nub", "0.1.0"],
+      ["pnpm", "^9.0.0"],
+      ["pnpm", "9"],
+      ["pnpm", ">=9.0.0 <10.0.0"],
+      ["pnpm", ">=9.0.0 <10.0.0 || >=9.5.0 <10.0.0"]
     ] as const)("reads %s from devEngines.packageManager", (name, version) => {
       const workspaceRoot = makeWorkspace({
         devEngines: {
@@ -164,10 +168,6 @@ describe("utils", () => {
         "version` must not contain"
       ],
       [
-        { devEngines: { packageManager: { name: "pnpm", version: "^9.0.0" } } },
-        "exact semantic version"
-      ],
-      [
         {
           devEngines: {
             packageManager: {
@@ -176,11 +176,7 @@ describe("utils", () => {
             }
           }
         },
-        "exact semantic version"
-      ],
-      [
-        { devEngines: { packageManager: { name: "pnpm", version: "9" } } },
-        "exact semantic version"
+        "valid semantic version range"
       ],
       [
         {
@@ -191,7 +187,39 @@ describe("utils", () => {
             }
           }
         },
-        "exact semantic version"
+        "valid semantic version range"
+      ],
+      [
+        {
+          devEngines: {
+            packageManager: { name: "pnpm", version: ">=1.0.0 <1.0.0" }
+          }
+        },
+        "at least one version"
+      ],
+      [
+        { devEngines: { packageManager: { name: "pnpm", version: "*" } } },
+        "one major version"
+      ],
+      [
+        {
+          devEngines: { packageManager: { name: "pnpm", version: ">=9.0.0" } }
+        },
+        "one major version"
+      ],
+      [
+        {
+          devEngines: {
+            packageManager: { name: "pnpm", version: ">=6.0.0 <10.0.0" }
+          }
+        },
+        "one major version"
+      ],
+      [
+        {
+          devEngines: { packageManager: { name: "pnpm", version: "9 || 10" } }
+        },
+        "one major version"
       ]
     ])(
       "rejects invalid devEngines.packageManager %#",

--- a/packages/turbo-workspaces/__tests__/utils.test.ts
+++ b/packages/turbo-workspaces/__tests__/utils.test.ts
@@ -68,7 +68,10 @@ describe("utils", () => {
       ["pnpm", "^9.0.0"],
       ["pnpm", "9"],
       ["pnpm", ">=9.0.0 <10.0.0"],
-      ["pnpm", ">=9.0.0 <10.0.0 || >=9.5.0 <10.0.0"]
+      ["pnpm", ">=9.0.0 <10.0.0 || >=9.5.0 <10.0.0"],
+      ["pnpm", "^6.35.1"],
+      ["yarn", "^4.0.0"],
+      ["yarn", "^1.22.0"]
     ] as const)("reads %s from devEngines.packageManager", (name, version) => {
       const workspaceRoot = makeWorkspace({
         devEngines: {
@@ -193,6 +196,17 @@ describe("utils", () => {
         {
           devEngines: {
             packageManager: { name: "pnpm", version: ">=1.0.0 <1.0.0" }
+          }
+        },
+        "at least one version"
+      ],
+      [
+        {
+          devEngines: {
+            packageManager: {
+              name: "pnpm",
+              version: "9 || >=1.0.0 <1.0.0"
+            }
           }
         },
         "at least one version"

--- a/packages/turbo-workspaces/src/utils.ts
+++ b/packages/turbo-workspaces/src/utils.ts
@@ -49,8 +49,6 @@ const SUPPORTED_PACKAGE_MANAGERS = new Set<PackageManager>([
   "nub",
   "aube"
 ]);
-const DEV_ENGINES_VERSION_REGEX =
-  /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 
 function getPackageJson({
   workspaceRoot
@@ -189,12 +187,30 @@ function getWorkspacePackageManager({
     );
   }
 
+  if (semver.validRange(version) === null) {
+    throw invalidDevEnginesPackageManager(
+      "`devEngines.packageManager.version` must be a valid semantic version range"
+    );
+  }
+
+  const minVersion = semver.minVersion(version);
+  if (minVersion === null) {
+    throw invalidDevEnginesPackageManager(
+      "`devEngines.packageManager.version` must admit at least one version"
+    );
+  }
+
   if (
-    !DEV_ENGINES_VERSION_REGEX.test(version) ||
-    semver.valid(version) === null
+    version
+      .split("||")
+      .some(
+        (disjunct) =>
+          semver.minVersion(disjunct)?.major !== minVersion.major ||
+          semver.satisfies(`${minVersion.major + 1}.0.0`, disjunct)
+      )
   ) {
     throw invalidDevEnginesPackageManager(
-      "`devEngines.packageManager.version` must be an exact semantic version"
+      "`devEngines.packageManager.version` must only allow versions within one major version"
     );
   }
 

--- a/packages/turbo-workspaces/src/utils.ts
+++ b/packages/turbo-workspaces/src/utils.ts
@@ -200,18 +200,22 @@ function getWorkspacePackageManager({
     );
   }
 
-  if (
-    version
-      .split("||")
-      .some(
-        (disjunct) =>
-          semver.minVersion(disjunct)?.major !== minVersion.major ||
-          semver.satisfies(`${minVersion.major + 1}.0.0`, disjunct)
-      )
-  ) {
-    throw invalidDevEnginesPackageManager(
-      "`devEngines.packageManager.version` must only allow versions within one major version"
-    );
+  for (const disjunct of version.split("||")) {
+    const disjunctMinVersion = semver.minVersion(disjunct.trim());
+    if (disjunctMinVersion === null) {
+      throw invalidDevEnginesPackageManager(
+        "`devEngines.packageManager.version` must admit at least one version"
+      );
+    }
+
+    if (
+      disjunctMinVersion.major !== minVersion.major ||
+      semver.satisfies(`${disjunctMinVersion.major + 1}.0.0`, disjunct.trim())
+    ) {
+      throw invalidDevEnginesPackageManager(
+        "`devEngines.packageManager.version` must only allow versions within one major version"
+      );
+    }
   }
 
   return name;


### PR DESCRIPTION
### Description

#13150 added support for `devEngines.packageManager`, but the `version` field only accepted one exact version.

This PR also accepts a semver range, like `^9.0.0`, `9`, or `>=9.0.0 <10.0.0`, as [mod.rs](https://github.com/vercel/turborepo/blob/main/crates/turborepo-repository/src/package_manager/mod.rs) does.

### Testing Instructions

```sh
pnpm --dir=packages/turbo-workspaces jest
```