### PR TITLE
docs: Fix duplicated word in runtime dependencies guide summary

### DIFF
--- a/apps/docs/content/docs/guides/coordinating-runtime-dependencies.mdx
+++ b/apps/docs/content/docs/guides/coordinating-runtime-dependencies.mdx
@@ -3,7 +3,7 @@ title: Coordinating development runtime dependencies
 description: Learn how to coordinate development services that depend on each other at runtime.
 product: turborepo
 type: guide
-summary: Combine a readiness probe with with and dependsOn to coordinate runtime dependencies between development services.
+summary: Combine a readiness probe with `with` and `dependsOn` to coordinate runtime dependencies between development services.
 prerequisites:
   - /docs/crafting-your-repository/developing-applications
 related:


### PR DESCRIPTION

### Description

Fixes a doubled word in the `summary` frontmatter of the "Coordinating development runtime dependencies" guide. The word "with" appeared twice, The second one is the Turborepo `with` configuration key, which had lost its backticks and read as a repeat.

Wrapped both config keys in backticks so the summary reads naturally and matches how the guide body and other guide summaries format code.