### PR TITLE
refactor: Remove turborepo-lsp dependency on turborepo-lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8436,6 +8436,7 @@ dependencies = [
  "pidlock",
  "prost 0.14.3",
  "semver 1.0.23",
+ "serde",
  "serde_json",
  "sha2",
  "sysinfo",
@@ -8458,6 +8459,7 @@ dependencies = [
  "turborepo-scm",
  "turborepo-types",
  "uds_windows",
+ "which 4.4.0",
  "windows-sys 0.59.0",
 ]
 
@@ -8849,7 +8851,10 @@ dependencies = [
 name = "turborepo-lsp"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "crop",
+ "go-parse-duration",
+ "humantime",
  "itertools 0.14.0",
  "jsonc-parser 0.23.0",
  "pidlock",
@@ -8858,6 +8863,9 @@ dependencies = [
  "tokio",
  "tokio-retry",
  "tower-lsp",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
  "turbopath",
  "turborepo-daemon",
  "turborepo-repository",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8859,7 +8859,7 @@ dependencies = [
  "tokio-retry",
  "tower-lsp",
  "turbopath",
- "turborepo-lib",
+ "turborepo-daemon",
  "turborepo-repository",
  "wax",
 ]

--- a/crates/turborepo-daemon/Cargo.toml
+++ b/crates/turborepo-daemon/Cargo.toml
@@ -17,10 +17,11 @@ hyper-util = { version = "0.1", features = ["tokio"] }
 notify = { workspace = true }
 prost = "0.14"
 semver = { workspace = true }
+serde = { workspace = true }
 sha2 = { workspace = true }
 sysinfo = "0.27.7"
 thiserror = { workspace = true }
-time = "0.3.20"
+time = { version = "0.3.20", features = ["formatting"] }
 tokio = { workspace = true, features = ["full", "time"] }
 tokio-stream = { version = "0.1.12", features = ["net"] }
 tokio-util = { version = "0.7.7", features = ["compat"] }
@@ -28,6 +29,7 @@ tonic = { version = "0.14", features = ["transport"] }
 tonic-prost = "0.14"
 tower = "0.5"
 tracing = { workspace = true }
+which = { workspace = true }
 
 pidlock = { path = "../turborepo-pidlock" }
 turbopath = { workspace = true }

--- a/crates/turborepo-daemon/src/lib.rs
+++ b/crates/turborepo-daemon/src/lib.rs
@@ -32,6 +32,8 @@ mod client;
 mod connector;
 mod default_timeout_layer;
 pub mod endpoint;
+mod lifecycle;
+mod package_changes_watcher;
 mod package_discovery;
 mod server;
 
@@ -39,6 +41,11 @@ use std::{collections::HashSet, path::PathBuf, sync::Arc};
 
 pub use client::{DaemonClient, DaemonError};
 pub use connector::{DaemonConnector, DaemonConnectorError};
+pub use lifecycle::{
+    clean_daemon, clean_daemon_files, daemon_log_filename, follow_daemon_logs,
+    run_lifecycle_command, serve, DaemonLifecycleCommand, DaemonLifecycleOutput, DaemonStatus,
+};
+pub use package_changes_watcher::RediscoveringPackageChangesWatcher;
 pub use package_discovery::DaemonPackageDiscovery;
 pub use server::{CloseReason, FileWatching, TurboGrpcService};
 use sha2::{Digest, Sha256};

--- a/crates/turborepo-daemon/src/lib.rs
+++ b/crates/turborepo-daemon/src/lib.rs
@@ -32,12 +32,14 @@ mod client;
 mod connector;
 mod default_timeout_layer;
 pub mod endpoint;
+mod package_discovery;
 mod server;
 
 use std::{collections::HashSet, path::PathBuf, sync::Arc};
 
 pub use client::{DaemonClient, DaemonError};
 pub use connector::{DaemonConnector, DaemonConnectorError};
+pub use package_discovery::DaemonPackageDiscovery;
 pub use server::{CloseReason, FileWatching, TurboGrpcService};
 use sha2::{Digest, Sha256};
 use tokio::sync::broadcast;

--- a/crates/turborepo-daemon/src/lifecycle.rs
+++ b/crates/turborepo-daemon/src/lifecycle.rs
@@ -1,0 +1,294 @@
+use std::{future::Future, path::PathBuf, time::Duration};
+
+use pidlock::PidlockError::AlreadyOwned;
+use serde::Serialize;
+use time::{format_description, OffsetDateTime};
+use tracing::{trace, warn};
+use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
+use which::which;
+
+use crate::{
+    endpoint::SocketOpenError, CloseReason, DaemonConnector, DaemonConnectorError, DaemonError,
+    PackageChangesWatcher, PackageChangesWatcherArgs, Paths, TurboGrpcService,
+};
+
+#[derive(Clone, Copy, Debug)]
+pub enum DaemonLifecycleCommand {
+    Restart,
+    Start,
+    Status,
+    Stop,
+}
+
+#[derive(Debug)]
+pub enum DaemonLifecycleOutput {
+    Restarted,
+    Running,
+    Status(Option<DaemonStatus>),
+    Stopped,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DaemonStatus {
+    pub uptime_ms: u64,
+    pub log_file: String,
+    pub pid_file: AbsoluteSystemPathBuf,
+    pub sock_file: AbsoluteSystemPathBuf,
+}
+
+pub async fn run_lifecycle_command(
+    command: DaemonLifecycleCommand,
+    repo_root: &AbsoluteSystemPath,
+    custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
+) -> Result<DaemonLifecycleOutput, DaemonError> {
+    let (can_start_server, can_kill_server) = match command {
+        DaemonLifecycleCommand::Status => (false, false),
+        DaemonLifecycleCommand::Stop => (false, true),
+        DaemonLifecycleCommand::Restart | DaemonLifecycleCommand::Start => (true, true),
+    };
+    let connector = DaemonConnector::new(
+        can_start_server,
+        can_kill_server,
+        repo_root,
+        custom_turbo_json_path,
+    )?;
+
+    match command {
+        DaemonLifecycleCommand::Restart => {
+            let result: Result<_, DaemonError> = async {
+                let client = connector
+                    .clone()
+                    .connect()
+                    .await
+                    .map_err(DaemonError::DaemonConnect)?;
+                client.restart().await
+            }
+            .await;
+
+            if let Err(error) = result {
+                tracing::debug!(
+                    ?error,
+                    "failed to restart the daemon; falling back to clean"
+                );
+                clean_daemon_files(&connector.paths.pid_file, &connector.paths.sock_file)?;
+                let _ = connector.connect().await?;
+            }
+
+            Ok(DaemonLifecycleOutput::Restarted)
+        }
+        DaemonLifecycleCommand::Start => {
+            let _ = connector.connect().await?;
+            Ok(DaemonLifecycleOutput::Running)
+        }
+        DaemonLifecycleCommand::Status => {
+            let mut client = match connector.connect().await {
+                Ok(client) => client,
+                Err(DaemonConnectorError::NotRunning) => {
+                    return Ok(DaemonLifecycleOutput::Status(None));
+                }
+                Err(error) => return Err(error.into()),
+            };
+            let status = client.status().await?;
+            let paths = client.paths();
+            Ok(DaemonLifecycleOutput::Status(Some(DaemonStatus {
+                uptime_ms: status.uptime_msec,
+                log_file: daemon_log_filename(&status.log_file)?,
+                pid_file: paths.pid_file.clone(),
+                sock_file: paths.sock_file.clone(),
+            })))
+        }
+        DaemonLifecycleCommand::Stop => {
+            let client = match connector.connect().await {
+                Ok(client) => client,
+                Err(DaemonConnectorError::NotRunning) => {
+                    return Ok(DaemonLifecycleOutput::Stopped);
+                }
+                Err(error) => return Err(error.into()),
+            };
+            client.stop().await?;
+            Ok(DaemonLifecycleOutput::Stopped)
+        }
+    }
+}
+
+#[allow(clippy::result_large_err)]
+pub fn clean_daemon_files(
+    pid_file: &AbsoluteSystemPath,
+    sock_file: &AbsoluteSystemPath,
+) -> Result<(), DaemonError> {
+    let mut success = true;
+    trace!("cleaning up daemon files");
+    if pid_file.exists() {
+        if let Err(error) = pid_file.remove_file() {
+            println!("Failed to remove pid file: {error}");
+            println!("Please remove manually: {pid_file}");
+            success = false;
+        }
+    }
+    if sock_file.exists() {
+        if let Err(error) = sock_file.remove_file() {
+            println!("Failed to remove socket file: {error}");
+            println!("Please remove manually: {sock_file}");
+            success = false;
+        }
+    }
+
+    if success {
+        Ok(())
+    } else {
+        Err(DaemonError::CleanFailed)
+    }
+}
+
+pub async fn clean_daemon(
+    repo_root: &AbsoluteSystemPath,
+    custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
+    clean_logs: bool,
+) -> Result<(), DaemonError> {
+    let connector = DaemonConnector::new(false, true, repo_root, custom_turbo_json_path)?;
+    let paths = connector.paths.clone();
+    match connector.connect().await {
+        Ok(client) => {
+            if let Err(error) = client.stop().await {
+                trace!(?error, "unable to stop daemon before cleaning");
+            }
+        }
+        Err(error) => trace!(?error, "unable to connect to daemon before cleaning"),
+    }
+
+    clean_daemon_files(&paths.pid_file, &paths.sock_file)?;
+    if clean_logs {
+        clean_daemon_logs(&paths.log_folder)?;
+    }
+    Ok(())
+}
+
+pub async fn follow_daemon_logs(
+    repo_root: &AbsoluteSystemPath,
+    custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
+) -> Result<(), DaemonError> {
+    let connector = DaemonConnector::new(false, false, repo_root, custom_turbo_json_path)?;
+    let log_file = if let Ok(log_file) = get_log_file_from_daemon(connector).await {
+        log_file
+    } else {
+        warn!("couldn't connect to daemon, looking for old log files");
+        latest_log_file_from_dir(&repo_root.join_components(&[".turbo", "daemon"]))?
+    };
+    let tail = which("tail").map_err(|_| DaemonError::TailNotInstalled)?;
+
+    if let Err(error) = std::process::Command::new(tail)
+        .arg("-f")
+        .arg(log_file)
+        .status()
+    {
+        tracing::error!(%error, "failed to execute tail");
+    }
+    Ok(())
+}
+
+pub async fn serve<W, F, S>(
+    repo_root: AbsoluteSystemPathBuf,
+    timeout: Duration,
+    external_shutdown: S,
+    custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
+    allow_no_package_manager: bool,
+    package_changes_watcher_factory: F,
+) -> Result<(), DaemonError>
+where
+    W: PackageChangesWatcher + 'static,
+    F: Fn(PackageChangesWatcherArgs) -> W + Send + Sync + 'static,
+    S: Future<Output = CloseReason>,
+{
+    let paths = Paths::from_repo_root(&repo_root)?;
+    let server = TurboGrpcService::new(
+        repo_root,
+        paths,
+        timeout,
+        external_shutdown,
+        custom_turbo_json_path,
+        allow_no_package_manager,
+        package_changes_watcher_factory,
+    );
+
+    let reason = server.serve().await?;
+    match reason {
+        CloseReason::SocketOpenError(SocketOpenError::LockError(AlreadyOwned)) => {
+            warn!("daemon already running");
+        }
+        CloseReason::SocketOpenError(error) => return Err(error.into()),
+        CloseReason::WatcherSetupError(error) => return Err(error.into()),
+        CloseReason::Interrupt
+        | CloseReason::ServerClosed
+        | CloseReason::WatcherClosed
+        | CloseReason::Timeout
+        | CloseReason::Shutdown => {
+            trace!(?reason, "shutting down daemon");
+        }
+    }
+
+    Ok(())
+}
+
+pub fn daemon_log_filename(base_filename: &str) -> Result<String, time::Error> {
+    let now = OffsetDateTime::now_utc();
+    let format = format_description::parse("[year]-[month]-[day]")?;
+    let date = now.format(&format)?;
+    Ok(format!("{base_filename}.{date}"))
+}
+
+async fn get_log_file_from_daemon(connector: DaemonConnector) -> Result<PathBuf, DaemonError> {
+    let mut client = connector.connect().await?;
+    let status = client.status().await?;
+    Ok(PathBuf::from(daemon_log_filename(&status.log_file)?))
+}
+
+#[allow(clippy::result_large_err)]
+fn latest_log_file_from_dir(log_folder: &AbsoluteSystemPath) -> Result<PathBuf, DaemonError> {
+    let Ok(dir) = std::fs::read_dir(log_folder) else {
+        return Err(DaemonError::LogFileNotFound);
+    };
+
+    let (latest_file, _) = dir
+        .flatten()
+        .filter_map(|entry| {
+            let modified_time = entry.metadata().ok()?.modified().ok()?;
+            Some((entry, modified_time))
+        })
+        .max_by(|(_, first), (_, second)| first.cmp(second))
+        .ok_or(DaemonError::LogFileNotFound)?;
+
+    Ok(latest_file.path())
+}
+
+#[allow(clippy::result_large_err)]
+fn clean_daemon_logs(log_folder: &AbsoluteSystemPath) -> Result<(), DaemonError> {
+    trace!("cleaning up daemon logs");
+    log_folder.remove_dir_all().map_err(|error| {
+        println!("Failed to remove log files: {error}");
+        println!("Please remove manually: {log_folder}");
+        DaemonError::CleanFailed
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[test]
+    fn latest_log_file_from_dir_returns_non_utf8_path() {
+        use std::{ffi::OsString, os::unix::ffi::OsStringExt};
+
+        use turbopath::AbsoluteSystemPathBuf;
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let log_folder = AbsoluteSystemPathBuf::try_from(tempdir.path()).unwrap();
+        let log_file = log_folder
+            .as_std_path()
+            .join(OsString::from_vec(b"turbo-\xFF.log".to_vec()));
+        std::fs::write(&log_file, "").unwrap();
+
+        assert_eq!(
+            super::latest_log_file_from_dir(&log_folder).unwrap(),
+            log_file
+        );
+    }
+}

--- a/crates/turborepo-daemon/src/package_changes_watcher.rs
+++ b/crates/turborepo-daemon/src/package_changes_watcher.rs
@@ -1,0 +1,65 @@
+use std::{ffi::OsStr, path::Path};
+
+use tokio::{sync::broadcast, task::JoinHandle};
+use turborepo_filewatch::WatchScope;
+
+use crate::{PackageChangeEvent, PackageChangesWatcher, PackageChangesWatcherArgs};
+
+pub struct RediscoveringPackageChangesWatcher {
+    _handle: JoinHandle<()>,
+    package_changes_rx: broadcast::Receiver<PackageChangeEvent>,
+}
+
+impl RediscoveringPackageChangesWatcher {
+    pub fn new(args: PackageChangesWatcherArgs) -> Self {
+        let (package_changes_tx, package_changes_rx) = broadcast::channel(16);
+        let _handle = tokio::spawn(async move {
+            let scope = WatchScope::predicate(should_rediscover);
+            let Ok(mut events) = args.file_events.subscribe(scope).await else {
+                return;
+            };
+
+            loop {
+                match events.recv().await {
+                    Ok(_) | Err(broadcast::error::RecvError::Lagged(_)) => {
+                        let _ = package_changes_tx.send(PackageChangeEvent::Rediscover);
+                    }
+                    Err(broadcast::error::RecvError::Closed) => return,
+                }
+            }
+        });
+
+        Self {
+            _handle,
+            package_changes_rx,
+        }
+    }
+}
+
+fn should_rediscover(path: &Path) -> bool {
+    !path.components().any(|component| {
+        component.as_os_str() == OsStr::new(".git") || component.as_os_str() == OsStr::new(".turbo")
+    })
+}
+
+impl PackageChangesWatcher for RediscoveringPackageChangesWatcher {
+    async fn package_changes(&self) -> broadcast::Receiver<PackageChangeEvent> {
+        self.package_changes_rx.resubscribe()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    #[test]
+    fn ignores_daemon_and_git_files() {
+        assert!(!super::should_rediscover(Path::new(
+            "repo/.turbo/cookies/1"
+        )));
+        assert!(!super::should_rediscover(Path::new("repo/.git/index")));
+        assert!(super::should_rediscover(Path::new(
+            "repo/apps/web/package.json"
+        )));
+    }
+}

--- a/crates/turborepo-daemon/src/package_discovery.rs
+++ b/crates/turborepo-daemon/src/package_discovery.rs
@@ -1,11 +1,12 @@
 use turbopath::AbsoluteSystemPathBuf;
-use turborepo_daemon::{
-    proto::{DiscoverPackagesResponse, PackageFiles, PackageManager as ProtoPackageManager},
-    DaemonClient,
-};
 use turborepo_repository::{
     discovery::{DiscoveryResponse, Error, PackageDiscovery, WorkspaceData},
     package_manager::PackageManager,
+};
+
+use crate::{
+    proto::{DiscoverPackagesResponse, PackageFiles, PackageManager as ProtoPackageManager},
+    DaemonClient,
 };
 
 #[derive(Debug)]

--- a/crates/turborepo-lib/src/commands/daemon.rs
+++ b/crates/turborepo-lib/src/commands/daemon.rs
@@ -1,19 +1,13 @@
-use std::{path::PathBuf, time::Duration};
+use std::time::Duration;
 
-use camino::Utf8PathBuf;
 use futures::FutureExt;
-use pidlock::PidlockError::AlreadyOwned;
 use serde_json::json;
-use time::{format_description, OffsetDateTime};
 use tokio::signal::ctrl_c;
-use tracing::{trace, warn};
-use turbopath::AbsoluteSystemPath;
 use turborepo_daemon::{
-    endpoint::SocketOpenError, CloseReason, DaemonConnector, DaemonConnectorError, DaemonError,
-    Paths, TurboGrpcService,
+    clean_daemon, follow_daemon_logs, serve, CloseReason, DaemonError, DaemonLifecycleCommand,
+    DaemonLifecycleOutput, Paths,
 };
 use turborepo_ui::{color, BOLD_GREEN, BOLD_RED, GREY};
-use which::which;
 
 use super::CommandBase;
 use crate::{
@@ -48,40 +42,16 @@ pub async fn daemon_client(
     base: &CommandBase,
     custom_turbo_json_path: Option<camino::Utf8PathBuf>,
 ) -> Result<(), DaemonError> {
-    let (can_start_server, can_kill_server) = match command {
-        DaemonCommand::Status { .. } | DaemonCommand::Logs => (false, false),
-        DaemonCommand::Stop => (false, true),
-        DaemonCommand::Restart | DaemonCommand::Start => (true, true),
-        DaemonCommand::Clean { .. } => (false, true),
-    };
-
     let custom_turbo_json_path = convert_turbo_json_path(custom_turbo_json_path.as_deref())?;
-
-    let connector = DaemonConnector::new(
-        can_start_server,
-        can_kill_server,
-        &base.repo_root,
-        custom_turbo_json_path,
-    )?;
 
     match command {
         DaemonCommand::Restart => {
-            let result: Result<_, DaemonError> = try {
-                let client = connector
-                    .clone()
-                    .connect()
-                    .await
-                    .map_err(DaemonError::DaemonConnect)?;
-                client.restart().await?
-            };
-
-            if let Err(e) = result {
-                tracing::debug!("failed to restart the daemon: {:?}", e);
-                tracing::debug!("falling back to clean");
-                clean(&connector.paths.pid_file, &connector.paths.sock_file)?;
-                tracing::debug!("connecting for second time");
-                let _ = connector.connect().await?;
-            }
+            let _ = turborepo_daemon::run_lifecycle_command(
+                DaemonLifecycleCommand::Restart,
+                &base.repo_root,
+                custom_turbo_json_path.clone(),
+            )
+            .await?;
 
             println!(
                 "{} restarted daemon",
@@ -89,42 +59,46 @@ pub async fn daemon_client(
             );
         }
         DaemonCommand::Start => {
-            // We don't care about the client, but we do care that we can connect
-            // which ensures that daemon is started if it wasn't already.
-            let _ = connector.connect().await?;
+            let _ = turborepo_daemon::run_lifecycle_command(
+                DaemonLifecycleCommand::Start,
+                &base.repo_root,
+                custom_turbo_json_path.clone(),
+            )
+            .await?;
             println!(
                 "{} daemon is running",
                 color!(base.color_config, BOLD_GREEN, "✓")
             );
         }
         DaemonCommand::Stop => {
-            let client = match connector.connect().await {
-                Ok(client) => client,
-                Err(DaemonConnectorError::NotRunning) => {
-                    println!(
-                        "{} stopped daemon",
-                        color!(base.color_config, BOLD_GREEN, "✓")
-                    );
-                    return Ok(());
-                }
-                Err(e) => {
-                    return Err(e.into());
-                }
-            };
-            client.stop().await?;
+            let _ = turborepo_daemon::run_lifecycle_command(
+                DaemonLifecycleCommand::Stop,
+                &base.repo_root,
+                custom_turbo_json_path.clone(),
+            )
+            .await?;
             println!(
                 "{} stopped daemon",
                 color!(base.color_config, BOLD_GREEN, "✓")
             );
         }
         DaemonCommand::Status { json } => {
-            let mut client = match connector.connect().await {
-                Ok(status) => status,
-                Err(DaemonConnectorError::NotRunning) if *json => {
+            let output = turborepo_daemon::run_lifecycle_command(
+                DaemonLifecycleCommand::Status,
+                &base.repo_root,
+                custom_turbo_json_path.clone(),
+            )
+            .await?;
+            let DaemonLifecycleOutput::Status(status) = output else {
+                unreachable!("status command must return status output");
+            };
+            let status = match status {
+                Some(status) => status,
+                None if *json => {
                     println!("{}", json!({ "error": DAEMON_NOT_RUNNING_MESSAGE }));
                     return Ok(());
                 }
-                Err(DaemonConnectorError::NotRunning) => {
+                None => {
                     println!(
                         "{} {}",
                         color!(base.color_config, BOLD_RED, "x"),
@@ -132,18 +106,6 @@ pub async fn daemon_client(
                     );
                     return Ok(());
                 }
-                Err(e) => {
-                    return Err(e.into());
-                }
-            };
-            let status = client.status().await?;
-            let log_file = log_filename(&status.log_file)?;
-            let paths = client.paths();
-            let status = DaemonStatus {
-                uptime_ms: status.uptime_msec,
-                log_file: log_file.into(),
-                pid_file: paths.pid_file.to_owned(),
-                sock_file: paths.sock_file.to_owned(),
             };
 
             if *json {
@@ -177,133 +139,22 @@ pub async fn daemon_client(
             }
         }
         DaemonCommand::Logs => {
-            let log_file = if let Ok(log_file) = get_log_file_from_daemon(connector).await {
-                log_file
-            } else {
-                get_log_file_from_folder(base).await?
-            };
-
-            let tail = which("tail").map_err(|_| DaemonError::TailNotInstalled)?;
-
-            if let Err(err) = std::process::Command::new(tail)
-                .arg("-f")
-                .arg(log_file)
-                .status()
-            {
-                tracing::error!("failed to execute tail: {err}");
-            }
+            follow_daemon_logs(&base.repo_root, custom_turbo_json_path.clone()).await?;
         }
         DaemonCommand::Clean {
             clean_logs: should_clean_logs,
         } => {
-            // try to connect and shutdown the daemon
-            let paths = connector.paths.clone();
-            let client = connector.connect().await;
-            match client {
-                Ok(client) => match client.stop().await {
-                    Ok(_) => {
-                        tracing::trace!("successfully stopped the daemon");
-                    }
-                    Err(e) => {
-                        tracing::trace!("unable to stop the daemon: {:?}", e);
-                    }
-                },
-                Err(e) => {
-                    tracing::trace!("unable to connect to the daemon: {:?}", e);
-                }
-            }
-            clean(&paths.pid_file, &paths.sock_file)?;
-            if *should_clean_logs {
-                clean_logs(&paths.log_folder)?;
-            }
+            clean_daemon(
+                &base.repo_root,
+                custom_turbo_json_path.clone(),
+                *should_clean_logs,
+            )
+            .await?;
             println!("Done");
         }
     };
 
     Ok(())
-}
-
-async fn get_log_file_from_daemon(connector: DaemonConnector) -> Result<PathBuf, DaemonError> {
-    let mut client = connector.connect().await?;
-    let status = client.status().await?;
-    Ok(PathBuf::from(log_filename(&status.log_file)?))
-}
-
-async fn get_log_file_from_folder(base: &CommandBase) -> Result<PathBuf, DaemonError> {
-    warn!("couldn't connect to daemon, looking for old log files");
-    let log_folder = base.repo_root.join_components(&[".turbo", "daemon"]);
-    latest_log_file_from_dir(&log_folder)
-}
-
-fn latest_log_file_from_dir(log_folder: &AbsoluteSystemPath) -> Result<PathBuf, DaemonError> {
-    let Ok(dir) = std::fs::read_dir(log_folder) else {
-        return Err(DaemonError::LogFileNotFound);
-    };
-
-    let (latest_file, _) = dir
-        .flatten()
-        .filter_map(|entry| {
-            let modified_time = entry.metadata().ok()?.modified().ok()?;
-            Some((entry, modified_time))
-        })
-        .max_by(|(_, mt1), (_, mt2)| mt1.cmp(mt2))
-        .ok_or(DaemonError::LogFileNotFound)?;
-
-    Ok(latest_file.path())
-}
-
-fn clean(pid_file: &AbsoluteSystemPath, sock_file: &AbsoluteSystemPath) -> Result<(), DaemonError> {
-    // remove pid and sock files
-    let mut success = true;
-    trace!("cleaning up daemon files");
-    // if the pid_file and sock_file still exist, remove them:
-    if pid_file.exists() {
-        let result = pid_file.remove_file();
-        // ignore this error
-        if let Err(e) = result {
-            println!("Failed to remove pid file: {e}");
-            println!("Please remove manually: {pid_file}");
-            success = false;
-        }
-    }
-    if sock_file.exists() {
-        let result = sock_file.remove_file();
-        // ignore this error
-        if let Err(e) = result {
-            println!("Failed to remove socket file: {e}");
-            println!("Please remove manually: {sock_file}");
-            success = false;
-        }
-    }
-
-    if success {
-        Ok(())
-    } else {
-        // return error
-        Err(DaemonError::CleanFailed)
-    }
-}
-
-fn clean_logs(log_folder: &AbsoluteSystemPath) -> Result<(), DaemonError> {
-    trace!("cleaning up log files");
-    // clear all files in the log folder. we want to keep the
-    // folder just remove the contents
-    // `remove_dir_all_recursive` is lifted from `std`
-    log_folder.remove_dir_all().map_err(|e| {
-        println!("Failed to remove log files: {e}");
-        println!("Please remove manually: {log_folder}");
-        DaemonError::CleanFailed
-    })
-}
-
-// log_filename matches the algorithm used by tracing_appender::Rotation::DAILY
-// to generate the log filename. This is kind of a hack, but there didn't appear
-// to be a simple way to grab the generated filename.
-fn log_filename(base_filename: &str) -> Result<String, time::Error> {
-    let now = OffsetDateTime::now_utc();
-    let format = format_description::parse("[year]-[month]-[day]")?;
-    let date = now.format(&format)?;
-    Ok(format!("{base_filename}.{date}"))
 }
 
 #[tracing::instrument(skip(base, logging), fields(repo_root = %base.repo_root))]
@@ -336,9 +187,8 @@ pub async fn daemon_server(
     });
     let custom_turbo_json_path = convert_turbo_json_path(turbo_json_path.as_deref())?;
     let allow_no_package_manager = base.opts().repo_opts.allow_no_package_manager;
-    let server = TurboGrpcService::new(
+    serve(
         base.repo_root.clone(),
-        paths,
         timeout,
         exit_signal,
         custom_turbo_json_path,
@@ -358,58 +208,6 @@ pub async fn daemon_server(
                 )
             }
         },
-    );
-
-    let reason = server.serve().await?;
-
-    match reason {
-        CloseReason::SocketOpenError(SocketOpenError::LockError(AlreadyOwned)) => {
-            warn!("daemon already running");
-        }
-        CloseReason::SocketOpenError(e) => return Err(e.into()),
-        CloseReason::WatcherSetupError(e) => return Err(e.into()),
-        CloseReason::Interrupt
-        | CloseReason::ServerClosed
-        | CloseReason::WatcherClosed
-        | CloseReason::Timeout
-        | CloseReason::Shutdown => {
-            // these are all ok, just exit
-            trace!("shutting down daemon: {:?}", reason);
-        }
-    };
-
-    Ok(())
-}
-
-#[derive(serde::Serialize)]
-pub struct DaemonStatus {
-    pub uptime_ms: u64,
-    // this comes from the daemon server, so we trust that
-    // it is correct
-    pub log_file: Utf8PathBuf,
-    pub pid_file: turbopath::AbsoluteSystemPathBuf,
-    pub sock_file: turbopath::AbsoluteSystemPathBuf,
-}
-
-#[cfg(test)]
-mod tests {
-    #[cfg(all(unix, not(target_os = "macos")))]
-    #[test]
-    fn latest_log_file_from_dir_returns_non_utf8_path() {
-        use std::{ffi::OsString, os::unix::ffi::OsStringExt};
-
-        use turbopath::AbsoluteSystemPathBuf;
-
-        let tempdir = tempfile::tempdir().unwrap();
-        let log_folder = AbsoluteSystemPathBuf::try_from(tempdir.path()).unwrap();
-        let log_file = log_folder
-            .as_std_path()
-            .join(OsString::from_vec(b"turbo-\xFF.log".to_vec()));
-        std::fs::write(&log_file, "").unwrap();
-
-        assert_eq!(
-            super::latest_log_file_from_dir(&log_folder).unwrap(),
-            log_file
-        );
-    }
+    )
+    .await
 }

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(box_patterns)]
-#![feature(try_blocks)]
 // miette's derive macro causes false positives for this lint
 #![allow(unused_assignments)]
 #![deny(clippy::all)]
@@ -34,7 +33,8 @@ mod turbo_json;
 
 // Re-export daemon types from the new crate location
 pub use turborepo_daemon::{
-    DaemonClient, DaemonConnector, DaemonConnectorError, DaemonError, Paths as DaemonPaths,
+    DaemonClient, DaemonConnector, DaemonConnectorError, DaemonError, DaemonPackageDiscovery,
+    Paths as DaemonPaths,
 };
 pub use turborepo_query_api::QueryServer;
 

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -32,7 +32,6 @@ mod task_hash;
 mod tracing;
 mod turbo_json;
 
-pub use run::package_discovery::DaemonPackageDiscovery;
 // Re-export daemon types from the new crate location
 pub use turborepo_daemon::{
     DaemonClient, DaemonConnector, DaemonConnectorError, DaemonError, Paths as DaemonPaths,

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -2,7 +2,6 @@
 
 pub mod builder;
 mod error;
-pub(crate) mod package_discovery;
 pub(crate) mod scope;
 pub mod task_access;
 pub(crate) mod task_filter;

--- a/crates/turborepo-lsp/Cargo.toml
+++ b/crates/turborepo-lsp/Cargo.toml
@@ -19,7 +19,10 @@ rustls-tls = []
 workspace = true
 
 [dependencies]
+clap = { workspace = true, features = ["derive"] }
 crop = "0.4.0"
+go-parse-duration = "0.1.1"
+humantime = "2.1.0"
 itertools.workspace = true
 jsonc-parser = "0.23.0"
 pidlock = { version = "0.1.4", path = "../turborepo-pidlock" }
@@ -27,6 +30,9 @@ serde_json.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "io-std"] }
 tokio-retry = "0.3.0"
 tower-lsp = "0.20.0"
+tracing = { workspace = true }
+tracing-appender = { workspace = true }
+tracing-subscriber = { workspace = true }
 turbopath = { version = "0.1.0", path = "../turborepo-paths" }
 turborepo-daemon = { workspace = true }
 turborepo-repository = { version = "0.1.0", path = "../turborepo-repository" }

--- a/crates/turborepo-lsp/Cargo.toml
+++ b/crates/turborepo-lsp/Cargo.toml
@@ -6,8 +6,12 @@ license = "MIT"
 
 [features]
 default = ["rustls-tls"]
-native-tls = ["turborepo-lib/native-tls"]
-rustls-tls = ["turborepo-lib/rustls-tls"]
+# The language server itself performs no TLS I/O (it talks to the daemon over a
+# local socket). These features are retained as inert aliases so the workspace
+# and the `turborepo` crate's `turborepo-lsp/{native-tls,rustls-tls}` feature
+# references continue to resolve.
+native-tls = []
+rustls-tls = []
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -24,7 +28,7 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros", "io-std"] }
 tokio-retry = "0.3.0"
 tower-lsp = "0.20.0"
 turbopath = { version = "0.1.0", path = "../turborepo-paths" }
-turborepo-lib = { version = "0.1.0", path = "../turborepo-lib" }
+turborepo-daemon = { workspace = true }
 turborepo-repository = { version = "0.1.0", path = "../turborepo-repository" }
 wax.workspace = true
 

--- a/crates/turborepo-lsp/src/lib.rs
+++ b/crates/turborepo-lsp/src/lib.rs
@@ -31,9 +31,9 @@ use tower_lsp::{
     lsp_types::*,
 };
 use turbopath::AbsoluteSystemPathBuf;
-use turborepo_lib::{
+use turborepo_daemon::{
     DaemonClient, DaemonConnector, DaemonConnectorError, DaemonError, DaemonPackageDiscovery,
-    DaemonPaths,
+    Paths as DaemonPaths,
 };
 use turborepo_repository::{
     discovery::{self, PackageDiscovery},

--- a/crates/turborepo-lsp/src/main.rs
+++ b/crates/turborepo-lsp/src/main.rs
@@ -1,38 +1,222 @@
-use std::ffi::{OsStr, OsString};
+use std::{ffi::OsString, time::Duration};
+
+use clap::{ArgAction, Args, Parser, Subcommand};
+use tokio::signal::ctrl_c;
+use turbopath::AbsoluteSystemPathBuf;
+use turborepo_daemon::{
+    CloseReason, DaemonLifecycleCommand, DaemonLifecycleOutput, Paths,
+    RediscoveringPackageChangesWatcher, clean_daemon, follow_daemon_logs, run_lifecycle_command,
+    serve,
+};
+use turborepo_repository::inference::RepoState;
+
+const DAEMON_NOT_RUNNING_MESSAGE: &str =
+    "daemon is not running, run `turbo daemon start` to start it";
 
 fn main() {
-    if is_daemon_command() {
+    if has_daemon_command(std::env::args_os()) {
         run_daemon_command();
     }
 
     turborepo_lsp::run_lsp_server();
 }
 
-fn is_daemon_command() -> bool {
-    has_daemon_command(std::env::args_os())
-}
-
 fn has_daemon_command(args: impl IntoIterator<Item = OsString>) -> bool {
-    args.into_iter()
-        .skip(1)
-        .any(|arg| arg == OsStr::new("daemon"))
+    args.into_iter().skip(1).any(|arg| arg == "daemon")
 }
 
 fn run_daemon_command() -> ! {
-    // The Turborepo language server no longer embeds the `turbo daemon`
-    // runtime, so it no longer depends on the application crate. The `daemon`
-    // subcommand is kept as an informational no-op so that any lingering
-    // invocation (e.g. the VS Code extension's daemon start/stop/status
-    // commands) exits cleanly instead of failing.
-    eprintln!("The turbo daemon is not available from the Turborepo language server.");
-    std::process::exit(0)
+    let args = DaemonCli::parse();
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build();
+    let exit_code = match runtime {
+        Ok(runtime) => runtime
+            .block_on(execute_daemon_command(args))
+            .map(|_| 0)
+            .unwrap_or_else(|error| {
+                eprintln!("{error:?}");
+                1
+            }),
+        Err(error) => {
+            eprintln!("failed to build tokio runtime: {error}");
+            1
+        }
+    };
+
+    std::process::exit(exit_code)
+}
+
+async fn execute_daemon_command(args: DaemonCli) -> Result<(), turborepo_daemon::DaemonError> {
+    let verbosity = args.verbosity.unwrap_or(args.v);
+    let cwd = AbsoluteSystemPathBuf::cwd()?;
+    let invocation_dir = args
+        .cwd
+        .as_deref()
+        .map(AbsoluteSystemPathBuf::from_cwd)
+        .transpose()?
+        .unwrap_or(cwd);
+    let repo_root = RepoState::infer(&invocation_dir)
+        .map(|state| state.root)
+        .unwrap_or_else(|_| invocation_dir.clone());
+    let DaemonTopLevelCommand::Daemon(daemon_args) = args.command;
+    let custom_turbo_json_path = daemon_args
+        .turbo_json_path
+        .or(args.root_turbo_json)
+        .map(|path| AbsoluteSystemPathBuf::from_unknown(&invocation_dir, path));
+
+    match daemon_args.command {
+        Some(DaemonSubcommand::Clean { clean_logs }) => {
+            clean_daemon(&repo_root, custom_turbo_json_path, clean_logs).await?;
+            println!("Done");
+        }
+        Some(DaemonSubcommand::Logs) => {
+            follow_daemon_logs(&repo_root, custom_turbo_json_path).await?;
+        }
+        Some(command) => {
+            let (command, json) = match command {
+                DaemonSubcommand::Restart => (DaemonLifecycleCommand::Restart, false),
+                DaemonSubcommand::Start => (DaemonLifecycleCommand::Start, false),
+                DaemonSubcommand::Status { json } => (DaemonLifecycleCommand::Status, json),
+                DaemonSubcommand::Stop => (DaemonLifecycleCommand::Stop, false),
+                DaemonSubcommand::Clean { .. } | DaemonSubcommand::Logs => unreachable!(),
+            };
+            let output = run_lifecycle_command(command, &repo_root, custom_turbo_json_path).await?;
+            print_lifecycle_output(output, json)?;
+        }
+        None => {
+            let timeout =
+                go_parse_duration::parse_duration(&daemon_args.idle_time).map_err(|_| {
+                    turborepo_daemon::DaemonError::InvalidTimeout(daemon_args.idle_time.clone())
+                })?;
+            let timeout = Duration::from_nanos(timeout as u64);
+            let paths = Paths::from_repo_root(&repo_root)?;
+            let appender = tracing_appender::rolling::daily(&paths.log_folder, &paths.log_file);
+            let level = match verbosity {
+                0 | 1 => tracing::level_filters::LevelFilter::INFO,
+                2 => tracing::level_filters::LevelFilter::DEBUG,
+                _ => tracing::level_filters::LevelFilter::TRACE,
+            };
+            let _ = tracing_subscriber::fmt()
+                .with_ansi(false)
+                .with_writer(appender)
+                .with_max_level(level)
+                .try_init();
+            tracing::info!("daemon started");
+            let exit_signal = async {
+                if let Err(error) = ctrl_c().await {
+                    eprintln!("error waiting for interrupt signal: {error}");
+                }
+                CloseReason::Interrupt
+            };
+            serve(
+                repo_root,
+                timeout,
+                exit_signal,
+                custom_turbo_json_path,
+                args.dangerously_disable_package_manager_check,
+                RediscoveringPackageChangesWatcher::new,
+            )
+            .await?;
+        }
+    }
+
+    Ok(())
+}
+
+fn print_lifecycle_output(
+    output: DaemonLifecycleOutput,
+    json: bool,
+) -> Result<(), serde_json::Error> {
+    match output {
+        DaemonLifecycleOutput::Restarted => println!("✓ restarted daemon"),
+        DaemonLifecycleOutput::Running => println!("✓ daemon is running"),
+        DaemonLifecycleOutput::Stopped => println!("✓ stopped daemon"),
+        DaemonLifecycleOutput::Status(None) if json => {
+            println!(
+                "{}",
+                serde_json::json!({ "error": DAEMON_NOT_RUNNING_MESSAGE })
+            );
+        }
+        DaemonLifecycleOutput::Status(None) => println!("x {DAEMON_NOT_RUNNING_MESSAGE}"),
+        DaemonLifecycleOutput::Status(Some(status)) if json => {
+            println!("{}", serde_json::to_string_pretty(&status)?);
+        }
+        DaemonLifecycleOutput::Status(Some(status)) => {
+            println!("✓ daemon is running");
+            println!("log file: {}", status.log_file);
+            println!(
+                "uptime: {}s",
+                humantime::format_duration(Duration::from_millis(status.uptime_ms))
+            );
+            println!("pid file: {}", status.pid_file);
+            println!("socket file: {}", status.sock_file);
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Parser)]
+struct DaemonCli {
+    #[arg(long = "skip-infer", global = true, hide = true)]
+    _skip_infer: bool,
+    #[arg(long, global = true)]
+    cwd: Option<String>,
+    #[arg(long, global = true)]
+    root_turbo_json: Option<String>,
+    #[arg(long, global = true)]
+    dangerously_disable_package_manager_check: bool,
+    #[arg(long = "color", global = true)]
+    _color: bool,
+    #[arg(long = "no-color", global = true)]
+    _no_color: bool,
+    #[arg(long, global = true, value_name = "COUNT")]
+    verbosity: Option<u8>,
+    #[arg(short = 'v', global = true, action = ArgAction::Count, hide = true)]
+    v: u8,
+    #[command(subcommand)]
+    command: DaemonTopLevelCommand,
+}
+
+#[derive(Subcommand)]
+enum DaemonTopLevelCommand {
+    Daemon(DaemonArgs),
+}
+
+#[derive(Args)]
+struct DaemonArgs {
+    #[arg(long, default_value = "4h0m0s")]
+    idle_time: String,
+    #[arg(long)]
+    turbo_json_path: Option<String>,
+    #[command(subcommand)]
+    command: Option<DaemonSubcommand>,
+}
+
+#[derive(Subcommand)]
+enum DaemonSubcommand {
+    Clean {
+        #[arg(long, default_value_t = true)]
+        clean_logs: bool,
+    },
+    Logs,
+    Restart,
+    Start,
+    Status {
+        #[arg(long)]
+        json: bool,
+    },
+    Stop,
 }
 
 #[cfg(test)]
 mod tests {
     use std::ffi::OsString;
 
-    use super::has_daemon_command;
+    use clap::Parser;
+
+    use super::{DaemonCli, has_daemon_command};
 
     #[test]
     fn detects_daemon_command() {
@@ -41,6 +225,36 @@ mod tests {
             OsString::from("--skip-infer"),
             OsString::from("daemon"),
         ]));
+    }
+
+    #[test]
+    fn parses_spawned_daemon_server_command() {
+        DaemonCli::try_parse_from([
+            "turborepo-lsp",
+            "--skip-infer",
+            "daemon",
+            "--turbo-json-path",
+            "turbo.json",
+        ])
+        .unwrap();
+    }
+
+    #[test]
+    fn parses_daemon_status_command() {
+        DaemonCli::try_parse_from(["turborepo-lsp", "daemon", "status", "--json"]).unwrap();
+    }
+
+    #[test]
+    fn parses_behavioral_global_options() {
+        DaemonCli::try_parse_from([
+            "turborepo-lsp",
+            "daemon",
+            "status",
+            "--cwd",
+            "repo",
+            "--dangerously-disable-package-manager-check",
+        ])
+        .unwrap();
     }
 
     #[test]

--- a/crates/turborepo-lsp/src/main.rs
+++ b/crates/turborepo-lsp/src/main.rs
@@ -19,14 +19,13 @@ fn has_daemon_command(args: impl IntoIterator<Item = OsString>) -> bool {
 }
 
 fn run_daemon_command() -> ! {
-    std::panic::set_hook(Box::new(turborepo_lib::panic_handler));
-
-    let exit_code = turborepo_lib::main(None).unwrap_or_else(|err| {
-        eprintln!("{err:?}");
-        1
-    });
-
-    std::process::exit(exit_code)
+    // The Turborepo language server no longer embeds the `turbo daemon`
+    // runtime, so it no longer depends on the application crate. The `daemon`
+    // subcommand is kept as an informational no-op so that any lingering
+    // invocation (e.g. the VS Code extension's daemon start/stop/status
+    // commands) exits cleanly instead of failing.
+    eprintln!("The turbo daemon is not available from the Turborepo language server.");
+    std::process::exit(0)
 }
 
 #[cfg(test)]

--- a/crates/turborepo-lsp/tests/daemon_lifecycle.rs
+++ b/crates/turborepo-lsp/tests/daemon_lifecycle.rs
@@ -1,0 +1,81 @@
+#![allow(clippy::unwrap_used)]
+
+use std::{path::Path, process::Command};
+
+fn run_daemon(repo_root: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_turborepo-lsp"))
+        .current_dir(repo_root)
+        .arg("daemon")
+        .args(args)
+        .output()
+        .unwrap()
+}
+
+struct StopOnDrop<'a>(&'a Path);
+
+impl Drop for StopOnDrop<'_> {
+    fn drop(&mut self) {
+        let _ = run_daemon(self.0, &["stop"]);
+    }
+}
+
+#[test]
+fn manages_daemon_lifecycle() {
+    let repo = tempfile::tempdir().unwrap();
+    std::fs::write(
+        repo.path().join("package.json"),
+        r#"{"name":"daemon-lifecycle-test","packageManager":"pnpm@10.28.0"}"#,
+    )
+    .unwrap();
+    let _stop_on_drop = StopOnDrop(repo.path());
+
+    let start = run_daemon(repo.path(), &["start"]);
+    assert!(
+        start.status.success(),
+        "{}",
+        String::from_utf8_lossy(&start.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&start.stdout),
+        "✓ daemon is running\n"
+    );
+
+    let status = run_daemon(repo.path(), &["status", "--json"]);
+    assert!(
+        status.status.success(),
+        "{}",
+        String::from_utf8_lossy(&status.stderr)
+    );
+    let status: serde_json::Value = serde_json::from_slice(&status.stdout).unwrap();
+    assert!(status["uptime_ms"].is_u64());
+    assert!(status["pid_file"].is_string());
+    assert!(status["sock_file"].is_string());
+    assert!(Path::new(status["log_file"].as_str().unwrap()).exists());
+
+    let restart = run_daemon(repo.path(), &["restart"]);
+    assert!(
+        restart.status.success(),
+        "{}",
+        String::from_utf8_lossy(&restart.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&restart.stdout),
+        "✓ restarted daemon\n"
+    );
+
+    let stop = run_daemon(repo.path(), &["stop"]);
+    assert!(
+        stop.status.success(),
+        "{}",
+        String::from_utf8_lossy(&stop.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&stop.stdout), "✓ stopped daemon\n");
+
+    let clean = run_daemon(repo.path(), &["clean"]);
+    assert!(
+        clean.status.success(),
+        "{}",
+        String::from_utf8_lossy(&clean.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&clean.stdout), "Done\n");
+}

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -90,6 +90,20 @@ behavior:
 - Existing final-output coverage should continue proving that shutdown keeps the
   UI and log pipeline alive long enough to drain task output.
 
+### Daemon Lifecycle
+
+`crates/turborepo-daemon` owns daemon lifecycle operations, server shutdown
+semantics, and the daemon-backed package-discovery adapter. Both the `turbo`
+application and the standalone `turborepo-lsp` binary use this shared API, so a
+`DaemonConnector` can start the current executable with `--skip-infer daemon`
+without requiring the LSP to depend on `turborepo-lib`.
+
+The `turbo` application supplies its package-graph-aware change watcher and
+keeps CLI-specific rendering in `turborepo-lib`. The standalone LSP supplies a
+conservative daemon-owned watcher that emits full rediscovery for filesystem
+changes. This preserves correctness when the packaged LSP hosts the daemon,
+while the richer watcher avoids unnecessary rediscovery when `turbo` hosts it.
+
 ### 1. Run Builder (`crates/turborepo-lib/src/run/builder.rs`)
 
 **Key responsibilities:**


### PR DESCRIPTION
The turborepo-lsp crate depended on the entire turborepo-lib application crate. Because a crate-level dependency edge forces build ordering for all targets, the LSP could not compile concurrently with turborepo-lib and was rebuilt on unrelated application changes such as run and prune.

turborepo-lsp only needs a narrow daemon API. This change:

- Moves `DaemonPackageDiscovery` from turborepo-lib into the turborepo-daemon crate while retaining the existing turborepo-lib re-export.
- Moves daemon lifecycle operations and shared server shutdown handling into turborepo-daemon.
- Keeps the standalone LSP binary's `daemon` command functional for start, stop, status, restart, clean, logs, and automatic server startup.
- Adds a conservative daemon-owned package-change watcher for LSP-hosted daemon instances; the turbo application retains its package-graph-aware watcher.
- Repoints turborepo-lsp's daemon imports from turborepo-lib to turborepo-daemon.
- Removes the turborepo-lib dependency from turborepo-lsp; the now-unused native-tls and rustls-tls features remain as inert aliases so existing feature references continue to resolve.
- Adds black-box coverage for the standalone LSP daemon lifecycle.