### PR TITLE
fix: Invalidate only when Git ignore sources change

### DIFF
--- a/crates/turborepo-filewatch/src/repository_ignore.rs
+++ b/crates/turborepo-filewatch/src/repository_ignore.rs
@@ -5,7 +5,7 @@ use std::{
     fs,
     path::{Component, Path, PathBuf},
     process::Command,
-    sync::{Arc, RwLock},
+    sync::{Arc, Mutex, RwLock},
 };
 
 use ignore::{Match, gitignore::Gitignore};
@@ -19,9 +19,14 @@ use tracing::warn;
 pub struct RepositoryIgnore {
     root: Arc<PathBuf>,
     match_root: Arc<PathBuf>,
-    snapshot: Arc<RwLock<Snapshot>>,
-    control_paths: Arc<RwLock<HashSet<PathBuf>>>,
-    derived_controls: Arc<RwLock<HashSet<PathBuf>>>,
+    state: Arc<RwLock<RepositoryState>>,
+    refresh_lock: Arc<Mutex<()>>,
+}
+
+struct RepositoryState {
+    snapshot: Snapshot,
+    control_paths: HashSet<PathBuf>,
+    derived_controls: HashSet<PathBuf>,
 }
 
 #[derive(Default)]
@@ -50,16 +55,12 @@ impl RepositoryIgnore {
     pub fn new(root: &Path) -> Self {
         let root = Arc::new(normalize_lexically(root));
         let match_root = Arc::new(normalize_path(&root));
-        let context = GitContext::discover(&match_root);
-        let control_paths = context.control_paths(&match_root);
-        let derived_controls = context.derived_controls();
-        let snapshot = Snapshot::load(&match_root, &context);
+        let state = RepositoryState::load(&match_root);
         Self {
             root,
             match_root,
-            snapshot: Arc::new(RwLock::new(snapshot)),
-            control_paths: Arc::new(RwLock::new(control_paths)),
-            derived_controls: Arc::new(RwLock::new(derived_controls)),
+            state: Arc::new(RwLock::new(state)),
+            refresh_lock: Arc::new(Mutex::new(())),
         }
     }
 
@@ -71,37 +72,38 @@ impl RepositoryIgnore {
     ///
     /// Returns whether the refresh observed a change that consumers cannot
     /// discover from the triggering event alone: a different set of ignore
-    /// sources, or a tracked path whose ignore relevance flipped.
+    /// sources or worktree root, or a tracked path whose ignore relevance
+    /// flipped.
     pub fn refresh(&self) -> bool {
-        // Re-discovering the context makes an explicit refresh observe changes
-        // to core.excludesFile as well as changes to the exclude file itself.
-        let context = GitContext::discover(&self.match_root);
-        let control_paths = context.control_paths(&self.match_root);
-        let mut controls = self
-            .control_paths
+        self.refresh_with(|| RepositoryState::load(&self.match_root))
+    }
+
+    fn refresh_with(&self, load: impl FnOnce() -> RepositoryState) -> bool {
+        let _refresh = self
+            .refresh_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let replacement = load();
+        let mut state = self
+            .state
             .write()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let sources_changed = *controls != control_paths;
-        *controls = control_paths;
-        drop(controls);
-        let replacement = Snapshot::load(&self.match_root, &context);
-        *self
-            .derived_controls
-            .write()
-            .unwrap_or_else(|poisoned| poisoned.into_inner()) = context.derived_controls();
-        let mut snapshot = self
+        let sources_changed = state.control_paths != replacement.control_paths;
+        let worktree_changed = state.snapshot.worktree_root != replacement.snapshot.worktree_root;
+        let tracked_relevance_changed = state
             .snapshot
-            .write()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let tracked_relevance_changed = snapshot
             .tracked
-            .symmetric_difference(&replacement.tracked)
+            .symmetric_difference(&replacement.snapshot.tracked)
             .any(|path| {
-                snapshot.path_is_ignored(&self.match_root, path, false)
-                    || replacement.path_is_ignored(&self.match_root, path, false)
+                state
+                    .snapshot
+                    .path_is_ignored(&self.match_root, path, false)
+                    || replacement
+                        .snapshot
+                        .path_is_ignored(&self.match_root, path, false)
             });
-        *snapshot = replacement;
-        sources_changed || tracked_relevance_changed
+        *state = replacement;
+        sources_changed || worktree_changed || tracked_relevance_changed
     }
 
     pub fn is_gitignore(path: &Path) -> bool {
@@ -111,18 +113,20 @@ impl RepositoryIgnore {
     pub fn should_refresh(&self, path: &Path) -> bool {
         Self::is_gitignore(path)
             || self
-                .control_paths
+                .state
                 .read()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .control_paths
                 .contains(&normalize_event_path(&self.root, &self.match_root, path))
     }
 
     pub fn is_control_path(&self, path: &Path) -> bool {
         !Self::is_gitignore(path)
             && self
-                .control_paths
+                .state
                 .read()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .control_paths
                 .contains(&normalize_event_path(&self.root, &self.match_root, path))
     }
 
@@ -138,25 +142,23 @@ impl RepositoryIgnore {
     /// deferred to that refresh instead: writing to them is not evidence that
     /// anything about the ignore rules moved.
     pub fn invalidates_consumers(&self, path: &Path) -> bool {
-        if self.is_control_path(path) {
-            let path = normalize_event_path(&self.root, &self.match_root, path);
-            return !self
-                .derived_controls
-                .read()
-                .unwrap_or_else(|poisoned| poisoned.into_inner())
-                .contains(&path);
-        }
         if !Self::is_gitignore(path) {
-            return false;
+            let path = normalize_event_path(&self.root, &self.match_root, path);
+            let state = self
+                .state
+                .read()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            return state.control_paths.contains(&path) && !state.derived_controls.contains(&path);
         }
         let path = normalize_event_path(&self.root, &self.match_root, path);
         !path.starts_with(self.match_root.as_path())
     }
 
     pub fn control_paths(&self) -> Vec<PathBuf> {
-        self.control_paths
+        self.state
             .read()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .control_paths
             .iter()
             .cloned()
             .collect()
@@ -179,10 +181,11 @@ impl RepositoryIgnore {
             return true;
         }
 
-        let snapshot = self
-            .snapshot
+        let state = self
+            .state
             .read()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let snapshot = &state.snapshot;
         if snapshot.tracked.contains(relative)
             || (is_dir && snapshot.tracked_ancestors.contains(relative))
         {
@@ -205,6 +208,19 @@ impl RepositoryIgnore {
             }
         }
         true
+    }
+}
+
+impl RepositoryState {
+    fn load(root: &Path) -> Self {
+        // Re-discovering the context makes an explicit refresh observe changes
+        // to core.excludesFile and core.worktree.
+        let context = GitContext::discover(root);
+        Self {
+            snapshot: Snapshot::load(root, &context),
+            control_paths: context.control_paths(root),
+            derived_controls: context.derived_controls(),
+        }
     }
 }
 
@@ -543,9 +559,16 @@ fn normalize_lexically(path: &Path) -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use std::{fs, path::Path, process::Command};
+    use std::{
+        collections::HashSet,
+        fs,
+        path::{Path, PathBuf},
+        process::Command,
+        sync::{TryLockError, mpsc},
+        thread,
+    };
 
-    use super::{RepositoryIgnore, normalize_lexically};
+    use super::{RepositoryIgnore, RepositoryState, Snapshot, normalize_lexically};
 
     fn git(root: &Path, args: &[&str]) {
         assert!(
@@ -739,6 +762,64 @@ mod tests {
             "dropping core.excludesFile changes the ignore sources"
         );
         assert!(model.is_relevant(&root.join("excluded.txt"), false));
+    }
+
+    #[test]
+    fn core_worktree_change_invalidates_consumers() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("worktree");
+        let alternate = temp.path().join("alternate");
+        fs::create_dir_all(&root).unwrap();
+        fs::create_dir_all(&alternate).unwrap();
+        git(&root, &["init", "-q"]);
+        fs::write(root.join(".git/info/exclude"), "/excluded.txt\n").unwrap();
+
+        let model = RepositoryIgnore::new(&root);
+        assert!(!model.is_relevant(&root.join("excluded.txt"), false));
+
+        git(
+            &root,
+            &["config", "core.worktree", alternate.to_str().unwrap()],
+        );
+        assert!(model.refresh(), "changing the worktree root is observable");
+        assert!(model.is_relevant(&root.join("excluded.txt"), false));
+    }
+
+    #[test]
+    fn refreshes_are_serialized_while_loading() {
+        fn state(control: PathBuf) -> RepositoryState {
+            RepositoryState {
+                snapshot: Snapshot::default(),
+                control_paths: HashSet::from([control.clone()]),
+                derived_controls: HashSet::from([control]),
+            }
+        }
+
+        let temp = tempfile::tempdir().unwrap();
+        let model = RepositoryIgnore::new(temp.path());
+        let older_control = temp.path().join("older");
+        let newer_control = temp.path().join("newer");
+        let (older_entered_tx, older_entered_rx) = mpsc::channel();
+        let (release_older_tx, release_older_rx) = mpsc::channel();
+        let older_model = model.clone();
+        let older = thread::spawn(move || {
+            older_model.refresh_with(|| {
+                older_entered_tx.send(()).unwrap();
+                release_older_rx.recv().unwrap();
+                state(older_control)
+            })
+        });
+        older_entered_rx.recv().unwrap();
+
+        assert!(
+            matches!(model.refresh_lock.try_lock(), Err(TryLockError::WouldBlock)),
+            "the refresh lock must cover state loading"
+        );
+
+        release_older_tx.send(()).unwrap();
+        older.join().unwrap();
+        model.refresh_with(|| state(newer_control.clone()));
+        assert_eq!(model.control_paths(), vec![newer_control]);
     }
 
     #[test]

--- a/crates/turborepo-filewatch/src/repository_ignore.rs
+++ b/crates/turborepo-filewatch/src/repository_ignore.rs
@@ -21,7 +21,7 @@ pub struct RepositoryIgnore {
     match_root: Arc<PathBuf>,
     snapshot: Arc<RwLock<Snapshot>>,
     control_paths: Arc<RwLock<HashSet<PathBuf>>>,
-    index_path: Arc<RwLock<Option<PathBuf>>>,
+    derived_controls: Arc<RwLock<HashSet<PathBuf>>>,
 }
 
 #[derive(Default)]
@@ -40,6 +40,10 @@ struct GitContext {
     index: Option<PathBuf>,
     info_exclude: Option<PathBuf>,
     global_exclude: Option<PathBuf>,
+    /// Config files can change core.excludesFile and core.worktree. They are
+    /// also useful controls in linked worktrees, where the administrative
+    /// directory is outside the worktree.
+    config: HashSet<PathBuf>,
 }
 
 impl RepositoryIgnore {
@@ -48,13 +52,14 @@ impl RepositoryIgnore {
         let match_root = Arc::new(normalize_path(&root));
         let context = GitContext::discover(&match_root);
         let control_paths = context.control_paths(&match_root);
+        let derived_controls = context.derived_controls();
         let snapshot = Snapshot::load(&match_root, &context);
         Self {
             root,
             match_root,
             snapshot: Arc::new(RwLock::new(snapshot)),
             control_paths: Arc::new(RwLock::new(control_paths)),
-            index_path: Arc::new(RwLock::new(context.index)),
+            derived_controls: Arc::new(RwLock::new(derived_controls)),
         }
     }
 
@@ -63,20 +68,27 @@ impl RepositoryIgnore {
     }
 
     /// Re-read repository ignore rules and tracked index state.
+    ///
+    /// Returns whether the refresh observed a change that consumers cannot
+    /// discover from the triggering event alone: a different set of ignore
+    /// sources, or a tracked path whose ignore relevance flipped.
     pub fn refresh(&self) -> bool {
         // Re-discovering the context makes an explicit refresh observe changes
         // to core.excludesFile as well as changes to the exclude file itself.
         let context = GitContext::discover(&self.match_root);
-        *self
+        let control_paths = context.control_paths(&self.match_root);
+        let mut controls = self
             .control_paths
             .write()
-            .unwrap_or_else(|poisoned| poisoned.into_inner()) =
-            context.control_paths(&self.match_root);
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let sources_changed = *controls != control_paths;
+        *controls = control_paths;
+        drop(controls);
         let replacement = Snapshot::load(&self.match_root, &context);
         *self
-            .index_path
+            .derived_controls
             .write()
-            .unwrap_or_else(|poisoned| poisoned.into_inner()) = context.index;
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = context.derived_controls();
         let mut snapshot = self
             .snapshot
             .write()
@@ -89,7 +101,7 @@ impl RepositoryIgnore {
                     || replacement.path_is_ignored(&self.match_root, path, false)
             });
         *snapshot = replacement;
-        tracked_relevance_changed
+        sources_changed || tracked_relevance_changed
     }
 
     pub fn is_gitignore(path: &Path) -> bool {
@@ -121,15 +133,18 @@ impl RepositoryIgnore {
     /// semantics to the event. An inherited ignore file cannot be represented
     /// by an in-root event (and may change the relevance of the root itself),
     /// so it must invalidate every consumer.
+    ///
+    /// Control paths whose contribution a refresh re-derives in full are
+    /// deferred to that refresh instead: writing to them is not evidence that
+    /// anything about the ignore rules moved.
     pub fn invalidates_consumers(&self, path: &Path) -> bool {
         if self.is_control_path(path) {
             let path = normalize_event_path(&self.root, &self.match_root, path);
-            return self
-                .index_path
+            return !self
+                .derived_controls
                 .read()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
-                .as_ref()
-                != Some(&path);
+                .contains(&path);
         }
         if !Self::is_gitignore(path) {
             return false;
@@ -219,11 +234,16 @@ impl GitContext {
         });
         #[cfg(not(target_os = "macos"))]
         let global_exclude = discovered_global_exclude;
+        let config = git_path(root, "config")
+            .into_iter()
+            .chain(git_path(root, "config.worktree"))
+            .collect();
         Self {
             worktree_root,
             index,
             info_exclude,
             global_exclude,
+            config,
         }
     }
 
@@ -232,16 +252,22 @@ impl GitContext {
         paths.extend(self.index.iter().cloned());
         paths.extend(self.info_exclude.iter().cloned());
         paths.extend(self.global_exclude.iter().cloned());
-        // These files can change core.excludesFile. They are also useful
-        // controls in linked worktrees, where the administrative directory is
-        // outside the worktree.
-        paths.extend(git_path(root, "config"));
-        paths.extend(git_path(root, "config.worktree"));
+        paths.extend(self.config.iter().cloned());
         paths.extend(
             directories_between(&self.worktree_root, root)
                 .into_iter()
                 .map(|directory| directory.join(".gitignore")),
         );
+        paths
+    }
+
+    /// Control paths that only matter through state a refresh re-derives: the
+    /// index through the tracked set, and the config files through the ignore
+    /// sources they name. Comparing the refreshed state is exact, so a write
+    /// that leaves it alone is not a reason to invalidate consumers.
+    fn derived_controls(&self) -> HashSet<PathBuf> {
+        let mut paths = self.config.clone();
+        paths.extend(self.index.iter().cloned());
         paths
     }
 }
@@ -671,6 +697,48 @@ mod tests {
         assert!(!model.invalidates_consumers(&root_ignore));
         assert!(model.should_refresh(&nested));
         assert!(!model.invalidates_consumers(&nested));
+    }
+
+    #[test]
+    fn config_refresh_invalidates_only_when_ignore_sources_change() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("worktree");
+        fs::create_dir_all(&root).unwrap();
+        git(&root, &["init", "-q"]);
+        fs::write(root.join(".gitignore"), "ignored.txt\n").unwrap();
+
+        let model = RepositoryIgnore::new(&root);
+        let config = fs::canonicalize(root.join(".git/config")).unwrap();
+        assert!(model.should_refresh(&config));
+        assert!(
+            !model.invalidates_consumers(&config),
+            "a config write is not evidence that the ignore sources moved"
+        );
+
+        git(&root, &["config", "watch.unrelated", "1"]);
+        assert!(
+            !model.refresh(),
+            "a config key unrelated to ignore rules changes nothing"
+        );
+
+        let global = temp.path().join("global-ignore");
+        fs::write(&global, "excluded.txt\n").unwrap();
+        git(
+            &root,
+            &["config", "core.excludesFile", global.to_str().unwrap()],
+        );
+        assert!(
+            model.refresh(),
+            "pointing core.excludesFile at a new file changes the ignore sources"
+        );
+        assert!(!model.is_relevant(&root.join("excluded.txt"), false));
+
+        git(&root, &["config", "--unset", "core.excludesFile"]);
+        assert!(
+            model.refresh(),
+            "dropping core.excludesFile changes the ignore sources"
+        );
+        assert!(model.is_relevant(&root.join("excluded.txt"), false));
     }
 
     #[test]

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -746,10 +746,13 @@ The core task graph consists of:
   refreshes the active `WatchSpec` from the current graph generation whenever
   the package graph is initialized or rediscovered. Turbo config and ecosystem definition changes
   trigger full rediscovery after routing.
-- Git index and `.git/info/exclude` control paths are watched separately so
-  tracked-file and exclude state stays current without exposing `.git` events
-  to normal consumers. Backend rescan signals bypass path scopes and invoke
-  each consumer's conservative recovery.
+- Git index, `.git/info/exclude`, `core.excludesFile`, and repository Git config
+  control paths are watched separately so tracked-file and exclude state stays
+  current without exposing `.git` events to normal consumers. Refreshes publish
+  the complete control-path and ignore snapshot as one generation and
+  conservatively invalidate consumers when `core.worktree` changes. Backend
+  rescan signals bypass path scopes and invoke each consumer's conservative
+  recovery.
 - Output and hash watchers retain their independent event requirements: ignored
   outputs and explicitly configured inputs may still be relevant to those
   consumers. Git-ignore filtering is therefore consumer-specific rather than a


### PR DESCRIPTION
### Description

`turbo watch` treats every write to `.git/config` as a change to the repository's ignore state. The invalidation is unconditional, so writing a config key that has nothing to do with ignore rules flushes all watched globs and force-executes every task in the graph.

`.git/config` is watched because it can change `core.excludesFile`, and that coverage is correct. What is missing is a comparison: the watcher never checks whether the write actually changed anything it reads out of the config. This PR defers the decision to the refresh that the same event already selects, so a config write invalidates consumers only when the resolved set of ignore sources differs.

#### Reproduction

```bash
mkdir -p repro/packages/a repro/packages/b && cd repro

cat > package.json <<'JSON'
{
  "name": "repro-root",
  "private": true,
  "workspaces": ["packages/*"],
  "packageManager": "npm@11.16.0",
  "devDependencies": { "turbo": "2.10.8-canary.4" }
}
JSON

cat > turbo.json <<'JSON'
{
  "$schema": "https://turborepo.com/schema.json",
  "tasks": { "dev": { "cache": false, "persistent": true } }
}
JSON

for p in a b; do
  cat > "packages/$p/package.json" <<JSON
{ "name": "pkg-$p", "version": "0.0.0", "scripts": { "dev": "node -e \"console.log('pkg-$p dev started at '+new Date().toISOString()); setInterval(()=>{},1e9)\"" } }
JSON
  echo "console.log('$p');" > "packages/$p/index.js"
done

printf 'node_modules\n.turbo\n' > .gitignore
git init -q . && git add -A && git commit -qm init
npm install

npx turbo watch dev --ui=stream
```

With `turbo watch dev` running, from another shell in the same repository:

```bash
git config foo.bar 1
```

#### Expected behavior

`foo.bar` does not affect Git's ignore rules, so nothing about the watched file set changed and no task re-runs.

#### Actual behavior

Every write to `.git/config` invalidates all globs and force-executes every task:

```
 WARNING  encountered filewatching error, flushing all globs: Git index or exclude state changed
 ERROR  file event error: NotifyError { error: Error { kind: Generic("Git index or exclude state changed"), paths: [] }, invalidation: true }
pkg-a:dev: cache bypass, force executing f28ac356e48a93e6
pkg-b:dev: cache bypass, force executing b99eb5e3ec09a157
pkg-a:dev: pkg-a dev started at 2026-08-01T06:09:43.928Z
pkg-b:dev: pkg-b dev started at 2026-08-01T06:09:43.927Z
```

Two controls were run in the same session:

- Appending a line to the tracked file `packages/a/index.js`: no task restarts. `dev` is persistent and not `interruptible`, so this is the expected behavior — and it shows that an unrelated config write restarts tasks that a real source change deliberately does not.
- `git config core.excludesFile <path>`: invalidation and restart. This is correct; the ignore rules did change.

Measured on `2.10.7` and `2.10.8-canary.4`; five out of five unrelated `git config` writes restarted both persistent tasks in each run.

#### Cause

`.git/config` and `.git/config.worktree` are registered as Git control paths, with a comment noting that they are watched because they can change `core.excludesFile`:

https://github.com/vercel/turborepo/blob/c6fbc97bb8841f9c87d106af2d89ce11e97ea56c/crates/turborepo-filewatch/src/repository_ignore.rs#L230-L246

`invalidates_consumers` returns `true` for every control path except the index, so any event on a config file is reported as requiring conservative invalidation:

https://github.com/vercel/turborepo/blob/c6fbc97bb8841f9c87d106af2d89ce11e97ea56c/crates/turborepo-filewatch/src/repository_ignore.rs#L117-L139

Every route that classifies an event ORs that result into the invalidation decision, so the refresh cannot override it. `WatchEventSender::send` additionally short-circuits, and never refreshes at all:

https://github.com/vercel/turborepo/blob/c6fbc97bb8841f9c87d106af2d89ce11e97ea56c/crates/turborepo-filewatch/src/lib.rs#L444-L470

In other words, the fact that a write happened is taken as evidence that the ignore rules changed; what the config now resolves to is never compared against what it resolved to before.

#### Fix

The index is already handled this way: an index event refreshes the snapshot, and `refresh` reports whether the tracked set changed in a way that matters for ignore relevance. The config files fit the same shape — their entire contribution is the set of ignore sources they name — so this PR groups them with the index:

- `GitContext` resolves the config paths once during discovery and exposes `derived_controls`: control paths whose contribution a refresh re-derives in full (the index, and the config files).
- `invalidates_consumers` no longer invalidates for those paths; they are left to the refresh that `should_refresh` already selects them for.
- `refresh` compares the resolved control paths before and after re-discovery. Changing, adding, or removing `core.excludesFile` changes that set. It also compares the effective worktree root so `core.worktree` changes invalidate even when the control-path set remains stable.\n- Refresh-derived state is published atomically under one lock, and refreshes are serialized before discovery so an older refresh cannot overwrite newer state.

Content changes to an exclude file (`.git/info/exclude`, the global excludes file) and to inherited `.gitignore` files are unaffected: those arrive as events on their own paths and still invalidate conservatively.

#### Tests

`config_refresh_invalidates_only_when_ignore_sources_change` in `crates/turborepo-filewatch/src/repository_ignore.rs` asserts that `.git/config` is a refresh trigger but not an invalidation trigger, that a write to an unrelated key reports no change, and that setting and then unsetting `core.excludesFile` both report a change and are reflected in `is_relevant`. Additional regressions verify that changing `core.worktree` invalidates consumers and that refresh serialization covers state discovery.

#### Validation

- `cargo test -p turborepo-filewatch` — 74 passed, 0 failed
- `cargo clippy -p turborepo-filewatch --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- The reproduction above, driven by a script that writes `foo.bar` five times, then edits a tracked source file, then sets `core.excludesFile`. Counted over the whole session:

  | | `2.10.7` | `2.10.8-canary.4` | this branch |
  |---|---|---|---|
  | `flushing all globs` after the 5 unrelated `git config` writes | 10 | 10 | 0 |
  | task restarts after those writes | 5 rounds (both tasks each) | 5 rounds | 0 |
  | `flushing all globs` after `git config core.excludesFile` | 2 | 2 | 1 |
  | task restarts after `core.excludesFile` | 1 round | 1 round | 1 round |
  | task restarts after editing a tracked source file | 0 | 0 | 0 |

#### Impact

Tools that persist state in `.git/config` are increasingly common. While such a tool is running, `turbo watch` restarts every persistent task on every write, which makes watch mode unusable alongside a development server. The reproduction uses `git config foo.bar 1` because the key is irrelevant — any writer of an ignore-unrelated key produces the same result.

### Testing Instructions

1. Build this branch and run the reproduction above with the built binary (`turbo --skip-infer watch dev --ui=stream`).
2. From another shell in the same repository, run `git config foo.bar 1` a few times. No `flushing all globs` warning appears and no task re-runs.
3. Run `git config core.excludesFile /tmp/globalignore`. The invalidation and restart still happen.
4. `cargo test -p turborepo-filewatch --lib`

#### Environment

```
CLI:
   Version: 2.10.8-canary.4
   Package manager: npm

Platform:
   Architecture: aarch64
   Operating system: macos (26.5.2)
   Available memory (MB): 20214
   Available CPU cores: 12

Environment:
   Node.js version: v24.18.1
   git version 2.55.0
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
