### PR TITLE
perf: Memoize framework inference per package during task hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9296,6 +9296,7 @@ dependencies = [
 name = "turborepo-task-hash"
 version = "0.1.0"
 dependencies = [
+ "dashmap 6.1.0",
  "dunce",
  "either",
  "globwalk",

--- a/crates/turborepo-frameworks/src/lib.rs
+++ b/crates/turborepo-frameworks/src/lib.rs
@@ -136,7 +136,7 @@ impl std::fmt::Display for Slug {
 pub fn infer_framework(
     declarations: PackageExternalDeclarations<'_>,
     is_monorepo: bool,
-) -> Option<&Framework> {
+) -> Option<&'static Framework> {
     let frameworks = get_frameworks().ok()?;
 
     frameworks

--- a/crates/turborepo-task-hash/Cargo.toml
+++ b/crates/turborepo-task-hash/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 description = "Task hashing utilities for Turborepo cache invalidation"
 
 [dependencies]
+dashmap = { workspace = true }
 either = { workspace = true }
 globwalk = { version = "0.1.0", path = "../turborepo-globwalk" }
 itertools = { workspace = true }

--- a/crates/turborepo-task-hash/src/lib.rs
+++ b/crates/turborepo-task-hash/src/lib.rs
@@ -13,6 +13,7 @@ use std::{
     sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
 
+use dashmap::DashMap;
 pub use global_hash::*;
 use rayon::prelude::*;
 use serde::Serialize;
@@ -343,6 +344,11 @@ pub struct TaskHasher<'a, R> {
     /// environment.
     wildcard_cache: WildcardMapCache,
     external_deps_hash_cache: HashMap<String, String>,
+    /// Memoized framework inference keyed by package name. Inference scans
+    /// every known framework's dependency matchers against the package's
+    /// external declarations, and the result is identical for every task in
+    /// the package, so compute it once per package instead of once per task.
+    framework_cache: DashMap<String, Option<&'static Framework>>,
 }
 
 impl<'a, R: RunOptsHashInfo> TaskHasher<'a, R> {
@@ -385,6 +391,7 @@ impl<'a, R: RunOptsHashInfo> TaskHasher<'a, R> {
             builtin_pass_through_env,
             wildcard_cache: WildcardMapCache::default(),
             external_deps_hash_cache: HashMap::new(),
+            framework_cache: DashMap::new(),
         }
     }
 
@@ -555,9 +562,21 @@ impl<'a, R: RunOptsHashInfo> TaskHasher<'a, R> {
         let do_framework_inference = self.run_opts.framework_inference();
         let is_monorepo = !self.run_opts.single_package();
 
-        // See if we can infer a framework
+        // See if we can infer a framework. The result only depends on the
+        // package's external declarations, so it's memoized per package and
+        // shared by all of the package's tasks. A racing recompute between
+        // `get` and `insert` produces the same value, so it's harmless.
         let framework = do_framework_inference
-            .then(|| infer_framework(package_context.external_declarations(), is_monorepo))
+            .then(|| match self.framework_cache.get(task_id.package()) {
+                Some(cached) => *cached,
+                None => {
+                    let inferred =
+                        infer_framework(package_context.external_declarations(), is_monorepo);
+                    self.framework_cache
+                        .insert(task_id.package().to_string(), inferred);
+                    inferred
+                }
+            })
             .flatten()
             .inspect(|framework| {
                 debug!("auto detected framework for {}", task_id.package());


### PR DESCRIPTION
### Description

Framework inference runs for **every task** in the run graph (it's on by default), but its result only depends on the package's external dependency declarations — it scans every known framework's dependency matchers against those declarations, and the answer is identical for every task in the same package. A package with five tasks (build/lint/test/typecheck/dev) paid the same scan five times.

Two changes:

- `infer_framework` now returns `Option<&'static Framework>`. The data already lives in a `static OnceLock`; the elided lifetime just tied the result to the borrowed declarations, which made the reference impossible to cache.
- `TaskHasher` memoizes inference in a `DashMap` keyed by package name, mirroring the existing `wildcard_cache` (task hashing runs in parallel rayon waves with `&self`, so the cache must be concurrent). A racing recompute between `get` and `insert` produces the same value, so it's harmless.

All tasks in a package now share one inference; per-task work drops to a map lookup. Telemetry tracking (`track_framework`) intentionally stays per task, as before.

### Testing Instructions

- `cargo test -p turborepo-frameworks -p turborepo-task-hash` passes.
- `cargo clippy -p turborepo-frameworks -p turborepo-task-hash --all-targets` is clean.
- Behavior is unchanged: the memoized value is exactly what `infer_framework` returned per task before, since external declarations are fixed per package for the lifetime of a run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGZtfhEfgWhrAFMTMhwTfU

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGZtfhEfgWhrAFMTMhwTfU)_