### PR TITLE
fix(turbo-trace): exclude require() calls when tracing type imports only

### DIFF
--- a/crates/turbo-trace/src/import_finder.rs
+++ b/crates/turbo-trace/src/import_finder.rs
@@ -64,7 +64,11 @@ pub fn find_imports(
         }
     }
 
-    find_require_calls(statements, &mut results);
+    // require() calls are always value imports; skip them entirely when the
+    // caller only wants type-only imports.
+    if import_trace_type != ImportTraceType::Types {
+        find_require_calls(statements, &mut results);
+    }
 
     results
 }


### PR DESCRIPTION
`find_require_calls` was called unconditionally at the end of `find_imports`, regardless of the `import_trace_type` argument.

CommonJS `require()` calls always produce value imports (`ImportType::Value`). When a caller passes `ImportTraceType::Types`, only type-only imports should be returned, but `require()` calls were still appended to the results — every `const x = require("./y")` in the traced file appeared in a types-only trace output.

The fix guards the call behind a check: `find_require_calls` is now skipped entirely when `import_trace_type == ImportTraceType::Types`.