### PR TITLE
fix: Respect filters in task-level affected runs

### DIFF
--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -855,6 +855,26 @@ impl RunBuilder {
             && self.opts.scope_opts.affected_range.is_some()
             && self.opts.future_flags.affected_using_task_inputs;
 
+        // Package filters still constrain task-level --affected runs. Resolve
+        // that scope without package-level --affected so tasks matched only
+        // through custom inputs (for example $TURBO_ROOT$) remain eligible
+        // before the task graph is pruned.
+        let task_level_affected_packages =
+            if use_task_level_affected && !self.opts.scope_opts.filter_patterns.is_empty() {
+                let mut opts = self.opts.clone();
+                opts.scope_opts.affected_range = None;
+                let (packages, _, _) = Self::calculate_filtered_packages(
+                    &self.repo_root,
+                    &opts,
+                    &pkg_dep_graph,
+                    &scm,
+                    &root_turbo_json,
+                )?;
+                Some(packages.into_keys().collect())
+            } else {
+                None
+            };
+
         let use_watch_task_level_filter = self
             .changed_files_for_watch
             .as_ref()
@@ -1006,6 +1026,11 @@ impl RunBuilder {
                 &root_turbo_json,
                 &scm,
             )?;
+
+            if let Some(scoped_packages) = &task_level_affected_packages {
+                let scoped_tasks = engine.task_ids_for_packages(scoped_packages);
+                engine = engine.retain_filtered_tasks(&scoped_tasks);
+            }
         }
 
         if needs_all_packages {

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -125,6 +125,9 @@ construction:
    containing directly affected tasks, their transitive dependents, and all
    transitive dependencies required for execution (upstream tasks needed as
    cache hits)
+5. **Package scope intersection**: When `--filter` is present, the run builder
+   resolves it without package-level `--affected`, then keeps the scoped
+   affected tasks and their execution dependencies
 
 This differs from the default `--affected` behavior which operates at the
 package level (all tasks in changed packages run).

--- a/crates/turborepo/tests/affected_test.rs
+++ b/crates/turborepo/tests/affected_test.rs
@@ -818,6 +818,92 @@ fn test_task_level_affected_root_package_json_not_global() {
 }
 
 #[test]
+fn test_task_level_affected_filter_limits_scheduled_tasks() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_task_level_affected(tempdir.path());
+
+    // Change two independent packages so both are affected before --filter is
+    // applied to the task graph.
+    fs::write(
+        tempdir.path().join("packages/lib-a/index.ts"),
+        "export const changed = true;",
+    )
+    .unwrap();
+    fs::write(
+        tempdir.path().join("packages/lib-no-test/index.ts"),
+        "export const changed = true;",
+    )
+    .unwrap();
+
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "run",
+            "build",
+            "--affected",
+            "--filter=lib-no-test",
+            "--dry=json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "turbo run failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("failed to parse dry run JSON: {e}\nstdout: {stdout}"));
+
+    let packages: Vec<_> = json["packages"]
+        .as_array()
+        .expect("packages array")
+        .iter()
+        .map(|package| package.as_str().expect("package name"))
+        .collect();
+    assert_eq!(packages, ["lib-no-test"]);
+
+    let task_ids: Vec<_> = json["tasks"]
+        .as_array()
+        .expect("tasks array")
+        .iter()
+        .map(|task| task["taskId"].as_str().expect("task ID"))
+        .collect();
+    assert_eq!(task_ids, ["lib-no-test#build"]);
+
+    // Filtering to app-a still retains lib-a#build because it is an upstream
+    // task dependency, while excluding the independently affected package.
+    let output = run_turbo(
+        tempdir.path(),
+        &["run", "build", "--affected", "--filter=app-a", "--dry=json"],
+    );
+    assert!(
+        output.status.success(),
+        "turbo run failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("failed to parse dry run JSON: {e}\nstdout: {stdout}"));
+
+    let packages: Vec<_> = json["packages"]
+        .as_array()
+        .expect("packages array")
+        .iter()
+        .map(|package| package.as_str().expect("package name"))
+        .collect();
+    assert_eq!(packages, ["app-a"]);
+
+    let mut task_ids: Vec<_> = json["tasks"]
+        .as_array()
+        .expect("tasks array")
+        .iter()
+        .map(|task| task["taskId"].as_str().expect("task ID"))
+        .collect();
+    task_ids.sort_unstable();
+    assert_eq!(task_ids, ["app-a#build", "lib-a#build"]);
+}
+
+#[test]
 fn test_affected_with_nonexistent_task_errors() {
     let tempdir = tempfile::tempdir().unwrap();
     setup_affected(tempdir.path());


### PR DESCRIPTION
### Description

Fixes #13636.

With `affectedUsingTaskInputs`, the run builder constructs the task graph from all packages before pruning it to affected tasks. Package resolution still narrowed the reported package list with `--filter`, but that package scope was never applied to the scheduled task graph.

Resolve the `--filter` package scope without package-level `--affected`, then intersect it with the task-level affected graph. Required task dependencies remain in the graph, while affected tasks outside the requested scope are removed. The task-level affected architecture notes now document this final scope intersection.

### Testing Instructions

- `cargo test --locked -p turbo --test affected_test` (28 passed)
- `cargo clippy --locked -p turborepo-lib -p turbo --all-targets --features rustls-tls --no-deps -- -D warnings`
- `cargo fmt --check`
- Built `turbo` from this branch and ran the reproduction from #13636 with `--affected --filter=beta --dry=json`; both `packages` and executable tasks contain only `beta`.
