### PR TITLE
perf: Parse pnpm explicit-key entries in the lockfile fast path

### DIFF
--- a/crates/turborepo-lockfiles/src/pnpm/data_fast_parse.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data_fast_parse.rs
@@ -179,11 +179,15 @@ fn parse_fragment(fragment: &str) -> FResult<TopLevelFields> {
 /// Byte offsets of child-entry starts: lines indented by exactly two
 /// spaces whose first content byte could begin a pnpm map key (package
 /// keys like `'@scope/name@1.0.0':`, importer paths like `packages/foo` or
-/// `.`). `-` is excluded so block-sequence items never look like keys, and
-/// any line indented by exactly one space aborts (the two-space level
-/// would not be a direct child). Continuation lines of multi-line scalars
-/// are indented deeper than two spaces, so a boundary can never land
-/// inside an entry the scanner accepts.
+/// `.`), plus explicit-key entries (`? 'very long key'`). `-` is excluded
+/// so block-sequence items never look like keys, and any line indented by
+/// exactly one space aborts (the two-space level would not be a direct
+/// child). Continuation lines of multi-line scalars are indented deeper
+/// than two spaces, and an explicit key's `: value` line is treated as
+/// interior, so a boundary can never land inside an entry the scanner
+/// accepts. Non-blank content before the first entry start aborts: the
+/// chunk assembly drops everything before the first start, so accepting it
+/// could change meaning.
 fn child_entry_starts(fragment: &str) -> Option<Vec<usize>> {
     let bytes = fragment.as_bytes();
     let mut starts = Vec::new();
@@ -215,8 +219,20 @@ fn child_entry_starts(fragment: &str) -> Option<Vec<usize>> {
             continue;
         };
         match third {
-            // Deeper indentation or blank remainder: interior line.
-            b' ' | b'\n' | b'\r' => continue,
+            // Blank remainder: interior line.
+            b'\n' | b'\r' => continue,
+            // Deeper indentation before the first entry would be dropped
+            // by the chunk assembly; after it, it's an interior line.
+            b' ' if starts.is_empty() => return None,
+            b' ' => continue,
+            // Explicit-key entry (`? 'key'`, value on the next `: value`
+            // line). The `: ` line is interior to it, so a chunk boundary
+            // can't separate the pair; a stray `: ` line without its
+            // `? ` key makes the chunk's scanner decline, which falls
+            // back to sequential parsing.
+            b'?' if bytes.get(line_start + 3) == Some(&b' ') => starts.push(line_start),
+            b':' if starts.is_empty() => return None,
+            b':' => continue,
             c if c.is_ascii_alphanumeric()
                 || matches!(c, b'_' | b'\'' | b'"' | b'@' | b'.' | b'/') =>
             {
@@ -1539,6 +1555,99 @@ packages:
       folded with trailing newline
 "#,
         );
+    }
+
+    #[test]
+    fn test_explicit_keys_differential() {
+        // The `yaml` library pnpm uses emits explicit keys (`? key` with
+        // the value on the following `: value` line) for mapping keys
+        // longer than 1024 bytes — real lockfiles hit this with heavily
+        // peer-suffixed snapshot keys. The scanner must accept both a
+        // block-mapping value starting on the `: ` line and an inline
+        // scalar value, at any mapping depth.
+        assert_scanner_matches_serde(
+            r#"lockfileVersion: '9.0'
+
+importers:
+
+  .: {}
+
+overrides:
+  ? some-really-long-override-name
+  : 7.5.3
+
+snapshots:
+
+  ? 'long-key@1.0.0(peer-a@2.0.0)(peer-b@3.0.0)'
+  : dependencies:
+      dep-a: 1.0.0
+      dep-b: 2.0.0(dep-a@1.0.0)
+
+  short@1.0.0:
+    dependencies:
+      ? another-long-name-in-a-nested-mapping
+      : 1.0.0
+"#,
+        );
+    }
+
+    #[test]
+    fn test_explicit_key_without_value_line_falls_back() {
+        // `? key` at EOF (saphyr gives it a null value; the scanner
+        // declines rather than model that).
+        assert_falls_back("lockfileVersion: '9.0'\nimporters:\n  .: {}\noverrides:\n  ? orphan\n");
+        // `? key` followed by a line that is not its `: value` line.
+        assert_falls_back(
+            "lockfileVersion: '9.0'\nimporters:\n  .: {}\noverrides:\n  ? orphan\n  other: 1.0.0\n",
+        );
+        // `? key` whose `: value` line sits at a different indent.
+        assert_falls_back(
+            "lockfileVersion: '9.0'\nimporters:\n  .: {}\noverrides:\n  ? orphan\n      : 1.0.0\n",
+        );
+    }
+
+    #[test]
+    fn test_chunked_split_handles_explicit_keys() {
+        // Build a snapshots section big enough to cross the chunked-split
+        // threshold, with explicit-key entries at the start, middle, and
+        // end, so chunk boundaries interact with `? `/`: ` pairs.
+        let mut yaml =
+            String::from("lockfileVersion: '9.0'\n\nimporters:\n\n  .: {}\n\nsnapshots:\n\n");
+        let explicit = |name: &str| {
+            format!("  ? '{name}@1.0.0(peer@2.0.0)'\n  : dependencies:\n      dep: 1.0.0\n\n")
+        };
+        yaml.push_str(&explicit("first-explicit"));
+        for i in 0..12000 {
+            yaml.push_str(&format!(
+                "  pkg{i}@1.0.0:\n    dependencies:\n      dep{i}: 1.0.0\n\n"
+            ));
+            if i == 6000 {
+                yaml.push_str(&explicit("middle-explicit"));
+            }
+        }
+        yaml.push_str(&explicit("last-explicit"));
+        assert!(
+            yaml.len() >= 2 * CHUNKED_FRAGMENT_MIN_BYTES,
+            "input must be large enough to exercise the chunked path"
+        );
+        assert_scanner_matches_serde(&yaml);
+    }
+
+    #[test]
+    fn test_chunked_split_rejects_content_before_first_entry() {
+        // Deeper-indented content between a section header and its first
+        // child entry would be dropped by the chunk assembly; the splitter
+        // must decline so the sequential tiers (which also decline) decide.
+        let mut yaml = String::from(
+            "lockfileVersion: '9.0'\n\nimporters:\n\n  .: {}\n\nsnapshots:\n    stray: 1.0.0\n",
+        );
+        for i in 0..12000 {
+            yaml.push_str(&format!(
+                "  pkg{i}@1.0.0:\n    dependencies:\n      dep{i}: 1.0.0\n\n"
+            ));
+        }
+        assert!(yaml.len() >= 2 * CHUNKED_FRAGMENT_MIN_BYTES);
+        assert_falls_back(&yaml);
     }
 
     #[test]

--- a/crates/turborepo-lockfiles/src/pnpm/data_scanner.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data_scanner.rs
@@ -56,6 +56,9 @@ pub(super) struct LineScanner<'a> {
     /// Set after a `key:` line whose value, if any, is a nested block
     /// collection introduced by the next line's indentation.
     pending_child: Option<usize>,
+    /// Set after an explicit `? key` line; holds the key's indent. The
+    /// next content line must be its `: value` line at the same indent.
+    pending_explicit_value: Option<usize>,
     state: State,
 }
 
@@ -69,6 +72,7 @@ impl<'a> LineScanner<'a> {
             queue: std::collections::VecDeque::with_capacity(16),
             stack: Vec::new(),
             pending_child: None,
+            pending_explicit_value: None,
             state: State::Start,
         }
     }
@@ -99,6 +103,10 @@ impl<'a> LineScanner<'a> {
                 // Empty input isn't a mapping; let the fallback error.
                 return Err(Unsupported::here());
             }
+            if self.pending_explicit_value.is_some() {
+                // `? key` at EOF with no `: value` line.
+                return Err(Unsupported::here());
+            }
             if self.pending_child.take().is_some() {
                 self.queue.push_back(null_scalar());
             }
@@ -123,6 +131,15 @@ impl<'a> LineScanner<'a> {
         } else if is_document_marker(content) {
             // Multi-document input.
             return Err(Unsupported::here());
+        }
+
+        // An explicit `? key` line must be followed by its `: value` line
+        // at the same indent; anything else leaves the fast path.
+        if let Some(key_indent) = self.pending_explicit_value.take() {
+            if indent != key_indent {
+                return Err(Unsupported::here());
+            }
+            return self.explicit_value_line(key_indent, content);
         }
 
         // A `key:` line opens a child collection only if the next content
@@ -210,6 +227,17 @@ impl<'a> LineScanner<'a> {
     }
 
     fn key_line(&mut self, indent: usize, content: &'a str) -> FResult<()> {
+        // Explicit-key form: `? key` with the value on the following
+        // `: value` line. pnpm emits this for mapping keys longer than
+        // 1024 bytes — the YAML limit for implicit keys — which real
+        // lockfiles hit with heavily peer-suffixed snapshot keys.
+        if let Some(key) = content.strip_prefix("? ") {
+            let ev = inline_scalar(key, FlowContext::Block)?;
+            self.queue.push_back(ev);
+            self.pending_explicit_value = Some(indent);
+            return Ok(());
+        }
+
         let (key_event, rest) = split_key(content)?;
         self.queue.push_back(key_event);
 
@@ -219,6 +247,33 @@ impl<'a> LineScanner<'a> {
             return Ok(());
         }
         self.value_events(indent, value)
+    }
+
+    /// Value line (`: value`) completing a preceding explicit `? key`
+    /// line. The value is either an inline scalar or a block mapping
+    /// whose first entry begins on this line (e.g. `: dependencies:`),
+    /// with children indented past the `: ` marker.
+    fn explicit_value_line(&mut self, key_indent: usize, content: &'a str) -> FResult<()> {
+        let Some(rest) = content.strip_prefix(": ") else {
+            return Err(Unsupported::here());
+        };
+        if rest.starts_with(' ') {
+            // Extra spaces would shift the value's block indent; let the
+            // general parser decide.
+            return Err(Unsupported::here());
+        }
+        // The value node starts in the column right after the `: ` marker.
+        let value_indent = key_indent + 2;
+        if split_key(rest).is_ok() {
+            // `key:` or `key: value` here means the explicit key's value
+            // is a block mapping starting on this line.
+            self.queue.push_back(start_event(Kind::Mapping));
+            self.stack.push((value_indent, Kind::Mapping));
+            return self.key_line(value_indent, rest);
+        }
+        let ev = inline_scalar(rest, FlowContext::Block)?;
+        self.queue.push_back(ev);
+        Ok(())
     }
 
     fn sequence_item(&mut self, content: &'a str) -> FResult<()> {


### PR DESCRIPTION
### Description

Profiling package-graph construction on a large real-world pnpm monorepo showed `parse_lockfile` dominating the critical path: the structural fast parser was declining the lockfile and falling back to the general YAML parser.

The cause: the `yaml` library pnpm uses emits **explicit keys** (`? key` with the value on the following `: value` line) for mapping keys longer than 1024 bytes — the YAML spec limit for implicit keys. Heavily peer-suffixed snapshot keys hit this in practice, and a *single* such entry (the profiled repo had two, in a 75k-line lockfile) knocked the entire file off the fast path.

Changes:

- **Line scanner** (`data_scanner.rs`): a `? key` line records a pending explicit value; the next content line must be its `: value` line at the same indent, carrying either an inline scalar or a block mapping whose first entry starts on that line (`: dependencies:` — the shape pnpm emits). Any other shape (orphaned `? key`, wrong indent, multi-line quoted key) still declines to the general parser, preserving the tier's "never accept input with a different meaning than saphyr" contract.
- **Chunked parallel splitter** (`data_fast_parse.rs`): `? ` lines are now child-entry starts and `: ` lines interior, so a chunk boundary can never separate a `? `/`: ` pair. Also hardened: the splitter now declines when non-blank content precedes the first child entry, since the chunk assembly silently drops everything before the first start (previously a latent accept-with-drop edge at ≥256 KB fragment sizes).

**Measured on the real repo** (75k-line lockfile, release build, steady-state medians over 12 samples):

| Phase | Before | After |
|---|---|---|
| `parse_lockfile` | ~139 ms | ~29 ms (**4.8×**) |
| package graph build (total) | ~240 ms | ~125 ms (**1.9×**) |

This cost is paid on every `turbo` invocation in affected repos. The fast-parse result was verified byte-identical to the serde oracle (including re-encoding) on two large production lockfiles (165k and 75k lines).

### Testing Instructions

- `cargo test -p turborepo-lockfiles` — 285 tests pass. New differential tests cover: explicit keys with block-mapping and inline-scalar values at top-level and nested depths (`test_explicit_keys_differential`), decline cases (`test_explicit_key_without_value_line_falls_back`), a >512 KB input exercising the chunked splitter with explicit keys at start/middle/end (`test_chunked_split_handles_explicit_keys`), and the content-before-first-entry hardening (`test_chunked_split_rejects_content_before_first_entry`).
- All differential tests assert scanner == parallel-split == serde on accepted inputs, and that declined inputs are declined by every tier.
- `cargo clippy -p turborepo-lockfiles --all-targets` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGZtfhEfgWhrAFMTMhwTfU

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGZtfhEfgWhrAFMTMhwTfU)_