### PR TITLE
perf: Share resolution identity lists across identical workspace closures

### DIFF
--- a/crates/turborepo-repository/src/external_resolution.rs
+++ b/crates/turborepo-repository/src/external_resolution.rs
@@ -5,6 +5,7 @@ use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     fmt,
     ops::Range,
+    sync::Arc,
 };
 
 use turbopath::{AnchoredSystemPath, AnchoredSystemPathBuf};
@@ -278,10 +279,16 @@ impl ResolutionFingerprint {
 }
 
 /// Exact external identities attributed to one authoritative package.
+///
+/// The identity list is immutable once constructed (`new` sorts and
+/// dedups) and stored behind an `Arc` so packages with identical
+/// resolutions — common when many workspaces share the same external
+/// closure — can share one materialized list via
+/// [`PackageResolution::from_shared`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PackageResolution {
     package: String,
-    identities: Vec<ExternalPackageIdentity>,
+    identities: Arc<[ExternalPackageIdentity]>,
     fingerprint: Option<ResolutionFingerprint>,
 }
 
@@ -295,9 +302,28 @@ impl PackageResolution {
         identities.dedup();
         Self {
             package: package.into(),
+            identities: identities.into(),
+            fingerprint: None,
+        }
+    }
+
+    /// Attribute an already-materialized identity list to another package.
+    /// The list carries `new`'s sorted/deduped invariant with it.
+    pub(crate) fn from_shared(
+        package: impl Into<String>,
+        identities: Arc<[ExternalPackageIdentity]>,
+    ) -> Self {
+        Self {
+            package: package.into(),
             identities,
             fingerprint: None,
         }
+    }
+
+    /// The identity list in its shareable form, for reuse via
+    /// [`PackageResolution::from_shared`].
+    pub(crate) fn shared_identities(&self) -> Arc<[ExternalPackageIdentity]> {
+        Arc::clone(&self.identities)
     }
 
     pub fn package(&self) -> &str {
@@ -484,10 +510,23 @@ impl ExternalResolutionGeneration {
             domain.definition_sources.sort();
             domain.definition_sources.dedup();
             if let ExternalResolutionData::Resolved { packages, .. } = &mut domain.data {
+                // Identity lists are sorted and deduped at construction
+                // (`PackageResolution::new`) and immutable afterward, so
+                // packages sharing one list (via `from_shared`) hash it
+                // once. The memo is keyed by slice address: at most one
+                // probe per package, and a miss costs nothing beyond the
+                // hash that was already required.
+                let mut fingerprint_memo: HashMap<
+                    *const [ExternalPackageIdentity],
+                    ResolutionFingerprint,
+                > = HashMap::new();
                 for package in packages.iter_mut() {
-                    package.identities.sort();
-                    package.identities.dedup();
-                    package.set_fingerprint(ResolutionFingerprint::new(
+                    let slice_ptr = Arc::as_ptr(&package.identities);
+                    if let Some(fingerprint) = fingerprint_memo.get(&slice_ptr) {
+                        package.set_fingerprint(fingerprint.clone());
+                        continue;
+                    }
+                    let fingerprint = ResolutionFingerprint::new(
                         turborepo_lockfile_hash::hash(
                             package
                                 .identities
@@ -495,7 +534,9 @@ impl ExternalResolutionGeneration {
                                 .map(|identity| (identity.key(), identity.version())),
                         )
                         .map_err(ExternalResolutionError::Fingerprint)?,
-                    ));
+                    );
+                    fingerprint_memo.insert(slice_ptr, fingerprint.clone());
+                    package.set_fingerprint(fingerprint);
                 }
                 packages.sort_by(|left, right| left.package.cmp(&right.package));
             }

--- a/crates/turborepo-repository/src/package_graph/javascript.rs
+++ b/crates/turborepo-repository/src/package_graph/javascript.rs
@@ -121,24 +121,40 @@ pub(super) fn resolve_dependencies(
             );
         }
     };
-    let packages = resolution_packages(knowledge)
-        .into_iter()
-        .map(|(identity, directory)| {
-            let exact_identities = closures
-                .get(directory.to_unix().as_str())
-                .into_iter()
-                .flatten()
-                .map(|package| {
-                    let mut identity =
-                        ExternalPackageIdentity::new(package.key.clone(), package.version.clone());
-                    if let Some(human_name) = lockfile.human_name(package) {
-                        identity = identity.with_human_name(human_name);
-                    }
-                    identity
-                });
-            PackageResolution::new(identity, exact_identities)
-        })
-        .collect::<Vec<_>>();
+    // Workspaces sharing an identical external closure (common when a
+    // monorepo has many packages with the same dependencies) share one
+    // materialized identity list instead of each cloning every member's
+    // strings and re-reading its lockfile display name. Closure members
+    // are interned `Arc`s when the shared closure DP produced them, so
+    // an identical pointer sequence means an identical closure; formats
+    // that fall back to the legacy per-workspace walk produce distinct
+    // pointers and simply keep building their lists independently.
+    let mut slice_memo: HashMap<
+        Vec<*const turborepo_lockfiles::Package>,
+        Arc<[ExternalPackageIdentity]>,
+    > = HashMap::new();
+    let resolution_members = resolution_packages(knowledge);
+    let mut packages = Vec::with_capacity(resolution_members.len());
+    for (identity, directory) in resolution_members {
+        let members = closures.get(directory.to_unix().as_str());
+        let pointer_key: Vec<*const turborepo_lockfiles::Package> =
+            members.into_iter().flatten().map(Arc::as_ptr).collect();
+        if let Some(shared) = slice_memo.get(&pointer_key) {
+            packages.push(PackageResolution::from_shared(identity, Arc::clone(shared)));
+            continue;
+        }
+        let exact_identities = members.into_iter().flatten().map(|package| {
+            let mut identity =
+                ExternalPackageIdentity::new(package.key.clone(), package.version.clone());
+            if let Some(human_name) = lockfile.human_name(package) {
+                identity = identity.with_human_name(human_name);
+            }
+            identity
+        });
+        let resolution = PackageResolution::new(identity, exact_identities);
+        slice_memo.insert(pointer_key, resolution.shared_identities());
+        packages.push(resolution);
+    }
     let members = packages
         .iter()
         .map(|package| package.package().to_string())


### PR DESCRIPTION
### Description

> **Base of a 3-PR stack**: #13641 (this) → #13642 (parallel fingerprint) → #13643 (parallel identity build). This PR targets `main`; review in order. Together they cut package-graph construction ~264 ms → ~178 ms (~33%) on the profiled repo.

Profiling package-graph construction on a large real-world pnpm monorepo (~1,200 workspaces) showed `resolve_dependencies` materializing every workspace's external closure independently: one `ExternalPackageIdentity` per closure member per workspace (two string clones plus a `human_name` lockfile lookup each — ~390k constructions total), then one fingerprint hash per workspace over the full `(key, version)` sequence. Only ~two-thirds of those closures are actually distinct — the rest is duplicated work.

Changes:

- `PackageResolution` now stores its identity list as `Arc<[ExternalPackageIdentity]>`. The list is sorted/deduped at construction (`new`, the only constructor) and immutable afterward.
- `resolve_dependencies` shares one materialized list across workspaces whose closures are identical, detected by the closure's `Arc` pointer sequence. Closure members are interned `Arc`s whenever the shared closure DP produced them (pnpm today; npm/yarn1 with #13635), so identical pointer sequences ⇔ identical closures. Legacy-walk formats produce distinct pointers per workspace and simply keep building independently — behavior unchanged, no penalty.
- `ExternalResolutionGeneration::build` fingerprints each distinct list once, memoized by slice address — at most one map probe per *package* (not per member), so unshared lists pay nothing measurable beyond the hash they already required. Its per-package re-sort is dropped since `new` already guarantees the invariant.

Public surface is unchanged: `identities()` still returns `&[ExternalPackageIdentity]`, `new()` has the same signature, and cargo/uv resolution producers are untouched. Cloning a resolution/generation is now a refcount bump instead of a deep identity-list copy.

**Measured** on the profiled repo (release, 8 warm samples per side): package graph construction ~264 ms → ~249 ms median (**~6%**) from this PR alone, with a ~35% cut in identity-list allocations. The two PRs stacked on top take it to ~178 ms.

For transparency: two cheaper alternatives were tried first — per-member identity memoization and content-keyed fingerprint dedup — and both measured neutral-to-worse (per-member map probes cost what they saved), which is why this lands as the structural pointer-keyed sharing instead.

### Testing Instructions

- `cargo test -p turborepo-repository` — all 419 tests pass (identity ordering/dedup through `new`, generation building, cross-domain validation).
- `cargo check -p turborepo-lib` compiles unchanged against the new field representation.
- `cargo clippy -p turborepo-repository --all-targets` is clean.
- Fingerprint semantics are unchanged: the hash input is the same sorted, deduped `(key, version)` sequence as before; sharing only avoids recomputing it for byte-identical sequences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGZtfhEfgWhrAFMTMhwTfU