### PR TITLE
perf: Parallelize resolution fingerprint hashing

### DIFF
--- a/crates/turborepo-repository/src/external_resolution.rs
+++ b/crates/turborepo-repository/src/external_resolution.rs
@@ -511,32 +511,49 @@ impl ExternalResolutionGeneration {
             domain.definition_sources.dedup();
             if let ExternalResolutionData::Resolved { packages, .. } = &mut domain.data {
                 // Identity lists are sorted and deduped at construction
-                // (`PackageResolution::new`) and immutable afterward, so
-                // packages sharing one list (via `from_shared`) hash it
-                // once. The memo is keyed by slice address: at most one
-                // probe per package, and a miss costs nothing beyond the
-                // hash that was already required.
-                let mut fingerprint_memo: HashMap<
-                    *const [ExternalPackageIdentity],
-                    ResolutionFingerprint,
-                > = HashMap::new();
+                // (`PackageResolution::new`) and immutable afterward, and
+                // packages sharing one list (via `from_shared`) share its
+                // `Arc`. Fingerprint each *distinct* list exactly once —
+                // keyed by slice address — and hash those distinct lists in
+                // parallel, since each is an independent Cap'n Proto
+                // canonicalization plus xxHash. On a monorepo with thousands
+                // of workspaces this is the dominant cost of building a
+                // generation. Output is unchanged: the canonical bytes are
+                // deterministic per input, and packages are re-sorted
+                // deterministically below.
+                use rayon::prelude::*;
+
+                // First-seen distinct lists, and each package's index into
+                // them. Raw pointers stay on this sequential side; only the
+                // borrowed slices cross into the parallel hash.
+                let mut index_of: HashMap<*const [ExternalPackageIdentity], usize> = HashMap::new();
+                let mut distinct: Vec<&[ExternalPackageIdentity]> = Vec::new();
+                for package in packages.iter() {
+                    let slice_ptr = Arc::as_ptr(&package.identities);
+                    index_of.entry(slice_ptr).or_insert_with(|| {
+                        distinct.push(&package.identities);
+                        distinct.len() - 1
+                    });
+                }
+
+                let fingerprints = distinct
+                    .par_iter()
+                    .map(|identities| {
+                        Ok(ResolutionFingerprint::new(
+                            turborepo_lockfile_hash::hash(
+                                identities
+                                    .iter()
+                                    .map(|identity| (identity.key(), identity.version())),
+                            )
+                            .map_err(ExternalResolutionError::Fingerprint)?,
+                        ))
+                    })
+                    .collect::<Result<Vec<_>, ExternalResolutionError>>()?;
+                drop(distinct);
+
                 for package in packages.iter_mut() {
                     let slice_ptr = Arc::as_ptr(&package.identities);
-                    if let Some(fingerprint) = fingerprint_memo.get(&slice_ptr) {
-                        package.set_fingerprint(fingerprint.clone());
-                        continue;
-                    }
-                    let fingerprint = ResolutionFingerprint::new(
-                        turborepo_lockfile_hash::hash(
-                            package
-                                .identities
-                                .iter()
-                                .map(|identity| (identity.key(), identity.version())),
-                        )
-                        .map_err(ExternalResolutionError::Fingerprint)?,
-                    );
-                    fingerprint_memo.insert(slice_ptr, fingerprint.clone());
-                    package.set_fingerprint(fingerprint);
+                    package.set_fingerprint(fingerprints[index_of[&slice_ptr]].clone());
                 }
                 packages.sort_by(|left, right| left.package.cmp(&right.package));
             }


### PR DESCRIPTION
### Description

> **Stacked on #13641** (shared resolution identity lists). Base branch is `claude/perf-shared-resolution-identities`; review/merge #13641 first. The diff shown here is only this PR's commit.

Building an external resolution generation fingerprints every workspace's package resolution: one Cap'n Proto canonicalization plus an xxHash64 over its sorted `(key, version)` sequence. Profiling a large real-world monorepo (~1,200 workspaces) showed this loop as the dominant cost of `ExternalResolutionGeneration::build` — ~41 ms of a ~56 ms phase — and it ran **sequentially**.

#13641 made packages that share an identity list share its `Arc`. Building on that, this PR fingerprints each **distinct** list exactly once (keyed by slice address) and hashes those distinct lists **in parallel** with rayon. Each list is an independent hash; only the borrowed identity slices cross into the parallel iterator, while the slice-pointer dedup keys stay on the sequential side.

Output is byte-identical to sequential: the canonical bytes are deterministic per input, packages are re-sorted deterministically afterward, and the cache-compatibility-critical hash algorithm and byte layout are untouched — only the iteration changes.

**Measured** (4-core machine, ~1,200-workspace repo, release, 8 warm samples per side): package graph construction ~249 ms (shared lists alone) → ~213 ms median with this on top, versus ~264 ms on the pre-stack base. The fingerprint phase itself falls from ~41 ms to single-digit ms; the speedup scales with core count. Small repos are unaffected (rayon runs tiny inputs effectively serially), and `build` already executes inside the discovery `block_in_place` region where manifest parsing is likewise parallelized.

### Testing Instructions

- `cargo test -p turborepo-repository` — all 419 tests pass, including the fingerprint-stability tests (hash input and algorithm unchanged; only the loop is parallel).
- `cargo clippy -p turborepo-repository --all-targets` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGZtfhEfgWhrAFMTMhwTfU