### PR TITLE
docs: Correct verified inaccuracies in the Turborepo Agent Skill

### DIFF
--- a/skills/turborepo/SKILL.md
+++ b/skills/turborepo/SKILL.md
@@ -128,12 +128,12 @@ Cache problems?
 ```
 Run only what changed?
 ├─ Changed packages + dependents (RECOMMENDED) → turbo run build --affected
-├─ Custom base branch → --affected --affected-base=origin/develop
+├─ Custom base branch → TURBO_SCM_BASE=origin/develop turbo run build --affected
 ├─ Manual git comparison → --filter=...[origin/main]
 └─ See all filter options → references/filtering/RULE.md
 ```
 
-**`--affected` is the primary way to run only changed packages.** It automatically compares against the default branch and includes dependents.
+**`--affected` is the primary way to run only changed packages.** It compares against `main` (falling back to `master`) — not the repo's configured default branch — and includes dependents. Set `TURBO_SCM_BASE` for any other base branch.
 
 ### "I want to filter packages"
 
@@ -427,7 +427,7 @@ A large `env` array (even 50+ variables) is **not** a problem. It usually means 
 
 ### Using `--parallel` Flag
 
-The `--parallel` flag bypasses Turborepo's dependency graph. If tasks need parallel execution, configure `dependsOn` correctly instead.
+The `--parallel` flag bypasses Turborepo's dependency graph. It is deprecated and will be removed in a future major version—use task configuration (`persistent`, `with`) instead.
 
 ```bash
 # WRONG - bypasses dependency graph

--- a/skills/turborepo/references/best-practices/structure.md
+++ b/skills/turborepo/references/best-practices/structure.md
@@ -13,7 +13,7 @@ packages:
   - "packages/*"
 ```
 
-### npm/yarn/bun
+### npm/yarn/bun/nub
 
 ```json
 // package.json
@@ -21,6 +21,17 @@ packages:
   "workspaces": ["apps/*", "packages/*"]
 }
 ```
+
+nub follows the repo's existing lockfile: with a pnpm-format lockfile (`pnpm-lock.yaml` or nub's `lock.yaml`) it reads `pnpm-workspace.yaml` when that file exists, otherwise `package.json` workspaces.
+
+### aube
+
+aube uses `aube-workspace.yaml` (same `packages:` format as pnpm), falling back to `pnpm-workspace.yaml` or `package.json` workspaces.
+
+### Polyglot workspaces (experimental)
+
+- `futureFlags.experimentalCargoWorkspaces` - Treat Cargo workspace crates as Turborepo packages
+- `futureFlags.experimentalPythonWorkspaces` - Treat uv workspace members as Turborepo packages
 
 ## Root package.json
 
@@ -262,28 +273,34 @@ packages/
     ├── package.json
     ├── base.js
     ├── next.js
-    └── library.js
+    └── react-internal.js
 ```
 
 ```json
 // packages/eslint-config/package.json
 {
   "name": "@repo/eslint-config",
+  "type": "module",
   "exports": {
     "./base": "./base.js",
-    "./next": "./next.js",
-    "./library": "./library.js"
+    "./next-js": "./next.js",
+    "./react-internal": "./react-internal.js"
+  },
+  "devDependencies": {
+    "eslint": "^9.39.1"
   }
 }
 ```
 
 ### Using in Packages
 
+ESLint 9 flat config:
+
 ```js
-// apps/web/.eslintrc.js
-module.exports = {
-  extends: ["@repo/eslint-config/next"]
-};
+// apps/web/eslint.config.js
+import { nextJsConfig } from "@repo/eslint-config/next-js";
+
+export default nextJsConfig;
 ```
 
 ## Lockfile

--- a/skills/turborepo/references/caching/RULE.md
+++ b/skills/turborepo/references/caching/RULE.md
@@ -16,8 +16,8 @@ If inputs haven't changed, restore outputs from cache instead of re-running the 
 
 These affect ALL tasks in the repo:
 
-- `package-lock.json` / `yarn.lock` / `pnpm-lock.yaml`
-- Files listed in `globalDependencies` (or `global.env` when using `globalConfiguration`)
+- `package-lock.json` / `yarn.lock` / `pnpm-lock.yaml` / `bun.lock` (binary `bun.lockb` is unsupported — run `bun install --save-text-lockfile`)
+- Files listed in `globalDependencies` (or `global.inputs` when using `globalConfiguration` — those move to task hashes, see below)
 - Environment variables in `globalEnv` (or `global.env`)
 - `turbo.json` configuration
 

--- a/skills/turborepo/references/caching/gotchas.md
+++ b/skills/turborepo/references/caching/gotchas.md
@@ -145,7 +145,7 @@ Task reads a file outside default inputs:
     "build": {
       "inputs": [
         "$TURBO_DEFAULT$",
-        "../../shared-config.json" // file outside package
+        "$TURBO_ROOT$/shared-config.json" // file outside package
       ]
     }
   }

--- a/skills/turborepo/references/caching/remote-cache.md
+++ b/skills/turborepo/references/caching/remote-cache.md
@@ -103,11 +103,11 @@ TURBO_TEAM=your-team
 
 ```bash
 # Disable remote cache for a run
-turbo build --remote-cache-read-only  # read but don't write
-turbo build --no-cache                # skip cache entirely
+turbo build --remote-cache-read-only  # read but don't write; deprecated, use --cache=local:rw,remote:r
+turbo build --no-cache                # skip cache writes (reads still hit); deprecated, use --cache=local:r,remote:r
 
 # Environment variable alternative
-TURBO_REMOTE_ONLY=true  # only use remote, skip local
+TURBO_CACHE=remote:rw  # only use remote, skip local (TURBO_REMOTE_ONLY is deprecated)
 ```
 
 ## Debugging Remote Cache

--- a/skills/turborepo/references/ci/RULE.md
+++ b/skills/turborepo/references/ci/RULE.md
@@ -65,12 +65,12 @@ fetch-depth: 0 # Full history
 
 ## Environment Variables Reference
 
-| Variable            | Purpose                              |
-| ------------------- | ------------------------------------ |
-| `TURBO_TOKEN`       | Vercel access token for remote cache |
-| `TURBO_TEAM`        | Your Vercel team slug                |
-| `TURBO_REMOTE_ONLY` | Skip local cache, use remote only    |
-| `TURBO_LOG_ORDER`   | Set to `grouped` for cleaner CI logs |
+| Variable          | Purpose                                                                    |
+| ----------------- | -------------------------------------------------------------------------- |
+| `TURBO_TOKEN`     | Vercel access token for remote cache                                       |
+| `TURBO_TEAM`      | Your Vercel team slug                                                      |
+| `TURBO_CACHE`     | Set to `remote:rw` to skip local cache (`TURBO_REMOTE_ONLY` is deprecated) |
+| `TURBO_LOG_ORDER` | Set to `grouped` for cleaner CI logs                                       |
 
 ## See Also
 

--- a/skills/turborepo/references/ci/vercel.md
+++ b/skills/turborepo/references/ci/vercel.md
@@ -56,8 +56,17 @@ npx turbo-ignore web
 # Use specific comparison ref
 npx turbo-ignore --fallback=HEAD~1
 
-# Verbose output
-npx turbo-ignore --verbose
+# Check a task other than build
+npx turbo-ignore --task=test
+
+# Run in a specific directory
+npx turbo-ignore --directory=apps/web
+
+# Explicitly set which version of turbo to invoke
+npx turbo-ignore --turbo-version=2.5.0
+
+# Raise child process maxBuffer in KB (default: 1024)
+npx turbo-ignore --max-buffer=2048
 ```
 
 ## Environment Variables

--- a/skills/turborepo/references/cli/commands.md
+++ b/skills/turborepo/references/cli/commands.md
@@ -73,10 +73,13 @@ turbo build --concurrency=50%    # 50% of CPU cores
 
 ### `--continue`
 
-Keep running other tasks when one fails.
+Control whether other tasks keep running when one fails. Value requires `=` — `--continue never` parses `never` as a task name and the flag becomes `--continue=always`.
 
 ```bash
-turbo build test --continue
+turbo build test --continue                          # bare flag = --continue=always
+turbo build test --continue=never                    # cancel remaining tasks on failure (default)
+turbo build test --continue=dependencies-successful  # continue tasks whose dependencies succeeded
+turbo build test --continue=always                   # continue all tasks, even with failed dependencies
 ```
 
 ### `--only`
@@ -87,9 +90,9 @@ Run only the specified task, skip its dependencies.
 turbo build --only  # skip running dependsOn tasks
 ```
 
-### `--parallel` (Discouraged)
+### `--parallel` (Deprecated)
 
-Ignores task graph dependencies, runs all tasks simultaneously. **Avoid using this flag**—if tasks need to run in parallel, configure `dependsOn` correctly instead. Using `--parallel` bypasses Turborepo's dependency graph, which can cause race conditions and incorrect builds.
+Ignores task graph dependencies, runs all tasks simultaneously. **Deprecated, will be removed in a future major version**—use task configuration (`persistent`, `with`) in `turbo.json` instead. Using `--parallel` bypasses Turborepo's dependency graph, which can cause race conditions and incorrect builds.
 
 ## Cache Control
 
@@ -118,12 +121,14 @@ turbo build --cache=local:,remote:
 Generate task graph visualization.
 
 ```bash
-turbo build --graph                # opens in browser
+turbo build --graph                # prints dot graph to stdout
 turbo build --graph=graph.svg      # SVG file
-turbo build --graph=graph.png      # PNG file
-turbo build --graph=graph.json     # JSON data
+turbo build --graph=graph.html     # HTML file
 turbo build --graph=graph.mermaid  # Mermaid diagram
+turbo build --graph=graph.dot      # DOT file
 ```
+
+`.png`, `.jpg`, `.pdf`, and `.json` are deprecated (removed in 3.0; require external Graphviz). For programmatic access, use `turbo query` instead.
 
 ### `--summarize`
 
@@ -140,6 +145,7 @@ Control log output verbosity.
 
 ```bash
 turbo build --output-logs=full        # all logs (default)
+turbo build --output-logs=hash-only   # only task hashes
 turbo build --output-logs=new-only    # only cache misses
 turbo build --output-logs=errors-only # only failures
 turbo build --output-logs=none        # silent
@@ -172,7 +178,7 @@ Control environment variable handling.
 
 ```bash
 turbo build --env-mode=strict  # only declared env vars (default)
-turbo build --env-mode=loose   # include all env vars in hash
+turbo build --env-mode=loose   # all env vars available at runtime; hashing still limited to declared vars
 ```
 
 ## UI
@@ -182,9 +188,25 @@ turbo build --env-mode=loose   # include all env vars in hash
 Select output interface.
 
 ```bash
-turbo build --ui=tui     # interactive terminal UI (default in TTY)
-turbo build --ui=stream  # streaming logs (default in CI)
+turbo build --ui=stream  # streaming logs (default)
+turbo build --ui=tui     # interactive terminal UI (opt-in; requires a TTY)
+turbo build --ui=stream-with-experimental-timestamps  # streaming logs with timestamps (experimental)
 ```
+
+### TUI keybinds
+
+| Key | Action |
+| --- | --- |
+| `↑`/`k`, `↓`/`j` | Select previous/next task |
+| `h` | Show selected task's logs full-screen, verbatim (toggle) |
+| `s` | Stream all task logs (toggle) |
+| `Shift+H` | Toggle task list sidebar |
+| `i` or `Enter` | Interact with selected task |
+| `Ctrl+Z` | Stop interacting with task |
+| `/` | Filter tasks to search term (`Esc` clears) |
+| `p` | Toggle pinned task selection |
+| `u` / `d` | Scroll logs up/down |
+| `m` | Toggle keybind help popup |
 
 ---
 
@@ -267,7 +289,10 @@ See `references/watch/` for details.
 Create sparse checkout for Docker.
 
 ```bash
-turbo prune web --docker
+turbo prune web --docker                # split output into json/ and full/ for layer caching
+turbo prune web --production            # exclude in-workspace devDependencies
+turbo prune web --out-dir=./custom-out  # output directory (default: ./out)
+turbo prune web --use-gitignore=false   # copy files ignored by .gitignore (default: true)
 ```
 
 ## turbo link / unlink
@@ -295,3 +320,41 @@ Scaffold new packages.
 ```bash
 turbo generate
 ```
+
+## turbo docs
+
+Search the Turborepo documentation.
+
+```bash
+turbo docs "how does caching work"
+turbo docs "prune" --docs-version=2.7.5  # override docs version (minimum: 2.7.5)
+```
+
+## turbo ls
+
+List packages in the monorepo (experimental).
+
+```bash
+turbo ls                 # all packages
+turbo ls web             # details for a specific package
+turbo ls --affected      # only packages changed vs main
+turbo ls --output=json   # machine-readable (default: pretty)
+```
+
+## turbo query
+
+Query the monorepo using GraphQL.
+
+```bash
+turbo query                                          # spins up GraphiQL server
+turbo query "query { packages { items { name } } }"  # run a query string
+turbo query ./query.gql                              # run a query from a file
+```
+
+## More
+
+- `turbo devtools` - visualize the package graph in the browser
+- `turbo info` - print debugging information
+- `turbo bin` - print the path to the turbo binary
+- `turbo daemon` - run/manage the background daemon
+- `turbo telemetry` - enable or disable anonymous telemetry

--- a/skills/turborepo/references/configuration/global-options.md
+++ b/skills/turborepo/references/configuration/global-options.md
@@ -40,11 +40,11 @@ Use for credentials that shouldn't affect cache keys.
 
 ## cacheDir
 
-Custom cache location. Default: `node_modules/.cache/turbo`.
+Custom cache location. Default: `.turbo/cache`.
 
 ```json
 {
-  "cacheDir": ".turbo/cache"
+  "cacheDir": ".cache/turbo"
 }
 ```
 
@@ -95,17 +95,17 @@ Configure remote caching.
 }
 ```
 
-| Option          | Default                | Description                                            |
-| --------------- | ---------------------- | ------------------------------------------------------ |
-| `enabled`       | `true`                 | Enable/disable remote caching                          |
-| `signature`     | `false`                | Sign artifacts with `TURBO_REMOTE_CACHE_SIGNATURE_KEY` |
-| `preflight`     | `false`                | Send OPTIONS request before cache requests             |
-| `timeout`       | `30`                   | Timeout in seconds for cache operations                |
-| `uploadTimeout` | `60`                   | Timeout in seconds for uploads                         |
-| `apiUrl`        | `"https://vercel.com"` | Remote cache API endpoint                              |
-| `loginUrl`      | `"https://vercel.com"` | Login endpoint                                         |
-| `teamId`        | -                      | Team ID (must start with `team_`)                      |
-| `teamSlug`      | -                      | Team slug for querystring                              |
+| Option          | Default                    | Description                                            |
+| --------------- | -------------------------- | ------------------------------------------------------ |
+| `enabled`       | `true`                     | Enable/disable remote caching                          |
+| `signature`     | `false`                    | Sign artifacts with `TURBO_REMOTE_CACHE_SIGNATURE_KEY` |
+| `preflight`     | `false`                    | Send OPTIONS request before cache requests             |
+| `timeout`       | `30`                       | Timeout in seconds for cache operations                |
+| `uploadTimeout` | `60`                       | Timeout in seconds for uploads                         |
+| `apiUrl`        | `"https://vercel.com/api"` | Remote cache API endpoint                              |
+| `loginUrl`      | `"https://vercel.com"`     | Login endpoint                                         |
+| `teamId`        | -                          | Team ID (must start with `team_`)                      |
+| `teamSlug`      | -                          | Team slug for querystring                              |
 
 See https://turborepo.dev/docs/core-concepts/remote-caching for setup.
 
@@ -145,6 +145,34 @@ When using `outputLogs: "errors-only"`, show task hashes on start/completion:
 ### `longerSignatureKey`
 
 Enforce a minimum key length of 32 bytes for `TURBO_REMOTE_CACHE_SIGNATURE_KEY` when `remoteCache.signature` is enabled. Short keys weaken HMAC-SHA256 signatures. Fails the run immediately if the key is too short.
+
+### `experimentalObservability`
+
+Enable experimental OpenTelemetry exporter support: honors the `experimentalObservability` configuration block (if present) to send run summaries to an observability backend.
+
+### `affectedUsingTaskInputs`
+
+Use task-level `inputs` globs to determine which tasks `--affected` selects — only tasks whose declared inputs match the changed files, rather than all tasks in changed packages.
+
+### `githubActionsRemoteBaseRefFallback`
+
+When GitHub Actions reports a base branch that is not available as a local ref, fall back to `origin/<branch>` (supports detached checkouts with only remote-tracking refs).
+
+### `watchUsingTaskInputs`
+
+Use task-level `inputs` globs to determine which tasks `turbo watch` re-runs when files change, rather than re-running all tasks in changed packages.
+
+### `pruneIncludesGlobalFiles`
+
+Include files matching `globalDependencies` globs in the `turbo prune` output. Without this flag, the entries are preserved in the pruned `turbo.json` but the files are not copied.
+
+### `filterUsingTasks`
+
+Resolve `--filter` at the task level: git-range filters (e.g. `--filter=[main]`) match against task `inputs` globs, and `...` traverses the task graph in addition to the package graph.
+
+### `strictTaskEntrypointSelection`
+
+When any package can run a requested task, skip packages without a command as entrypoints. Tasks with no command anywhere remain available for graph-only orchestration.
 
 ### `globalConfiguration`
 
@@ -197,6 +225,14 @@ With `global.inputs` (new): files are treated as **implicit task inputs** prepen
 - Tasks with no explicit `inputs` still hash all package files plus the global inputs
 
 See the [gotchas doc](./gotchas.md) for guidance on using `$TURBO_DEFAULT$` with `global.inputs`.
+
+### `experimentalCargoWorkspaces`
+
+Treat the crates of a Cargo workspace as Turborepo packages: crates are discovered via `cargo metadata` and participate in the package graph, `--filter`, `--affected`, and `turbo query`. Experimental.
+
+### `experimentalPythonWorkspaces`
+
+Treat the members of a uv workspace as Turborepo packages: packages are discovered from the root `pyproject.toml`'s `[tool.uv.workspace]` members and participate in the package graph. uv is the only supported Python package manager. Experimental.
 
 ## noUpdateNotifier
 

--- a/skills/turborepo/references/environment/modes.md
+++ b/skills/turborepo/references/environment/modes.md
@@ -51,20 +51,22 @@ Turborepo automatically detects frameworks and includes their conventional env v
 
 ### Inferred Variables by Framework
 
-| Framework        | Pattern             |
-| ---------------- | ------------------- |
-| Next.js          | `NEXT_PUBLIC_*`     |
-| Vite             | `VITE_*`            |
-| Create React App | `REACT_APP_*`       |
-| Gatsby           | `GATSBY_*`          |
-| Nuxt             | `NUXT_*`, `NITRO_*` |
-| Expo             | `EXPO_PUBLIC_*`     |
-| Astro            | `PUBLIC_*`          |
-| SvelteKit        | `PUBLIC_*`          |
-| Remix            | `REMIX_*`           |
-| Redwood          | `REDWOOD_ENV_*`     |
-| Sanity           | `SANITY_STUDIO_*`   |
-| Solid            | `VITE_*`            |
+| Framework        | Pattern                                                    |
+| ---------------- | ---------------------------------------------------------- |
+| Next.js          | `NEXT_PUBLIC_*`                                            |
+| Blitz.js         | `NEXT_PUBLIC_*`                                            |
+| Vite             | `VITE_*`                                                   |
+| Create React App | `REACT_APP_*`                                              |
+| Gatsby           | `GATSBY_*`                                                 |
+| Nitro            | `NITRO_*`, `SERVER_*`, plus deploy-platform vars           |
+| Nuxt             | All Nitro vars plus `NUXT_*`, `LAUNCH_EDITOR`              |
+| Expo             | `EXPO_PUBLIC_*`                                            |
+| Astro            | `PUBLIC_*`                                                 |
+| SvelteKit        | `VITE_*`, `PUBLIC_*`                                       |
+| Redwood          | `REDWOOD_ENV_*`                                            |
+| Sanity           | `SANITY_STUDIO_*`                                          |
+| Solid            | `VITE_*`                                                   |
+| Vue              | `VUE_APP_*`, `LAUNCH_EDITOR`                               |
 
 ### Disabling Framework Inference
 

--- a/skills/turborepo/references/filtering/RULE.md
+++ b/skills/turborepo/references/filtering/RULE.md
@@ -9,7 +9,7 @@
 turbo run build test lint --affected
 ```
 
-This compares your current branch to the default branch (usually `main` or `master`) and runs tasks in:
+This compares your current branch to `main` (falling back to `master`) and runs tasks in:
 
 1. Packages with file changes
 2. Packages that depend on changed packages (dependents)
@@ -22,11 +22,13 @@ If you change `@repo/ui`, packages that import `@repo/ui` (like `apps/web`) need
 
 ```bash
 # Use a different base branch
-turbo run build --affected --affected-base=origin/develop
+TURBO_SCM_BASE=origin/develop turbo run build --affected
 
 # Use a different head (current state)
-turbo run build --affected --affected-head=HEAD~5
+TURBO_SCM_HEAD=HEAD~5 turbo run build --affected
 ```
+
+Base resolution order: `TURBO_SCM_BASE`, then the CI base ref on GitHub Actions (`GITHUB_BASE_REF` for PRs, the push event's previous SHA otherwise — errors if unresolvable rather than falling through), then the literal refs `main`, `master`. Turborepo does NOT read the repo's configured default branch — if the default branch is anything else (e.g. `develop`), set `TURBO_SCM_BASE`.
 
 ### Common CI Pattern
 
@@ -139,10 +141,10 @@ turbo run build --filter=web --filter=api   # runs in both
 
 ## Quick Reference: Changed Packages
 
-| Goal                               | Command                                                     |
-| ---------------------------------- | ----------------------------------------------------------- |
-| Changed + dependents (recommended) | `turbo run build --affected`                                |
-| Custom base branch                 | `turbo run build --affected --affected-base=origin/develop` |
-| Only changed (no dependents)       | `turbo run build --filter=[origin/main]`                    |
-| Changed + dependencies             | `turbo run build --filter=[origin/main]...`                 |
-| Since last commit                  | `turbo run build --filter=...[HEAD^1]`                      |
+| Goal                               | Command                                                    |
+| ---------------------------------- | ---------------------------------------------------------- |
+| Changed + dependents (recommended) | `turbo run build --affected`                               |
+| Custom base branch                 | `TURBO_SCM_BASE=origin/develop turbo run build --affected` |
+| Only changed (no dependents)       | `turbo run build --filter=[origin/main]`                   |
+| Changed + dependencies             | `turbo run build --filter=[origin/main]...`                |
+| Since last commit                  | `turbo run build --filter=...[HEAD^1]`                     |

--- a/skills/turborepo/references/filtering/patterns.md
+++ b/skills/turborepo/references/filtering/patterns.md
@@ -105,10 +105,12 @@ turbo run lint --filter=!legacy-app --filter=!deprecated-pkg
 
 ## Complex Combinations
 
-Apps that changed, plus their dependents:
+Separate `--filter` flags are unioned, not intersected — to intersect a directory with a git range, wrap the directory in `{}` inside a single filter.
+
+Apps that changed since the last commit:
 
 ```bash
-turbo run build --filter=...[HEAD^1] --filter=./apps/*
+turbo run build --filter={./apps/*}[HEAD^1]
 ```
 
 All packages except docs, but only if changed:
@@ -142,7 +144,7 @@ turbo run build test lint --affected
 Deploy only changed apps:
 
 ```bash
-turbo run deploy --filter=./apps/* --filter=[main...HEAD]
+turbo run deploy --filter={./apps/*}[main...HEAD]
 ```
 
 Full rebuild of specific app and deps:

--- a/skills/turborepo/references/watch/RULE.md
+++ b/skills/turborepo/references/watch/RULE.md
@@ -16,9 +16,14 @@ turbo watch build
 
 # Watch multiple tasks
 turbo watch build test lint
+
+# No tasks: lists available tasks and exits non-zero
+turbo watch
 ```
 
 Tasks re-run in order configured in `turbo.json` when source files change.
+
+By default, any file change in a package re-runs all of that package's tasks. Enable `futureFlags.watchUsingTaskInputs` in `turbo.json` to re-run only tasks whose `inputs` globs match the changed files.
 
 ## With Persistent Tasks
 


### PR DESCRIPTION
### Description

The Agent Skill in `skills/turborepo/` (installed via `npx skills add vercel/turborepo`, recommended by the [AI guide](https://turborepo.dev/docs/guides/ai)) is consumed directly by AI coding agents, so inaccuracies here propagate into real repositories as broken commands and wrong configuration. An audit of the skill against the code produced 26 verified findings; this PR fixes 25 of them. The remaining one (`$TURBO_EXTENDS$` ordering) required no change — the skill text was already correct.

**Commands that fail argument parsing:**

- `--affected-base=<ref>` / `--affected-head=<ref>` don't exist — `--affected` is a bare boolean (`crates/turborepo-lib/src/cli/args.rs`). Replaced with `TURBO_SCM_BASE` / `TURBO_SCM_HEAD` at all four sites, and documented the real base resolution: `TURBO_SCM_BASE`, then the CI base ref on GitHub Actions (`GITHUB_BASE_REF` for PRs, the push event's previous SHA otherwise), then the literal refs `main`, `master` — the repo's configured default branch is never read.
- `npx turbo-ignore --verbose` doesn't exist — replaced with the real option set from `packages/turbo-ignore/src/cli.ts` (`--task`, `--directory`, `--turbo-version`, `--max-buffer`).

**Wrong values that break configuration:**

- `remoteCache.apiUrl` default corrected to `https://vercel.com/api` (`DEFAULT_API_URL`, `crates/turborepo-config/src/lib.rs`). The client appends `/v8/artifacts/...` directly to `apiUrl`, so copying the previously documented `https://vercel.com` produces requests that miss the API mount.
- `cacheDir` default corrected from the pre-2.x `node_modules/.cache/turbo` to `.turbo/cache` (`DEFAULT_CACHE_DIR`).
- Removed the fabricated Remix → `REMIX_*` framework-inference row (no `remix` slug exists in `packages/turbo-types/src/json/frameworks.json`) and aligned the whole table with the registry (SvelteKit gains `VITE_*`; Blitz.js, Nitro, and Vue rows added).

**Wrong semantics:**

- `--ui`: `stream` is the default everywhere; `tui` is opt-in and TTY-gated. Added the third value `stream-with-experimental-timestamps`.
- `--env-mode=loose`: makes all env vars available at runtime; the set of vars whose values are hashed stays limited to declared vars.
- `--no-cache`: skips cache writes only, reads still hit (previously "skip cache entirely").
- `--graph`: bare flag prints dot to stdout, not "opens in browser"; `.png`/`.jpg`/`.pdf`/`.json` marked deprecated, `.html`/`.dot` added.
- Multiple `--filter` flags union rather than intersect — the two "changed apps" examples now use single-expression filters (`--filter={./apps/*}[HEAD^1]`).
- Global-hash list: `globalDependencies` renames to `global.inputs` (not `global.env`) under `futureFlags.globalConfiguration`; `bun.lock` added to the lockfile list (binary `bun.lockb` is unsupported).

**Missing coverage added:**

- The full public `futureFlags` set from `packages/turbo-types/src/types/config-v2.ts` (previously 3 of 12 flags).
- `--continue`'s value form (`never` | `dependencies-successful` | `always`, `=` required, bare flag means `always`), `--output-logs=hash-only`, prune's `--production`/`--out-dir`/`--use-gitignore`.
- `turbo docs`, `turbo ls`, `turbo query` entries plus one-line mentions of `devtools`/`info`/`bin`/`daemon`/`telemetry`.
- A TUI keybind table derived from `crates/turborepo-ui/src/tui/input.rs`.
- nub/aube package managers; `experimentalCargoWorkspaces`/`experimentalPythonWorkspaces`; `futureFlags.watchUsingTaskInputs` in the watch reference.

**Deprecations marked:** `--parallel`, `--remote-cache-read-only`, and `TURBO_REMOTE_ONLY`, each with its `--cache`/`TURBO_CACHE` replacement, matching the CLI's runtime warnings.

Also switched the ESLint guidance from legacy `.eslintrc.js`/ESLint 8 to flat config, matching `examples/basic/packages/eslint-config`.

### Testing Instructions

Docs-only change to `skills/turborepo/` — no code paths affected.

- `grep -rEn 'affected-base|affected-head' skills/` returns nothing.
- Spot-check corrected values against their sources: `DEFAULT_API_URL`/`DEFAULT_CACHE_DIR` in `crates/turborepo-config/src/lib.rs`, the `--continue` clap attributes in `crates/turborepo-lib/src/cli/args.rs`, the framework table against `packages/turbo-types/src/json/frameworks.json`, the `futureFlags` list against `packages/turbo-types/src/types/config-v2.ts`, the keybind table against `crates/turborepo-ui/src/tui/input.rs`.
- Commands shown in the skill parse per the CLI: `--continue=dependencies-successful` appears in the long-help snapshot (`turborepo_lib__cli__test__turbo_long_help.snap`), and `turbo prune web --production` is covered by the parse tests (`crates/turborepo-lib/src/cli/test.rs`).
