### PR TITLE
fix: Compose affected tasks with package filters

### DIFF
--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -801,19 +801,46 @@ impl RunBuilder {
             turbo_json_loader.preload_all();
         });
 
+        // When filterUsingTasks is active, --affected is handled by the
+        // same task-level filter rather than a separate codepath.
+        let use_task_level_filter = self.opts.future_flags.filter_using_tasks
+            && (!self.opts.scope_opts.filter_patterns.is_empty()
+                || self.opts.scope_opts.affected_range.is_some());
+
+        let use_task_level_affected = !use_task_level_filter
+            && self.opts.scope_opts.affected_range.is_some()
+            && self.opts.future_flags.affected_using_task_inputs;
+
+        let has_task_level_affected_package_scope = use_task_level_affected
+            && (!self.opts.scope_opts.filter_patterns.is_empty()
+                || self.opts.scope_opts.pkg_inference_root.is_some());
+
+        // Task-level affectedness replaces package-level affectedness. Resolve
+        // package constraints independently so SCM is queried only by the task
+        // detector and the final package list can come from selected tasks.
+        let package_scope_opts = use_task_level_affected.then(|| {
+            let mut opts = self.opts.clone();
+            opts.scope_opts.affected_range = None;
+            opts
+        });
+        let package_resolution_opts = package_scope_opts.as_ref().unwrap_or(&self.opts);
+
         // Resolution knowledge is complete at package-graph construction, so
         // scope filtering can read lockfile-affected packages without joining
         // deferred closure work.
-        let (filtered_pkgs, filter_mode, unqualified_entrypoint_packages) = {
+        let (mut filtered_pkgs, mut filter_mode, unqualified_entrypoint_packages) = {
             let _span = tracing::info_span!("calculate_filtered_packages").entered();
             Self::calculate_filtered_packages(
                 &self.repo_root,
-                &self.opts,
+                package_resolution_opts,
                 &pkg_dep_graph,
                 &scm,
                 &root_turbo_json,
             )?
         };
+        if use_task_level_affected {
+            filter_mode = FilterMode::ExplicitSelection;
+        }
         // The root Turbo task namespace exists independently of a root
         // JavaScript package scope. Non-root namespaces, including aggregate
         // scopes, come from authoritative repository knowledge.
@@ -845,15 +872,11 @@ impl RunBuilder {
         scoped_entrypoint_exclusions
             .retain(|task_id| !explicitly_requested_tasks.contains(task_id));
 
-        // When filterUsingTasks is active, --affected is handled by the
-        // same task-level filter rather than a separate codepath.
-        let use_task_level_filter = self.opts.future_flags.filter_using_tasks
-            && (!self.opts.scope_opts.filter_patterns.is_empty()
-                || self.opts.scope_opts.affected_range.is_some());
-
-        let use_task_level_affected = !use_task_level_filter
-            && self.opts.scope_opts.affected_range.is_some()
-            && self.opts.future_flags.affected_using_task_inputs;
+        let task_level_affected_package_scope = if has_task_level_affected_package_scope {
+            Some(filtered_pkgs.keys().cloned().collect())
+        } else {
+            None
+        };
 
         let use_watch_task_level_filter = self
             .changed_files_for_watch
@@ -1000,12 +1023,17 @@ impl RunBuilder {
 
         // Task-level --affected detection (separate from --filter).
         if use_task_level_affected {
-            engine = self.filter_engine_to_affected_tasks(
+            let (affected_engine, selected_packages) = self.filter_engine_to_affected_tasks(
                 engine,
                 &pkg_dep_graph,
                 &root_turbo_json,
                 &scm,
+                task_level_affected_package_scope.as_ref(),
             )?;
+            engine = affected_engine;
+            if let Some(selected_packages) = selected_packages {
+                filtered_pkgs.retain(|package, _| selected_packages.contains(package));
+            }
         }
 
         if needs_all_packages {
@@ -1171,7 +1199,8 @@ impl RunBuilder {
         pkg_dep_graph: &PackageGraph,
         root_turbo_json: &TurboJson,
         scm: &SCM,
-    ) -> Result<Engine, Error> {
+        package_scope: Option<&HashSet<PackageName>>,
+    ) -> Result<(Engine, Option<HashSet<PackageName>>), Error> {
         let (from_ref, to_ref) = self
             .opts
             .scope_opts
@@ -1202,7 +1231,26 @@ impl RunBuilder {
                     changed_files = changed_files.len(),
                     "task-level affected detection complete"
                 );
-                Ok(engine.retain_affected_tasks(&affected_tasks))
+                // Scope affected entrypoints before retaining their execution
+                // dependencies. Scoping the fully expanded execution graph
+                // would incorrectly promote unaffected upstream dependencies
+                // to selected tasks.
+                let mut affected_entrypoints = engine.collect_task_dependents(&affected_tasks);
+                affected_entrypoints.extend(affected_tasks);
+                if let Some(package_scope) = package_scope {
+                    let scoped_tasks = engine.task_ids_for_packages(package_scope);
+                    affected_entrypoints.retain(|task| scoped_tasks.contains(task));
+                }
+                let selected_packages = affected_entrypoints
+                    .iter()
+                    .map(|task| PackageName::from(task.package()))
+                    .collect();
+                let affected_entrypoints =
+                    super::task_filter::expand_with_siblings(&engine, affected_entrypoints);
+                Ok((
+                    engine.retain_filtered_tasks(&affected_entrypoints),
+                    Some(selected_packages),
+                ))
             }
             Err(e) => {
                 tracing::warn!(
@@ -1216,7 +1264,12 @@ impl RunBuilder {
                 )
                 .field("error", format!("{e:?}"))
                 .emit();
-                Ok(engine)
+                let Some(package_scope) = package_scope else {
+                    return Ok((engine, None));
+                };
+                let scoped_tasks = engine.task_ids_for_packages(package_scope);
+                let scoped_tasks = super::task_filter::expand_with_siblings(&engine, scoped_tasks);
+                Ok((engine.retain_filtered_tasks(&scoped_tasks), None))
             }
         }
     }

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -135,10 +135,18 @@ construction:
    Shared with `turbo query { affectedTasks }`.
 3. **Task change detection** (`turborepo-lib/src/task_change_detector.rs`):
    Determines directly affected tasks, handling global deps and per-task inputs
-4. **Engine pruning** (`Engine::retain_affected_tasks`): Returns a new engine
-   containing directly affected tasks, their transitive dependents, and all
-   transitive dependencies required for execution (upstream tasks needed as
-   cache hits)
+4. **Affected expansion**: The engine expands directly affected tasks to their
+   transitive dependents, without adding upstream execution dependencies yet.
+5. **Package scope composition**: When package scope is present, it intersects
+   with those affected entrypoints. This prevents an unaffected upstream
+   dependency from becoming selected merely because it was needed by an
+   out-of-scope task. The run's reported packages come from these selected
+   entrypoints, not from a separate package-level affected calculation.
+6. **Co-scheduled task expansion**: Selected entrypoints expand through `with`
+   relationships, which are not represented by task graph edges.
+7. **Engine pruning** (`Engine::retain_filtered_tasks`): The engine retains the
+   selected tasks and adds their transitive execution dependencies (upstream
+   tasks needed as cache hits).
 
 This differs from the default `--affected` behavior which operates at the
 package level (all tasks in changed packages run).

--- a/crates/turborepo/tests/affected_test.rs
+++ b/crates/turborepo/tests/affected_test.rs
@@ -754,7 +754,7 @@ const TURBO_JSON_WITH_TASK_INPUTS_FLAG: &str = r#"{
     },
     "test": {
       "dependsOn": ["^build"],
-      "inputs": ["$TURBO_DEFAULT$", "!**/*.md"]
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/shared.txt", "!**/*.md"]
     },
     "typecheck": {
       "dependsOn": ["^build"],
@@ -773,6 +773,7 @@ fn setup_task_level_affected(dir: &Path) {
     setup::setup_integration_test(dir, "affected_tasks_inputs", "npm@10.5.0", false).unwrap();
     // Enable the future flag before branching so it's on main.
     fs::write(dir.join("turbo.json"), TURBO_JSON_WITH_TASK_INPUTS_FLAG).unwrap();
+    fs::write(dir.join("shared.txt"), "original").unwrap();
     git(dir, &["add", "."]);
     git(
         dir,
@@ -815,6 +816,179 @@ fn test_task_level_affected_root_package_json_not_global() {
         tasks.is_empty(),
         "root package.json change should not globally affect tasks: {tasks:?}"
     );
+}
+
+#[test]
+fn test_task_level_affected_filter_limits_scheduled_tasks() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_task_level_affected(tempdir.path());
+
+    // Both independent packages are affected, but only the filtered package
+    // should remain an execution entrypoint.
+    fs::write(
+        tempdir.path().join("packages/lib-a/index.ts"),
+        "export const changed = true;",
+    )
+    .unwrap();
+    fs::write(
+        tempdir.path().join("packages/lib-no-test/index.ts"),
+        "export const changed = true;",
+    )
+    .unwrap();
+
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "run",
+            "build",
+            "--affected",
+            "--filter=lib-no-test",
+            "--dry=json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "turbo run failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let task_ids: Vec<_> = json["tasks"]
+        .as_array()
+        .expect("tasks array")
+        .iter()
+        .map(|task| task["taskId"].as_str().expect("task ID"))
+        .collect();
+    assert_eq!(task_ids, ["lib-no-test#build"]);
+}
+
+#[test]
+fn test_task_level_affected_filter_does_not_promote_execution_dependency() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_task_level_affected(tempdir.path());
+
+    // app-a#build is affected and depends on lib-a#build. Filtering to lib-a
+    // must not promote that unaffected execution dependency to an entrypoint.
+    fs::write(
+        tempdir.path().join("packages/app-a/index.ts"),
+        "export const changed = true;",
+    )
+    .unwrap();
+
+    let output = run_turbo(
+        tempdir.path(),
+        &["run", "build", "--affected", "--filter=lib-a", "--dry=json"],
+    );
+    assert!(
+        output.status.success(),
+        "turbo run failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["packages"], serde_json::json!([]));
+    assert_eq!(json["tasks"], serde_json::json!([]));
+}
+
+#[test]
+fn test_task_level_affected_filter_retains_execution_dependencies() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_task_level_affected(tempdir.path());
+
+    fs::write(
+        tempdir.path().join("packages/app-a/index.ts"),
+        "export const changed = true;",
+    )
+    .unwrap();
+
+    let output = run_turbo(
+        tempdir.path(),
+        &["run", "build", "--affected", "--filter=app-a", "--dry=json"],
+    );
+    assert!(
+        output.status.success(),
+        "turbo run failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let mut task_ids: Vec<_> = json["tasks"]
+        .as_array()
+        .expect("tasks array")
+        .iter()
+        .map(|task| task["taskId"].as_str().expect("task ID"))
+        .collect();
+    task_ids.sort_unstable();
+    assert_eq!(task_ids, ["app-a#build", "lib-a#build"]);
+}
+
+#[test]
+fn test_task_level_affected_filter_reports_task_input_package() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_task_level_affected(tempdir.path());
+
+    // This root file is not a package-level change, but it is an explicit task
+    // input for test. Task-level affectedness must drive both scheduling and
+    // the reported package list.
+    fs::write(tempdir.path().join("shared.txt"), "changed").unwrap();
+
+    let output = run_turbo(
+        tempdir.path(),
+        &["run", "test", "--affected", "--filter=lib-a", "--dry=json"],
+    );
+    assert!(
+        output.status.success(),
+        "turbo run failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["packages"], serde_json::json!(["lib-a"]));
+    let task_ids: Vec<_> = json["tasks"]
+        .as_array()
+        .expect("tasks array")
+        .iter()
+        .map(|task| task["taskId"].as_str().expect("task ID"))
+        .collect();
+    assert_eq!(task_ids, ["lib-a#test"]);
+}
+
+#[test]
+fn test_task_level_affected_respects_inferred_package_scope() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_task_level_affected(tempdir.path());
+
+    fs::write(
+        tempdir.path().join("packages/lib-a/index.ts"),
+        "export const changed = true;",
+    )
+    .unwrap();
+    fs::write(
+        tempdir.path().join("packages/lib-no-test/index.ts"),
+        "export const changed = true;",
+    )
+    .unwrap();
+
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "run",
+            "build",
+            "--affected",
+            "--pkg-inference-root=packages/lib-no-test",
+            "--dry=json",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "turbo run failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["packages"], serde_json::json!(["lib-no-test"]));
+    let task_ids: Vec<_> = json["tasks"]
+        .as_array()
+        .expect("tasks array")
+        .iter()
+        .map(|task| task["taskId"].as_str().expect("task ID"))
+        .collect();
+    assert_eq!(task_ids, ["lib-no-test#build"]);
 }
 
 #[test]


### PR DESCRIPTION
### Description

Fixes #13636.

When `affectedUsingTaskInputs` is enabled, resolve package constraints independently from affectedness, then intersect those constraints with affected task entrypoints before adding execution dependencies. This preserves affected-task provenance, prevents unaffected upstream dependencies from becoming selected, and keeps reported packages aligned with task-input-based affectedness.

The composition also preserves inferred package scope and `with` siblings, while retaining upstream tasks required for execution.

### Testing

- `cargo test --locked -p turbo --test affected_test`
- `cargo clippy --locked -p turborepo-lib -p turbo --all-targets --features rustls-tls --no-deps -- -D warnings`
- `cargo fmt --check`
- Verified the reproduction from #13636 with the locally built binary.