### PR TITLE
docs: Explain worktree cache path isolation

### DIFF
--- a/apps/docs/content/docs/crafting-your-repository/caching.mdx
+++ b/apps/docs/content/docs/crafting-your-repository/caching.mdx
@@ -171,6 +171,14 @@ When worktree cache sharing is active, you'll see a message in the output:
   use its own cache directory as specified.
 </Callout>
 
+<Callout type="warn" title="Outputs containing absolute paths">
+  Cache artifacts are restored without rewriting their contents. If a task
+  output contains the absolute path to its worktree, sharing that artifact can
+  restore an output that points to another checkout. Set an explicit
+  [`cacheDir`](/docs/reference/configuration#cachedir), such as `.turbo/cache`,
+  to keep the local cache isolated to each worktree.
+</Callout>
+
 ### With Remote Caching
 
 Git worktree cache sharing works alongside [Remote Caching](/docs/core-concepts/remote-caching). When both are enabled:

--- a/apps/docs/content/docs/reference/configuration.mdx
+++ b/apps/docs/content/docs/reference/configuration.mdx
@@ -169,8 +169,12 @@ Specify the filesystem cache directory.
   When no `cacheDir` is specified and you're working in a [Git
   worktree](https://git-scm.com/docs/git-worktree), Turborepo automatically
   shares the cache with the main worktree. This allows cache hits across
-  different branches checked out in separate worktrees. Setting an explicit
-  `cacheDir` disables this behavior.
+  different branches checked out in separate worktrees. Cache artifacts are
+  restored without rewriting their contents, so outputs containing absolute
+  worktree paths can point to another checkout after a cache hit. Setting an
+  explicit relative `cacheDir`, such as `.turbo/cache`, resolves from the root
+  of the current worktree and disables sharing, giving each worktree its own
+  local cache.
 </Callout>
 
 ### `cacheMaxAge`


### PR DESCRIPTION
## Summary

- Warn that shared worktree cache artifacts can retain absolute paths to another checkout.
- Document an explicit relative `cacheDir` as the way to isolate each worktree's local cache.
- Clarify that relative cache directories resolve from the current worktree root.

## Testing

- `pnpm --filter docs check-links`
- Pre-push `format` and `check:toml` checks

Closes #13651