### PR TITLE
fix: Upgrade brace-expansion to 5.0.9

### DIFF
--- a/packages/turbo-codemod/package.json
+++ b/packages/turbo-codemod/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^7.10.1",
-    "brace-expansion": "5.0.8",
+    "brace-expansion": "5.0.9",
     "commander": "9.5.0",
     "diff": "5.2.2",
     "find-up": "4.1.0",

--- a/packages/turbo-gen/package.json
+++ b/packages/turbo-gen/package.json
@@ -34,7 +34,7 @@
     "@types/fs-extra": "9.0.13",
     "@types/node": "18.17.4",
     "@types/validate-npm-package-name": "4.0.0",
-    "brace-expansion": "5.0.8",
+    "brace-expansion": "5.0.9",
     "commander": "10.0.0",
     "fs-extra": "10.1.0",
     "handlebars": "4.7.9",

--- a/packages/turbo-vsc/package.json
+++ b/packages/turbo-vsc/package.json
@@ -37,7 +37,7 @@
     "check-types": "tsc -p ./ --noEmit"
   },
   "dependencies": {
-    "brace-expansion": "5.0.8",
+    "brace-expansion": "5.0.9",
     "vscode-languageclient": "9.0.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -401,8 +401,8 @@ importers:
         specifier: ^7.10.1
         version: 7.10.1(@types/node@18.17.4)
       brace-expansion:
-        specifier: 5.0.8
-        version: 5.0.8
+        specifier: 5.0.9
+        version: 5.0.9
       commander:
         specifier: 9.5.0
         version: 9.5.0
@@ -529,8 +529,8 @@ importers:
         specifier: 4.0.0
         version: 4.0.0
       brace-expansion:
-        specifier: 5.0.8
-        version: 5.0.8
+        specifier: 5.0.9
+        version: 5.0.9
       commander:
         specifier: 10.0.0
         version: 10.0.0
@@ -864,8 +864,8 @@ importers:
   packages/turbo-vsc:
     dependencies:
       brace-expansion:
-        specifier: 5.0.8
-        version: 5.0.8
+        specifier: 5.0.9
+        version: 5.0.9
       vscode-languageclient:
         specifier: 9.0.1
         version: 9.0.1
@@ -5623,8 +5623,8 @@ packages:
   brace-expansion@2.1.2:
     resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -14715,7 +14715,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -17897,7 +17897,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.4:
     dependencies:
@@ -17913,7 +17913,7 @@ snapshots:
 
   minimatch@9.0.7:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## Summary

- Upgrade `brace-expansion` from 5.0.8 to 5.0.9 in `@turbo/codemod`, `@turbo/gen`, and `turbo-vsc`.
- Update the pnpm lockfile to remove the vulnerable 5.0.8 resolution.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm exec turbo run check-types test --filter=@turbo/codemod --filter=@turbo/gen --filter=turbo-vsc --ui=stream`
- `pnpm exec oxfmt --check packages/turbo-codemod/package.json packages/turbo-gen/package.json packages/turbo-vsc/package.json pnpm-lock.yaml`