### PR TITLE
refactor: Add aggregate native task support

### DIFF
--- a/crates/turborepo-engine/src/builder/definitions.rs
+++ b/crates/turborepo-engine/src/builder/definitions.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use miette::{NamedSource, SourceSpan};
 use turborepo_errors::Spanned;
 use turborepo_repository::{
-    native_tasks::NativeTaskExecution,
+    native_tasks::{NativeTaskContract, NativeTaskExecution},
     package_graph::{PackageGraph, PackageName, PackageNode},
 };
 use turborepo_task_id::{TaskId, TaskName};
@@ -29,6 +29,7 @@ pub(super) struct TaskDefMemoKey {
     task_name: TaskName<'static>,
     path_to_root: turbopath::RelativeUnixPathBuf,
     native_execution: NativeTaskExecution,
+    native_contract: Option<NativeTaskContract>,
     authored_task: bool,
     registered_task: bool,
 }
@@ -252,9 +253,11 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         // global input files — they don't execute, and including the files
         // would cause their hash to change and cascade into downstream
         // tasks that depend on them.
-        let mut native_execution = package_context
+        let native_task = package_context
             .as_ref()
-            .and_then(|context| context.native_tasks().get(task_id.task()))
+            .and_then(|context| context.native_tasks().get(task_id.task()));
+        let native_contract = native_task.map(|task| task.contract().clone());
+        let mut native_execution = native_task
             .map(|task| task.execution().clone())
             .unwrap_or(NativeTaskExecution::None);
         if task_is_excluded(&turbo_json_chain, task_id.as_inner(), task_name) {
@@ -283,9 +286,16 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
                     .get(&task_id.as_inner().as_task_name())
                     .is_some()
             });
-            let memoizable_contract = package_context
-                .as_ref()
-                .is_none_or(|context| !context.task_contract().derives_io());
+            let memoizable_contract = package_context.as_ref().is_none_or(|context| {
+                !native_contract.as_ref().map_or_else(
+                    || {
+                        context
+                            .task_contract()
+                            .derives_task_io(task_id.as_inner().task())
+                    },
+                    NativeTaskContract::derives_io,
+                )
+            });
             (!package_scoped && memoizable_contract).then(|| TaskDefMemoKey {
                 chain: turbo_json_chain
                     .iter()
@@ -294,6 +304,7 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
                 task_name: task_name.clone().into_owned(),
                 path_to_root: path_to_root.clone(),
                 native_execution: native_execution.clone(),
+                native_contract: native_contract.clone(),
                 authored_task,
                 registered_task,
             })
@@ -347,9 +358,14 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         if should_apply_toolchain_defaults(command_override.as_ref())
             && let Some(context) = package_context.as_ref()
         {
-            let defaults = context
-                .task_contract()
-                .defaults_for_task(task_id.as_inner().task());
+            let defaults = native_contract
+                .as_ref()
+                .map(|contract| contract.defaults().clone())
+                .unwrap_or_else(|| {
+                    context
+                        .task_contract()
+                        .defaults_for_task(task_id.as_inner().task())
+                });
             if processed_task_definition.cache.is_none() {
                 processed_task_definition.cache = defaults.cache.map(Spanned::new);
             }
@@ -426,9 +442,14 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         // `$TURBO_DEFAULT$` take full control.
         if inherits_toolchain_task_io(task_def.command.as_ref())
             && let Some(package_context) = package_context.as_ref().filter(|context| {
-                context
-                    .task_contract()
-                    .derives_task_io(task_id.as_inner().task())
+                native_contract.as_ref().map_or_else(
+                    || {
+                        context
+                            .task_contract()
+                            .derives_task_io(task_id.as_inner().task())
+                    },
+                    NativeTaskContract::derives_io,
+                )
             })
         {
             let wants_automatic_inputs = !had_explicit_inputs || task_def.inputs.default;

--- a/crates/turborepo-engine/src/builder/definitions.rs
+++ b/crates/turborepo-engine/src/builder/definitions.rs
@@ -2,7 +2,10 @@ use std::collections::{HashMap, HashSet};
 
 use miette::{NamedSource, SourceSpan};
 use turborepo_errors::Spanned;
-use turborepo_repository::package_graph::{PackageGraph, PackageName, PackageNode};
+use turborepo_repository::{
+    native_tasks::NativeTaskExecution,
+    package_graph::{PackageGraph, PackageName, PackageNode},
+};
 use turborepo_task_id::{TaskId, TaskName};
 use turborepo_turbo_json::{
     HasConfigBeyondExtends, ProcessedCommand, ProcessedTaskDefinition, RawTaskDefinition, TurboJson,
@@ -17,15 +20,17 @@ use crate::{
 
 /// Memo key for resolved task definitions: the turbo.json chain (by
 /// address; loader-owned for the duration of a build), the task name, and
-/// the two package-dependent inputs that survive resolution — path to the
-/// repo root and whether the package's toolchain defines a command for the
-/// task. See `task_definition_cached`.
+/// the package-dependent inputs that survive resolution: path to the repo
+/// root and the native task's execution/definition facts. See
+/// `task_definition_cached`.
 #[derive(PartialEq, Eq, Hash)]
 pub(super) struct TaskDefMemoKey {
     chain: Vec<usize>,
     task_name: TaskName<'static>,
     path_to_root: turbopath::RelativeUnixPathBuf,
-    defines_task: bool,
+    native_execution: NativeTaskExecution,
+    authored_task: bool,
+    registered_task: bool,
 }
 
 impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
@@ -247,18 +252,27 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         // global input files — they don't execute, and including the files
         // would cause their hash to change and cascade into downstream
         // tasks that depend on them.
-        let defines_task = package_context
+        let mut native_execution = package_context
             .as_ref()
-            .is_some_and(|context| context.native_tasks().defines(task_id.task()));
+            .and_then(|context| context.native_tasks().get(task_id.task()))
+            .map(|task| task.execution().clone())
+            .unwrap_or(NativeTaskExecution::None);
+        if task_is_excluded(&turbo_json_chain, task_id.as_inner(), task_name) {
+            native_execution = NativeTaskExecution::None;
+        }
+        let defines_task = matches!(native_execution, NativeTaskExecution::Command(_));
         let registered_task = package_context
             .as_ref()
             .is_some_and(|context| context.native_tasks().registers(task_id.task()));
+        let authored_task = package_context
+            .as_ref()
+            .is_some_and(|context| context.native_tasks().authors(task_id.task()));
 
         // Most tasks resolve to an identical definition: the same turbo.json
         // chain and task name, differing only by the package's depth (for
-        // `$TURBO_ROOT$`/global-input anchoring) and whether the package's
-        // toolchain defines a command for the task. Memoize on exactly
-        // those inputs. Two exceptions must skip the memo: a package-scoped
+        // `$TURBO_ROOT$`/global-input anchoring) and native execution facts.
+        // Memoize on exactly those inputs. Two exceptions must skip the memo:
+        // a package-scoped
         // task key (`web#build`) in the chain, which `TurboJson::task`
         // consults first, and packages whose toolchain derives per-package
         // hash wiring (e.g. Cargo crate closures differ per crate).
@@ -279,7 +293,9 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
                     .collect(),
                 task_name: task_name.clone().into_owned(),
                 path_to_root: path_to_root.clone(),
-                defines_task,
+                native_execution: native_execution.clone(),
+                authored_task,
+                registered_task,
             })
         };
         if let Some(key) = &memo_key
@@ -317,12 +333,9 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         let command_override = resolve_command_override(
             scoped_command,
             unscoped_command,
-            package_context.as_ref().map(|context| {
-                (
-                    context.task_contract(),
-                    context.native_tasks().authors(task_id.as_inner().task()),
-                )
-            }),
+            package_context
+                .as_ref()
+                .map(|context| (context.task_contract(), authored_task)),
         );
 
         let mut processed_task_definition = ProcessedTaskDefinition::from_iter(
@@ -346,6 +359,31 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         let mut task_def =
             TaskDefinition::from_processed(processed_task_definition, &path_to_root)?;
         task_def.command = command_override;
+
+        if task_def.command.is_none()
+            && let NativeTaskExecution::Aggregate(dependencies) = &native_execution
+        {
+            let task_args = TaskArgs::new(&self.pass_through_args, &self.requested_tasks);
+            if task_args.args_for_task(task_id.as_inner()).is_some() {
+                return Err(BuilderError::AggregatePassThrough {
+                    task_id: task_id.to_string(),
+                    package: task_id.package().to_string(),
+                });
+            }
+            let mut seen: HashSet<String> = task_def
+                .task_dependencies
+                .iter()
+                .map(|dependency| dependency.task().to_string())
+                .collect();
+            task_def.task_dependencies.extend(
+                dependencies
+                    .iter()
+                    .filter(|dependency| seen.insert((*dependency).clone()))
+                    .map(|dependency| {
+                        Spanned::new(TaskName::from(dependency.clone()).into_owned())
+                    }),
+            );
+        }
 
         if !self.future_flags.incremental_tasks {
             task_def.incremental = None;
@@ -696,6 +734,29 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
 
         Ok(turbo_jsons.into_iter().rev().collect())
     }
+}
+
+fn task_is_excluded(
+    turbo_json_chain: &[&TurboJson],
+    task_id: &TaskId,
+    task_name: &TaskName,
+) -> bool {
+    let task_id_name = task_id.as_task_name();
+    let base_name = TaskName::from(task_name.task());
+    turbo_json_chain.iter().rev().find_map(|turbo_json| {
+        turbo_json
+            .tasks
+            .get(&task_id_name)
+            .or_else(|| turbo_json.tasks.get(task_name))
+            .or_else(|| turbo_json.tasks.get(&base_name))
+            .map(|definition| {
+                definition
+                    .extends
+                    .as_ref()
+                    .is_some_and(|extends| !*extends.as_inner())
+                    && !definition.has_config_beyond_extends()
+            })
+    }) == Some(true)
 }
 
 /// Resolve a task's `command` override across the five precedence levels

--- a/crates/turborepo-engine/src/builder/definitions.rs
+++ b/crates/turborepo-engine/src/builder/definitions.rs
@@ -365,20 +365,31 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         {
             let task_args = TaskArgs::new(&self.pass_through_args, &self.requested_tasks);
             if task_args.args_for_task(task_id.as_inner()).is_some() {
+                let alternatives = dependencies
+                    .iter()
+                    .map(|dependency| format!("{}#{dependency}", task_id.package()))
+                    .collect::<Vec<_>>()
+                    .join(", ");
                 return Err(BuilderError::AggregatePassThrough {
                     task_id: task_id.to_string(),
-                    package: task_id.package().to_string(),
+                    alternatives,
                 });
             }
             let mut seen: HashSet<String> = task_def
                 .task_dependencies
                 .iter()
-                .map(|dependency| dependency.task().to_string())
+                .map(|dependency| {
+                    format!(
+                        "{}#{}",
+                        dependency.package().unwrap_or(task_id.package()),
+                        dependency.task()
+                    )
+                })
                 .collect();
             task_def.task_dependencies.extend(
                 dependencies
                     .iter()
-                    .filter(|dependency| seen.insert((*dependency).clone()))
+                    .filter(|dependency| seen.insert(format!("{}#{dependency}", task_id.package())))
                     .map(|dependency| {
                         Spanned::new(TaskName::from(dependency.clone()).into_owned())
                     }),
@@ -525,12 +536,6 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         should_validate_engine: bool,
         registered_task: bool,
     ) -> Result<Vec<(ProcessedTaskDefinition, bool)>, BuilderError> {
-        let root_used_scoped_key = |turbo_json: &TurboJson| {
-            turbo_json
-                .tasks
-                .get(&task_id.as_inner().as_task_name())
-                .is_some()
-        };
         let mut task_definitions = Vec::new();
 
         // Find the first package in the chain (iterating in reverse from leaf to root)
@@ -538,7 +543,8 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         // packages.
         let mut extends_false_index: Option<usize> = None;
         for (index, turbo_json) in turbo_json_chain.iter().enumerate().rev() {
-            if let Some(task_def) = turbo_json.tasks.get(task_name)
+            if let Some(key) = configured_task_key(turbo_json, task_id, task_name)
+                && let Some(task_def) = turbo_json.tasks.get(&key)
                 && task_def
                     .extends
                     .as_ref()
@@ -554,15 +560,18 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         // If we found extends: false, only process from that point onwards
         if let Some(index) = extends_false_index {
             if let Some(turbo_json) = turbo_json_chain.get(index)
-                && let Some(local_def) = turbo_json.task(task_id, task_name)?
+                && let Some(key) = configured_task_key(turbo_json, task_id, task_name)
+                && let Some(local_def) = turbo_json.task(task_id, &key)?
                 && local_def.has_config_beyond_extends()
             {
-                let scoped = index > 0 || root_used_scoped_key(turbo_json);
+                let scoped = index > 0 || key.is_package_task();
                 task_definitions.push((local_def, scoped));
             }
             // Process any packages after this one (towards the leaf)
             for turbo_json in turbo_json_chain.iter().skip(index + 1) {
-                if let Some(workspace_def) = turbo_json.task(task_id, task_name)? {
+                if let Some(key) = configured_task_key(turbo_json, task_id, task_name)
+                    && let Some(workspace_def) = turbo_json.task(task_id, &key)?
+                {
                     task_definitions.push((workspace_def, true));
                 }
             }
@@ -573,9 +582,10 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         let mut turbo_json_chain = turbo_json_chain.into_iter();
 
         if let Some(root_turbo_json) = turbo_json_chain.next()
-            && let Some(root_definition) = root_turbo_json.task(task_id, task_name)?
+            && let Some(key) = configured_task_key(root_turbo_json, task_id, task_name)
+            && let Some(root_definition) = root_turbo_json.task(task_id, &key)?
         {
-            let scoped = root_used_scoped_key(root_turbo_json);
+            let scoped = key.is_package_task();
             task_definitions.push((root_definition, scoped))
         }
 
@@ -596,7 +606,9 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         }
 
         for turbo_json in turbo_json_chain {
-            if let Some(workspace_def) = turbo_json.task(task_id, task_name)? {
+            if let Some(key) = configured_task_key(turbo_json, task_id, task_name)
+                && let Some(workspace_def) = turbo_json.task(task_id, &key)?
+            {
                 task_definitions.push((workspace_def, true));
             }
         }
@@ -741,22 +753,30 @@ fn task_is_excluded(
     task_id: &TaskId,
     task_name: &TaskName,
 ) -> bool {
-    let task_id_name = task_id.as_task_name();
-    let base_name = TaskName::from(task_name.task());
     turbo_json_chain.iter().rev().find_map(|turbo_json| {
-        turbo_json
-            .tasks
-            .get(&task_id_name)
-            .or_else(|| turbo_json.tasks.get(task_name))
-            .or_else(|| turbo_json.tasks.get(&base_name))
-            .map(|definition| {
+        configured_task_key(turbo_json, task_id, task_name).and_then(|key| {
+            turbo_json.tasks.get(&key).map(|definition| {
                 definition
                     .extends
                     .as_ref()
                     .is_some_and(|extends| !*extends.as_inner())
                     && !definition.has_config_beyond_extends()
             })
+        })
     }) == Some(true)
+}
+
+fn configured_task_key(
+    turbo_json: &TurboJson,
+    task_id: &TaskId,
+    task_name: &TaskName,
+) -> Option<TaskName<'static>> {
+    let scoped = task_id.as_task_name();
+    let base = TaskName::from(task_name.task());
+    [&scoped, task_name, &base]
+        .into_iter()
+        .find(|key| turbo_json.tasks.contains_key(*key))
+        .map(|key| key.clone().into_owned())
 }
 
 /// Resolve a task's `command` override across the five precedence levels

--- a/crates/turborepo-engine/src/builder/test.rs
+++ b/crates/turborepo-engine/src/builder/test.rs
@@ -12,6 +12,9 @@ use turborepo_errors::Spanned;
 use turborepo_lockfiles::Lockfile;
 use turborepo_repository::{
     discovery::PackageDiscovery,
+    native_tasks::{
+        NativeCommandArguments, NativeCommandProgram, NativeTask, WorkingDirectoryPolicy,
+    },
     package_graph::{PackageGraph, PackageName, ROOT_PKG_NAME},
     package_json::PackageJson,
     package_manager::PackageManager,
@@ -130,16 +133,60 @@ impl RepositoryContributor for AggregateContributor {
 
     fn discover_packages(&self) -> DiscoverPackagesFuture<'_> {
         Box::pin(async move {
+            let command = |name: &str| {
+                NativeTask::command_task(
+                    name,
+                    format!("tool {name}"),
+                    NativeCommandProgram::Tool("tool".to_string()),
+                    NativeCommandArguments::new(vec![name.to_string()]),
+                    None,
+                    WorkingDirectoryPolicy::RepositoryRoot,
+                )
+            };
             Ok(DiscoveredPackages::new(
-                vec![DiscoveredPackage::aggregate(
-                    "cargo-workspace".to_owned(),
-                    PackageJson::default(),
-                    self.repo_root.join_component("Cargo.toml"),
-                )],
+                vec![
+                    DiscoveredPackage::aggregate(
+                        "cargo-workspace".to_owned(),
+                        PackageJson::default(),
+                        self.repo_root.join_component("Cargo.toml"),
+                    )
+                    .with_native_tasks(vec![
+                        NativeTask::aggregate("all", ["check", "lint"]),
+                        command("check"),
+                        command("lint"),
+                    ]),
+                    DiscoveredPackage::aggregate(
+                        "other-workspace".to_owned(),
+                        PackageJson::default(),
+                        self.repo_root.join_component("Other.toml"),
+                    )
+                    .with_native_tasks(vec![
+                        NativeTask::aggregate("all", ["check"]),
+                        command("check"),
+                    ]),
+                ],
                 vec![WorkspaceRoot::new("aggregate-test", self.repo_root.clone())],
             ))
         })
     }
+}
+
+fn mock_aggregate_package_graph(repo_root: &AbsoluteSystemPathBuf) -> PackageGraph {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    runtime
+        .block_on(
+            PackageGraph::builder_optional(repo_root, None)
+                .with_package_discovery(MockDiscovery)
+                .with_package_jsons(Some(HashMap::new()))
+                .with_contributor(Arc::new(AggregateContributor {
+                    repo_root: repo_root.clone(),
+                }))
+                .build(),
+        )
+        .unwrap()
 }
 
 type StubIOEngineResult = Engine<Built, TaskDefinition>;

--- a/crates/turborepo-engine/src/builder/test/core.rs
+++ b/crates/turborepo-engine/src/builder/test/core.rs
@@ -50,6 +50,163 @@ fn test_default_engine() {
     assert_eq!(all_dependencies(&engine), expected);
 }
 
+fn aggregate_engine(
+    repo_root: &AbsoluteSystemPathBuf,
+    root_config: serde_json::Value,
+    aggregate_config: Option<serde_json::Value>,
+    pass_through_args: Vec<String>,
+) -> Result<Engine<Built, TaskDefinition>, BuilderError> {
+    let package_graph = mock_aggregate_package_graph(repo_root);
+    let flags = FutureFlags {
+        experimental_task_command: true,
+        ..Default::default()
+    };
+    let mut root_config = turbo_json(root_config);
+    root_config.future_flags = flags;
+    let mut configs = HashMap::from([(PackageName::Root, root_config)]);
+    if let Some(config) = aggregate_config {
+        let mut config = turbo_json(config);
+        config.future_flags = flags;
+        configs.insert(PackageName::from("cargo-workspace"), config);
+    }
+    EngineBuilder::new(
+        repo_root,
+        &package_graph,
+        &TestTurboJsonLoader::new(configs),
+        false,
+    )
+    .with_tasks(Some(Spanned::new(TaskName::from("all"))))
+    .with_workspaces(vec![PackageName::from("cargo-workspace")])
+    .with_task_io_context(pass_through_args, vec!["all".to_string()], HashMap::new())
+    .with_future_flags(flags)
+    .build()
+}
+
+#[test]
+fn native_aggregate_composes_same_scope_dependencies_and_deduplicates() {
+    let repo = TempDir::new().unwrap();
+    let repo_root = AbsoluteSystemPathBuf::try_from(repo.path().to_path_buf()).unwrap();
+    let engine = aggregate_engine(
+        &repo_root,
+        json!({ "tasks": { "all": { "dependsOn": ["check"] } } }),
+        None,
+        Vec::new(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        all_dependencies(&engine),
+        deps! {
+            "cargo-workspace#all" => ["cargo-workspace#check", "cargo-workspace#lint"],
+            "cargo-workspace#check" => ["___ROOT___"],
+            "cargo-workspace#lint" => ["___ROOT___"]
+        }
+    );
+}
+
+#[test]
+fn native_aggregate_execution_is_part_of_definition_memoization() {
+    let repo = TempDir::new().unwrap();
+    let repo_root = AbsoluteSystemPathBuf::try_from(repo.path().to_path_buf()).unwrap();
+    let package_graph = mock_aggregate_package_graph(&repo_root);
+    let loader = TestTurboJsonLoader::new(HashMap::from([(
+        PackageName::Root,
+        turbo_json(json!({ "tasks": {} })),
+    )]));
+    let engine = EngineBuilder::new(&repo_root, &package_graph, &loader, false)
+        .with_tasks(Some(Spanned::new(TaskName::from("all"))))
+        .with_workspaces(vec![
+            PackageName::from("cargo-workspace"),
+            PackageName::from("other-workspace"),
+        ])
+        .build()
+        .unwrap();
+
+    assert_eq!(
+        all_dependencies(&engine),
+        deps! {
+            "cargo-workspace#all" => ["cargo-workspace#check", "cargo-workspace#lint"],
+            "cargo-workspace#check" => ["___ROOT___"],
+            "cargo-workspace#lint" => ["___ROOT___"],
+            "other-workspace#all" => ["other-workspace#check"],
+            "other-workspace#check" => ["___ROOT___"]
+        }
+    );
+}
+
+#[test]
+fn native_aggregate_dependencies_participate_in_cycle_validation() {
+    let repo = TempDir::new().unwrap();
+    let repo_root = AbsoluteSystemPathBuf::try_from(repo.path().to_path_buf()).unwrap();
+    let error = aggregate_engine(
+        &repo_root,
+        json!({ "tasks": { "check": { "dependsOn": ["all"] } } }),
+        None,
+        Vec::new(),
+    )
+    .unwrap_err();
+
+    assert!(matches!(error, BuilderError::Graph(_)), "got {error:?}");
+}
+
+#[test]
+fn command_override_and_opt_out_disable_native_aggregate_dependencies() {
+    for command in [json!(["echo", "all"]), serde_json::Value::Null] {
+        let repo = TempDir::new().unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo.path().to_path_buf()).unwrap();
+        let engine = aggregate_engine(
+            &repo_root,
+            json!({
+                "tasks": {
+                    "cargo-workspace#all": { "command": command }
+                }
+            }),
+            None,
+            Vec::new(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            all_dependencies(&engine),
+            deps! { "cargo-workspace#all" => ["___ROOT___"] }
+        );
+    }
+}
+
+#[test]
+fn extends_false_preserves_native_aggregate_opt_out() {
+    let repo = TempDir::new().unwrap();
+    let repo_root = AbsoluteSystemPathBuf::try_from(repo.path().to_path_buf()).unwrap();
+    let engine = aggregate_engine(
+        &repo_root,
+        json!({ "tasks": { "all": {} } }),
+        Some(json!({
+            "extends": ["//"],
+            "tasks": { "all": { "extends": false } }
+        })),
+        Vec::new(),
+    )
+    .unwrap();
+
+    assert!(all_dependencies(&engine).is_empty());
+}
+
+#[test]
+fn native_aggregate_rejects_pass_through_arguments_with_qualified_guidance() {
+    let repo = TempDir::new().unwrap();
+    let repo_root = AbsoluteSystemPathBuf::try_from(repo.path().to_path_buf()).unwrap();
+    let error = aggregate_engine(
+        &repo_root,
+        json!({ "tasks": {} }),
+        None,
+        vec!["--fix".to_string()],
+    )
+    .unwrap_err();
+
+    assert!(matches!(error, BuilderError::AggregatePassThrough { .. }));
+    assert!(error.to_string().contains("cargo-workspace#<task>"));
+}
+
 #[test]
 fn test_dependencies_on_unspecified_packages() {
     let repo_root_dir = TempDir::with_prefix("repo").unwrap();

--- a/crates/turborepo-engine/src/builder/test/core.rs
+++ b/crates/turborepo-engine/src/builder/test/core.rs
@@ -56,6 +56,22 @@ fn aggregate_engine(
     aggregate_config: Option<serde_json::Value>,
     pass_through_args: Vec<String>,
 ) -> Result<Engine<Built, TaskDefinition>, BuilderError> {
+    aggregate_engine_for_task(
+        repo_root,
+        root_config,
+        aggregate_config,
+        pass_through_args,
+        "all",
+    )
+}
+
+fn aggregate_engine_for_task(
+    repo_root: &AbsoluteSystemPathBuf,
+    root_config: serde_json::Value,
+    aggregate_config: Option<serde_json::Value>,
+    pass_through_args: Vec<String>,
+    task: &str,
+) -> Result<Engine<Built, TaskDefinition>, BuilderError> {
     let package_graph = mock_aggregate_package_graph(repo_root);
     let flags = FutureFlags {
         experimental_task_command: true,
@@ -75,9 +91,9 @@ fn aggregate_engine(
         &TestTurboJsonLoader::new(configs),
         false,
     )
-    .with_tasks(Some(Spanned::new(TaskName::from("all"))))
+    .with_tasks(Some(Spanned::new(TaskName::from(task).into_owned())))
     .with_workspaces(vec![PackageName::from("cargo-workspace")])
-    .with_task_io_context(pass_through_args, vec!["all".to_string()], HashMap::new())
+    .with_task_io_context(pass_through_args, vec![task.to_string()], HashMap::new())
     .with_future_flags(flags)
     .build()
 }
@@ -100,6 +116,29 @@ fn native_aggregate_composes_same_scope_dependencies_and_deduplicates() {
             "cargo-workspace#all" => ["cargo-workspace#check", "cargo-workspace#lint"],
             "cargo-workspace#check" => ["___ROOT___"],
             "cargo-workspace#lint" => ["___ROOT___"]
+        }
+    );
+}
+
+#[test]
+fn native_aggregate_dedupe_uses_effective_same_scope_task_id() {
+    let repo = TempDir::new().unwrap();
+    let repo_root = AbsoluteSystemPathBuf::try_from(repo.path().to_path_buf()).unwrap();
+    let engine = aggregate_engine(
+        &repo_root,
+        json!({ "tasks": { "all": { "dependsOn": ["other-workspace#check"] } } }),
+        None,
+        Vec::new(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        all_dependencies(&engine),
+        deps! {
+            "cargo-workspace#all" => ["cargo-workspace#check", "cargo-workspace#lint", "other-workspace#check"],
+            "cargo-workspace#check" => ["___ROOT___"],
+            "cargo-workspace#lint" => ["___ROOT___"],
+            "other-workspace#check" => ["___ROOT___"]
         }
     );
 }
@@ -192,6 +231,49 @@ fn extends_false_preserves_native_aggregate_opt_out() {
 }
 
 #[test]
+fn qualified_extends_false_suppresses_and_scoped_config_readds_native_aggregate() {
+    let repo = TempDir::new().unwrap();
+    let repo_root = AbsoluteSystemPathBuf::try_from(repo.path().to_path_buf()).unwrap();
+    let suppressed = aggregate_engine_for_task(
+        &repo_root,
+        json!({ "tasks": {} }),
+        Some(json!({
+            "extends": ["//"],
+            "tasks": { "all": { "extends": false } }
+        })),
+        Vec::new(),
+        "cargo-workspace#all",
+    )
+    .unwrap();
+    assert!(all_dependencies(&suppressed).is_empty());
+
+    let readded = aggregate_engine_for_task(
+        &repo_root,
+        json!({ "tasks": {} }),
+        Some(json!({
+            "extends": ["//"],
+            "tasks": {
+                "all": {
+                    "extends": false,
+                    "dependsOn": ["check"]
+                }
+            }
+        })),
+        Vec::new(),
+        "cargo-workspace#all",
+    )
+    .unwrap();
+    assert_eq!(
+        all_dependencies(&readded),
+        deps! {
+            "cargo-workspace#all" => ["cargo-workspace#check", "cargo-workspace#lint"],
+            "cargo-workspace#check" => ["___ROOT___"],
+            "cargo-workspace#lint" => ["___ROOT___"]
+        }
+    );
+}
+
+#[test]
 fn native_aggregate_rejects_pass_through_arguments_with_qualified_guidance() {
     let repo = TempDir::new().unwrap();
     let repo_root = AbsoluteSystemPathBuf::try_from(repo.path().to_path_buf()).unwrap();
@@ -204,7 +286,9 @@ fn native_aggregate_rejects_pass_through_arguments_with_qualified_guidance() {
     .unwrap_err();
 
     assert!(matches!(error, BuilderError::AggregatePassThrough { .. }));
-    assert!(error.to_string().contains("cargo-workspace#<task>"));
+    let message = error.to_string();
+    assert!(message.contains("cargo-workspace#check"));
+    assert!(message.contains("cargo-workspace#lint"));
 }
 
 #[test]

--- a/crates/turborepo-engine/src/builder_error.rs
+++ b/crates/turborepo-engine/src/builder_error.rs
@@ -61,6 +61,12 @@ pub enum Error {
     InvalidTaskName(Box<InvalidTaskNameError>),
     #[error("Engine builder cannot be constructed without a turbo.json loader")]
     MissingTurboJsonLoader,
+    #[error(
+        "Cannot pass arguments to aggregate task `{task_id}` because it does not run a process. \
+         Run a qualified dependency task instead, for example `turbo run {package}#<task> -- \
+         <args>`."
+    )]
+    AggregatePassThrough { task_id: String, package: String },
 }
 
 impl From<ValidateError> for Error {

--- a/crates/turborepo-engine/src/builder_error.rs
+++ b/crates/turborepo-engine/src/builder_error.rs
@@ -63,10 +63,12 @@ pub enum Error {
     MissingTurboJsonLoader,
     #[error(
         "Cannot pass arguments to aggregate task `{task_id}` because it does not run a process. \
-         Run a qualified dependency task instead, for example `turbo run {package}#<task> -- \
-         <args>`."
+         Run one of its qualified dependency tasks instead: {alternatives}."
     )]
-    AggregatePassThrough { task_id: String, package: String },
+    AggregatePassThrough {
+        task_id: String,
+        alternatives: String,
+    },
 }
 
 impl From<ValidateError> for Error {

--- a/crates/turborepo-lib/src/devtools.rs
+++ b/crates/turborepo-lib/src/devtools.rs
@@ -91,7 +91,7 @@ impl ProperTaskGraphBuilder {
                             .native_tasks()
                             .tasks()
                             .iter()
-                            .filter(|task| task.executable() || task.authored())
+                            .filter(|task| task.participates() || task.authored())
                             .map(|task| task.name().to_string())
                             .collect()
                     })

--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -94,6 +94,25 @@ pub(crate) fn task_has_command(
     }
 }
 
+pub(crate) fn task_participates(
+    engine: &Engine<Built>,
+    package_graph: &PackageGraph,
+    task: &TaskId<'static>,
+) -> bool {
+    let Some(context) = package_graph.package_task_context(&PackageName::from(task.package()))
+    else {
+        return false;
+    };
+    match engine
+        .task_definition(task)
+        .and_then(|definition| definition.command.as_ref())
+    {
+        Some(turborepo_types::TaskCommandOverride::Argv(_)) => true,
+        Some(turborepo_types::TaskCommandOverride::OptOut) => false,
+        None => context.native_tasks().participates(task.task()),
+    }
+}
+
 impl EngineExt for Engine<Built> {
     fn tasks_with_command(&self, pkg_graph: &PackageGraph) -> Vec<String> {
         self.tasks()

--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -457,7 +457,7 @@ impl Subscriber {
                         .native_tasks()
                         .tasks()
                         .iter()
-                        .filter(|task| task.executable() || task.authored())
+                        .filter(|task| task.participates() || task.authored())
                         .map(|task| task.name().to_string())
                         .collect()
                 })

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -732,7 +732,7 @@ impl RunBuilder {
                             .native_tasks()
                             .tasks()
                             .iter()
-                            .filter(|task| task.executable() || task.authored())
+                            .filter(|task| task.participates() || task.authored())
                             .map(|task| task.name().to_string())
                             .collect::<Vec<_>>()
                     })
@@ -754,7 +754,7 @@ impl RunBuilder {
                             .native_tasks()
                             .tasks()
                             .iter()
-                            .filter(|task| task.executable() || task.authored())
+                            .filter(|task| task.participates() || task.authored())
                             .map(|task| task.name().to_string())
                             .collect();
                         Ok((package, scripts))
@@ -1326,12 +1326,12 @@ impl RunBuilder {
                 continue;
             }
 
-            let has_command = pkg_dep_graph
+            let has_participant = pkg_dep_graph
                 .package_task_contexts()
-                .any(|context| context.native_tasks().defines(task.task()))
+                .any(|context| context.native_tasks().participates(task.task()))
                 || engine.task_ids().any(|task_id| {
                     task_id.task() == task.task()
-                        && task_has_command(engine, pkg_dep_graph, task_id)
+                        && crate::engine::task_participates(engine, pkg_dep_graph, task_id)
                 });
 
             for package in candidate_packages {
@@ -1341,9 +1341,11 @@ impl RunBuilder {
                 }
 
                 selection.candidates.insert(task_id.clone());
-                if !has_command || task_has_command(engine, pkg_dep_graph, &task_id) {
+                if !has_participant
+                    || crate::engine::task_participates(engine, pkg_dep_graph, &task_id)
+                {
                     selection.selected.insert(task_id.clone());
-                    if !has_command {
+                    if !has_participant {
                         selection
                             .orchestration
                             .entry(task.task().to_string())

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -522,7 +522,7 @@ impl Run {
             // Authored scripts and registered native tasks both come from the
             // native-task catalog produced at repository construction.
             for native_task in context.native_tasks().tasks() {
-                if !native_task.executable() && !native_task.registered() {
+                if !native_task.participates() && !native_task.registered() {
                     continue;
                 }
                 tasks

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -464,11 +464,11 @@ pub fn native_tasks_for_package(
     package: &str,
 ) -> Vec<crate::native_tasks::NativeTask> {
     use crate::native_tasks::{
-        NativeCommandArguments, NativeCommandProgram, NativeTask, PassThroughPlacement,
-        PassThroughSeparator, WorkingDirectoryPolicy,
+        NativeCommandArguments, NativeCommandProgram, NativeTask, NativeTaskContract,
+        PassThroughPlacement, PassThroughSeparator, WorkingDirectoryPolicy,
     };
 
-    registered_tasks(details)
+    let mut tasks: Vec<_> = registered_tasks(details)
         .into_iter()
         .filter_map(|task| {
             let subcommand = task_subcommand(details.kind, task)?;
@@ -480,25 +480,68 @@ pub fn native_tasks_for_package(
                     format!("--package={package}")
                 }
             };
-            Some(NativeTask::command_task(
-                task,
-                display,
-                NativeCommandProgram::Tool("cargo".to_string()),
-                NativeCommandArguments {
-                    prefix: vec![subcommand.to_string(), scope_arg],
-                    pass_through_placement: PassThroughPlacement::AfterSuffix,
-                    pass_through_separator: pass_through_uses_separator(subcommand)
-                        .then(|| PassThroughSeparator::Fixed("--".to_string())),
-                    suffix: (subcommand != "fmt")
-                        .then(|| "--locked".to_string())
-                        .into_iter()
-                        .collect(),
-                },
-                (!matches!(subcommand, "run" | "fmt")).then(|| "cargo".to_string()),
-                WorkingDirectoryPolicy::RepositoryRoot,
-            ))
+            Some(
+                NativeTask::command_task(
+                    task,
+                    display,
+                    NativeCommandProgram::Tool("cargo".to_string()),
+                    NativeCommandArguments {
+                        prefix: vec![subcommand.to_string(), scope_arg],
+                        pass_through_placement: PassThroughPlacement::AfterSuffix,
+                        pass_through_separator: pass_through_uses_separator(subcommand)
+                            .then(|| PassThroughSeparator::Fixed("--".to_string())),
+                        suffix: (subcommand != "fmt")
+                            .then(|| "--locked".to_string())
+                            .into_iter()
+                            .collect(),
+                    },
+                    (!matches!(subcommand, "run" | "fmt")).then(|| "cargo".to_string()),
+                    WorkingDirectoryPolicy::RepositoryRoot,
+                )
+                .with_contract(NativeTaskContract::new(
+                    cargo_task_defaults(details, task),
+                    cargo_task_entrypoint(details.kind, task),
+                    true,
+                )),
+            )
         })
-        .collect()
+        .collect();
+    if !tasks.iter().any(|task| task.name() == "build") {
+        tasks.push(NativeTask::contract_task(
+            "build",
+            NativeTaskContract::new(
+                cargo_task_defaults(details, "build"),
+                cargo_task_entrypoint(details.kind, "build"),
+                false,
+            ),
+        ));
+    }
+    tasks
+}
+
+fn cargo_task_defaults(details: &CargoPackageDetails, task: &str) -> toolchain::TaskDefaults {
+    let cache = task_subcommand(details.kind, task).and_then(|subcommand| {
+        (subcommand == "run"
+            || subcommand == "fmt"
+            || (details.kind == CargoPackageKind::Library && subcommand == "build"))
+            .then_some(false)
+    });
+    toolchain::TaskDefaults { cache }
+}
+
+fn cargo_task_entrypoint(
+    kind: CargoPackageKind,
+    task: &str,
+) -> Option<crate::native_tasks::TaskEntrypoint> {
+    use crate::native_tasks::TaskEntrypoint;
+
+    library_subcommand(task)?;
+    Some(match (task == "build", kind) {
+        (true, CargoPackageKind::Workspace) => TaskEntrypoint::Excluded,
+        (true, CargoPackageKind::Entrypoint) => TaskEntrypoint::Preferred,
+        (false, CargoPackageKind::Workspace) => TaskEntrypoint::PreferredOnly,
+        _ => TaskEntrypoint::Candidate,
+    })
 }
 
 /// Whether pass-through args for `subcommand` must follow a `--` separator.
@@ -770,16 +813,6 @@ impl CargoTaskContract {
         }
     }
 
-    pub(crate) fn task_defaults(&self, task: &str) -> toolchain::TaskDefaults {
-        let cache = task_subcommand(self.package.kind, task).and_then(|subcommand| {
-            (subcommand == "run"
-                || subcommand == "fmt"
-                || (self.package.kind == CargoPackageKind::Library && subcommand == "build"))
-                .then_some(false)
-        });
-        toolchain::TaskDefaults { cache }
-    }
-
     /// Classifies Cargo package sources for dependent derived-input closures.
     /// Workspace aggregates have no package source directory to include.
     pub(crate) fn dependency_source_inputs(&self) -> crate::task_contracts::DependencySourceInputs {
@@ -796,29 +829,6 @@ impl CargoTaskContract {
         task_env: &std::collections::HashMap<String, String>,
     ) -> Vec<(String, String)> {
         cargo_compile_cache_env(endpoint, task_env)
-    }
-
-    pub(crate) fn derives_task_io(&self, task: &str) -> bool {
-        registered_tasks(&self.package)
-            .into_iter()
-            .any(|registered| registered == task)
-    }
-
-    pub(crate) fn task_entrypoint(
-        &self,
-        task: &str,
-    ) -> Option<crate::task_contracts::TaskEntrypoint> {
-        library_subcommand(task)?;
-        Some(match (task == "build", self.package.kind) {
-            (true, CargoPackageKind::Workspace) => crate::task_contracts::TaskEntrypoint::Excluded,
-            (true, CargoPackageKind::Entrypoint) => {
-                crate::task_contracts::TaskEntrypoint::Preferred
-            }
-            (false, CargoPackageKind::Workspace) => {
-                crate::task_contracts::TaskEntrypoint::PreferredOnly
-            }
-            _ => crate::task_contracts::TaskEntrypoint::Candidate,
-        })
     }
 
     pub(crate) fn derived_task_io(
@@ -3896,17 +3906,6 @@ release: 1.96.0-nightly\n",
         write_fixture_workspace(&root);
 
         let toolchain = CargoContributor::new(root.clone());
-        let discovered = toolchain.discover_packages().await.unwrap();
-        let contracts: HashMap<_, _> = discovered
-            .packages()
-            .iter()
-            .cloned()
-            .filter_map(|package| {
-                let parts = package.into_parts();
-                Some((parts.name?, parts.task_contract?))
-            })
-            .collect();
-
         let app_context = task_context(&toolchain, &root, "app", "crates/app");
         let lib_a_context = task_context(&toolchain, &root, "lib-a", "crates/lib-a");
         let workspace_context = task_context(&toolchain, &root, "fixture-ws", "");
@@ -3999,17 +3998,18 @@ release: 1.96.0-nightly\n",
             Some("cargo build --package=lib-a --locked")
         );
 
-        let app_contract = &contracts["app"];
-        let library_contract = &contracts["lib-a"];
-        let workspace_contract = &contracts["fixture-ws"];
-        assert_eq!(app_contract.defaults_for_task("run").cache, Some(false));
-        assert_eq!(app_contract.defaults_for_task("dev").cache, Some(false));
-        assert_eq!(app_contract.defaults_for_task("build").cache, None);
-        assert_eq!(workspace_contract.defaults_for_task("test").cache, None);
-        assert_eq!(library_contract.defaults_for_task("test").cache, None);
-        assert_eq!(workspace_contract.defaults_for_task("format").cache, Some(false));
-        assert_eq!(library_contract.defaults_for_task("format").cache, Some(false));
-        assert_eq!(library_contract.defaults_for_task("build").cache, Some(false));
+        let app_build = app_context.native_tasks().get("build").unwrap().contract();
+        let library_build = lib_a_context.native_tasks().get("build").unwrap().contract();
+        let workspace_build = workspace_context.native_tasks().get("build").unwrap().contract();
+        assert_eq!(app_context.native_tasks().get("run").unwrap().contract().defaults().cache, Some(false));
+        assert_eq!(app_context.native_tasks().get("dev").unwrap().contract().defaults().cache, Some(false));
+        assert_eq!(app_build.defaults().cache, None);
+        assert_eq!(workspace_context.native_tasks().get("test").unwrap().contract().defaults().cache, None);
+        assert_eq!(lib_a_context.native_tasks().get("test").unwrap().contract().defaults().cache, None);
+        assert_eq!(workspace_context.native_tasks().get("format").unwrap().contract().defaults().cache, Some(false));
+        assert_eq!(lib_a_context.native_tasks().get("format").unwrap().contract().defaults().cache, Some(false));
+        assert_eq!(library_build.defaults().cache, Some(false));
+        assert!(app_build.derives_io());
         assert_eq!(
             app_context
                 .native_tasks()
@@ -4024,23 +4024,23 @@ release: 1.96.0-nightly\n",
         );
 
         assert_eq!(
-            app_contract.task_entrypoint("build"),
+            app_build.entrypoint(),
             Some(crate::task_contracts::TaskEntrypoint::Preferred)
         );
         assert_eq!(
-            library_contract.task_entrypoint("build"),
+            library_build.entrypoint(),
             Some(crate::task_contracts::TaskEntrypoint::Candidate)
         );
         assert_eq!(
-            workspace_contract.task_entrypoint("build"),
+            workspace_build.entrypoint(),
             Some(crate::task_contracts::TaskEntrypoint::Excluded)
         );
         assert_eq!(
-            workspace_contract.task_entrypoint("test"),
+            workspace_context.native_tasks().get("test").unwrap().contract().entrypoint(),
             Some(crate::task_contracts::TaskEntrypoint::PreferredOnly)
         );
         assert_eq!(
-            workspace_contract.task_entrypoint("format"),
+            workspace_context.native_tasks().get("format").unwrap().contract().entrypoint(),
             Some(crate::task_contracts::TaskEntrypoint::PreferredOnly)
         );
     }

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -463,7 +463,10 @@ pub fn native_tasks_for_package(
     details: &CargoPackageDetails,
     package: &str,
 ) -> Vec<crate::native_tasks::NativeTask> {
-    use crate::native_tasks::NativeTask;
+    use crate::native_tasks::{
+        NativeCommandArguments, NativeCommandProgram, NativeTask, PassThroughPlacement,
+        PassThroughSeparator, WorkingDirectoryPolicy,
+    };
 
     registered_tasks(details)
         .into_iter()
@@ -477,14 +480,22 @@ pub fn native_tasks_for_package(
                     format!("--package={package}")
                 }
             };
-            Some(NativeTask::cargo(
+            Some(NativeTask::command_task(
                 task,
                 display,
-                subcommand,
-                scope_arg,
-                subcommand != "fmt",
+                NativeCommandProgram::Tool("cargo".to_string()),
+                NativeCommandArguments {
+                    prefix: vec![subcommand.to_string(), scope_arg],
+                    pass_through_placement: PassThroughPlacement::AfterSuffix,
+                    pass_through_separator: pass_through_uses_separator(subcommand)
+                        .then(|| PassThroughSeparator::Fixed("--".to_string())),
+                    suffix: (subcommand != "fmt")
+                        .then(|| "--locked".to_string())
+                        .into_iter()
+                        .collect(),
+                },
                 (!matches!(subcommand, "run" | "fmt")).then(|| "cargo".to_string()),
-                pass_through_uses_separator(subcommand),
+                WorkingDirectoryPolicy::RepositoryRoot,
             ))
         })
         .collect()
@@ -3862,7 +3873,6 @@ release: 1.96.0-nightly\n",
                 None,
                 None,
                 cargo_binary.as_deref(),
-                None,
                 pass_through_args,
                 override_command,
             )

--- a/crates/turborepo-repository/src/native_tasks.rs
+++ b/crates/turborepo-repository/src/native_tasks.rs
@@ -7,7 +7,6 @@ use std::{
     ffi::OsString,
 };
 
-use turbopath::AbsoluteSystemPathBuf;
 use turborepo_errors::Spanned;
 
 use crate::{
@@ -27,29 +26,62 @@ pub enum WorkingDirectoryPolicy {
     RepositoryRoot,
 }
 
+/// Where pass-through arguments are placed relative to fixed command arguments.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PassThroughPlacement {
+    BeforeSuffix,
+    AfterSuffix,
+}
+
+/// Separator inserted before pass-through arguments.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum PassThroughSeparator {
+    Fixed(String),
+    PackageManager,
+}
+
+/// General argument layout for a native command.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct NativeCommandArguments {
+    pub prefix: Vec<String>,
+    pub pass_through_placement: PassThroughPlacement,
+    pub pass_through_separator: Option<PassThroughSeparator>,
+    pub suffix: Vec<String>,
+}
+
+impl NativeCommandArguments {
+    pub fn new(prefix: Vec<String>) -> Self {
+        Self {
+            prefix,
+            pass_through_placement: PassThroughPlacement::AfterSuffix,
+            pass_through_separator: None,
+            suffix: Vec::new(),
+        }
+    }
+}
+
+/// How the executable for a native command is selected.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum NativeCommandProgram {
+    PackageManager,
+    Tool(String),
+}
+
 /// Declarative command template resolved into a [`TaskCommand`] at execution.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum NativeCommandTemplate {
-    /// `<package-manager> run <task>` with package-manager arg separators.
-    JavaScriptPackageManagerRun { task: String },
-    /// `cargo <subcommand> <scope>` with optional locking and serial grouping.
-    Cargo {
-        subcommand: String,
-        /// `--package=<name>`, `--workspace`, or `--all`.
-        scope_arg: String,
-        locked: bool,
-        serial_group: Option<String>,
-        pass_through_uses_separator: bool,
-    },
-    /// `uv <subcommand> <args>` with uv serial grouping. None of the
-    /// registered subcommands forwards trailing args to another tool, so
-    /// pass-through args attach directly as uv flags.
-    Uv {
-        subcommand: String,
-        /// Fixed arguments, e.g. `--package=<name>` or `--all-packages`.
-        args: Vec<String>,
-        serial_group: Option<String>,
-    },
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct NativeCommandTemplate {
+    pub program: NativeCommandProgram,
+    pub arguments: NativeCommandArguments,
+    pub serial_group: Option<String>,
+}
+
+/// What a native task does when selected.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum NativeTaskExecution {
+    Command(NativeCommandTemplate),
+    /// Same-scope tasks that this task aggregates.
+    Aggregate(Box<[String]>),
+    None,
 }
 
 /// One native task observed for an authoritative scope.
@@ -60,12 +92,10 @@ pub struct NativeTask {
     authored: bool,
     /// Appears in toolchain registered-task tables without turbo.json.
     registered: bool,
-    /// Has a concrete executable command (non-empty script / known Cargo verb).
-    executable: bool,
+    execution: NativeTaskExecution,
     display: Option<String>,
     /// Source span for authored script text when available.
     script: Option<Spanned<String>>,
-    command: Option<NativeCommandTemplate>,
     cwd_policy: WorkingDirectoryPolicy,
 }
 
@@ -82,8 +112,16 @@ impl NativeTask {
         self.registered
     }
 
-    pub fn executable(&self) -> bool {
-        self.executable
+    pub fn execution(&self) -> &NativeTaskExecution {
+        &self.execution
+    }
+
+    pub fn executes(&self) -> bool {
+        matches!(self.execution, NativeTaskExecution::Command(_))
+    }
+
+    pub fn participates(&self) -> bool {
+        !matches!(self.execution, NativeTaskExecution::None)
     }
 
     pub fn display(&self) -> Option<&str> {
@@ -95,63 +133,60 @@ impl NativeTask {
     }
 
     pub fn command(&self) -> Option<&NativeCommandTemplate> {
-        self.command.as_ref()
+        match &self.execution {
+            NativeTaskExecution::Command(command) => Some(command),
+            NativeTaskExecution::Aggregate(_) | NativeTaskExecution::None => None,
+        }
     }
 
     pub fn cwd_policy(&self) -> WorkingDirectoryPolicy {
         self.cwd_policy
     }
 
-    /// Construct a Cargo-synthesized native task (not package-authored).
-    pub fn cargo(
+    /// Construct a synthesized native command task (not package-authored).
+    pub fn command_task(
         name: impl Into<String>,
         display: String,
-        subcommand: impl Into<String>,
-        scope_arg: impl Into<String>,
-        locked: bool,
+        program: NativeCommandProgram,
+        arguments: NativeCommandArguments,
         serial_group: Option<String>,
-        pass_through_uses_separator: bool,
+        cwd_policy: WorkingDirectoryPolicy,
     ) -> Self {
         let name = name.into();
         Self {
             name: name.clone(),
             authored: false,
             registered: true,
-            executable: true,
+            execution: NativeTaskExecution::Command(NativeCommandTemplate {
+                program,
+                arguments,
+                serial_group,
+            }),
             display: Some(display),
             script: None,
-            command: Some(NativeCommandTemplate::Cargo {
-                subcommand: subcommand.into(),
-                scope_arg: scope_arg.into(),
-                locked,
-                serial_group,
-                pass_through_uses_separator,
-            }),
-            cwd_policy: WorkingDirectoryPolicy::RepositoryRoot,
+            cwd_policy,
         }
     }
 
-    /// Construct a uv-synthesized native task (not package-authored).
-    pub fn uv(
+    /// Construct a synthesized same-scope aggregate task.
+    pub fn aggregate(
         name: impl Into<String>,
-        display: String,
-        subcommand: impl Into<String>,
-        args: Vec<String>,
-        serial_group: Option<String>,
+        dependencies: impl IntoIterator<Item = impl Into<String>>,
     ) -> Self {
         let name = name.into();
         Self {
-            name: name.clone(),
+            name,
             authored: false,
             registered: true,
-            executable: true,
-            display: Some(display),
+            execution: NativeTaskExecution::Aggregate(
+                dependencies
+                    .into_iter()
+                    .map(Into::into)
+                    .collect::<Vec<_>>()
+                    .into_boxed_slice(),
+            ),
+            display: None,
             script: None,
-            command: Some(NativeCommandTemplate::Uv {
-                subcommand: subcommand.into(),
-                args,
-                serial_group,
-            }),
             cwd_policy: WorkingDirectoryPolicy::RepositoryRoot,
         }
     }
@@ -183,7 +218,11 @@ impl ScopeNativeTasks {
     }
 
     pub fn defines(&self, name: &str) -> bool {
-        self.get(name).is_some_and(NativeTask::executable)
+        self.get(name).is_some_and(NativeTask::executes)
+    }
+
+    pub fn participates(&self, name: &str) -> bool {
+        self.get(name).is_some_and(NativeTask::participates)
     }
 
     pub fn authors(&self, name: &str) -> bool {
@@ -215,24 +254,14 @@ impl ScopeNativeTasks {
     /// command family. This also applies to override-only task names that have
     /// no catalog entry.
     pub fn override_serial_group(&self, override_command: &[String]) -> Option<String> {
-        let program = override_command.first().map(String::as_str);
-        if program == Some("cargo")
-            && self
-                .tasks()
-                .iter()
-                .any(|task| matches!(task.command(), Some(NativeCommandTemplate::Cargo { .. })))
-        {
-            return Some("cargo".to_string());
-        }
-        if program == Some("uv")
-            && self
-                .tasks()
-                .iter()
-                .any(|task| matches!(task.command(), Some(NativeCommandTemplate::Uv { .. })))
-        {
-            return Some("uv".to_string());
-        }
-        None
+        let program = override_command.first()?;
+        self.tasks().iter().find_map(|task| {
+            let command = task.command()?;
+            match &command.program {
+                NativeCommandProgram::Tool(tool) if tool == program => command.serial_group.clone(),
+                NativeCommandProgram::PackageManager | NativeCommandProgram::Tool(_) => None,
+            }
+        })
     }
 }
 
@@ -336,11 +365,22 @@ pub fn observation_from_scripts(
             name: name.clone(),
             authored: executable,
             registered: false,
-            executable,
+            execution: if executable {
+                NativeTaskExecution::Command(NativeCommandTemplate {
+                    program: NativeCommandProgram::PackageManager,
+                    arguments: NativeCommandArguments {
+                        prefix: vec!["run".to_string(), name.clone()],
+                        pass_through_placement: PassThroughPlacement::AfterSuffix,
+                        pass_through_separator: Some(PassThroughSeparator::PackageManager),
+                        suffix: Vec::new(),
+                    },
+                    serial_group: None,
+                })
+            } else {
+                NativeTaskExecution::None
+            },
             display: executable.then(|| script.as_inner().clone()),
             script: Some(script.clone()),
-            command: executable
-                .then(|| NativeCommandTemplate::JavaScriptPackageManagerRun { task: name.clone() }),
             cwd_policy: WorkingDirectoryPolicy::PackageDirectory,
         });
     }
@@ -365,8 +405,7 @@ pub fn resolve_task_command(
     task: &NativeTask,
     package_manager: Option<&PackageManager>,
     package_manager_binary: Option<&std::path::Path>,
-    cargo_binary: Option<&std::path::Path>,
-    uv_binary: Option<&std::path::Path>,
+    tool_binary: Option<&std::path::Path>,
     pass_through_args: Option<&[String]>,
     override_command: Option<&[String]>,
 ) -> Result<Option<TaskCommand>, ResolveNativeCommandError> {
@@ -385,7 +424,7 @@ pub fn resolve_task_command(
     let Some(template) = task.command() else {
         return Ok(None);
     };
-    if !task.executable() {
+    if !task.executes() {
         return Ok(None);
     }
 
@@ -396,93 +435,67 @@ pub fn resolve_task_command(
         WorkingDirectoryPolicy::RepositoryRoot => context.repository_root().to_owned(),
     };
 
-    match template {
-        NativeCommandTemplate::JavaScriptPackageManagerRun { task: task_name } => {
+    let (program, mut args) = match &template.program {
+        NativeCommandProgram::PackageManager => {
             let package_manager =
                 package_manager.ok_or(ResolveNativeCommandError::MissingPackageManager)?;
             let package_manager_binary = package_manager_binary
                 .ok_or(ResolveNativeCommandError::MissingPackageManagerBinary)?;
-            let (program, mut args) =
-                package_manager_command(package_manager, package_manager_binary);
-            args.extend([OsString::from("run"), OsString::from(task_name)]);
-            if let Some(pass_through_args) = pass_through_args {
-                args.extend(
-                    package_manager
-                        .arg_separator(pass_through_args)
-                        .map(OsString::from),
-                );
-                args.extend(pass_through_args.iter().map(OsString::from));
-            }
-            Ok(Some(TaskCommand {
-                program,
-                args,
-                cwd,
-                serial_group: None,
-            }))
+            package_manager_command(package_manager, package_manager_binary)
         }
-        NativeCommandTemplate::Cargo {
-            subcommand,
-            scope_arg,
-            locked,
-            serial_group,
-            pass_through_uses_separator,
-        } => {
-            let cargo_binary = cargo_binary.ok_or(ResolveNativeCommandError::MissingCargoBinary)?;
-            let mut args: Vec<OsString> = vec![subcommand.into(), scope_arg.into()];
-            if *locked {
-                args.push("--locked".into());
-            }
-            if let Some(pass_through_args) = pass_through_args {
-                if *pass_through_uses_separator {
-                    args.push("--".into());
-                }
-                args.extend(pass_through_args.iter().map(OsString::from));
-            }
-            Ok(Some(TaskCommand {
-                program: cargo_binary.as_os_str().to_owned(),
-                args,
-                cwd,
-                serial_group: serial_group.clone(),
-            }))
+        NativeCommandProgram::Tool(tool) => {
+            let binary = tool_binary.ok_or_else(|| {
+                ResolveNativeCommandError::MissingToolBinary { tool: tool.clone() }
+            })?;
+            (binary.as_os_str().to_owned(), Vec::new())
         }
-        NativeCommandTemplate::Uv {
-            subcommand,
-            args: fixed_args,
-            serial_group,
-        } => resolve_uv_task_command(
-            uv_binary,
-            cwd,
-            subcommand,
-            fixed_args,
-            serial_group.clone(),
+    };
+    args.extend(template.arguments.prefix.iter().map(OsString::from));
+    if template.arguments.pass_through_placement == PassThroughPlacement::BeforeSuffix {
+        append_pass_through(
+            &mut args,
+            &template.arguments,
             pass_through_args,
-        )
-        .map(Some),
+            package_manager,
+        );
     }
-}
-
-fn resolve_uv_task_command(
-    uv_binary: Option<&std::path::Path>,
-    cwd: AbsoluteSystemPathBuf,
-    subcommand: &str,
-    fixed_args: &[String],
-    serial_group: Option<String>,
-    pass_through_args: Option<&[String]>,
-) -> Result<TaskCommand, ResolveNativeCommandError> {
-    let uv_binary = uv_binary.ok_or(ResolveNativeCommandError::MissingUvBinary)?;
-    let mut args: Vec<OsString> = std::iter::once(subcommand)
-        .chain(fixed_args.iter().map(String::as_str))
-        .map(OsString::from)
-        .collect();
-    if let Some(pass_through_args) = pass_through_args {
-        args.extend(pass_through_args.iter().map(OsString::from));
+    args.extend(template.arguments.suffix.iter().map(OsString::from));
+    if template.arguments.pass_through_placement == PassThroughPlacement::AfterSuffix {
+        append_pass_through(
+            &mut args,
+            &template.arguments,
+            pass_through_args,
+            package_manager,
+        );
     }
-    Ok(TaskCommand {
-        program: uv_binary.as_os_str().to_owned(),
+    Ok(Some(TaskCommand {
+        program,
         args,
         cwd,
-        serial_group,
-    })
+        serial_group: template.serial_group.clone(),
+    }))
+}
+
+fn append_pass_through(
+    args: &mut Vec<OsString>,
+    layout: &NativeCommandArguments,
+    pass_through_args: Option<&[String]>,
+    package_manager: Option<&PackageManager>,
+) {
+    let Some(pass_through_args) = pass_through_args else {
+        return;
+    };
+    match &layout.pass_through_separator {
+        Some(PassThroughSeparator::Fixed(separator)) => args.push(separator.into()),
+        Some(PassThroughSeparator::PackageManager) => args.extend(
+            package_manager
+                .into_iter()
+                .flat_map(|manager| manager.arg_separator(pass_through_args))
+                .map(OsString::from),
+        ),
+        None => {}
+    }
+    args.extend(pass_through_args.iter().map(OsString::from));
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -491,13 +504,8 @@ pub enum ResolveNativeCommandError {
     MissingPackageManager,
     #[error("JavaScript package manager binary is not available for native task resolution")]
     MissingPackageManagerBinary,
-    #[error("Cargo binary is not available for native task resolution")]
-    MissingCargoBinary,
-    #[error(
-        "The `uv` binary is required to run Python tasks but was not found on PATH. Install uv: \
-         https://docs.astral.sh/uv/getting-started/installation/"
-    )]
-    MissingUvBinary,
+    #[error("The `{tool}` binary is not available for native task resolution")]
+    MissingToolBinary { tool: String },
 }
 
 #[cfg(test)]
@@ -509,6 +517,7 @@ mod tests {
         knowledge::{
             PackageScopeObservation, RepositoryKnowledge, ScopeKind, WorkspaceRootObservation,
         },
+        package_graph::{PackageName, PackageTaskContextKind},
         toolchain::{ToolchainId, WorkspaceRoot},
     };
 
@@ -546,7 +555,7 @@ mod tests {
             .find(|task| task.name() == "build")
             .unwrap();
         assert!(build.authored());
-        assert!(build.executable());
+        assert!(build.executes());
         assert!(!build.registered());
         assert_eq!(build.display(), Some("next build"));
         let empty = observation
@@ -555,7 +564,7 @@ mod tests {
             .find(|task| task.name() == "empty")
             .unwrap();
         assert!(!empty.authored());
-        assert!(!empty.executable());
+        assert!(!empty.executes());
         let tasks = ScopeNativeTasks::Available(observation.tasks.into_boxed_slice());
         assert_eq!(tasks.script_names(), ["build", "empty"]);
     }
@@ -592,18 +601,22 @@ mod tests {
 
     #[test]
     fn cargo_tasks_are_registered_not_authored() {
-        let task = NativeTask::cargo(
+        let task = NativeTask::command_task(
             "build",
             "cargo build --package=app --locked".into(),
-            "build",
-            "--package=app",
-            true,
+            NativeCommandProgram::Tool("cargo".into()),
+            NativeCommandArguments {
+                prefix: vec!["build".into(), "--package=app".into()],
+                pass_through_placement: PassThroughPlacement::AfterSuffix,
+                pass_through_separator: None,
+                suffix: vec!["--locked".into()],
+            },
             Some("cargo".into()),
-            false,
+            WorkingDirectoryPolicy::RepositoryRoot,
         );
         assert!(!task.authored());
         assert!(task.registered());
-        assert!(task.executable());
+        assert!(task.executes());
         assert_eq!(task.cwd_policy(), WorkingDirectoryPolicy::RepositoryRoot);
         assert!(
             ScopeNativeTasks::Available(vec![task].into_boxed_slice())
@@ -613,7 +626,7 @@ mod tests {
     }
 
     #[test]
-    fn uv_command_resolution_preserves_argument_order_and_group() {
+    fn generalized_command_resolution_preserves_argument_layout_and_group() {
         let root =
             AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
         let binary = std::path::Path::new(if cfg!(windows) {
@@ -622,31 +635,70 @@ mod tests {
             "/bin/uv"
         });
         let pass_through = ["--frozen".to_string()];
-        let command = resolve_uv_task_command(
-            Some(binary),
-            root.clone(),
+        let task = NativeTask::command_task(
             "sync",
-            &["--package=app".to_string()],
-            Some("uv".to_string()),
+            "tool sync --package=app --locked".into(),
+            NativeCommandProgram::Tool("tool".into()),
+            NativeCommandArguments {
+                prefix: vec!["sync".into(), "--package=app".into()],
+                pass_through_placement: PassThroughPlacement::BeforeSuffix,
+                pass_through_separator: Some(PassThroughSeparator::Fixed("--".into())),
+                suffix: vec!["--locked".into()],
+            },
+            Some("tool".into()),
+            WorkingDirectoryPolicy::RepositoryRoot,
+        );
+        let directory = turbopath::AnchoredSystemPath::new("apps/web").unwrap();
+        let context = PackageTaskContext::new_for_test(
+            PackageName::from("web"),
+            &root,
+            directory,
+            PackageTaskContextKind::Package,
+            None,
+        );
+        let command = resolve_task_command(
+            &context,
+            &task,
+            None,
+            None,
+            Some(binary),
             Some(&pass_through),
+            None,
         )
+        .unwrap()
         .unwrap();
         assert_eq!(command.program, binary.as_os_str());
         assert_eq!(
             command.args,
-            ["sync", "--package=app", "--frozen"].map(OsString::from)
+            ["sync", "--package=app", "--", "--frozen", "--locked"].map(OsString::from)
         );
         assert_eq!(command.cwd, root);
-        assert_eq!(command.serial_group.as_deref(), Some("uv"));
+        assert_eq!(command.serial_group.as_deref(), Some("tool"));
     }
 
     #[test]
-    fn uv_command_resolution_requires_binary() {
+    fn aggregate_participates_without_executing() {
+        let task = NativeTask::aggregate("all", ["lint", "test"]);
+        assert!(task.participates());
+        assert!(!task.executes());
+        assert_eq!(
+            task.execution(),
+            &NativeTaskExecution::Aggregate(vec!["lint".into(), "test".into()].into_boxed_slice())
+        );
         let root =
             AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
-        assert!(matches!(
-            resolve_uv_task_command(None, root, "build", &[], None, None),
-            Err(ResolveNativeCommandError::MissingUvBinary)
-        ));
+        let directory = turbopath::AnchoredSystemPath::new("").unwrap();
+        let context = PackageTaskContext::new_for_test(
+            PackageName::from("workspace"),
+            &root,
+            directory,
+            PackageTaskContextKind::Aggregate,
+            None,
+        );
+        assert!(
+            resolve_task_command(&context, &task, None, None, None, None, None)
+                .unwrap()
+                .is_none()
+        );
     }
 }

--- a/crates/turborepo-repository/src/native_tasks.rs
+++ b/crates/turborepo-repository/src/native_tasks.rs
@@ -14,8 +14,50 @@ use crate::{
     package_graph::PackageTaskContext,
     package_json::PackageJson,
     package_manager::PackageManager,
-    toolchain::{TaskCommand, override_task_command, package_manager_command},
+    toolchain::{TaskCommand, TaskDefaults, override_task_command, package_manager_command},
 };
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TaskEntrypoint {
+    Preferred,
+    PreferredOnly,
+    Candidate,
+    Excluded,
+}
+
+/// Immutable task-local behavior supplied by a native-task producer.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+pub struct NativeTaskContract {
+    defaults: TaskDefaults,
+    entrypoint: Option<TaskEntrypoint>,
+    derives_io: bool,
+}
+
+impl NativeTaskContract {
+    pub fn new(
+        defaults: TaskDefaults,
+        entrypoint: Option<TaskEntrypoint>,
+        derives_io: bool,
+    ) -> Self {
+        Self {
+            defaults,
+            entrypoint,
+            derives_io,
+        }
+    }
+
+    pub fn defaults(&self) -> &TaskDefaults {
+        &self.defaults
+    }
+
+    pub fn entrypoint(&self) -> Option<TaskEntrypoint> {
+        self.entrypoint
+    }
+
+    pub fn derives_io(&self) -> bool {
+        self.derives_io
+    }
+}
 
 /// How a native command chooses its working directory.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -97,6 +139,7 @@ pub struct NativeTask {
     /// Source span for authored script text when available.
     script: Option<Spanned<String>>,
     cwd_policy: WorkingDirectoryPolicy,
+    contract: NativeTaskContract,
 }
 
 impl NativeTask {
@@ -143,6 +186,15 @@ impl NativeTask {
         self.cwd_policy
     }
 
+    pub fn contract(&self) -> &NativeTaskContract {
+        &self.contract
+    }
+
+    pub fn with_contract(mut self, contract: NativeTaskContract) -> Self {
+        self.contract = contract;
+        self
+    }
+
     /// Construct a synthesized native command task (not package-authored).
     pub fn command_task(
         name: impl Into<String>,
@@ -165,6 +217,7 @@ impl NativeTask {
             display: Some(display),
             script: None,
             cwd_policy,
+            contract: NativeTaskContract::default(),
         }
     }
 
@@ -188,6 +241,21 @@ impl NativeTask {
             display: None,
             script: None,
             cwd_policy: WorkingDirectoryPolicy::RepositoryRoot,
+            contract: NativeTaskContract::default(),
+        }
+    }
+
+    /// Construct a non-participating task carrying classification facts.
+    pub fn contract_task(name: impl Into<String>, contract: NativeTaskContract) -> Self {
+        Self {
+            name: name.into(),
+            authored: false,
+            registered: false,
+            execution: NativeTaskExecution::None,
+            display: None,
+            script: None,
+            cwd_policy: WorkingDirectoryPolicy::RepositoryRoot,
+            contract,
         }
     }
 }
@@ -450,6 +518,7 @@ pub fn observation_from_scripts(
             display: executable.then(|| script.as_inner().clone()),
             script: Some(script.clone()),
             cwd_policy: WorkingDirectoryPolicy::PackageDirectory,
+            contract: NativeTaskContract::default(),
         });
     }
     NativeTaskObservation {

--- a/crates/turborepo-repository/src/native_tasks.rs
+++ b/crates/turborepo-repository/src/native_tasks.rs
@@ -3,7 +3,7 @@
 //! Ecosystems contribute observations once; core consumes an immutable catalog.
 
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, HashSet},
     ffi::OsString,
 };
 
@@ -321,6 +321,54 @@ impl NativeTaskKnowledge {
                 });
             }
 
+            let participating: HashMap<_, _> = tasks
+                .iter()
+                .map(|task| (task.name.clone(), task.participates()))
+                .collect();
+            for task in &mut tasks {
+                let NativeTaskExecution::Aggregate(dependencies) = &mut task.execution else {
+                    continue;
+                };
+                let mut seen = HashSet::new();
+                let mut normalized = Vec::with_capacity(dependencies.len());
+                for dependency in dependencies.iter() {
+                    if dependency.contains('#') {
+                        return Err(NativeTaskError::QualifiedAggregateChild {
+                            scope: observation.scope,
+                            task: task.name.clone(),
+                            dependency: dependency.clone(),
+                        });
+                    }
+                    if dependency == &task.name {
+                        return Err(NativeTaskError::SelfAggregateChild {
+                            scope: observation.scope,
+                            task: task.name.clone(),
+                        });
+                    }
+                    match participating.get(dependency) {
+                        None => {
+                            return Err(NativeTaskError::UnknownAggregateChild {
+                                scope: observation.scope,
+                                task: task.name.clone(),
+                                dependency: dependency.clone(),
+                            });
+                        }
+                        Some(false) => {
+                            return Err(NativeTaskError::NonParticipatingAggregateChild {
+                                scope: observation.scope,
+                                task: task.name.clone(),
+                                dependency: dependency.clone(),
+                            });
+                        }
+                        Some(true) => {}
+                    }
+                    if seen.insert(dependency.clone()) {
+                        normalized.push(dependency.clone());
+                    }
+                }
+                *dependencies = normalized.into_boxed_slice();
+            }
+
             let state = if tasks.is_empty() {
                 ScopeNativeTasks::Empty
             } else {
@@ -350,6 +398,26 @@ pub enum NativeTaskError {
     UnknownScope { identity: String },
     #[error("scope {scope} contributed duplicate native task {task}")]
     DuplicateTask { scope: String, task: String },
+    #[error("aggregate native task {scope}#{task} has qualified child {dependency}")]
+    QualifiedAggregateChild {
+        scope: String,
+        task: String,
+        dependency: String,
+    },
+    #[error("aggregate native task {scope}#{task} cannot depend on itself")]
+    SelfAggregateChild { scope: String, task: String },
+    #[error("aggregate native task {scope}#{task} has unknown child {dependency}")]
+    UnknownAggregateChild {
+        scope: String,
+        task: String,
+        dependency: String,
+    },
+    #[error("aggregate native task {scope}#{task} has non-participating child {dependency}")]
+    NonParticipatingAggregateChild {
+        scope: String,
+        task: String,
+        dependency: String,
+    },
 }
 
 /// Convert package.json scripts into native-task observations.
@@ -597,6 +665,103 @@ mod tests {
         let observation = observation_from_scripts("other", &BTreeMap::new());
         let error = NativeTaskKnowledge::build(&repository, vec![observation]).unwrap_err();
         assert!(matches!(error, NativeTaskError::UnknownScope { .. }));
+    }
+
+    fn test_command(name: &str) -> NativeTask {
+        NativeTask::command_task(
+            name,
+            format!("tool {name}"),
+            NativeCommandProgram::Tool("tool".into()),
+            NativeCommandArguments::new(vec![name.to_string()]),
+            None,
+            WorkingDirectoryPolicy::RepositoryRoot,
+        )
+    }
+
+    fn test_observation(tasks: Vec<NativeTask>) -> NativeTaskObservation {
+        NativeTaskObservation {
+            scope: "web".into(),
+            tasks,
+            task_contract: crate::task_contracts::ScopeTaskContract::javascript(),
+        }
+    }
+
+    #[test]
+    fn catalog_rejects_invalid_aggregate_children() {
+        let repository = repository();
+        let error = NativeTaskKnowledge::build(
+            &repository,
+            vec![test_observation(vec![
+                NativeTask::aggregate("all", ["other#check"]),
+                test_command("check"),
+            ])],
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            NativeTaskError::QualifiedAggregateChild { .. }
+        ));
+
+        let error = NativeTaskKnowledge::build(
+            &repository,
+            vec![test_observation(vec![NativeTask::aggregate(
+                "all",
+                ["all"],
+            )])],
+        )
+        .unwrap_err();
+        assert!(matches!(error, NativeTaskError::SelfAggregateChild { .. }));
+
+        let error = NativeTaskKnowledge::build(
+            &repository,
+            vec![test_observation(vec![NativeTask::aggregate(
+                "all",
+                ["missing"],
+            )])],
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            NativeTaskError::UnknownAggregateChild { .. }
+        ));
+
+        let empty = observation_from_scripts(
+            "web",
+            &BTreeMap::from([("empty".into(), Spanned::new(String::new()))]),
+        )
+        .tasks
+        .pop()
+        .unwrap();
+        let error = NativeTaskKnowledge::build(
+            &repository,
+            vec![test_observation(vec![
+                NativeTask::aggregate("all", ["empty"]),
+                empty,
+            ])],
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            NativeTaskError::NonParticipatingAggregateChild { .. }
+        ));
+    }
+
+    #[test]
+    fn catalog_deduplicates_aggregate_children_in_observation_order() {
+        let knowledge = NativeTaskKnowledge::build(
+            &repository(),
+            vec![test_observation(vec![
+                NativeTask::aggregate("all", ["check", "lint", "check"]),
+                test_command("check"),
+                test_command("lint"),
+            ])],
+        )
+        .unwrap();
+
+        assert_eq!(
+            knowledge.for_scope("web").get("all").unwrap().execution(),
+            &NativeTaskExecution::Aggregate(vec!["check".into(), "lint".into()].into_boxed_slice())
+        );
     }
 
     #[test]

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -708,7 +708,10 @@ impl PackageGraph {
             let Some(domain) = contract.task_entrypoint_domain() else {
                 continue;
             };
-            let Some(entrypoint) = contract.task_entrypoint(task) else {
+            let Some(entrypoint) = context.native_tasks().get(task).map_or_else(
+                || contract.task_entrypoint(task),
+                |task| task.contract().entrypoint(),
+            ) else {
                 continue;
             };
             classified
@@ -761,10 +764,14 @@ impl PackageGraph {
                     return false;
                 };
                 let contract = context.task_contract();
+                let classified = context.native_tasks().get(task).map_or_else(
+                    || contract.task_entrypoint(task),
+                    |task| task.contract().entrypoint(),
+                );
                 contract
                     .task_entrypoint_domain()
                     .is_some_and(|domain| active_domains.contains(domain))
-                    && contract.task_entrypoint(task).is_some()
+                    && classified.is_some()
             })
             .cloned()
             .collect()

--- a/crates/turborepo-repository/src/task_contracts.rs
+++ b/crates/turborepo-repository/src/task_contracts.rs
@@ -11,15 +11,8 @@
 
 use std::{borrow::Cow, collections::BTreeMap};
 
+pub use crate::native_tasks::TaskEntrypoint;
 use crate::toolchain::{TaskDefaults, ToolchainId};
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TaskEntrypoint {
-    Preferred,
-    PreferredOnly,
-    Candidate,
-    Excluded,
-}
 
 /// Groups scopes whose preferred entrypoints compete with one another.
 /// Deliberately independent from ecosystem provenance.
@@ -285,12 +278,6 @@ impl ScopeTaskContract {
     }
 
     pub fn defaults_for_task(&self, task: &str) -> TaskDefaults {
-        if let Some(dynamic) = self.dynamic.as_ref() {
-            return match dynamic {
-                DynamicTaskContract::Cargo(contract) => contract.task_defaults(task),
-                DynamicTaskContract::Python(contract) => contract.task_defaults(task),
-            };
-        }
         self.static_defaults
             .get(task)
             .cloned()
@@ -299,10 +286,6 @@ impl ScopeTaskContract {
 
     pub fn derives_task_io(&self, task: &str) -> bool {
         self.static_io.contains_key(task)
-            || self.dynamic.as_ref().is_some_and(|dynamic| match dynamic {
-                DynamicTaskContract::Cargo(contract) => contract.derives_task_io(task),
-                DynamicTaskContract::Python(contract) => contract.derives_task_io(task),
-            })
     }
 
     pub fn derived_task_io(
@@ -338,13 +321,7 @@ impl ScopeTaskContract {
     }
 
     pub fn task_entrypoint(&self, task: &str) -> Option<TaskEntrypoint> {
-        self.static_entrypoints
-            .get(task)
-            .copied()
-            .or_else(|| match self.dynamic.as_ref()? {
-                DynamicTaskContract::Cargo(contract) => contract.task_entrypoint(task),
-                DynamicTaskContract::Python(contract) => contract.task_entrypoint(task),
-            })
+        self.static_entrypoints.get(task).copied()
     }
 
     pub fn task_entrypoint_domain(&self) -> Option<&TaskEntrypointDomain> {

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -900,7 +900,6 @@ mod tests {
             None,
             None,
             None,
-            None,
         )
         .unwrap()
         .expect("script exists, command resolves");

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -445,7 +445,7 @@ pub struct WatchSpec {
 }
 
 /// Default task behavior supplied by task-contract knowledge.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct TaskDefaults {
     /// Whether task logs and outputs are cacheable.
     pub cache: Option<bool>,

--- a/crates/turborepo-repository/src/uv.rs
+++ b/crates/turborepo-repository/src/uv.rs
@@ -786,7 +786,9 @@ pub fn native_tasks_for_package(
     package_directory: &str,
     workspace_directories: &[String],
 ) -> Vec<crate::native_tasks::NativeTask> {
-    use crate::native_tasks::NativeTask;
+    use crate::native_tasks::{
+        NativeCommandArguments, NativeCommandProgram, NativeTask, WorkingDirectoryPolicy,
+    };
 
     registered_tasks(kind)
         .filter_map(|task| {
@@ -798,18 +800,23 @@ pub fn native_tasks_for_package(
                 package_directory,
                 workspace_directories,
             )?;
-            Some(NativeTask::uv(
+            Some(NativeTask::command_task(
                 task,
                 display,
-                subcommand,
-                task_arguments(
-                    kind,
-                    task,
-                    package,
-                    package_directory,
-                    workspace_directories,
+                NativeCommandProgram::Tool("uv".to_string()),
+                NativeCommandArguments::new(
+                    std::iter::once(subcommand.to_string())
+                        .chain(task_arguments(
+                            kind,
+                            task,
+                            package,
+                            package_directory,
+                            workspace_directories,
+                        ))
+                        .collect(),
                 ),
                 (task == "check").then(|| "uv".to_string()),
+                WorkingDirectoryPolicy::RepositoryRoot,
             ))
         })
         .collect()
@@ -2045,7 +2052,7 @@ overridden = { index = "private" }
         assert!(
             tasks
                 .iter()
-                .all(|task| task.registered() && task.executable())
+                .all(|task| task.registered() && task.executes())
         );
     }
 

--- a/crates/turborepo-repository/src/uv.rs
+++ b/crates/turborepo-repository/src/uv.rs
@@ -787,10 +787,11 @@ pub fn native_tasks_for_package(
     workspace_directories: &[String],
 ) -> Vec<crate::native_tasks::NativeTask> {
     use crate::native_tasks::{
-        NativeCommandArguments, NativeCommandProgram, NativeTask, WorkingDirectoryPolicy,
+        NativeCommandArguments, NativeCommandProgram, NativeTask, NativeTaskContract,
+        WorkingDirectoryPolicy,
     };
 
-    registered_tasks(kind)
+    let mut tasks: Vec<_> = registered_tasks(kind)
         .filter_map(|task| {
             let subcommand = task_subcommand(kind, task)?;
             let display = display_command(
@@ -800,26 +801,73 @@ pub fn native_tasks_for_package(
                 package_directory,
                 workspace_directories,
             )?;
-            Some(NativeTask::command_task(
-                task,
-                display,
-                NativeCommandProgram::Tool("uv".to_string()),
-                NativeCommandArguments::new(
-                    std::iter::once(subcommand.to_string())
-                        .chain(task_arguments(
-                            kind,
-                            task,
-                            package,
-                            package_directory,
-                            workspace_directories,
-                        ))
-                        .collect(),
-                ),
-                (task == "check").then(|| "uv".to_string()),
-                WorkingDirectoryPolicy::RepositoryRoot,
-            ))
+            Some(
+                NativeTask::command_task(
+                    task,
+                    display,
+                    NativeCommandProgram::Tool("uv".to_string()),
+                    NativeCommandArguments::new(
+                        std::iter::once(subcommand.to_string())
+                            .chain(task_arguments(
+                                kind,
+                                task,
+                                package,
+                                package_directory,
+                                workspace_directories,
+                            ))
+                            .collect(),
+                    ),
+                    (task == "check").then(|| "uv".to_string()),
+                    WorkingDirectoryPolicy::RepositoryRoot,
+                )
+                .with_contract(NativeTaskContract::new(
+                    uv_task_defaults(kind, task),
+                    uv_task_entrypoint(kind, task),
+                    true,
+                )),
+            )
         })
-        .collect()
+        .collect();
+    if !tasks.iter().any(|task| task.name() == "build") {
+        tasks.push(NativeTask::contract_task(
+            "build",
+            NativeTaskContract::new(
+                uv_task_defaults(kind, "build"),
+                uv_task_entrypoint(kind, "build"),
+                false,
+            ),
+        ));
+    }
+    tasks
+}
+
+fn uv_task_defaults(kind: UvPackageKind, task: &str) -> toolchain::TaskDefaults {
+    // Tool versions are not yet part of the task fingerprint.
+    toolchain::TaskDefaults {
+        cache: task_subcommand(kind, task).map(|_| false),
+    }
+}
+
+fn uv_task_entrypoint(
+    kind: UvPackageKind,
+    task: &str,
+) -> Option<crate::native_tasks::TaskEntrypoint> {
+    use crate::native_tasks::TaskEntrypoint;
+
+    if task_subcommand(kind, task).is_some() {
+        return Some(match kind {
+            UvPackageKind::Workspace => TaskEntrypoint::PreferredOnly,
+            UvPackageKind::Package | UvPackageKind::VirtualPackage => TaskEntrypoint::Candidate,
+        });
+    }
+    matches!(
+        (kind, task),
+        (
+            UvPackageKind::Workspace | UvPackageKind::VirtualPackage,
+            "build"
+        )
+    )
+    .then_some(TaskEntrypoint::Excluded)
 }
 
 // ---------------------------------------------------------------------------
@@ -982,14 +1030,6 @@ impl UvTaskContract {
         }
     }
 
-    pub(crate) fn task_defaults(&self, task: &str) -> toolchain::TaskDefaults {
-        // uv, Python, ty, and isolated build-backend versions are not
-        // yet part of the task fingerprint, so built-in uv commands fail
-        // closed on cache.
-        let cache = task_subcommand(self.kind, task).map(|_| false);
-        toolchain::TaskDefaults { cache }
-    }
-
     /// Classifies Python package sources for dependent derived-input
     /// closures. Workspace aggregates have no package source directory to
     /// include.
@@ -999,32 +1039,6 @@ impl UvTaskContract {
                 crate::task_contracts::DependencySourceInputs::Include
             }
             UvPackageKind::Workspace => crate::task_contracts::DependencySourceInputs::Exclude,
-        }
-    }
-
-    pub(crate) fn derives_task_io(&self, task: &str) -> bool {
-        registered_tasks(self.kind).any(|registered| registered == task)
-    }
-
-    pub(crate) fn task_entrypoint(
-        &self,
-        task: &str,
-    ) -> Option<crate::task_contracts::TaskEntrypoint> {
-        if task_subcommand(self.kind, task).is_some() {
-            return Some(match self.kind {
-                // Unfiltered quality tasks use the workspace-scoped command
-                // only; per-package commands are for filtered runs.
-                UvPackageKind::Workspace => crate::task_contracts::TaskEntrypoint::PreferredOnly,
-                UvPackageKind::Package | UvPackageKind::VirtualPackage => {
-                    crate::task_contracts::TaskEntrypoint::Candidate
-                }
-            });
-        }
-        match (self.kind, task) {
-            (UvPackageKind::Workspace | UvPackageKind::VirtualPackage, "build") => {
-                Some(crate::task_contracts::TaskEntrypoint::Excluded)
-            }
-            _ => None,
         }
     }
 
@@ -2054,22 +2068,36 @@ overridden = { index = "private" }
                 .iter()
                 .all(|task| task.registered() && task.executes())
         );
+        let build = tasks.iter().find(|task| task.name() == "build").unwrap();
+        assert_eq!(build.contract().defaults().cache, Some(false));
+        assert_eq!(
+            build.contract().entrypoint(),
+            Some(crate::native_tasks::TaskEntrypoint::Candidate)
+        );
+        assert!(build.contract().derives_io());
+
+        let virtual_tasks = native_tasks_for_package(
+            UvPackageKind::VirtualPackage,
+            "py-app",
+            "packages/py-app",
+            &[],
+        );
+        let build = virtual_tasks
+            .iter()
+            .find(|task| task.name() == "build")
+            .unwrap();
+        assert!(!build.participates());
+        assert_eq!(
+            build.contract().entrypoint(),
+            Some(crate::native_tasks::TaskEntrypoint::Excluded)
+        );
+        assert!(!build.contract().derives_io());
     }
 
     #[test]
     fn test_derived_outputs_for_build() {
         let contract = UvTaskContract::new(UvPackageKind::Package, "py-app");
-        assert!(contract.derives_task_io("build"));
-        assert!(contract.derives_task_io("format"));
-        assert!(contract.derives_task_io("check"));
-        assert!(!contract.derives_task_io("test"));
-        assert_eq!(contract.task_defaults("check").cache, Some(false));
-        assert_eq!(contract.task_defaults("build").cache, Some(false));
         assert_eq!(contract.dist_name, "py_app");
-
-        let virtual_contract = UvTaskContract::new(UvPackageKind::VirtualPackage, "py-app");
-        assert!(!virtual_contract.derives_task_io("build"));
-        assert!(virtual_contract.derives_task_io("check"));
     }
 
     #[test]

--- a/crates/turborepo-run-summary/src/task_factory.rs
+++ b/crates/turborepo-run-summary/src/task_factory.rs
@@ -268,7 +268,15 @@ fn summary_command(
         None => package_context
             .native_tasks()
             .get(task)
-            .and_then(|native_task| native_task.display().map(str::to_string))
+            .map(|native_task| match native_task.execution() {
+                turborepo_repository::native_tasks::NativeTaskExecution::Aggregate(_) => {
+                    "<AGGREGATE>".to_string()
+                }
+                _ => native_task
+                    .display()
+                    .map(str::to_string)
+                    .unwrap_or_else(|| "<NONEXISTENT>".to_string()),
+            })
             .unwrap_or_else(|| "<NONEXISTENT>".to_string()),
     }
 }

--- a/crates/turborepo-task-executor/src/command.rs
+++ b/crates/turborepo-task-executor/src/command.rs
@@ -10,7 +10,6 @@ use turbopath::{PathError, RelativeUnixPath};
 use turborepo_env::EnvironmentVariableMap;
 use turborepo_process::Command;
 use turborepo_repository::{
-    native_tasks::NativeCommandTemplate,
     package_graph::{PackageGraph, PackageName, PackageTaskContext},
     toolchain::CompileCacheEndpoint,
 };
@@ -263,16 +262,25 @@ impl<'a, M: MfeConfigProvider, E: From<CommandProviderError>> CommandProvider<E>
         };
 
         let spec = if let Some(native_task) = package_context.native_tasks().get(task_id.task()) {
-            let (package_manager_binary, cargo_binary, uv_binary) = if override_command.is_some() {
-                (None, None, None)
+            let (package_manager_binary, tool_binary) = if override_command.is_some() {
+                (None, None)
             } else {
-                match native_task.command() {
-                    Some(NativeCommandTemplate::JavaScriptPackageManagerRun { .. }) => {
-                        (self.package_manager_binary()?, None, None)
+                match native_task.command().map(|command| &command.program) {
+                    Some(
+                        turborepo_repository::native_tasks::NativeCommandProgram::PackageManager,
+                    ) => (self.package_manager_binary()?, None),
+                    Some(turborepo_repository::native_tasks::NativeCommandProgram::Tool(tool))
+                        if tool == "cargo" =>
+                    {
+                        (None, self.cargo_binary()?)
                     }
-                    Some(NativeCommandTemplate::Cargo { .. }) => (None, self.cargo_binary()?, None),
-                    Some(NativeCommandTemplate::Uv { .. }) => (None, None, self.uv_binary()?),
-                    None => (None, None, None),
+                    Some(turborepo_repository::native_tasks::NativeCommandProgram::Tool(tool))
+                        if tool == "uv" =>
+                    {
+                        (None, self.uv_binary()?)
+                    }
+                    Some(turborepo_repository::native_tasks::NativeCommandProgram::Tool(_))
+                    | None => (None, None),
                 }
             };
             turborepo_repository::native_tasks::resolve_task_command(
@@ -280,8 +288,7 @@ impl<'a, M: MfeConfigProvider, E: From<CommandProviderError>> CommandProvider<E>
                 native_task,
                 self.package_graph.package_manager(),
                 package_manager_binary,
-                cargo_binary,
-                uv_binary,
+                tool_binary,
                 self.task_args.args_for_task(task_id),
                 override_command,
             )


### PR DESCRIPTION
### Description

This is PR 1 of 3 in the dependency-driven Python Native Tasks stack.

- Model native execution explicitly as a command, same-scope aggregate, or non-participating task.
- Compose validated aggregate children into task definitions after inheritance and command override resolution.
- Generalize native argument placement and separate graph participation from process execution across selection, execution, summaries, devtools, and watch consumers.
- Move defaults, entrypoint classification, and derived-I/O eligibility into parser-neutral task-local contracts while retaining scope-wide environment, dependency-source, prune, and dynamic-I/O facts.
- Add focused coverage for dependency merging, deduplication, cycles, overrides, opt-outs, `extends: false`, argument rejection, aggregate validation, and memoization.

Stack:
1. This PR: core aggregate Native Tasks.
2. #13661: dependency-driven Python quality-tool discovery.
3. #13662: architecture and user documentation.

### Testing Instructions

Verification run on the complete stacked tip:

- `cargo fmt --all -- --check` passed.
- `cargo test -p turborepo-repository --no-fail-fast` passed: 429 tests.
- `cargo test -p turborepo-engine --no-fail-fast` passed: 135 tests.
- `cargo test -p turbo --test task_entrypoints_test --no-fail-fast` passed: 12 tests.
- `cargo test -p turbo --test uv_workspace_test --no-fail-fast` passed: 13 tests.
- `cargo clippy -p turborepo-repository -p turborepo-engine -p turborepo-lib -p turborepo-task-executor -p turborepo-run-summary -p turborepo-query --all-targets -- -D warnings` passed.

A full workspace test/lint run was not performed. `uv` is unavailable in the devbox, so tests requiring a real uv process skip execution; command resolution and dry-run behavior are covered.