### PR TITLE
refactor: Generalize native command arguments

### DIFF
--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -463,7 +463,10 @@ pub fn native_tasks_for_package(
     details: &CargoPackageDetails,
     package: &str,
 ) -> Vec<crate::native_tasks::NativeTask> {
-    use crate::native_tasks::NativeTask;
+    use crate::native_tasks::{
+        NativeCommandArguments, NativeCommandProgram, NativeTask, PassThroughPlacement,
+        PassThroughSeparator, WorkingDirectoryPolicy,
+    };
 
     registered_tasks(details)
         .into_iter()
@@ -477,14 +480,22 @@ pub fn native_tasks_for_package(
                     format!("--package={package}")
                 }
             };
-            Some(NativeTask::cargo(
+            Some(NativeTask::command_task(
                 task,
                 display,
-                subcommand,
-                scope_arg,
-                subcommand != "fmt",
+                NativeCommandProgram::Tool("cargo".to_string()),
+                NativeCommandArguments {
+                    prefix: vec![subcommand.to_string(), scope_arg],
+                    pass_through_placement: PassThroughPlacement::AfterSuffix,
+                    pass_through_separator: pass_through_uses_separator(subcommand)
+                        .then(|| PassThroughSeparator::Fixed("--".to_string())),
+                    suffix: (subcommand != "fmt")
+                        .then(|| "--locked".to_string())
+                        .into_iter()
+                        .collect(),
+                },
                 (!matches!(subcommand, "run" | "fmt")).then(|| "cargo".to_string()),
-                pass_through_uses_separator(subcommand),
+                WorkingDirectoryPolicy::RepositoryRoot,
             ))
         })
         .collect()
@@ -3862,7 +3873,6 @@ release: 1.96.0-nightly\n",
                 None,
                 None,
                 cargo_binary.as_deref(),
-                None,
                 pass_through_args,
                 override_command,
             )

--- a/crates/turborepo-repository/src/native_tasks.rs
+++ b/crates/turborepo-repository/src/native_tasks.rs
@@ -7,7 +7,6 @@ use std::{
     ffi::OsString,
 };
 
-use turbopath::AbsoluteSystemPathBuf;
 use turborepo_errors::Spanned;
 
 use crate::{
@@ -27,29 +26,53 @@ pub enum WorkingDirectoryPolicy {
     RepositoryRoot,
 }
 
+/// Where pass-through arguments are placed relative to fixed command arguments.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PassThroughPlacement {
+    BeforeSuffix,
+    AfterSuffix,
+}
+
+/// Separator inserted before pass-through arguments.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PassThroughSeparator {
+    Fixed(String),
+    PackageManager,
+}
+
+/// General argument layout for a native command.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NativeCommandArguments {
+    pub prefix: Vec<String>,
+    pub pass_through_placement: PassThroughPlacement,
+    pub pass_through_separator: Option<PassThroughSeparator>,
+    pub suffix: Vec<String>,
+}
+
+impl NativeCommandArguments {
+    pub fn new(prefix: Vec<String>) -> Self {
+        Self {
+            prefix,
+            pass_through_placement: PassThroughPlacement::AfterSuffix,
+            pass_through_separator: None,
+            suffix: Vec::new(),
+        }
+    }
+}
+
+/// How the executable for a native command is selected.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NativeCommandProgram {
+    PackageManager,
+    Tool(String),
+}
+
 /// Declarative command template resolved into a [`TaskCommand`] at execution.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum NativeCommandTemplate {
-    /// `<package-manager> run <task>` with package-manager arg separators.
-    JavaScriptPackageManagerRun { task: String },
-    /// `cargo <subcommand> <scope>` with optional locking and serial grouping.
-    Cargo {
-        subcommand: String,
-        /// `--package=<name>`, `--workspace`, or `--all`.
-        scope_arg: String,
-        locked: bool,
-        serial_group: Option<String>,
-        pass_through_uses_separator: bool,
-    },
-    /// `uv <subcommand> <args>` with uv serial grouping. None of the
-    /// registered subcommands forwards trailing args to another tool, so
-    /// pass-through args attach directly as uv flags.
-    Uv {
-        subcommand: String,
-        /// Fixed arguments, e.g. `--package=<name>` or `--all-packages`.
-        args: Vec<String>,
-        serial_group: Option<String>,
-    },
+pub struct NativeCommandTemplate {
+    pub program: NativeCommandProgram,
+    pub arguments: NativeCommandArguments,
+    pub serial_group: Option<String>,
 }
 
 /// One native task observed for an authoritative scope.
@@ -102,15 +125,14 @@ impl NativeTask {
         self.cwd_policy
     }
 
-    /// Construct a Cargo-synthesized native task (not package-authored).
-    pub fn cargo(
+    /// Construct a synthesized native command task (not package-authored).
+    pub fn command_task(
         name: impl Into<String>,
         display: String,
-        subcommand: impl Into<String>,
-        scope_arg: impl Into<String>,
-        locked: bool,
+        program: NativeCommandProgram,
+        arguments: NativeCommandArguments,
         serial_group: Option<String>,
-        pass_through_uses_separator: bool,
+        cwd_policy: WorkingDirectoryPolicy,
     ) -> Self {
         let name = name.into();
         Self {
@@ -120,39 +142,12 @@ impl NativeTask {
             executable: true,
             display: Some(display),
             script: None,
-            command: Some(NativeCommandTemplate::Cargo {
-                subcommand: subcommand.into(),
-                scope_arg: scope_arg.into(),
-                locked,
-                serial_group,
-                pass_through_uses_separator,
-            }),
-            cwd_policy: WorkingDirectoryPolicy::RepositoryRoot,
-        }
-    }
-
-    /// Construct a uv-synthesized native task (not package-authored).
-    pub fn uv(
-        name: impl Into<String>,
-        display: String,
-        subcommand: impl Into<String>,
-        args: Vec<String>,
-        serial_group: Option<String>,
-    ) -> Self {
-        let name = name.into();
-        Self {
-            name: name.clone(),
-            authored: false,
-            registered: true,
-            executable: true,
-            display: Some(display),
-            script: None,
-            command: Some(NativeCommandTemplate::Uv {
-                subcommand: subcommand.into(),
-                args,
+            command: Some(NativeCommandTemplate {
+                program,
+                arguments,
                 serial_group,
             }),
-            cwd_policy: WorkingDirectoryPolicy::RepositoryRoot,
+            cwd_policy,
         }
     }
 }
@@ -215,24 +210,14 @@ impl ScopeNativeTasks {
     /// command family. This also applies to override-only task names that have
     /// no catalog entry.
     pub fn override_serial_group(&self, override_command: &[String]) -> Option<String> {
-        let program = override_command.first().map(String::as_str);
-        if program == Some("cargo")
-            && self
-                .tasks()
-                .iter()
-                .any(|task| matches!(task.command(), Some(NativeCommandTemplate::Cargo { .. })))
-        {
-            return Some("cargo".to_string());
-        }
-        if program == Some("uv")
-            && self
-                .tasks()
-                .iter()
-                .any(|task| matches!(task.command(), Some(NativeCommandTemplate::Uv { .. })))
-        {
-            return Some("uv".to_string());
-        }
-        None
+        let program = override_command.first()?;
+        self.tasks().iter().find_map(|task| {
+            let command = task.command()?;
+            match &command.program {
+                NativeCommandProgram::Tool(tool) if tool == program => command.serial_group.clone(),
+                NativeCommandProgram::PackageManager | NativeCommandProgram::Tool(_) => None,
+            }
+        })
     }
 }
 
@@ -339,8 +324,16 @@ pub fn observation_from_scripts(
             executable,
             display: executable.then(|| script.as_inner().clone()),
             script: Some(script.clone()),
-            command: executable
-                .then(|| NativeCommandTemplate::JavaScriptPackageManagerRun { task: name.clone() }),
+            command: executable.then(|| NativeCommandTemplate {
+                program: NativeCommandProgram::PackageManager,
+                arguments: NativeCommandArguments {
+                    prefix: vec!["run".to_string(), name.clone()],
+                    pass_through_placement: PassThroughPlacement::AfterSuffix,
+                    pass_through_separator: Some(PassThroughSeparator::PackageManager),
+                    suffix: Vec::new(),
+                },
+                serial_group: None,
+            }),
             cwd_policy: WorkingDirectoryPolicy::PackageDirectory,
         });
     }
@@ -365,8 +358,7 @@ pub fn resolve_task_command(
     task: &NativeTask,
     package_manager: Option<&PackageManager>,
     package_manager_binary: Option<&std::path::Path>,
-    cargo_binary: Option<&std::path::Path>,
-    uv_binary: Option<&std::path::Path>,
+    tool_binary: Option<&std::path::Path>,
     pass_through_args: Option<&[String]>,
     override_command: Option<&[String]>,
 ) -> Result<Option<TaskCommand>, ResolveNativeCommandError> {
@@ -396,93 +388,67 @@ pub fn resolve_task_command(
         WorkingDirectoryPolicy::RepositoryRoot => context.repository_root().to_owned(),
     };
 
-    match template {
-        NativeCommandTemplate::JavaScriptPackageManagerRun { task: task_name } => {
+    let (program, mut args) = match &template.program {
+        NativeCommandProgram::PackageManager => {
             let package_manager =
                 package_manager.ok_or(ResolveNativeCommandError::MissingPackageManager)?;
             let package_manager_binary = package_manager_binary
                 .ok_or(ResolveNativeCommandError::MissingPackageManagerBinary)?;
-            let (program, mut args) =
-                package_manager_command(package_manager, package_manager_binary);
-            args.extend([OsString::from("run"), OsString::from(task_name)]);
-            if let Some(pass_through_args) = pass_through_args {
-                args.extend(
-                    package_manager
-                        .arg_separator(pass_through_args)
-                        .map(OsString::from),
-                );
-                args.extend(pass_through_args.iter().map(OsString::from));
-            }
-            Ok(Some(TaskCommand {
-                program,
-                args,
-                cwd,
-                serial_group: None,
-            }))
+            package_manager_command(package_manager, package_manager_binary)
         }
-        NativeCommandTemplate::Cargo {
-            subcommand,
-            scope_arg,
-            locked,
-            serial_group,
-            pass_through_uses_separator,
-        } => {
-            let cargo_binary = cargo_binary.ok_or(ResolveNativeCommandError::MissingCargoBinary)?;
-            let mut args: Vec<OsString> = vec![subcommand.into(), scope_arg.into()];
-            if *locked {
-                args.push("--locked".into());
-            }
-            if let Some(pass_through_args) = pass_through_args {
-                if *pass_through_uses_separator {
-                    args.push("--".into());
-                }
-                args.extend(pass_through_args.iter().map(OsString::from));
-            }
-            Ok(Some(TaskCommand {
-                program: cargo_binary.as_os_str().to_owned(),
-                args,
-                cwd,
-                serial_group: serial_group.clone(),
-            }))
+        NativeCommandProgram::Tool(tool) => {
+            let binary = tool_binary.ok_or_else(|| {
+                ResolveNativeCommandError::MissingToolBinary { tool: tool.clone() }
+            })?;
+            (binary.as_os_str().to_owned(), Vec::new())
         }
-        NativeCommandTemplate::Uv {
-            subcommand,
-            args: fixed_args,
-            serial_group,
-        } => resolve_uv_task_command(
-            uv_binary,
-            cwd,
-            subcommand,
-            fixed_args,
-            serial_group.clone(),
+    };
+    args.extend(template.arguments.prefix.iter().map(OsString::from));
+    if template.arguments.pass_through_placement == PassThroughPlacement::BeforeSuffix {
+        append_pass_through(
+            &mut args,
+            &template.arguments,
             pass_through_args,
-        )
-        .map(Some),
+            package_manager,
+        );
     }
-}
-
-fn resolve_uv_task_command(
-    uv_binary: Option<&std::path::Path>,
-    cwd: AbsoluteSystemPathBuf,
-    subcommand: &str,
-    fixed_args: &[String],
-    serial_group: Option<String>,
-    pass_through_args: Option<&[String]>,
-) -> Result<TaskCommand, ResolveNativeCommandError> {
-    let uv_binary = uv_binary.ok_or(ResolveNativeCommandError::MissingUvBinary)?;
-    let mut args: Vec<OsString> = std::iter::once(subcommand)
-        .chain(fixed_args.iter().map(String::as_str))
-        .map(OsString::from)
-        .collect();
-    if let Some(pass_through_args) = pass_through_args {
-        args.extend(pass_through_args.iter().map(OsString::from));
+    args.extend(template.arguments.suffix.iter().map(OsString::from));
+    if template.arguments.pass_through_placement == PassThroughPlacement::AfterSuffix {
+        append_pass_through(
+            &mut args,
+            &template.arguments,
+            pass_through_args,
+            package_manager,
+        );
     }
-    Ok(TaskCommand {
-        program: uv_binary.as_os_str().to_owned(),
+    Ok(Some(TaskCommand {
+        program,
         args,
         cwd,
-        serial_group,
-    })
+        serial_group: template.serial_group.clone(),
+    }))
+}
+
+fn append_pass_through(
+    args: &mut Vec<OsString>,
+    layout: &NativeCommandArguments,
+    pass_through_args: Option<&[String]>,
+    package_manager: Option<&PackageManager>,
+) {
+    let Some(pass_through_args) = pass_through_args else {
+        return;
+    };
+    match &layout.pass_through_separator {
+        Some(PassThroughSeparator::Fixed(separator)) => args.push(separator.into()),
+        Some(PassThroughSeparator::PackageManager) => args.extend(
+            package_manager
+                .into_iter()
+                .flat_map(|manager| manager.arg_separator(pass_through_args))
+                .map(OsString::from),
+        ),
+        None => {}
+    }
+    args.extend(pass_through_args.iter().map(OsString::from));
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -491,13 +457,8 @@ pub enum ResolveNativeCommandError {
     MissingPackageManager,
     #[error("JavaScript package manager binary is not available for native task resolution")]
     MissingPackageManagerBinary,
-    #[error("Cargo binary is not available for native task resolution")]
-    MissingCargoBinary,
-    #[error(
-        "The `uv` binary is required to run Python tasks but was not found on PATH. Install uv: \
-         https://docs.astral.sh/uv/getting-started/installation/"
-    )]
-    MissingUvBinary,
+    #[error("The `{tool}` binary is not available for native task resolution")]
+    MissingToolBinary { tool: String },
 }
 
 #[cfg(test)]
@@ -509,6 +470,7 @@ mod tests {
         knowledge::{
             PackageScopeObservation, RepositoryKnowledge, ScopeKind, WorkspaceRootObservation,
         },
+        package_graph::{PackageName, PackageTaskContextKind},
         toolchain::{ToolchainId, WorkspaceRoot},
     };
 
@@ -592,14 +554,18 @@ mod tests {
 
     #[test]
     fn cargo_tasks_are_registered_not_authored() {
-        let task = NativeTask::cargo(
+        let task = NativeTask::command_task(
             "build",
             "cargo build --package=app --locked".into(),
-            "build",
-            "--package=app",
-            true,
+            NativeCommandProgram::Tool("cargo".into()),
+            NativeCommandArguments {
+                prefix: vec!["build".into(), "--package=app".into()],
+                pass_through_placement: PassThroughPlacement::AfterSuffix,
+                pass_through_separator: None,
+                suffix: vec!["--locked".into()],
+            },
             Some("cargo".into()),
-            false,
+            WorkingDirectoryPolicy::RepositoryRoot,
         );
         assert!(!task.authored());
         assert!(task.registered());
@@ -613,40 +579,79 @@ mod tests {
     }
 
     #[test]
-    fn uv_command_resolution_preserves_argument_order_and_group() {
+    fn generalized_command_resolution_supports_prefix_suffix_and_fixed_separator() {
         let root =
             AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
         let binary = std::path::Path::new(if cfg!(windows) {
-            r"C:\bin\uv.exe"
+            r"C:\bin\tool.exe"
         } else {
-            "/bin/uv"
+            "/bin/tool"
         });
         let pass_through = ["--frozen".to_string()];
-        let command = resolve_uv_task_command(
-            Some(binary),
-            root.clone(),
+        let task = NativeTask::command_task(
             "sync",
-            &["--package=app".to_string()],
-            Some("uv".to_string()),
+            "tool sync --package=app --locked".into(),
+            NativeCommandProgram::Tool("tool".into()),
+            NativeCommandArguments {
+                prefix: vec!["sync".into(), "--package=app".into()],
+                pass_through_placement: PassThroughPlacement::BeforeSuffix,
+                pass_through_separator: Some(PassThroughSeparator::Fixed("--".into())),
+                suffix: vec!["--locked".into()],
+            },
+            Some("tool".into()),
+            WorkingDirectoryPolicy::RepositoryRoot,
+        );
+        let directory = turbopath::AnchoredSystemPath::new("apps/web").unwrap();
+        let context = PackageTaskContext::new_for_test(
+            PackageName::from("web"),
+            &root,
+            directory,
+            PackageTaskContextKind::Package,
+            None,
+        );
+        let command = resolve_task_command(
+            &context,
+            &task,
+            None,
+            None,
+            Some(binary),
             Some(&pass_through),
+            None,
         )
+        .unwrap()
         .unwrap();
         assert_eq!(command.program, binary.as_os_str());
         assert_eq!(
             command.args,
-            ["sync", "--package=app", "--frozen"].map(OsString::from)
+            ["sync", "--package=app", "--", "--frozen", "--locked"].map(OsString::from)
         );
         assert_eq!(command.cwd, root);
-        assert_eq!(command.serial_group.as_deref(), Some("uv"));
+        assert_eq!(command.serial_group.as_deref(), Some("tool"));
     }
 
     #[test]
-    fn uv_command_resolution_requires_binary() {
+    fn generalized_command_resolution_requires_tool_binary() {
         let root =
             AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+        let directory = turbopath::AnchoredSystemPath::new("").unwrap();
+        let context = PackageTaskContext::new_for_test(
+            PackageName::from("workspace"),
+            &root,
+            directory,
+            PackageTaskContextKind::Aggregate,
+            None,
+        );
+        let task = NativeTask::command_task(
+            "build",
+            "uv build".into(),
+            NativeCommandProgram::Tool("uv".into()),
+            NativeCommandArguments::new(vec!["build".into()]),
+            None,
+            WorkingDirectoryPolicy::RepositoryRoot,
+        );
         assert!(matches!(
-            resolve_uv_task_command(None, root, "build", &[], None, None),
-            Err(ResolveNativeCommandError::MissingUvBinary)
+            resolve_task_command(&context, &task, None, None, None, None, None),
+            Err(ResolveNativeCommandError::MissingToolBinary { tool }) if tool == "uv"
         ));
     }
 }

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -898,8 +898,7 @@ mod tests {
             Some(&PackageManager::Npm),
             which::which("npm").ok().as_deref(),
             None,
-            None,
-            None,
+            Some(&["--watch".to_string()]),
             None,
         )
         .unwrap()
@@ -909,8 +908,8 @@ mod tests {
         assert!(
             command
                 .args
-                .ends_with(&[OsString::from("run"), OsString::from("build")]),
-            "expected `run build` invocation, got {:?}",
+                .ends_with(&["run", "build", "--", "--watch"].map(OsString::from)),
+            "expected package-manager separator and pass-through args, got {:?}",
             command.args
         );
         assert_eq!(

--- a/crates/turborepo-repository/src/uv.rs
+++ b/crates/turborepo-repository/src/uv.rs
@@ -786,7 +786,9 @@ pub fn native_tasks_for_package(
     package_directory: &str,
     workspace_directories: &[String],
 ) -> Vec<crate::native_tasks::NativeTask> {
-    use crate::native_tasks::NativeTask;
+    use crate::native_tasks::{
+        NativeCommandArguments, NativeCommandProgram, NativeTask, WorkingDirectoryPolicy,
+    };
 
     registered_tasks(kind)
         .filter_map(|task| {
@@ -798,18 +800,23 @@ pub fn native_tasks_for_package(
                 package_directory,
                 workspace_directories,
             )?;
-            Some(NativeTask::uv(
+            Some(NativeTask::command_task(
                 task,
                 display,
-                subcommand,
-                task_arguments(
-                    kind,
-                    task,
-                    package,
-                    package_directory,
-                    workspace_directories,
+                NativeCommandProgram::Tool("uv".to_string()),
+                NativeCommandArguments::new(
+                    std::iter::once(subcommand.to_string())
+                        .chain(task_arguments(
+                            kind,
+                            task,
+                            package,
+                            package_directory,
+                            workspace_directories,
+                        ))
+                        .collect(),
                 ),
                 (task == "check").then(|| "uv".to_string()),
+                WorkingDirectoryPolicy::RepositoryRoot,
             ))
         })
         .collect()

--- a/crates/turborepo-task-executor/src/command.rs
+++ b/crates/turborepo-task-executor/src/command.rs
@@ -10,7 +10,7 @@ use turbopath::{PathError, RelativeUnixPath};
 use turborepo_env::EnvironmentVariableMap;
 use turborepo_process::Command;
 use turborepo_repository::{
-    native_tasks::NativeCommandTemplate,
+    native_tasks::NativeCommandProgram,
     package_graph::{PackageGraph, PackageName, PackageTaskContext},
     toolchain::CompileCacheEndpoint,
 };
@@ -263,16 +263,20 @@ impl<'a, M: MfeConfigProvider, E: From<CommandProviderError>> CommandProvider<E>
         };
 
         let spec = if let Some(native_task) = package_context.native_tasks().get(task_id.task()) {
-            let (package_manager_binary, cargo_binary, uv_binary) = if override_command.is_some() {
-                (None, None, None)
+            let (package_manager_binary, tool_binary) = if override_command.is_some() {
+                (None, None)
             } else {
-                match native_task.command() {
-                    Some(NativeCommandTemplate::JavaScriptPackageManagerRun { .. }) => {
-                        (self.package_manager_binary()?, None, None)
+                match native_task.command().map(|command| &command.program) {
+                    Some(NativeCommandProgram::PackageManager) => {
+                        (self.package_manager_binary()?, None)
                     }
-                    Some(NativeCommandTemplate::Cargo { .. }) => (None, self.cargo_binary()?, None),
-                    Some(NativeCommandTemplate::Uv { .. }) => (None, None, self.uv_binary()?),
-                    None => (None, None, None),
+                    Some(NativeCommandProgram::Tool(tool)) if tool == "cargo" => {
+                        (None, self.cargo_binary()?)
+                    }
+                    Some(NativeCommandProgram::Tool(tool)) if tool == "uv" => {
+                        (None, self.uv_binary()?)
+                    }
+                    Some(NativeCommandProgram::Tool(_)) | None => (None, None),
                 }
             };
             turborepo_repository::native_tasks::resolve_task_command(
@@ -280,8 +284,7 @@ impl<'a, M: MfeConfigProvider, E: From<CommandProviderError>> CommandProvider<E>
                 native_task,
                 self.package_graph.package_manager(),
                 package_manager_binary,
-                cargo_binary,
-                uv_binary,
+                tool_binary,
                 self.task_args.args_for_task(task_id),
                 override_command,
             )


### PR DESCRIPTION
### Description

Part 1 of 13 in stack #13677. Generalizes native command templates into program, prefix, suffix, pass-through placement, and separator facts while preserving JavaScript, Cargo, and uv behavior.

Next: #13665.

### Testing Instructions

- `cargo fmt --all -- --check`
- `cargo test -p turborepo-repository --no-fail-fast`
- `cargo test -p turborepo-engine --no-fail-fast`
- `cargo test -p turbo --test uv_workspace_test --test task_entrypoints_test --no-fail-fast`
- `cargo clippy -p turborepo-repository -p turborepo-engine -p turborepo-lib -p turborepo-task-executor -p turborepo-run-summary -p turborepo-query --all-targets -- -D warnings`

All commands passed on the complete stack tip. Every cumulative branch tip also passed `cargo check --tests`. A full workspace run was not performed. `uv` is unavailable, so real uv execution remains skipped.