### PR TITLE
refactor: Move native contracts to tasks

### DIFF
--- a/crates/turborepo-engine/src/builder/definitions.rs
+++ b/crates/turborepo-engine/src/builder/definitions.rs
@@ -2,7 +2,10 @@ use std::collections::{HashMap, HashSet};
 
 use miette::{NamedSource, SourceSpan};
 use turborepo_errors::Spanned;
-use turborepo_repository::package_graph::{PackageGraph, PackageName, PackageNode};
+use turborepo_repository::{
+    native_tasks::NativeTaskContract,
+    package_graph::{PackageGraph, PackageName, PackageNode},
+};
 use turborepo_task_id::{TaskId, TaskName};
 use turborepo_turbo_json::{
     HasConfigBeyondExtends, ProcessedCommand, ProcessedTaskDefinition, RawTaskDefinition, TurboJson,
@@ -17,15 +20,16 @@ use crate::{
 
 /// Memo key for resolved task definitions: the turbo.json chain (by
 /// address; loader-owned for the duration of a build), the task name, and
-/// the two package-dependent inputs that survive resolution — path to the
-/// repo root and whether the package's toolchain defines a command for the
-/// task. See `task_definition_cached`.
+/// the package-dependent inputs that survive resolution: path to the repo
+/// root, native execution eligibility, and task-local contract facts. See
+/// `task_definition_cached`.
 #[derive(PartialEq, Eq, Hash)]
 pub(super) struct TaskDefMemoKey {
     chain: Vec<usize>,
     task_name: TaskName<'static>,
     path_to_root: turbopath::RelativeUnixPathBuf,
     defines_task: bool,
+    native_contract: Option<NativeTaskContract>,
 }
 
 impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
@@ -247,9 +251,11 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         // global input files — they don't execute, and including the files
         // would cause their hash to change and cascade into downstream
         // tasks that depend on them.
-        let defines_task = package_context
+        let native_task = package_context
             .as_ref()
-            .is_some_and(|context| context.native_tasks().defines(task_id.task()));
+            .and_then(|context| context.native_tasks().get(task_id.task()));
+        let native_contract = native_task.map(|task| task.contract().clone());
+        let defines_task = native_task.is_some_and(|task| task.executable());
         let registered_task = package_context
             .as_ref()
             .is_some_and(|context| context.native_tasks().registers(task_id.task()));
@@ -257,8 +263,9 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         // Most tasks resolve to an identical definition: the same turbo.json
         // chain and task name, differing only by the package's depth (for
         // `$TURBO_ROOT$`/global-input anchoring) and whether the package's
-        // toolchain defines a command for the task. Memoize on exactly
-        // those inputs. Two exceptions must skip the memo: a package-scoped
+        // toolchain defines a command for the task, and task-local contract
+        // facts. Memoize on exactly those inputs. Two exceptions must skip the memo: a
+        // package-scoped
         // task key (`web#build`) in the chain, which `TurboJson::task`
         // consults first, and packages whose toolchain derives per-package
         // hash wiring (e.g. Cargo crate closures differ per crate).
@@ -269,9 +276,16 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
                     .get(&task_id.as_inner().as_task_name())
                     .is_some()
             });
-            let memoizable_contract = package_context
-                .as_ref()
-                .is_none_or(|context| !context.task_contract().derives_io());
+            let memoizable_contract = package_context.as_ref().is_none_or(|context| {
+                !native_contract.as_ref().map_or_else(
+                    || {
+                        context
+                            .task_contract()
+                            .derives_task_io(task_id.as_inner().task())
+                    },
+                    NativeTaskContract::derives_io,
+                )
+            });
             (!package_scoped && memoizable_contract).then(|| TaskDefMemoKey {
                 chain: turbo_json_chain
                     .iter()
@@ -280,6 +294,7 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
                 task_name: task_name.clone().into_owned(),
                 path_to_root: path_to_root.clone(),
                 defines_task,
+                native_contract: native_contract.clone(),
             })
         };
         if let Some(key) = &memo_key
@@ -334,9 +349,14 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         if should_apply_toolchain_defaults(command_override.as_ref())
             && let Some(context) = package_context.as_ref()
         {
-            let defaults = context
-                .task_contract()
-                .defaults_for_task(task_id.as_inner().task());
+            let defaults = native_contract
+                .as_ref()
+                .map(|contract| contract.defaults().clone())
+                .unwrap_or_else(|| {
+                    context
+                        .task_contract()
+                        .defaults_for_task(task_id.as_inner().task())
+                });
             if processed_task_definition.cache.is_none() {
                 processed_task_definition.cache = defaults.cache.map(Spanned::new);
             }
@@ -377,9 +397,14 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         // `$TURBO_DEFAULT$` take full control.
         if inherits_toolchain_task_io(task_def.command.as_ref())
             && let Some(package_context) = package_context.as_ref().filter(|context| {
-                context
-                    .task_contract()
-                    .derives_task_io(task_id.as_inner().task())
+                native_contract.as_ref().map_or_else(
+                    || {
+                        context
+                            .task_contract()
+                            .derives_task_io(task_id.as_inner().task())
+                    },
+                    NativeTaskContract::derives_io,
+                )
             })
         {
             let wants_automatic_inputs = !had_explicit_inputs || task_def.inputs.default;

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -464,11 +464,11 @@ pub fn native_tasks_for_package(
     package: &str,
 ) -> Vec<crate::native_tasks::NativeTask> {
     use crate::native_tasks::{
-        NativeCommandArguments, NativeCommandProgram, NativeTask, PassThroughPlacement,
-        PassThroughSeparator, WorkingDirectoryPolicy,
+        NativeCommandArguments, NativeCommandProgram, NativeTask, NativeTaskContract,
+        PassThroughPlacement, PassThroughSeparator, WorkingDirectoryPolicy,
     };
 
-    registered_tasks(details)
+    let mut tasks: Vec<_> = registered_tasks(details)
         .into_iter()
         .filter_map(|task| {
             let subcommand = task_subcommand(details.kind, task)?;
@@ -480,25 +480,68 @@ pub fn native_tasks_for_package(
                     format!("--package={package}")
                 }
             };
-            Some(NativeTask::command_task(
-                task,
-                display,
-                NativeCommandProgram::Tool("cargo".to_string()),
-                NativeCommandArguments {
-                    prefix: vec![subcommand.to_string(), scope_arg],
-                    pass_through_placement: PassThroughPlacement::AfterSuffix,
-                    pass_through_separator: pass_through_uses_separator(subcommand)
-                        .then(|| PassThroughSeparator::Fixed("--".to_string())),
-                    suffix: (subcommand != "fmt")
-                        .then(|| "--locked".to_string())
-                        .into_iter()
-                        .collect(),
-                },
-                (!matches!(subcommand, "run" | "fmt")).then(|| "cargo".to_string()),
-                WorkingDirectoryPolicy::RepositoryRoot,
-            ))
+            Some(
+                NativeTask::command_task(
+                    task,
+                    display,
+                    NativeCommandProgram::Tool("cargo".to_string()),
+                    NativeCommandArguments {
+                        prefix: vec![subcommand.to_string(), scope_arg],
+                        pass_through_placement: PassThroughPlacement::AfterSuffix,
+                        pass_through_separator: pass_through_uses_separator(subcommand)
+                            .then(|| PassThroughSeparator::Fixed("--".to_string())),
+                        suffix: (subcommand != "fmt")
+                            .then(|| "--locked".to_string())
+                            .into_iter()
+                            .collect(),
+                    },
+                    (!matches!(subcommand, "run" | "fmt")).then(|| "cargo".to_string()),
+                    WorkingDirectoryPolicy::RepositoryRoot,
+                )
+                .with_contract(NativeTaskContract::new(
+                    cargo_task_defaults(details, task),
+                    cargo_task_entrypoint(details.kind, task),
+                    true,
+                )),
+            )
         })
-        .collect()
+        .collect();
+    if !tasks.iter().any(|task| task.name() == "build") {
+        tasks.push(NativeTask::contract_task(
+            "build",
+            NativeTaskContract::new(
+                cargo_task_defaults(details, "build"),
+                cargo_task_entrypoint(details.kind, "build"),
+                false,
+            ),
+        ));
+    }
+    tasks
+}
+
+fn cargo_task_defaults(details: &CargoPackageDetails, task: &str) -> toolchain::TaskDefaults {
+    let cache = task_subcommand(details.kind, task).and_then(|subcommand| {
+        (subcommand == "run"
+            || subcommand == "fmt"
+            || (details.kind == CargoPackageKind::Library && subcommand == "build"))
+            .then_some(false)
+    });
+    toolchain::TaskDefaults { cache }
+}
+
+fn cargo_task_entrypoint(
+    kind: CargoPackageKind,
+    task: &str,
+) -> Option<crate::native_tasks::TaskEntrypoint> {
+    use crate::native_tasks::TaskEntrypoint;
+
+    library_subcommand(task)?;
+    Some(match (task == "build", kind) {
+        (true, CargoPackageKind::Workspace) => TaskEntrypoint::Excluded,
+        (true, CargoPackageKind::Entrypoint) => TaskEntrypoint::Preferred,
+        (false, CargoPackageKind::Workspace) => TaskEntrypoint::PreferredOnly,
+        _ => TaskEntrypoint::Candidate,
+    })
 }
 
 /// Whether pass-through args for `subcommand` must follow a `--` separator.
@@ -770,16 +813,6 @@ impl CargoTaskContract {
         }
     }
 
-    pub(crate) fn task_defaults(&self, task: &str) -> toolchain::TaskDefaults {
-        let cache = task_subcommand(self.package.kind, task).and_then(|subcommand| {
-            (subcommand == "run"
-                || subcommand == "fmt"
-                || (self.package.kind == CargoPackageKind::Library && subcommand == "build"))
-                .then_some(false)
-        });
-        toolchain::TaskDefaults { cache }
-    }
-
     /// Classifies Cargo package sources for dependent derived-input closures.
     /// Workspace aggregates have no package source directory to include.
     pub(crate) fn dependency_source_inputs(&self) -> crate::task_contracts::DependencySourceInputs {
@@ -796,29 +829,6 @@ impl CargoTaskContract {
         task_env: &std::collections::HashMap<String, String>,
     ) -> Vec<(String, String)> {
         cargo_compile_cache_env(endpoint, task_env)
-    }
-
-    pub(crate) fn derives_task_io(&self, task: &str) -> bool {
-        registered_tasks(&self.package)
-            .into_iter()
-            .any(|registered| registered == task)
-    }
-
-    pub(crate) fn task_entrypoint(
-        &self,
-        task: &str,
-    ) -> Option<crate::task_contracts::TaskEntrypoint> {
-        library_subcommand(task)?;
-        Some(match (task == "build", self.package.kind) {
-            (true, CargoPackageKind::Workspace) => crate::task_contracts::TaskEntrypoint::Excluded,
-            (true, CargoPackageKind::Entrypoint) => {
-                crate::task_contracts::TaskEntrypoint::Preferred
-            }
-            (false, CargoPackageKind::Workspace) => {
-                crate::task_contracts::TaskEntrypoint::PreferredOnly
-            }
-            _ => crate::task_contracts::TaskEntrypoint::Candidate,
-        })
     }
 
     pub(crate) fn derived_task_io(
@@ -3896,17 +3906,6 @@ release: 1.96.0-nightly\n",
         write_fixture_workspace(&root);
 
         let toolchain = CargoContributor::new(root.clone());
-        let discovered = toolchain.discover_packages().await.unwrap();
-        let contracts: HashMap<_, _> = discovered
-            .packages()
-            .iter()
-            .cloned()
-            .filter_map(|package| {
-                let parts = package.into_parts();
-                Some((parts.name?, parts.task_contract?))
-            })
-            .collect();
-
         let app_context = task_context(&toolchain, &root, "app", "crates/app");
         let lib_a_context = task_context(&toolchain, &root, "lib-a", "crates/lib-a");
         let workspace_context = task_context(&toolchain, &root, "fixture-ws", "");
@@ -3999,17 +3998,18 @@ release: 1.96.0-nightly\n",
             Some("cargo build --package=lib-a --locked")
         );
 
-        let app_contract = &contracts["app"];
-        let library_contract = &contracts["lib-a"];
-        let workspace_contract = &contracts["fixture-ws"];
-        assert_eq!(app_contract.defaults_for_task("run").cache, Some(false));
-        assert_eq!(app_contract.defaults_for_task("dev").cache, Some(false));
-        assert_eq!(app_contract.defaults_for_task("build").cache, None);
-        assert_eq!(workspace_contract.defaults_for_task("test").cache, None);
-        assert_eq!(library_contract.defaults_for_task("test").cache, None);
-        assert_eq!(workspace_contract.defaults_for_task("format").cache, Some(false));
-        assert_eq!(library_contract.defaults_for_task("format").cache, Some(false));
-        assert_eq!(library_contract.defaults_for_task("build").cache, Some(false));
+        let app_build = app_context.native_tasks().get("build").unwrap().contract();
+        let library_build = lib_a_context.native_tasks().get("build").unwrap().contract();
+        let workspace_build = workspace_context.native_tasks().get("build").unwrap().contract();
+        assert_eq!(app_context.native_tasks().get("run").unwrap().contract().defaults().cache, Some(false));
+        assert_eq!(app_context.native_tasks().get("dev").unwrap().contract().defaults().cache, Some(false));
+        assert_eq!(app_build.defaults().cache, None);
+        assert_eq!(workspace_context.native_tasks().get("test").unwrap().contract().defaults().cache, None);
+        assert_eq!(lib_a_context.native_tasks().get("test").unwrap().contract().defaults().cache, None);
+        assert_eq!(workspace_context.native_tasks().get("format").unwrap().contract().defaults().cache, Some(false));
+        assert_eq!(lib_a_context.native_tasks().get("format").unwrap().contract().defaults().cache, Some(false));
+        assert_eq!(library_build.defaults().cache, Some(false));
+        assert!(app_build.derives_io());
         assert_eq!(
             app_context
                 .native_tasks()
@@ -4024,23 +4024,23 @@ release: 1.96.0-nightly\n",
         );
 
         assert_eq!(
-            app_contract.task_entrypoint("build"),
+            app_build.entrypoint(),
             Some(crate::task_contracts::TaskEntrypoint::Preferred)
         );
         assert_eq!(
-            library_contract.task_entrypoint("build"),
+            library_build.entrypoint(),
             Some(crate::task_contracts::TaskEntrypoint::Candidate)
         );
         assert_eq!(
-            workspace_contract.task_entrypoint("build"),
+            workspace_build.entrypoint(),
             Some(crate::task_contracts::TaskEntrypoint::Excluded)
         );
         assert_eq!(
-            workspace_contract.task_entrypoint("test"),
+            workspace_context.native_tasks().get("test").unwrap().contract().entrypoint(),
             Some(crate::task_contracts::TaskEntrypoint::PreferredOnly)
         );
         assert_eq!(
-            workspace_contract.task_entrypoint("format"),
+            workspace_context.native_tasks().get("format").unwrap().contract().entrypoint(),
             Some(crate::task_contracts::TaskEntrypoint::PreferredOnly)
         );
     }

--- a/crates/turborepo-repository/src/native_tasks.rs
+++ b/crates/turborepo-repository/src/native_tasks.rs
@@ -14,8 +14,50 @@ use crate::{
     package_graph::PackageTaskContext,
     package_json::PackageJson,
     package_manager::PackageManager,
-    toolchain::{TaskCommand, override_task_command, package_manager_command},
+    toolchain::{TaskCommand, TaskDefaults, override_task_command, package_manager_command},
 };
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TaskEntrypoint {
+    Preferred,
+    PreferredOnly,
+    Candidate,
+    Excluded,
+}
+
+/// Immutable task-local behavior supplied by a native-task producer.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+pub struct NativeTaskContract {
+    defaults: TaskDefaults,
+    entrypoint: Option<TaskEntrypoint>,
+    derives_io: bool,
+}
+
+impl NativeTaskContract {
+    pub fn new(
+        defaults: TaskDefaults,
+        entrypoint: Option<TaskEntrypoint>,
+        derives_io: bool,
+    ) -> Self {
+        Self {
+            defaults,
+            entrypoint,
+            derives_io,
+        }
+    }
+
+    pub fn defaults(&self) -> &TaskDefaults {
+        &self.defaults
+    }
+
+    pub fn entrypoint(&self) -> Option<TaskEntrypoint> {
+        self.entrypoint
+    }
+
+    pub fn derives_io(&self) -> bool {
+        self.derives_io
+    }
+}
 
 /// How a native command chooses its working directory.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -90,6 +132,7 @@ pub struct NativeTask {
     script: Option<Spanned<String>>,
     command: Option<NativeCommandTemplate>,
     cwd_policy: WorkingDirectoryPolicy,
+    contract: NativeTaskContract,
 }
 
 impl NativeTask {
@@ -125,6 +168,15 @@ impl NativeTask {
         self.cwd_policy
     }
 
+    pub fn contract(&self) -> &NativeTaskContract {
+        &self.contract
+    }
+
+    pub fn with_contract(mut self, contract: NativeTaskContract) -> Self {
+        self.contract = contract;
+        self
+    }
+
     /// Construct a synthesized native command task (not package-authored).
     pub fn command_task(
         name: impl Into<String>,
@@ -148,6 +200,22 @@ impl NativeTask {
                 serial_group,
             }),
             cwd_policy,
+            contract: NativeTaskContract::default(),
+        }
+    }
+
+    /// Construct a non-executable task carrying classification facts.
+    pub fn contract_task(name: impl Into<String>, contract: NativeTaskContract) -> Self {
+        Self {
+            name: name.into(),
+            authored: false,
+            registered: false,
+            executable: false,
+            display: None,
+            script: None,
+            command: None,
+            cwd_policy: WorkingDirectoryPolicy::RepositoryRoot,
+            contract,
         }
     }
 }
@@ -335,6 +403,7 @@ pub fn observation_from_scripts(
                 serial_group: None,
             }),
             cwd_policy: WorkingDirectoryPolicy::PackageDirectory,
+            contract: NativeTaskContract::default(),
         });
     }
     NativeTaskObservation {

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -708,7 +708,10 @@ impl PackageGraph {
             let Some(domain) = contract.task_entrypoint_domain() else {
                 continue;
             };
-            let Some(entrypoint) = contract.task_entrypoint(task) else {
+            let Some(entrypoint) = context.native_tasks().get(task).map_or_else(
+                || contract.task_entrypoint(task),
+                |task| task.contract().entrypoint(),
+            ) else {
                 continue;
             };
             classified
@@ -761,10 +764,14 @@ impl PackageGraph {
                     return false;
                 };
                 let contract = context.task_contract();
+                let classified = context.native_tasks().get(task).map_or_else(
+                    || contract.task_entrypoint(task),
+                    |task| task.contract().entrypoint(),
+                );
                 contract
                     .task_entrypoint_domain()
                     .is_some_and(|domain| active_domains.contains(domain))
-                    && contract.task_entrypoint(task).is_some()
+                    && classified.is_some()
             })
             .cloned()
             .collect()

--- a/crates/turborepo-repository/src/task_contracts.rs
+++ b/crates/turborepo-repository/src/task_contracts.rs
@@ -11,15 +11,8 @@
 
 use std::{borrow::Cow, collections::BTreeMap};
 
+pub use crate::native_tasks::TaskEntrypoint;
 use crate::toolchain::{TaskDefaults, ToolchainId};
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TaskEntrypoint {
-    Preferred,
-    PreferredOnly,
-    Candidate,
-    Excluded,
-}
 
 /// Groups scopes whose preferred entrypoints compete with one another.
 /// Deliberately independent from ecosystem provenance.
@@ -285,12 +278,6 @@ impl ScopeTaskContract {
     }
 
     pub fn defaults_for_task(&self, task: &str) -> TaskDefaults {
-        if let Some(dynamic) = self.dynamic.as_ref() {
-            return match dynamic {
-                DynamicTaskContract::Cargo(contract) => contract.task_defaults(task),
-                DynamicTaskContract::Python(contract) => contract.task_defaults(task),
-            };
-        }
         self.static_defaults
             .get(task)
             .cloned()
@@ -299,10 +286,6 @@ impl ScopeTaskContract {
 
     pub fn derives_task_io(&self, task: &str) -> bool {
         self.static_io.contains_key(task)
-            || self.dynamic.as_ref().is_some_and(|dynamic| match dynamic {
-                DynamicTaskContract::Cargo(contract) => contract.derives_task_io(task),
-                DynamicTaskContract::Python(contract) => contract.derives_task_io(task),
-            })
     }
 
     pub fn derived_task_io(
@@ -338,13 +321,7 @@ impl ScopeTaskContract {
     }
 
     pub fn task_entrypoint(&self, task: &str) -> Option<TaskEntrypoint> {
-        self.static_entrypoints
-            .get(task)
-            .copied()
-            .or_else(|| match self.dynamic.as_ref()? {
-                DynamicTaskContract::Cargo(contract) => contract.task_entrypoint(task),
-                DynamicTaskContract::Python(contract) => contract.task_entrypoint(task),
-            })
+        self.static_entrypoints.get(task).copied()
     }
 
     pub fn task_entrypoint_domain(&self) -> Option<&TaskEntrypointDomain> {

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -445,7 +445,7 @@ pub struct WatchSpec {
 }
 
 /// Default task behavior supplied by task-contract knowledge.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct TaskDefaults {
     /// Whether task logs and outputs are cacheable.
     pub cache: Option<bool>,

--- a/crates/turborepo-repository/src/uv.rs
+++ b/crates/turborepo-repository/src/uv.rs
@@ -787,10 +787,11 @@ pub fn native_tasks_for_package(
     workspace_directories: &[String],
 ) -> Vec<crate::native_tasks::NativeTask> {
     use crate::native_tasks::{
-        NativeCommandArguments, NativeCommandProgram, NativeTask, WorkingDirectoryPolicy,
+        NativeCommandArguments, NativeCommandProgram, NativeTask, NativeTaskContract,
+        WorkingDirectoryPolicy,
     };
 
-    registered_tasks(kind)
+    let mut tasks: Vec<_> = registered_tasks(kind)
         .filter_map(|task| {
             let subcommand = task_subcommand(kind, task)?;
             let display = display_command(
@@ -800,26 +801,73 @@ pub fn native_tasks_for_package(
                 package_directory,
                 workspace_directories,
             )?;
-            Some(NativeTask::command_task(
-                task,
-                display,
-                NativeCommandProgram::Tool("uv".to_string()),
-                NativeCommandArguments::new(
-                    std::iter::once(subcommand.to_string())
-                        .chain(task_arguments(
-                            kind,
-                            task,
-                            package,
-                            package_directory,
-                            workspace_directories,
-                        ))
-                        .collect(),
-                ),
-                (task == "check").then(|| "uv".to_string()),
-                WorkingDirectoryPolicy::RepositoryRoot,
-            ))
+            Some(
+                NativeTask::command_task(
+                    task,
+                    display,
+                    NativeCommandProgram::Tool("uv".to_string()),
+                    NativeCommandArguments::new(
+                        std::iter::once(subcommand.to_string())
+                            .chain(task_arguments(
+                                kind,
+                                task,
+                                package,
+                                package_directory,
+                                workspace_directories,
+                            ))
+                            .collect(),
+                    ),
+                    (task == "check").then(|| "uv".to_string()),
+                    WorkingDirectoryPolicy::RepositoryRoot,
+                )
+                .with_contract(NativeTaskContract::new(
+                    uv_task_defaults(kind, task),
+                    uv_task_entrypoint(kind, task),
+                    true,
+                )),
+            )
         })
-        .collect()
+        .collect();
+    if !tasks.iter().any(|task| task.name() == "build") {
+        tasks.push(NativeTask::contract_task(
+            "build",
+            NativeTaskContract::new(
+                uv_task_defaults(kind, "build"),
+                uv_task_entrypoint(kind, "build"),
+                false,
+            ),
+        ));
+    }
+    tasks
+}
+
+fn uv_task_defaults(kind: UvPackageKind, task: &str) -> toolchain::TaskDefaults {
+    // Tool versions are not yet part of the task fingerprint.
+    toolchain::TaskDefaults {
+        cache: task_subcommand(kind, task).map(|_| false),
+    }
+}
+
+fn uv_task_entrypoint(
+    kind: UvPackageKind,
+    task: &str,
+) -> Option<crate::native_tasks::TaskEntrypoint> {
+    use crate::native_tasks::TaskEntrypoint;
+
+    if task_subcommand(kind, task).is_some() {
+        return Some(match kind {
+            UvPackageKind::Workspace => TaskEntrypoint::PreferredOnly,
+            UvPackageKind::Package | UvPackageKind::VirtualPackage => TaskEntrypoint::Candidate,
+        });
+    }
+    matches!(
+        (kind, task),
+        (
+            UvPackageKind::Workspace | UvPackageKind::VirtualPackage,
+            "build"
+        )
+    )
+    .then_some(TaskEntrypoint::Excluded)
 }
 
 // ---------------------------------------------------------------------------
@@ -982,14 +1030,6 @@ impl UvTaskContract {
         }
     }
 
-    pub(crate) fn task_defaults(&self, task: &str) -> toolchain::TaskDefaults {
-        // uv, Python, ty, and isolated build-backend versions are not
-        // yet part of the task fingerprint, so built-in uv commands fail
-        // closed on cache.
-        let cache = task_subcommand(self.kind, task).map(|_| false);
-        toolchain::TaskDefaults { cache }
-    }
-
     /// Classifies Python package sources for dependent derived-input
     /// closures. Workspace aggregates have no package source directory to
     /// include.
@@ -999,32 +1039,6 @@ impl UvTaskContract {
                 crate::task_contracts::DependencySourceInputs::Include
             }
             UvPackageKind::Workspace => crate::task_contracts::DependencySourceInputs::Exclude,
-        }
-    }
-
-    pub(crate) fn derives_task_io(&self, task: &str) -> bool {
-        registered_tasks(self.kind).any(|registered| registered == task)
-    }
-
-    pub(crate) fn task_entrypoint(
-        &self,
-        task: &str,
-    ) -> Option<crate::task_contracts::TaskEntrypoint> {
-        if task_subcommand(self.kind, task).is_some() {
-            return Some(match self.kind {
-                // Unfiltered quality tasks use the workspace-scoped command
-                // only; per-package commands are for filtered runs.
-                UvPackageKind::Workspace => crate::task_contracts::TaskEntrypoint::PreferredOnly,
-                UvPackageKind::Package | UvPackageKind::VirtualPackage => {
-                    crate::task_contracts::TaskEntrypoint::Candidate
-                }
-            });
-        }
-        match (self.kind, task) {
-            (UvPackageKind::Workspace | UvPackageKind::VirtualPackage, "build") => {
-                Some(crate::task_contracts::TaskEntrypoint::Excluded)
-            }
-            _ => None,
         }
     }
 
@@ -2054,22 +2068,36 @@ overridden = { index = "private" }
                 .iter()
                 .all(|task| task.registered() && task.executable())
         );
+        let build = tasks.iter().find(|task| task.name() == "build").unwrap();
+        assert_eq!(build.contract().defaults().cache, Some(false));
+        assert_eq!(
+            build.contract().entrypoint(),
+            Some(crate::native_tasks::TaskEntrypoint::Candidate)
+        );
+        assert!(build.contract().derives_io());
+
+        let virtual_tasks = native_tasks_for_package(
+            UvPackageKind::VirtualPackage,
+            "py-app",
+            "packages/py-app",
+            &[],
+        );
+        let build = virtual_tasks
+            .iter()
+            .find(|task| task.name() == "build")
+            .unwrap();
+        assert!(!build.executable());
+        assert_eq!(
+            build.contract().entrypoint(),
+            Some(crate::native_tasks::TaskEntrypoint::Excluded)
+        );
+        assert!(!build.contract().derives_io());
     }
 
     #[test]
     fn test_derived_outputs_for_build() {
         let contract = UvTaskContract::new(UvPackageKind::Package, "py-app");
-        assert!(contract.derives_task_io("build"));
-        assert!(contract.derives_task_io("format"));
-        assert!(contract.derives_task_io("check"));
-        assert!(!contract.derives_task_io("test"));
-        assert_eq!(contract.task_defaults("check").cache, Some(false));
-        assert_eq!(contract.task_defaults("build").cache, Some(false));
         assert_eq!(contract.dist_name, "py_app");
-
-        let virtual_contract = UvTaskContract::new(UvPackageKind::VirtualPackage, "py-app");
-        assert!(!virtual_contract.derives_task_io("build"));
-        assert!(virtual_contract.derives_task_io("check"));
     }
 
     #[test]


### PR DESCRIPTION
### Description

Part 2 of 13 in stack #13677, based on #13664. Moves defaults, entrypoint classification, and derived-I/O eligibility into parser-neutral task-local contracts while retaining scope-wide environment, prune, dependency-source, and dynamic-I/O facts.

Previous: #13664. Next: #13666.

### Testing Instructions

Full-tip verification passed: `cargo fmt --all -- --check`; `cargo test -p turborepo-repository --no-fail-fast` (437 tests); `cargo test -p turborepo-engine --no-fail-fast` (135 tests); `cargo test -p turbo --test uv_workspace_test --test task_entrypoints_test --no-fail-fast` (25 tests); and strict clippy across affected crates. Every cumulative tip passed `cargo check --tests`. `uv` is unavailable, and a full workspace run was not performed.