### PR TITLE
feat: Compose aggregate native task dependencies

### DIFF
--- a/crates/turborepo-engine/src/builder/definitions.rs
+++ b/crates/turborepo-engine/src/builder/definitions.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use miette::{NamedSource, SourceSpan};
 use turborepo_errors::Spanned;
 use turborepo_repository::{
-    native_tasks::NativeTaskContract,
+    native_tasks::{NativeTaskContract, NativeTaskExecution},
     package_graph::{PackageGraph, PackageName, PackageNode},
 };
 use turborepo_task_id::{TaskId, TaskName};
@@ -21,14 +21,14 @@ use crate::{
 /// Memo key for resolved task definitions: the turbo.json chain (by
 /// address; loader-owned for the duration of a build), the task name, and
 /// the package-dependent inputs that survive resolution: path to the repo
-/// root, native execution eligibility, and task-local contract facts. See
+/// root, native execution, and task-local contract facts. See
 /// `task_definition_cached`.
 #[derive(PartialEq, Eq, Hash)]
 pub(super) struct TaskDefMemoKey {
     chain: Vec<usize>,
     task_name: TaskName<'static>,
     path_to_root: turbopath::RelativeUnixPathBuf,
-    defines_task: bool,
+    native_execution: NativeTaskExecution,
     native_contract: Option<NativeTaskContract>,
 }
 
@@ -254,8 +254,11 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         let native_task = package_context
             .as_ref()
             .and_then(|context| context.native_tasks().get(task_id.task()));
+        let native_execution = native_task
+            .map(|task| task.execution().clone())
+            .unwrap_or(NativeTaskExecution::None);
         let native_contract = native_task.map(|task| task.contract().clone());
-        let defines_task = native_task.is_some_and(|task| task.executes());
+        let defines_task = matches!(native_execution, NativeTaskExecution::Command(_));
         let registered_task = package_context
             .as_ref()
             .is_some_and(|context| context.native_tasks().registers(task_id.task()));
@@ -263,8 +266,8 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         // Most tasks resolve to an identical definition: the same turbo.json
         // chain and task name, differing only by the package's depth (for
         // `$TURBO_ROOT$`/global-input anchoring) and whether the package's
-        // toolchain defines a command for the task, and task-local contract
-        // facts. Memoize on exactly those inputs. Two exceptions must skip the memo: a
+        // toolchain's execution for the task, and task-local contract facts.
+        // Memoize on exactly those inputs. Two exceptions must skip the memo: a
         // package-scoped
         // task key (`web#build`) in the chain, which `TurboJson::task`
         // consults first, and packages whose toolchain derives per-package
@@ -293,7 +296,7 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
                     .collect(),
                 task_name: task_name.clone().into_owned(),
                 path_to_root: path_to_root.clone(),
-                defines_task,
+                native_execution: native_execution.clone(),
                 native_contract: native_contract.clone(),
             })
         };
@@ -366,6 +369,44 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         let mut task_def =
             TaskDefinition::from_processed(processed_task_definition, &path_to_root)?;
         task_def.command = command_override;
+
+        if task_def.command.is_none()
+            && let NativeTaskExecution::Aggregate(dependencies) = &native_execution
+        {
+            let task_args = TaskArgs::new(&self.pass_through_args, &self.requested_tasks);
+            if task_args.args_for_task(task_id.as_inner()).is_some() {
+                let alternatives = dependencies
+                    .iter()
+                    .map(|dependency| format!("{}#{dependency}", task_id.package()))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                return Err(BuilderError::AggregatePassThrough {
+                    task_id: task_id.to_string(),
+                    alternatives,
+                });
+            }
+
+            let mut seen: HashSet<TaskId<'static>> = task_def
+                .task_dependencies
+                .iter()
+                .map(|dependency| {
+                    dependency
+                        .task_id()
+                        .unwrap_or_else(|| TaskId::new(task_id.package(), dependency.task()))
+                        .into_owned()
+                })
+                .collect();
+            task_def.task_dependencies.extend(
+                dependencies
+                    .iter()
+                    .filter(|dependency| {
+                        seen.insert(TaskId::new(task_id.package(), dependency).into_owned())
+                    })
+                    .map(|dependency| {
+                        Spanned::new(TaskName::from(dependency.clone()).into_owned())
+                    }),
+            );
+        }
 
         if !self.future_flags.incremental_tasks {
             task_def.incremental = None;

--- a/crates/turborepo-engine/src/builder/test.rs
+++ b/crates/turborepo-engine/src/builder/test.rs
@@ -12,6 +12,9 @@ use turborepo_errors::Spanned;
 use turborepo_lockfiles::Lockfile;
 use turborepo_repository::{
     discovery::PackageDiscovery,
+    native_tasks::{
+        NativeCommandArguments, NativeCommandProgram, NativeTask, WorkingDirectoryPolicy,
+    },
     package_graph::{PackageGraph, PackageName, ROOT_PKG_NAME},
     package_json::PackageJson,
     package_manager::PackageManager,
@@ -130,16 +133,60 @@ impl RepositoryContributor for AggregateContributor {
 
     fn discover_packages(&self) -> DiscoverPackagesFuture<'_> {
         Box::pin(async move {
+            let command = |name: &str| {
+                NativeTask::command_task(
+                    name,
+                    format!("tool {name}"),
+                    NativeCommandProgram::Tool("tool".to_string()),
+                    NativeCommandArguments::new(vec![name.to_string()]),
+                    None,
+                    WorkingDirectoryPolicy::RepositoryRoot,
+                )
+            };
             Ok(DiscoveredPackages::new(
-                vec![DiscoveredPackage::aggregate(
-                    "cargo-workspace".to_owned(),
-                    PackageJson::default(),
-                    self.repo_root.join_component("Cargo.toml"),
-                )],
+                vec![
+                    DiscoveredPackage::aggregate(
+                        "cargo-workspace".to_owned(),
+                        PackageJson::default(),
+                        self.repo_root.join_component("Cargo.toml"),
+                    )
+                    .with_native_tasks(vec![
+                        NativeTask::aggregate("all", ["check", "lint"]),
+                        command("check"),
+                        command("lint"),
+                    ]),
+                    DiscoveredPackage::aggregate(
+                        "other-workspace".to_owned(),
+                        PackageJson::default(),
+                        self.repo_root.join_component("Other.toml"),
+                    )
+                    .with_native_tasks(vec![
+                        NativeTask::aggregate("all", ["check"]),
+                        command("check"),
+                    ]),
+                ],
                 vec![WorkspaceRoot::new("aggregate-test", self.repo_root.clone())],
             ))
         })
     }
+}
+
+fn mock_aggregate_package_graph(repo_root: &AbsoluteSystemPathBuf) -> PackageGraph {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    runtime
+        .block_on(
+            PackageGraph::builder_optional(repo_root, None)
+                .with_package_discovery(MockDiscovery)
+                .with_package_jsons(Some(HashMap::new()))
+                .with_contributor(Arc::new(AggregateContributor {
+                    repo_root: repo_root.clone(),
+                }))
+                .build(),
+        )
+        .unwrap()
 }
 
 type StubIOEngineResult = Engine<Built, TaskDefinition>;

--- a/crates/turborepo-engine/src/builder/test/core.rs
+++ b/crates/turborepo-engine/src/builder/test/core.rs
@@ -50,6 +50,139 @@ fn test_default_engine() {
     assert_eq!(all_dependencies(&engine), expected);
 }
 
+fn aggregate_engine(
+    repo_root: &AbsoluteSystemPathBuf,
+    root_config: serde_json::Value,
+    pass_through_args: Vec<String>,
+) -> Result<Engine<Built, TaskDefinition>, BuilderError> {
+    let package_graph = mock_aggregate_package_graph(repo_root);
+    let loader = TestTurboJsonLoader::new(HashMap::from([(
+        PackageName::Root,
+        turbo_json(root_config),
+    )]));
+    EngineBuilder::new(repo_root, &package_graph, &loader, false)
+        .with_tasks(Some(Spanned::new(TaskName::from("all"))))
+        .with_workspaces(vec![PackageName::from("cargo-workspace")])
+        .with_task_io_context(pass_through_args, vec!["all".to_string()], HashMap::new())
+        .build()
+}
+
+#[test]
+fn native_aggregate_composes_same_scope_dependencies() {
+    let repo = TempDir::new().unwrap();
+    let repo_root = AbsoluteSystemPathBuf::try_from(repo.path().to_path_buf()).unwrap();
+    let engine = aggregate_engine(
+        &repo_root,
+        json!({ "tasks": { "all": { "dependsOn": ["check"] } } }),
+        Vec::new(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        all_dependencies(&engine),
+        deps! {
+            "cargo-workspace#all" => ["cargo-workspace#check", "cargo-workspace#lint"],
+            "cargo-workspace#check" => ["___ROOT___"],
+            "cargo-workspace#lint" => ["___ROOT___"]
+        }
+    );
+}
+
+#[test]
+fn native_aggregate_deduplicates_by_effective_task_id() {
+    let repo = TempDir::new().unwrap();
+    let repo_root = AbsoluteSystemPathBuf::try_from(repo.path().to_path_buf()).unwrap();
+    let engine = aggregate_engine(
+        &repo_root,
+        json!({
+            "tasks": {
+                "all": {
+                    "dependsOn": ["cargo-workspace#check", "other-workspace#check"]
+                }
+            }
+        }),
+        Vec::new(),
+    )
+    .unwrap();
+
+    let definition = task_definition(&engine, "cargo-workspace#all");
+    assert_eq!(definition.task_dependencies.len(), 3);
+    assert_eq!(
+        all_dependencies(&engine),
+        deps! {
+            "cargo-workspace#all" => [
+                "cargo-workspace#check",
+                "cargo-workspace#lint",
+                "other-workspace#check"
+            ],
+            "cargo-workspace#check" => ["___ROOT___"],
+            "cargo-workspace#lint" => ["___ROOT___"],
+            "other-workspace#check" => ["___ROOT___"]
+        }
+    );
+}
+
+#[test]
+fn native_aggregate_execution_is_part_of_definition_memoization() {
+    let repo = TempDir::new().unwrap();
+    let repo_root = AbsoluteSystemPathBuf::try_from(repo.path().to_path_buf()).unwrap();
+    let package_graph = mock_aggregate_package_graph(&repo_root);
+    let loader = TestTurboJsonLoader::new(HashMap::from([(
+        PackageName::Root,
+        turbo_json(json!({ "tasks": {} })),
+    )]));
+    let engine = EngineBuilder::new(&repo_root, &package_graph, &loader, false)
+        .with_tasks(Some(Spanned::new(TaskName::from("all"))))
+        .with_workspaces(vec![
+            PackageName::from("cargo-workspace"),
+            PackageName::from("other-workspace"),
+        ])
+        .build()
+        .unwrap();
+
+    assert_eq!(
+        all_dependencies(&engine),
+        deps! {
+            "cargo-workspace#all" => ["cargo-workspace#check", "cargo-workspace#lint"],
+            "cargo-workspace#check" => ["___ROOT___"],
+            "cargo-workspace#lint" => ["___ROOT___"],
+            "other-workspace#all" => ["other-workspace#check"],
+            "other-workspace#check" => ["___ROOT___"]
+        }
+    );
+}
+
+#[test]
+fn native_aggregate_dependencies_use_normal_cycle_validation() {
+    let repo = TempDir::new().unwrap();
+    let repo_root = AbsoluteSystemPathBuf::try_from(repo.path().to_path_buf()).unwrap();
+    let error = aggregate_engine(
+        &repo_root,
+        json!({ "tasks": { "check": { "dependsOn": ["all"] } } }),
+        Vec::new(),
+    )
+    .unwrap_err();
+
+    assert!(matches!(error, BuilderError::Graph(_)), "got {error:?}");
+}
+
+#[test]
+fn native_aggregate_rejects_pass_through_with_qualified_children() {
+    let repo = TempDir::new().unwrap();
+    let repo_root = AbsoluteSystemPathBuf::try_from(repo.path().to_path_buf()).unwrap();
+    let error = aggregate_engine(
+        &repo_root,
+        json!({ "tasks": {} }),
+        vec!["--fix".to_string()],
+    )
+    .unwrap_err();
+
+    assert!(matches!(error, BuilderError::AggregatePassThrough { .. }));
+    let message = error.to_string();
+    assert!(message.contains("cargo-workspace#check"));
+    assert!(message.contains("cargo-workspace#lint"));
+}
+
 #[test]
 fn test_dependencies_on_unspecified_packages() {
     let repo_root_dir = TempDir::with_prefix("repo").unwrap();

--- a/crates/turborepo-engine/src/builder_error.rs
+++ b/crates/turborepo-engine/src/builder_error.rs
@@ -61,6 +61,14 @@ pub enum Error {
     InvalidTaskName(Box<InvalidTaskNameError>),
     #[error("Engine builder cannot be constructed without a turbo.json loader")]
     MissingTurboJsonLoader,
+    #[error(
+        "Cannot pass arguments to aggregate task `{task_id}` because it does not run a process. \
+         Run one of its qualified dependency tasks instead: {alternatives}."
+    )]
+    AggregatePassThrough {
+        task_id: String,
+        alternatives: String,
+    },
 }
 
 impl From<ValidateError> for Error {


### PR DESCRIPTION
### Description

Part 4 of 13 in stack #13677, based on #13666. Composes aggregate children into engine task dependencies with effective-ID deduplication, memoization safety, normal cycle validation, and qualified pass-through guidance.

Previous: #13666. Next: #13668 completes override and exclusion semantics.

### Testing Instructions

Full-tip verification passed: formatting; 437 repository tests; 135 engine tests; 13 uv integration tests; 12 entrypoint tests; and strict clippy across affected crates. Every cumulative tip passed `cargo check --tests`. `uv` is unavailable, and a full workspace run was not performed.