### PR TITLE
fix: Respect aggregate task overrides

### DIFF
--- a/crates/turborepo-engine/src/builder/definitions.rs
+++ b/crates/turborepo-engine/src/builder/definitions.rs
@@ -30,6 +30,8 @@ pub(super) struct TaskDefMemoKey {
     path_to_root: turbopath::RelativeUnixPathBuf,
     native_execution: NativeTaskExecution,
     native_contract: Option<NativeTaskContract>,
+    authored_task: bool,
+    registered_task: bool,
 }
 
 impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
@@ -254,14 +256,20 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         let native_task = package_context
             .as_ref()
             .and_then(|context| context.native_tasks().get(task_id.task()));
-        let native_execution = native_task
+        let native_contract = native_task.map(|task| task.contract().clone());
+        let mut native_execution = native_task
             .map(|task| task.execution().clone())
             .unwrap_or(NativeTaskExecution::None);
-        let native_contract = native_task.map(|task| task.contract().clone());
+        if task_is_excluded(&turbo_json_chain, task_id.as_inner(), task_name) {
+            native_execution = NativeTaskExecution::None;
+        }
         let defines_task = matches!(native_execution, NativeTaskExecution::Command(_));
         let registered_task = package_context
             .as_ref()
             .is_some_and(|context| context.native_tasks().registers(task_id.task()));
+        let authored_task = package_context
+            .as_ref()
+            .is_some_and(|context| context.native_tasks().authors(task_id.task()));
 
         // Most tasks resolve to an identical definition: the same turbo.json
         // chain and task name, differing only by the package's depth (for
@@ -298,6 +306,8 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
                 path_to_root: path_to_root.clone(),
                 native_execution: native_execution.clone(),
                 native_contract: native_contract.clone(),
+                authored_task,
+                registered_task,
             })
         };
         if let Some(key) = &memo_key
@@ -335,12 +345,9 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         let command_override = resolve_command_override(
             scoped_command,
             unscoped_command,
-            package_context.as_ref().map(|context| {
-                (
-                    context.task_contract(),
-                    context.native_tasks().authors(task_id.as_inner().task()),
-                )
-            }),
+            package_context
+                .as_ref()
+                .map(|context| (context.task_contract(), authored_task)),
         );
 
         let mut processed_task_definition = ProcessedTaskDefinition::from_iter(
@@ -553,12 +560,6 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         should_validate_engine: bool,
         registered_task: bool,
     ) -> Result<Vec<(ProcessedTaskDefinition, bool)>, BuilderError> {
-        let root_used_scoped_key = |turbo_json: &TurboJson| {
-            turbo_json
-                .tasks
-                .get(&task_id.as_inner().as_task_name())
-                .is_some()
-        };
         let mut task_definitions = Vec::new();
 
         // Find the first package in the chain (iterating in reverse from leaf to root)
@@ -566,7 +567,8 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         // packages.
         let mut extends_false_index: Option<usize> = None;
         for (index, turbo_json) in turbo_json_chain.iter().enumerate().rev() {
-            if let Some(task_def) = turbo_json.tasks.get(task_name)
+            if let Some(key) = configured_task_key(turbo_json, task_id, task_name)
+                && let Some(task_def) = turbo_json.tasks.get(&key)
                 && task_def
                     .extends
                     .as_ref()
@@ -582,15 +584,18 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         // If we found extends: false, only process from that point onwards
         if let Some(index) = extends_false_index {
             if let Some(turbo_json) = turbo_json_chain.get(index)
-                && let Some(local_def) = turbo_json.task(task_id, task_name)?
+                && let Some(key) = configured_task_key(turbo_json, task_id, task_name)
+                && let Some(local_def) = turbo_json.task(task_id, &key)?
                 && local_def.has_config_beyond_extends()
             {
-                let scoped = index > 0 || root_used_scoped_key(turbo_json);
+                let scoped = index > 0 || key.is_package_task();
                 task_definitions.push((local_def, scoped));
             }
             // Process any packages after this one (towards the leaf)
             for turbo_json in turbo_json_chain.iter().skip(index + 1) {
-                if let Some(workspace_def) = turbo_json.task(task_id, task_name)? {
+                if let Some(key) = configured_task_key(turbo_json, task_id, task_name)
+                    && let Some(workspace_def) = turbo_json.task(task_id, &key)?
+                {
                     task_definitions.push((workspace_def, true));
                 }
             }
@@ -601,9 +606,10 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         let mut turbo_json_chain = turbo_json_chain.into_iter();
 
         if let Some(root_turbo_json) = turbo_json_chain.next()
-            && let Some(root_definition) = root_turbo_json.task(task_id, task_name)?
+            && let Some(key) = configured_task_key(root_turbo_json, task_id, task_name)
+            && let Some(root_definition) = root_turbo_json.task(task_id, &key)?
         {
-            let scoped = root_used_scoped_key(root_turbo_json);
+            let scoped = key.is_package_task();
             task_definitions.push((root_definition, scoped))
         }
 
@@ -624,7 +630,9 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         }
 
         for turbo_json in turbo_json_chain {
-            if let Some(workspace_def) = turbo_json.task(task_id, task_name)? {
+            if let Some(key) = configured_task_key(turbo_json, task_id, task_name)
+                && let Some(workspace_def) = turbo_json.task(task_id, &key)?
+            {
                 task_definitions.push((workspace_def, true));
             }
         }
@@ -762,6 +770,37 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
 
         Ok(turbo_jsons.into_iter().rev().collect())
     }
+}
+
+fn task_is_excluded(
+    turbo_json_chain: &[&TurboJson],
+    task_id: &TaskId,
+    task_name: &TaskName,
+) -> bool {
+    turbo_json_chain.iter().rev().find_map(|turbo_json| {
+        configured_task_key(turbo_json, task_id, task_name).and_then(|key| {
+            turbo_json.tasks.get(&key).map(|definition| {
+                definition
+                    .extends
+                    .as_ref()
+                    .is_some_and(|extends| !*extends.as_inner())
+                    && !definition.has_config_beyond_extends()
+            })
+        })
+    }) == Some(true)
+}
+
+fn configured_task_key(
+    turbo_json: &TurboJson,
+    task_id: &TaskId,
+    task_name: &TaskName,
+) -> Option<TaskName<'static>> {
+    let scoped = task_id.as_task_name();
+    let base = TaskName::from(task_name.task());
+    [&scoped, task_name, &base]
+        .into_iter()
+        .find(|key| turbo_json.tasks.contains_key(*key))
+        .map(|key| key.clone().into_owned())
 }
 
 /// Resolve a task's `command` override across the five precedence levels

--- a/crates/turborepo-engine/src/builder/test/core.rs
+++ b/crates/turborepo-engine/src/builder/test/core.rs
@@ -53,18 +53,49 @@ fn test_default_engine() {
 fn aggregate_engine(
     repo_root: &AbsoluteSystemPathBuf,
     root_config: serde_json::Value,
+    aggregate_config: Option<serde_json::Value>,
     pass_through_args: Vec<String>,
 ) -> Result<Engine<Built, TaskDefinition>, BuilderError> {
+    aggregate_engine_for_task(
+        repo_root,
+        root_config,
+        aggregate_config,
+        pass_through_args,
+        "all",
+    )
+}
+
+fn aggregate_engine_for_task(
+    repo_root: &AbsoluteSystemPathBuf,
+    root_config: serde_json::Value,
+    aggregate_config: Option<serde_json::Value>,
+    pass_through_args: Vec<String>,
+    task: &str,
+) -> Result<Engine<Built, TaskDefinition>, BuilderError> {
     let package_graph = mock_aggregate_package_graph(repo_root);
-    let loader = TestTurboJsonLoader::new(HashMap::from([(
-        PackageName::Root,
-        turbo_json(root_config),
-    )]));
-    EngineBuilder::new(repo_root, &package_graph, &loader, false)
-        .with_tasks(Some(Spanned::new(TaskName::from("all"))))
-        .with_workspaces(vec![PackageName::from("cargo-workspace")])
-        .with_task_io_context(pass_through_args, vec!["all".to_string()], HashMap::new())
-        .build()
+    let flags = FutureFlags {
+        experimental_task_command: true,
+        ..Default::default()
+    };
+    let mut root_config = turbo_json(root_config);
+    root_config.future_flags = flags;
+    let mut configs = HashMap::from([(PackageName::Root, root_config)]);
+    if let Some(config) = aggregate_config {
+        let mut config = turbo_json(config);
+        config.future_flags = flags;
+        configs.insert(PackageName::from("cargo-workspace"), config);
+    }
+    EngineBuilder::new(
+        repo_root,
+        &package_graph,
+        &TestTurboJsonLoader::new(configs),
+        false,
+    )
+    .with_tasks(Some(Spanned::new(TaskName::from(task).into_owned())))
+    .with_workspaces(vec![PackageName::from("cargo-workspace")])
+    .with_task_io_context(pass_through_args, vec![task.to_string()], HashMap::new())
+    .with_future_flags(flags)
+    .build()
 }
 
 #[test]
@@ -74,6 +105,7 @@ fn native_aggregate_composes_same_scope_dependencies() {
     let engine = aggregate_engine(
         &repo_root,
         json!({ "tasks": { "all": { "dependsOn": ["check"] } } }),
+        None,
         Vec::new(),
     )
     .unwrap();
@@ -101,6 +133,7 @@ fn native_aggregate_deduplicates_by_effective_task_id() {
                 }
             }
         }),
+        None,
         Vec::new(),
     )
     .unwrap();
@@ -159,11 +192,97 @@ fn native_aggregate_dependencies_use_normal_cycle_validation() {
     let error = aggregate_engine(
         &repo_root,
         json!({ "tasks": { "check": { "dependsOn": ["all"] } } }),
+        None,
         Vec::new(),
     )
     .unwrap_err();
 
     assert!(matches!(error, BuilderError::Graph(_)), "got {error:?}");
+}
+
+#[test]
+fn command_override_and_opt_out_disable_native_aggregate_dependencies() {
+    for command in [json!(["echo", "all"]), serde_json::Value::Null] {
+        let repo = TempDir::new().unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo.path().to_path_buf()).unwrap();
+        let engine = aggregate_engine(
+            &repo_root,
+            json!({
+                "tasks": {
+                    "cargo-workspace#all": { "command": command }
+                }
+            }),
+            None,
+            Vec::new(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            all_dependencies(&engine),
+            deps! { "cargo-workspace#all" => ["___ROOT___"] }
+        );
+    }
+}
+
+#[test]
+fn extends_false_preserves_native_aggregate_opt_out() {
+    let repo = TempDir::new().unwrap();
+    let repo_root = AbsoluteSystemPathBuf::try_from(repo.path().to_path_buf()).unwrap();
+    let engine = aggregate_engine(
+        &repo_root,
+        json!({ "tasks": { "all": {} } }),
+        Some(json!({
+            "extends": ["//"],
+            "tasks": { "all": { "extends": false } }
+        })),
+        Vec::new(),
+    )
+    .unwrap();
+
+    assert!(all_dependencies(&engine).is_empty());
+}
+
+#[test]
+fn qualified_extends_false_suppresses_and_scoped_config_readds_native_aggregate() {
+    let repo = TempDir::new().unwrap();
+    let repo_root = AbsoluteSystemPathBuf::try_from(repo.path().to_path_buf()).unwrap();
+    let suppressed = aggregate_engine_for_task(
+        &repo_root,
+        json!({ "tasks": {} }),
+        Some(json!({
+            "extends": ["//"],
+            "tasks": { "all": { "extends": false } }
+        })),
+        Vec::new(),
+        "cargo-workspace#all",
+    )
+    .unwrap();
+    assert!(all_dependencies(&suppressed).is_empty());
+
+    let readded = aggregate_engine_for_task(
+        &repo_root,
+        json!({ "tasks": {} }),
+        Some(json!({
+            "extends": ["//"],
+            "tasks": {
+                "all": {
+                    "extends": false,
+                    "dependsOn": ["check"]
+                }
+            }
+        })),
+        Vec::new(),
+        "cargo-workspace#all",
+    )
+    .unwrap();
+    assert_eq!(
+        all_dependencies(&readded),
+        deps! {
+            "cargo-workspace#all" => ["cargo-workspace#check", "cargo-workspace#lint"],
+            "cargo-workspace#check" => ["___ROOT___"],
+            "cargo-workspace#lint" => ["___ROOT___"]
+        }
+    );
 }
 
 #[test]
@@ -173,6 +292,7 @@ fn native_aggregate_rejects_pass_through_with_qualified_children() {
     let error = aggregate_engine(
         &repo_root,
         json!({ "tasks": {} }),
+        None,
         vec!["--fix".to_string()],
     )
     .unwrap_err();

--- a/crates/turborepo-lib/src/devtools.rs
+++ b/crates/turborepo-lib/src/devtools.rs
@@ -91,7 +91,7 @@ impl ProperTaskGraphBuilder {
                             .native_tasks()
                             .tasks()
                             .iter()
-                            .filter(|task| task.executes() || task.authored())
+                            .filter(|task| task.participates() || task.authored())
                             .map(|task| task.name().to_string())
                             .collect()
                     })

--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -94,6 +94,25 @@ pub(crate) fn task_has_command(
     }
 }
 
+pub(crate) fn task_participates(
+    engine: &Engine<Built>,
+    package_graph: &PackageGraph,
+    task: &TaskId<'static>,
+) -> bool {
+    let Some(context) = package_graph.package_task_context(&PackageName::from(task.package()))
+    else {
+        return false;
+    };
+    match engine
+        .task_definition(task)
+        .and_then(|definition| definition.command.as_ref())
+    {
+        Some(turborepo_types::TaskCommandOverride::Argv(_)) => true,
+        Some(turborepo_types::TaskCommandOverride::OptOut) => false,
+        None => context.native_tasks().participates(task.task()),
+    }
+}
+
 impl EngineExt for Engine<Built> {
     fn tasks_with_command(&self, pkg_graph: &PackageGraph) -> Vec<String> {
         self.tasks()
@@ -157,15 +176,13 @@ impl EngineExt for Engine<Built> {
                             })?;
 
                     let package_name = PackageName::from(dep_id.package());
-                    let Some(dep_context) = package_graph.package_task_context(&package_name)
+                    let Some(_dep_context) = package_graph.package_task_context(&package_name)
                     else {
                         return Err(ValidateError::MissingPackageJson {
                             package: dep_id.package().to_string(),
                         });
                     };
-                    if task_definition.persistent
-                        && dep_context.native_tasks().defines(dep_id.task())
-                    {
+                    if task_definition.persistent && task_has_command(self, package_graph, dep_id) {
                         let (span, text) = self
                             .task_locations()
                             .get(dep_id)
@@ -183,13 +200,13 @@ impl EngineExt for Engine<Built> {
 
                 // check if the package for the task defines an executable native task
                 let package_name = PackageName::from(task_id.package().to_string());
-                let Some(context) = package_graph.package_task_context(&package_name) else {
+                let Some(_context) = package_graph.package_task_context(&package_name) else {
                     return Err(ValidateError::MissingPackageJson {
                         package: task_id.package().to_string(),
                     });
                 };
 
-                let package_has_task = context.native_tasks().defines(task_id.task());
+                let package_has_task = task_has_command(self, package_graph, task_id);
 
                 let task_is_persistent = self
                     .task_definition(task_id)

--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -457,7 +457,7 @@ impl Subscriber {
                         .native_tasks()
                         .tasks()
                         .iter()
-                        .filter(|task| task.executes() || task.authored())
+                        .filter(|task| task.participates() || task.authored())
                         .map(|task| task.name().to_string())
                         .collect()
                 })

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -732,7 +732,7 @@ impl RunBuilder {
                             .native_tasks()
                             .tasks()
                             .iter()
-                            .filter(|task| task.executes() || task.authored())
+                            .filter(|task| task.participates() || task.authored())
                             .map(|task| task.name().to_string())
                             .collect::<Vec<_>>()
                     })
@@ -754,7 +754,7 @@ impl RunBuilder {
                             .native_tasks()
                             .tasks()
                             .iter()
-                            .filter(|task| task.executes() || task.authored())
+                            .filter(|task| task.participates() || task.authored())
                             .map(|task| task.name().to_string())
                             .collect();
                         Ok((package, scripts))
@@ -1326,12 +1326,12 @@ impl RunBuilder {
                 continue;
             }
 
-            let has_command = pkg_dep_graph
+            let has_participant = pkg_dep_graph
                 .package_task_contexts()
-                .any(|context| context.native_tasks().defines(task.task()))
+                .any(|context| context.native_tasks().participates(task.task()))
                 || engine.task_ids().any(|task_id| {
                     task_id.task() == task.task()
-                        && task_has_command(engine, pkg_dep_graph, task_id)
+                        && crate::engine::task_participates(engine, pkg_dep_graph, task_id)
                 });
 
             for package in candidate_packages {
@@ -1341,9 +1341,11 @@ impl RunBuilder {
                 }
 
                 selection.candidates.insert(task_id.clone());
-                if !has_command || task_has_command(engine, pkg_dep_graph, &task_id) {
+                if !has_participant
+                    || crate::engine::task_participates(engine, pkg_dep_graph, &task_id)
+                {
                     selection.selected.insert(task_id.clone());
-                    if !has_command {
+                    if !has_participant {
                         selection
                             .orchestration
                             .entry(task.task().to_string())

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -522,7 +522,7 @@ impl Run {
             // Authored scripts and registered native tasks both come from the
             // native-task catalog produced at repository construction.
             for native_task in context.native_tasks().tasks() {
-                if !native_task.executes() && !native_task.registered() {
+                if !native_task.participates() && !native_task.registered() {
                     continue;
                 }
                 tasks

--- a/crates/turborepo-run-summary/src/task_factory.rs
+++ b/crates/turborepo-run-summary/src/task_factory.rs
@@ -268,7 +268,15 @@ fn summary_command(
         None => package_context
             .native_tasks()
             .get(task)
-            .and_then(|native_task| native_task.display().map(str::to_string))
+            .map(|native_task| match native_task.execution() {
+                turborepo_repository::native_tasks::NativeTaskExecution::Aggregate(_) => {
+                    "<AGGREGATE>".to_string()
+                }
+                _ => native_task
+                    .display()
+                    .map(str::to_string)
+                    .unwrap_or_else(|| "<NONEXISTENT>".to_string()),
+            })
             .unwrap_or_else(|| "<NONEXISTENT>".to_string()),
     }
 }


### PR DESCRIPTION
### Description

Part 5 of 13 in stack #13677, based on #13667. Completes aggregate argv override, opt-out, and `extends: false` behavior; separates graph participation from process execution across run, watch, devtools, and summaries.

Previous: #13667. Next: #13669.

### Testing Instructions

Full-tip verification passed: formatting; 437 repository tests; 135 engine tests; 13 uv integration tests; 12 entrypoint tests; and strict clippy across affected crates. Every cumulative tip passed `cargo check --tests`. `uv` is unavailable, and a full workspace run was not performed.