### PR TITLE
docs: Exclude Turborepo from its own OSS products menu

### DIFF
--- a/apps/docs/lib/geistdocs/config.tsx
+++ b/apps/docs/lib/geistdocs/config.tsx
@@ -19,6 +19,8 @@ export const config = defineConfig({
   logo: <Logo />,
   github,
   nav,
+  // Drops Turborepo (this site) from geistdocs' default OSS products menu.
+  navbarActiveProduct: "turborepo",
   basePath,
   siteId,
   translations,


### PR DESCRIPTION
- bump to latest geistdocs
- fix logo bug in safari