### PR TITLE
docs: Fix loadTransformers reference in turbo-codemod README

### DIFF
--- a/packages/turbo-codemod/src/transforms/README.md
+++ b/packages/turbo-codemod/src/transforms/README.md
@@ -12,7 +12,7 @@ New Transformers will be automatically surfaced to the `transform` CLI command a
 
 ## How it works
 
-Transformers are loaded automatically from the `src/transforms/` directory via the [`loadTransforms`](../utils/loadTransformers.ts) function.
+Transformers are loaded automatically from the `src/transforms/` directory via the [`loadTransformers`](../utils/load-transformers.ts) function.
 
 All new transformers must contain a default export that matches the [`Transformer`](../types.ts) type:
 


### PR DESCRIPTION
The "How it works" section links to a `loadTransforms` function at `../utils/loadTransformers.ts`, but neither the name nor the path is correct:

- The exported function is `loadTransformers` (`src/utils/load-transformers.ts:11`), imported by the `transform` and `migrate` commands. There is no `loadTransforms`.
- The file is `load-transformers.ts` (kebab-case), so `../utils/loadTransformers.ts` 404s on GitHub.

This fixes both the link text and the path. The other links in the same README already resolve.
