### PR TITLE
docs: Add inbound cross-links to orphaned docs pages

### DIFF
--- a/apps/docs/content/docs/core-concepts/package-and-task-graph.mdx
+++ b/apps/docs/content/docs/core-concepts/package-and-task-graph.mdx
@@ -125,3 +125,5 @@ Let's say your monorepo has many apps and many packages. All packages have
 `test` tasks, but only one app has a `build` task. Turborepo's mental model
 says that when you run `turbo run build`, even if an app doesn't implement `build`
 the `test` task of all packages that are dependencies will show up in the graph.
+
+To visualize and inspect the graphs in your own repository, visit the [Understanding your repository](/docs/crafting-your-repository/understanding-your-repository) guide.

--- a/apps/docs/content/docs/core-concepts/remote-caching.mdx
+++ b/apps/docs/content/docs/core-concepts/remote-caching.mdx
@@ -89,7 +89,7 @@ Remote Caching is free and can be used with both [managed providers](https://tur
 
 ### For Local Development
 
-To link your local Turborepo to your Remote Cache, authenticate the Turborepo CLI with your Vercel account:
+To link your local Turborepo to your Remote Cache, authenticate the Turborepo CLI with your Vercel account using [`turbo login`](/docs/reference/login):
 
 ```bash title="Terminal"
 turbo login
@@ -138,7 +138,7 @@ bunx turbo login
   correct privileges.
 </Callout>
 
-Now, link your Turborepo to your Remote Cache:
+Now, link your Turborepo to your Remote Cache with [`turbo link`](/docs/reference/link):
 
 ```bash title="Terminal"
 turbo link
@@ -167,6 +167,8 @@ To verify, delete your local Turborepo cache with:
 </PlatformTabs>
 
 Then, run the same build again. If things are working properly, `turbo` should not execute tasks locally. Instead, it will download the logs and artifacts from your Remote Cache and replay them back to you.
+
+If you want to stop using the Remote Cache, run [`turbo unlink`](/docs/reference/unlink) to disconnect your repository, and [`turbo logout`](/docs/reference/logout) to sign out of your account.
 
 ### Remote Caching on Vercel
 

--- a/apps/docs/content/docs/crafting-your-repository/caching.mdx
+++ b/apps/docs/content/docs/crafting-your-repository/caching.mdx
@@ -217,6 +217,8 @@ Inputs are hashed by Turborepo, creating a "fingerprint" for the task run. When 
 
 Under the hood, Turborepo creates two hashes: a global hash and a task hash. If either of the hashes change, the task will miss cache.
 
+If your tasks run on multiple operating systems, architectures, or Node.js versions, visit the [Handling platforms guide](/docs/guides/handling-platforms) to account for those differences in your hashes.
+
 ### Global hash inputs
 
 | Input                                                                                  | Example                                                                                                                                                                                                         |

--- a/apps/docs/content/docs/crafting-your-repository/developing-applications.mdx
+++ b/apps/docs/content/docs/crafting-your-repository/developing-applications.mdx
@@ -69,6 +69,8 @@ You may also want to run scripts that set up your development environment or pre
 
 In this example, we're using a [Root Task](/docs/crafting-your-repository/configuring-tasks#registering-root-tasks) but you can use the same idea for [arbitrary tasks in packages](/docs/crafting-your-repository/configuring-tasks#depending-on-a-specific-task-in-a-specific-package).
 
+If a development task needs another long-running service to be available before it starts, visit the [coordinating runtime dependencies guide](/docs/guides/coordinating-runtime-dependencies).
+
 ### Running a specific application
 
 The `--filter` flag allows you to pick a subset of your [Package Graph](/docs/core-concepts/package-and-task-graph#package-graph) so you can run your `dev` task for a specific application and its dependencies:

--- a/apps/docs/content/docs/getting-started/add-to-existing-repository.mdx
+++ b/apps/docs/content/docs/getting-started/add-to-existing-repository.mdx
@@ -15,7 +15,7 @@ related:
 
 Turborepo can be incrementally adopted in **any repository, single or multi-package**, to speed up the developer and CI workflows of the repository.
 
-After installing `turbo` and configuring your tasks in `turbo.json`, you'll notice how [caching](/docs/crafting-your-repository/caching) helps you run tasks much faster.
+After installing `turbo` and configuring your tasks in `turbo.json`, you'll notice how [caching](/docs/crafting-your-repository/caching) helps you run tasks much faster. If you're coming from Nx, visit the [migration guide](/docs/guides/migrating-from-nx).
 
 ## Preparing a single-package workspace
 

--- a/apps/docs/content/docs/getting-started/index.mdx
+++ b/apps/docs/content/docs/getting-started/index.mdx
@@ -39,7 +39,7 @@ Install `turbo` globally so you can conveniently run `turbo` commands in your te
   </Tab>
 </Tabs>
 
-To learn more about installing `turbo`, see the [installation guide](/docs/getting-started/installation).
+To learn more about installing `turbo`, see the [installation guide](/docs/getting-started/installation). You can also set up [editor integration](/docs/getting-started/editor-integration) for autocomplete and linting in your `turbo.json` files.
 
 </Step>
 <Step>

--- a/apps/docs/content/docs/getting-started/installation.mdx
+++ b/apps/docs/content/docs/getting-started/installation.mdx
@@ -154,3 +154,5 @@ When collaborating with other developers in a repository, it's a good idea to pi
 You can continue to use your global installation of `turbo` to run commands. Global `turbo` will defer to the local version of your repository if it exists.
 
 This lets you to get the best of both installations: easily run commands in your terminal while maintaining a pinned version for consistent usage for all developers in the repository.
+
+To check which package managers, platforms, and versions Turborepo supports, see the [Support policy](/docs/support-policy). When a new version of `turbo` is released, visit the [upgrading guide](/docs/crafting-your-repository/upgrading) to bring it into your repository.

--- a/apps/docs/content/docs/guides/ci-vendors/index.mdx
+++ b/apps/docs/content/docs/guides/ci-vendors/index.mdx
@@ -13,7 +13,7 @@ related:
   - /docs/guides/ci-vendors/buildkite
 ---
 
-Turborepo not only speeds up builds, but also the rest of your Continuous Integration pipeline by using [Remote Caching](/docs/core-concepts/remote-caching). Below are a few platform recipes to use Turborepo with your CI providers.
+Turborepo not only speeds up builds, but also the rest of your Continuous Integration pipeline by using [Remote Caching](/docs/core-concepts/remote-caching). Below are a few platform recipes to use Turborepo with your CI providers: [Vercel](/docs/guides/ci-vendors/vercel), [GitHub Actions](/docs/guides/ci-vendors/github-actions), [CircleCI](/docs/guides/ci-vendors/circleci), [GitLab CI](/docs/guides/ci-vendors/gitlab-ci), [Travis CI](/docs/guides/ci-vendors/travis-ci), and [Buildkite](/docs/guides/ci-vendors/buildkite).
 
 <Cards>
 

--- a/apps/docs/content/docs/guides/frameworks/index.mdx
+++ b/apps/docs/content/docs/guides/frameworks/index.mdx
@@ -11,7 +11,7 @@ related:
   - /docs/guides/frameworks/nuxt
 ---
 
-Turborepo works with **any framework**. Below, you'll find guides for the most common frameworks being used with Turborepo.
+Turborepo works with **any framework**. Below, you'll find guides for the most common frameworks being used with Turborepo: [Next.js](/docs/guides/frameworks/nextjs), [SvelteKit](/docs/guides/frameworks/sveltekit), [Vite](/docs/guides/frameworks/vite), [Nuxt](/docs/guides/frameworks/nuxt), and [Rsbuild](/docs/guides/frameworks/rsbuild). If you're building a shared library, you can also learn how to create [framework bindings](/docs/guides/frameworks/framework-bindings).
 
 <Cards>
 <Card

--- a/apps/docs/content/docs/guides/index.mdx
+++ b/apps/docs/content/docs/guides/index.mdx
@@ -12,7 +12,7 @@ related:
 
 Turborepo works with your favorite frameworks, CI providers, tools, and use cases.
 
-In our community-supported guides, you'll find examples of how to use `turbo` with the rest of your tooling.
+In our community-supported guides, you'll find examples of how to use `turbo` with the rest of your tooling, including how to get the most out of [AI coding assistants](/docs/guides/ai) in your repository.
 
 <Cards>
 <Card

--- a/apps/docs/content/docs/guides/tools/index.mdx
+++ b/apps/docs/content/docs/guides/tools/index.mdx
@@ -11,7 +11,7 @@ related:
   - /docs/guides/tools/docker
 ---
 
-Turborepo works with **all of your favorite tooling**. Below, you'll find guides for the most common tools being used with Turborepo.
+Turborepo works with **all of your favorite tooling**. Below, you'll find guides for the most common tools being used with Turborepo: [Biome](/docs/guides/tools/biome), [Docker](/docs/guides/tools/docker), [ESLint](/docs/guides/tools/eslint), [Jest](/docs/guides/tools/jest), [Oxc](/docs/guides/tools/oxc), [Playwright](/docs/guides/tools/playwright), [Prisma](/docs/guides/tools/prisma), [Python](/docs/guides/tools/python), [Rust](/docs/guides/tools/rust), [shadcn/ui](/docs/guides/tools/shadcn-ui), [Storybook](/docs/guides/tools/storybook), [Tailwind CSS](/docs/guides/tools/tailwind), [TypeScript](/docs/guides/tools/typescript), and [Vitest](/docs/guides/tools/vitest).
 
 <Cards>
   <Card title="Biome" href="/docs/guides/tools/biome" />

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -42,4 +42,4 @@ We will do our best to keep jargon to a minimum - but there are some need-to-kno
 
 ## Join the community
 
-If you have questions about anything related to Turborepo, you're always welcome to ask the community on [GitHub Discussions](https://github.com/vercel/turborepo/discussions), [Vercel Community](https://community.vercel.com/tag/turborepo), and [Twitter](https://twitter.com/turborepo).
+If you have questions about anything related to Turborepo, you're always welcome to ask the community on [GitHub Discussions](https://github.com/vercel/turborepo/discussions), [Vercel Community](https://community.vercel.com/tag/turborepo), and [Twitter](https://twitter.com/turborepo). For more ways to get involved, visit the [Community page](/docs/community), and see the [Acknowledgments page](/docs/acknowledgments) for the projects and people that inspired Turborepo.

--- a/apps/docs/content/docs/reference/eslint-config-turbo.mdx
+++ b/apps/docs/content/docs/reference/eslint-config-turbo.mdx
@@ -9,7 +9,7 @@ related:
   - /docs/reference/configuration
 ---
 
-[The `eslint-config-turbo` package](https://www.npmjs.com/package/eslint-config-turbo) helps you find environment variables that are used in your code that are not a part of Turborepo's hashing. Environment variables used in your source code that are not accounted for in `turbo.json` will be highlighted in your editor and errors will show as ESLint output.
+[The `eslint-config-turbo` package](https://www.npmjs.com/package/eslint-config-turbo) helps you find environment variables that are used in your code that are not a part of Turborepo's hashing. Environment variables used in your source code that are not accounted for in `turbo.json` will be highlighted in your editor and errors will show as ESLint output. This configuration is powered by [`eslint-plugin-turbo`](/docs/reference/eslint-plugin-turbo), which you can also configure directly.
 
 ## Installation
 

--- a/apps/docs/content/docs/reference/index.mdx
+++ b/apps/docs/content/docs/reference/index.mdx
@@ -43,6 +43,8 @@ Turborepo's API reference is broken up into the following sections:
 
 ## Commands
 
+For a table of the flags, configurations, and environment variables that control these commands, visit the [options overview](/docs/reference/options-overview). Utility commands like [`turbo info`](/docs/reference/info), [`turbo bin`](/docs/reference/bin), [`turbo docs`](/docs/reference/docs), and [`turbo telemetry`](/docs/reference/telemetry) help you inspect your setup, locate the `turbo` binary, search these docs from your terminal, and manage [anonymous usage data](/docs/telemetry).
+
 <Cards>
     <Card
         title="run"


### PR DESCRIPTION
These docs pages had no inbound links from other pages, so they're only reachable via the sidebar. Adds minimal cross-links from their parent or related pages.

The `/docs/messages/*` error pages are intentionally left as-is — they're landing pages for CLI error output and have no natural prose home.