### PR TITLE
docs: Update redirected vercel.com/nextjs.org links to current targets

### DIFF
--- a/apps/docs/content/docs/core-concepts/remote-caching.mdx
+++ b/apps/docs/content/docs/core-concepts/remote-caching.mdx
@@ -170,7 +170,7 @@ Then, run the same build again. If things are working properly, `turbo` should n
 
 ### Remote Caching on Vercel
 
-If you are building and hosting your apps on Vercel, Remote Caching will be automatically set up on your behalf once you use `turbo`. Refer to the [Vercel documentation](https://vercel.com/docs/concepts/monorepos/remote-caching?utm_source=turborepo.dev&utm_medium=referral&utm_campaign=docs-link) for more information.
+If you are building and hosting your apps on Vercel, Remote Caching will be automatically set up on your behalf once you use `turbo`. Refer to the [Vercel documentation](https://vercel.com/docs/monorepos/remote-caching?utm_source=turborepo.dev&utm_medium=referral&utm_campaign=docs-link) for more information.
 
 ### Artifact Integrity and Authenticity Verification
 
@@ -196,7 +196,7 @@ A Remote Cache can be implemented by any HTTP server that meets Turborepo's Remo
 
 [Vercel](https://vercel.com), the creators and maintainers of Turborepo, provide a managed Remote Cache that is fully compatible with Turborepo.
 
-Using [Vercel Remote Cache](https://vercel.com/docs/monorepos/remote-caching) is zero-configuration and automatically integrates with [Vercel deployments](https://vercel.com/docs/deployments/overview) through the open-source [Vercel Remote Cache SDK](https://github.com/vercel/remote-cache).
+Using [Vercel Remote Cache](https://vercel.com/docs/monorepos/remote-caching) is zero-configuration and automatically integrates with [Vercel deployments](https://vercel.com/docs/deployments) through the open-source [Vercel Remote Cache SDK](https://github.com/vercel/remote-cache).
 
 Learn more about [Turborepo on Vercel](https://vercel.com/docs/monorepos/turborepo) or [deploy a template for free](https://vercel.com/templates?search=turborepo) to try it out.
 

--- a/apps/docs/content/docs/crafting-your-repository/constructing-ci.mdx
+++ b/apps/docs/content/docs/crafting-your-repository/constructing-ci.mdx
@@ -23,7 +23,7 @@ To enable Remote Caching for your CI, setup the environment variables for Turbor
 | Environment Variable | Description                                                                                                                                                                                                                         |
 | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `TURBO_TOKEN`        | The Bearer token to access the Remote Cache                                                                                                                                                                                         |
-| `TURBO_TEAM`         | The account name associated with your repository. When using [Vercel Remote Cache](https://vercel.com/docs/monorepos/remote-caching), this is [your team's slug](https://vercel.com/docs/accounts/create-a-team#find-your-team-id). |
+| `TURBO_TEAM`         | The account name associated with your repository. When using [Vercel Remote Cache](https://vercel.com/docs/monorepos/remote-caching), this is [your team's slug](https://vercel.com/docs/accounts#creating-a-team). |
 
 When you run tasks through `turbo`, your CI will be able to hit cache, speeding up your pipelines.
 

--- a/apps/docs/content/docs/crafting-your-repository/structuring-a-repository.mdx
+++ b/apps/docs/content/docs/crafting-your-repository/structuring-a-repository.mdx
@@ -10,7 +10,7 @@ related:
   - /docs/core-concepts/package-types
 ---
 
-`turbo` is built on top of [Workspaces](https://vercel.com/docs/vercel-platform/glossary#workspace), a feature of package managers in the JavaScript ecosystem that allows you to group multiple packages in one repository.
+`turbo` is built on top of [Workspaces](https://vercel.com/docs/glossary#workspace), a feature of package managers in the JavaScript ecosystem that allows you to group multiple packages in one repository.
 
 Following these conventions is important because it allows you to:
 
@@ -59,7 +59,7 @@ You can then review the repository for the characteristics described in this gui
 
 ## Anatomy of a workspace
 
-In JavaScript, a workspace can either be [a single package](/docs/guides/single-package-workspaces) or a collection of packages. In these guides, we'll be focusing on [a multi-package workspace](https://vercel.com/docs/vercel-platform/glossary#monorepo), often called a "monorepo".
+In JavaScript, a workspace can either be [a single package](/docs/guides/single-package-workspaces) or a collection of packages. In these guides, we'll be focusing on [a multi-package workspace](https://vercel.com/docs/glossary#monorepo), often called a "monorepo".
 
 Below, the structural elements of `create-turbo` that make it a valid workspace are highlighted.
 

--- a/apps/docs/content/docs/crafting-your-repository/using-environment-variables.mdx
+++ b/apps/docs/content/docs/crafting-your-repository/using-environment-variables.mdx
@@ -141,7 +141,7 @@ When you're using Loose Mode, `MY_API_URL` is available in the task runtime **ev
 
 ### Platform Environment Variables
 
-When deploying your application to [Vercel](https://vercel.com/new?ref=turborepo), you likely already have [environment variables](https://vercel.com/docs/projects/environment-variables) configured on your project. Turborepo will automatically check these variables against your `turbo.json` configuration to ensure that you've [accounted for them](#adding-environment-variables-to-task-hashes),
+When deploying your application to [Vercel](https://vercel.com/new?ref=turborepo), you likely already have [environment variables](https://vercel.com/docs/environment-variables) configured on your project. Turborepo will automatically check these variables against your `turbo.json` configuration to ensure that you've [accounted for them](#adding-environment-variables-to-task-hashes),
 and will warn you about any missing variables.
 
 This functionality can be disabled by setting `TURBO_PLATFORM_ENV_DISABLED=true`

--- a/apps/docs/content/docs/getting-started/add-to-existing-repository.mdx
+++ b/apps/docs/content/docs/getting-started/add-to-existing-repository.mdx
@@ -19,7 +19,7 @@ After installing `turbo` and configuring your tasks in `turbo.json`, you'll noti
 
 ## Preparing a single-package workspace
 
-A [single-package workspace](https://vercel.com/docs/vercel-platform/glossary#single-package-workspace) is, for example, what you get after running `npx create-next-app` or `npm create vite`. You don't need to do any extra work for Turborepo to handle your repo so you can jump to the first step below.
+A [single-package workspace](https://vercel.com/docs/glossary#single-package-workspace) is, for example, what you get after running `npx create-next-app` or `npm create vite`. You don't need to do any extra work for Turborepo to handle your repo so you can jump to the first step below.
 
 To learn more about Turborepo in single-package workspaces, visit [the dedicated guide](/docs/guides/single-package-workspaces).
 

--- a/apps/docs/content/docs/guides/ci-vendors/vercel.mdx
+++ b/apps/docs/content/docs/guides/ci-vendors/vercel.mdx
@@ -17,7 +17,7 @@ Vercel's zero-config integration with Turborepo automatically understands your m
 
 To deploy your Turborepo on Vercel, [create a new project](https://vercel.com/new) and import your code. Your projects will be pre-configured with the correct settings to use the [Vercel Remote Cache](https://vercel.com/docs/monorepos/remote-caching).
 
-For more information about deploying your Turborepo to Vercel, [visit the Vercel documentation](https://vercel.com/docs/concepts/monorepos/turborepo).
+For more information about deploying your Turborepo to Vercel, [visit the Vercel documentation](https://vercel.com/docs/monorepos/turborepo).
 
 ## Filtered installs
 

--- a/apps/docs/content/docs/guides/frameworks/framework-bindings.mdx
+++ b/apps/docs/content/docs/guides/frameworks/framework-bindings.mdx
@@ -67,7 +67,7 @@ Using export paths to split a package into framework-specific entrypoints is the
 The example below shows a library with two entrypoints, each for a different type of link component. These abstractions likely contain your own styles, APIs, and other adjustments on top of the element they're wrapping.
 
 - `./link`: An `<a>` HTML tag with some default styles from your design system
-- `./next-js/link`: A customized version of [the Next.js `Link` component](https://nextjs.org/docs/app/building-your-application/routing/linking-and-navigating#link-component) with props that are preset to your organization's preferences
+- `./next-js/link`: A customized version of [the Next.js `Link` component](https://nextjs.org/docs/app/getting-started/linking-and-navigating#link-component) with props that are preset to your organization's preferences
 - `./svelte/link`: A customized version of an [`a` tag for Svelte](https://svelte.dev/docs/kit/link-options) with presets.
 
 ```json title="./packages/ui/package.json"

--- a/apps/docs/content/docs/guides/frameworks/nextjs.mdx
+++ b/apps/docs/content/docs/guides/frameworks/nextjs.mdx
@@ -53,7 +53,7 @@ bunx create-turbo@latest
 
 ## Adding a Next.js application to an existing repository
 
-Use [`create-next-app`](https://nextjs.org/docs/app/api-reference/create-next-app) to set up a new Next.js application in a package. From the root of your repository, run:
+Use [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app) to set up a new Next.js application in a package. From the root of your repository, run:
 
 <PackageManagerTabs>
 

--- a/apps/docs/content/docs/guides/single-package-workspaces.mdx
+++ b/apps/docs/content/docs/guides/single-package-workspaces.mdx
@@ -8,7 +8,7 @@ related:
   - /docs/guides/skipping-tasks
 ---
 
-While Turborepo is highly effective in [multi-package workspaces](https://vercel.com/docs/vercel-platform/glossary#multi-package-workspace) (commonly referred to as monorepos), it can also be used to make [single-package workspaces](https://vercel.com/docs/vercel-platform/glossary#single-package-workspace) faster.
+While Turborepo is highly effective in [multi-package workspaces](https://vercel.com/docs/glossary#multi-package-workspace) (commonly referred to as monorepos), it can also be used to make [single-package workspaces](https://vercel.com/docs/glossary#single-package-workspace) faster.
 
 Turborepo's most important features work in single-package workspaces including local and [Remote Caching](/docs/core-concepts/remote-caching) and task parallelization. Features that don't work are ones that don't make sense in the context of a single package, like package tasks (`app#build`).
 

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -38,7 +38,7 @@ Turborepo can be **adopted incrementally** and you can **add it to any repositor
 
 ## How to use these docs
 
-We will do our best to keep jargon to a minimum - but there are some need-to-know words that will be important to understand as you read through the docs. We've created [a glossary page](https://vercel.com/docs/vercel-platform/glossary) to help you out in case you're learning about these terms.
+We will do our best to keep jargon to a minimum - but there are some need-to-know words that will be important to understand as you read through the docs. We've created [a glossary page](https://vercel.com/docs/glossary) to help you out in case you're learning about these terms.
 
 ## Join the community
 

--- a/apps/docs/content/docs/messages/recursive-turbo-invocations.mdx
+++ b/apps/docs/content/docs/messages/recursive-turbo-invocations.mdx
@@ -39,7 +39,7 @@ To resolve this, ensure that the name of the script in `package.json` is not the
 
 ### Package manager Workspace misconfiguration
 
-A misconfigured workspace can make it appear that a [multi-package workspace](https://vercel.com/docs/vercel-platform/glossary#multi-package-workspace) is a single-package workspace. This causes Turborepo to infer that the repository is of the wrong type, causing it to see the script in `package.json` to be recursive.
+A misconfigured workspace can make it appear that a [multi-package workspace](https://vercel.com/docs/glossary#multi-package-workspace) is a single-package workspace. This causes Turborepo to infer that the repository is of the wrong type, causing it to see the script in `package.json` to be recursive.
 
 Your repo can end up in this state in a few ways, with the most common being that the [packages are not defined according to your package manager](https://turborepo.dev/docs/crafting-your-repository/structuring-a-repository#specifying-packages-in-a-monorepo). An npm workspace that is missing the `workspaces` field in `package.json` or a pnpm workspace that is missing a `pnpm-workspace.yaml` file can result in this error message.
 

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -8,7 +8,7 @@
     "guides",
     "community",
     "support-policy",
-    "[Glossary](https://vercel.com/docs/vercel-platform/glossary)",
+    "[Glossary](https://vercel.com/docs/glossary)",
     "[Changelog](https://github.com/vercel/turborepo/releases)"
   ]
 }


### PR DESCRIPTION
## Description

These stale links were found by an automated docs link audit (docsgraph). Each old URL currently serves a **308** redirect; this PR points them at the current target so readers (and the crawler) skip the extra hop.

Only the path component of each href was rewritten — scheme and host are unchanged, and existing `#fragments`/query strings are preserved. Every new target was verified to resolve `200`.

| Page | Old path | New path |
| --- | --- | --- |
| `/docs` (+ sidebar `meta.json`) | `/docs/vercel-platform/glossary` | `/docs/glossary` |
| `/docs/core-concepts/remote-caching` | `/docs/concepts/monorepos/remote-caching` | `/docs/monorepos/remote-caching` |
| `/docs/core-concepts/remote-caching` | `/docs/deployments/overview` | `/docs/deployments` |
| `/docs/crafting-your-repository/constructing-ci` | `/docs/accounts/create-a-team#find-your-team-id` | `/docs/accounts#creating-a-team` |
| `/docs/crafting-your-repository/structuring-a-repository` | `/docs/vercel-platform/glossary` | `/docs/glossary` |
| `/docs/crafting-your-repository/using-environment-variables` | `/docs/projects/environment-variables` | `/docs/environment-variables` |
| `/docs/getting-started/add-to-existing-repository` | `/docs/vercel-platform/glossary` | `/docs/glossary` |
| `/docs/guides/ci-vendors/vercel` | `/docs/concepts/monorepos/turborepo` | `/docs/monorepos/turborepo` |
| `/docs/guides/frameworks/framework-bindings` | `nextjs.org/docs/app/building-your-application/routing/linking-and-navigating` | `nextjs.org/docs/app/getting-started/linking-and-navigating` |
| `/docs/guides/frameworks/nextjs` | `nextjs.org/docs/app/api-reference/create-next-app` | `nextjs.org/docs/app/api-reference/cli/create-next-app` |
| `/docs/guides/single-package-workspaces` | `/docs/vercel-platform/glossary` | `/docs/glossary` |
| `/docs/messages/recursive-turbo-invocations` | `/docs/vercel-platform/glossary` | `/docs/glossary` |

Notes:

- `/docs/accounts/create-a-team` redirects to a fragment URL (`/docs/accounts#creating-a-team`), so the replacement's fragment supersedes the old `#find-your-team-id`.
- The glossary link in `apps/docs/content/docs/meta.json` (sidebar) had the same stale path and was updated alongside the page content.
- Older blog posts also contain `/docs/concepts/monorepos/remote-caching`; those were left untouched as historical content, outside the audited docs pages.

## Testing Instructions

`pnpm check-links` in `apps/docs` passes.

▲ Created with [Vercel devbox](https://vercel.com/vercel/~/sandboxes/devboxes/2sevqnrrizhtmbnnl7kndkm1e0sd)