### PR TITLE
docs: Use BuildKit cache in Docker

### DIFF
--- a/apps/docs/content/docs/guides/tools/docker.mdx
+++ b/apps/docs/content/docs/guides/tools/docker.mdx
@@ -166,7 +166,8 @@ RUN turbo prune web --docker
 FROM base AS builder
 # First install the dependencies (as they change less often)
 COPY --from=prepare /app/out/json/ .
-RUN yarn install
+RUN --mount=type=cache,target=/usr/local/share/.cache/yarn,id=yarn-cache \
+    yarn install
 # Build the project
 COPY --from=prepare /app/out/full/ .
 
@@ -177,7 +178,8 @@ COPY --from=prepare /app/out/full/ .
 # ARG TURBO_TOKEN
 # ENV TURBO_TOKEN=$TURBO_TOKEN
 
-RUN yarn turbo build
+RUN --mount=type=cache,target=/app/.turbo/cache,id=turbo-cache \
+    yarn turbo build
 
 # ---
 FROM base AS runner
@@ -210,7 +212,8 @@ ENV TURBO_TEAM=$TURBO_TEAM
 ARG TURBO_TOKEN
 ENV TURBO_TOKEN=$TURBO_TOKEN
 
-RUN yarn turbo run build
+RUN --mount=type=cache,target=/app/.turbo/cache,id=turbo-cache \
+    yarn turbo run build
 ```
 
 `turbo` will now be able to hit your Remote Cache. To see a Turborepo cache hit for a non-cached Docker build image, run a command like this one from your project root:

--- a/examples/with-docker/apps/api/Dockerfile
+++ b/examples/with-docker/apps/api/Dockerfile
@@ -18,7 +18,8 @@ WORKDIR /app
 
 # First install dependencies (as they change less often)
 COPY --from=prepare /app/out/json/ .
-RUN yarn install
+RUN --mount=type=cache,target=/usr/local/share/.cache/yarn,id=yarn-cache \
+    yarn install
 
 # Build the project and its dependencies
 COPY --from=prepare /app/out/full/ .
@@ -30,7 +31,8 @@ COPY --from=prepare /app/out/full/ .
 # ARG TURBO_TOKEN
 # ENV TURBO_TOKEN=$TURBO_TOKEN
 
-RUN yarn turbo build
+RUN --mount=type=cache,target=/app/.turbo/cache,id=turbo-cache \
+    yarn turbo build
 
 FROM node:${NODE_VERSION}-alpine AS runner
 WORKDIR /app

--- a/examples/with-docker/apps/web/Dockerfile
+++ b/examples/with-docker/apps/web/Dockerfile
@@ -19,7 +19,8 @@ RUN turbo prune web --docker
 FROM base AS builder
 # First install the dependencies (as they change less often)
 COPY --from=prepare /app/out/json/ .
-RUN yarn install
+RUN --mount=type=cache,target=/usr/local/share/.cache/yarn,id=yarn-cache \
+    yarn install
 # Build the project
 COPY --from=prepare /app/out/full/ .
 
@@ -30,7 +31,8 @@ COPY --from=prepare /app/out/full/ .
 # ARG TURBO_TOKEN
 # ENV TURBO_TOKEN=$TURBO_TOKEN
 
-RUN yarn turbo build
+RUN --mount=type=cache,target=/app/.turbo/cache,id=turbo-cache \
+    yarn turbo build
 
 # ---
 FROM node:${NODE_VERSION}-alpine AS runner


### PR DESCRIPTION
### Description

Resolves #13688

Updates the Docker documentation and `with-docker` examples to use BuildKit cache mounts (`--mount=type=cache`) for both `yarn install` and `turbo build`. 
This prevents unnecessary full rebuilds of unchanged packages when a single package's source code or `package.json` is modified.


### Testing Instructions


Since this is purely a documentation and example update, no functional code is changed. To verify the examples locally:
1. Navigate to the root directory.
2. Run `docker build -f examples/with-docker/apps/web/Dockerfile .`

