### PR TITLE
fix: Apply nested parent gitignore patterns in manual hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,7 +531,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2768,9 +2768,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "globset"
-version = "0.4.14"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
 dependencies = [
  "aho-corasick",
  "bstr 1.12.1",
@@ -3344,9 +3344,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.22"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
+checksum = "0b17771570a2b94107741a7b033f19132c2eee21d59d21b24d2ced26500bd66e"
 dependencies = [
  "crossbeam-deque",
  "globset",

--- a/crates/turborepo-devtools/Cargo.toml
+++ b/crates/turborepo-devtools/Cargo.toml
@@ -20,7 +20,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 
 # File watching
-ignore = "0.4.22"
+ignore = "0.4.24"
 notify = { workspace = true }
 
 # Utilities

--- a/crates/turborepo-filewatch/Cargo.toml
+++ b/crates/turborepo-filewatch/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 futures = { workspace = true }
-ignore = "0.4.22"
+ignore = "0.4.24"
 notify = { workspace = true }
 radix_trie = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/turborepo-fs/Cargo.toml
+++ b/crates/turborepo-fs/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 fs-err = "2.9.0"
-ignore = "0.4.22"
+ignore = "0.4.24"
 thiserror = { workspace = true }
 turbopath = { workspace = true }
 

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -54,7 +54,7 @@ go-parse-duration = "0.1.1"
 human-panic = "1.2.1"
 human_format = "1.1.0"
 humantime = "2.1.0"
-ignore = "0.4.22"
+ignore = "0.4.24"
 indicatif = { workspace = true }
 itertools = { workspace = true }
 libc = "0.2.140"

--- a/crates/turborepo-scm/Cargo.toml
+++ b/crates/turborepo-scm/Cargo.toml
@@ -16,7 +16,7 @@ gix-index = { workspace = true, default-features = false }
 gix-object = { workspace = true, default-features = false }
 globwalk = { path = "../turborepo-globwalk" }
 hex = { workspace = true }
-ignore = "0.4.20"
+ignore = "0.4.24"
 
 nom = "7.1.3"
 rayon = "1"

--- a/crates/turborepo-scm/src/manual.rs
+++ b/crates/turborepo-scm/src/manual.rs
@@ -567,6 +567,54 @@ mod tests {
     }
 
     #[test]
+    fn test_nested_package_paths_in_parent_gitignore_are_applied() {
+        // A root .gitignore can ignore a path nested more than one level inside
+        // a package (e.g. "child-dir/libA/logs/exec"). Git-based hashing applies
+        // such patterns, and the manual walk must match: with ignore 0.4.22 they
+        // were silently dropped when the walk was rooted at the package
+        // directory, so per-run files under the "ignored" path leaked into the
+        // package's hashes and the affected tasks missed the cache on every run.
+        let (_tmp, turbo_root) = tmp_dir();
+        let pkg_path = AnchoredSystemPathBuf::from_raw("child-dir/libA").unwrap();
+
+        turbo_root
+            .join_component(".gitignore")
+            .create_with_contents("child-dir/libA/logs/exec\nchild-dir/libA/shallow\n")
+            .unwrap();
+
+        for raw_unix_path in [
+            "child-dir/libA/keep.txt",
+            "child-dir/libA/shallow/run.log",
+            "child-dir/libA/logs/exec/run.log",
+        ] {
+            let file_path =
+                turbo_root.join_unix_path(RelativeUnixPath::new(raw_unix_path).unwrap());
+            file_path.ensure_dir().unwrap();
+            file_path.create_with_contents("contents").unwrap();
+        }
+
+        let hashes = get_package_file_hashes_without_git::<&str>(
+            &turbo_root,
+            &pkg_path,
+            &[],
+            false,
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert!(hashes.contains_key(&RelativeUnixPathBuf::new("keep.txt").unwrap()));
+        assert!(
+            !hashes.contains_key(&RelativeUnixPathBuf::new("shallow/run.log").unwrap()),
+            "one-level-deep parent gitignore pattern must be applied"
+        );
+        assert!(
+            !hashes.contains_key(&RelativeUnixPathBuf::new("logs/exec/run.log").unwrap()),
+            "nested parent gitignore pattern must be applied"
+        );
+    }
+
+    #[test]
     fn test_include_default_files_deduplicates_with_explicit_includes() {
         // When include_default_files=true AND explicit includes are provided,
         // the first walk collects files matching the includes, and the second


### PR DESCRIPTION
### Description

The manual file-hashing fallback (`get_package_file_hashes_without_git`) walks a package directory with the `ignore` crate. The pinned version (0.4.22) silently **drops patterns from parent `.gitignore` files that point deeper than one level into the walk root**, while git-based hashing applies them:

| root `.gitignore` pattern | git-based hashing | manual fallback (ignore 0.4.22) |
| --- | --- | --- |
| `packages/app/shallow` (1 level into the package) | applied | applied |
| `packages/app/deep/nested` (2 levels) | applied | **dropped** |

Turbo switches to this fallback silently whenever a git command fails during hashing (`package_deps.rs` logs it at `debug` level only) — e.g. when `turbo` runs inside a container that has no `git`. When the "ignored" path holds per-run files (test logs, generated output), their content leaks into the task input hash, and the task — plus everything depending on it, since default-input tasks are affected too — **misses the cache on every run**. We traced weeks of "integration test suites re-run on every build despite identical code" in our CI to exactly this: a gitignored, per-run `backend/testing/output/logs_unit_test_exec_time/` log being hashed inside a test container.

This is the parent-gitignore bug family fixed upstream in the `ignore` crate shipped with ripgrep 15.0.0 ([BurntSushi/ripgrep#2836](https://github.com/BurntSushi/ripgrep/issues/2836), [#2933](https://github.com/BurntSushi/ripgrep/pull/2933), [#3067](https://github.com/BurntSushi/ripgrep/pull/3067) — "a commonly reported bug related to applying gitignore rules from parent directories").

The fix:

- raise the `ignore` requirement to `0.4.24` in the five crates that declare it (the first release containing the fix); `cargo update -p ignore` resolves the lockfile to 0.4.32 + globset 0.4.19 (the latest Rust-1.90-MSRV-compatible versions);
- add a regression test (`test_nested_package_paths_in_parent_gitignore_are_applied`) that fails on `ignore` 0.4.22 with `nested parent gitignore pattern must be applied` and passes after the bump. The test also pins the 1-level-deep behavior that already worked, so both shapes stay covered.

A possible follow-up (not included, happy to send separately): promote the git → manual fallback log in `package_deps.rs` from `debug!` to `warn!` — the silent degradation is what made this so hard to trace in CI.

### Testing Instructions

```sh
# regression test fails on current main (ignore 0.4.22):
git stash -- Cargo.lock crates/*/Cargo.toml   # keep only the test
cargo test -p turborepo-scm manual::tests::test_nested
# -> FAILED: nested parent gitignore pattern must be applied
git stash pop

# with the bump:
cargo test -p turborepo-scm
# -> 196 passed
```

Ran locally: full `turborepo-scm` suite (196 passed), plus `turborepo-fs`, `turborepo-gitignore` and `turborepo-devtools` (all green). `turborepo-filewatch` and `turborepo-lib` left to CI.

Standalone reproduction against released turbo binaries (2.10.5 and 2.10.8), if useful: a minimal npm workspace + script that shows the task hash tracking a gitignored file's content once `git` is removed from `PATH` — can share the repo on request.