### PR TITLE
fix: Prune Bun wildcard workspace dev dependencies

### DIFF
--- a/crates/turborepo-lib/src/commands/prune_js.rs
+++ b/crates/turborepo-lib/src/commands/prune_js.rs
@@ -13,6 +13,9 @@ use turborepo_repository::{package_json::PackageJson, package_manager::PackageMa
 use super::Error;
 
 pub(crate) fn workspace_dependency_target<'a>(name: &'a str, version: &'a str) -> Option<&'a str> {
+    if version == "*" {
+        return Some(name);
+    }
     let specifier = version.strip_prefix("workspace:")?;
     match specifier.rsplit_once('@') {
         Some((target, "*" | "^" | "~")) if !target.is_empty() => Some(target),

--- a/crates/turborepo-lockfiles/src/bun/subgraph.rs
+++ b/crates/turborepo-lockfiles/src/bun/subgraph.rs
@@ -8,6 +8,9 @@ use super::{
 };
 
 fn workspace_dependency_target<'a>(name: &'a str, version: &'a str) -> Option<&'a str> {
+    if version == "*" {
+        return Some(name);
+    }
     let specifier = version.strip_prefix("workspace:")?;
     match specifier.rsplit_once('@') {
         Some((target, "*" | "^" | "~")) if !target.is_empty() => Some(target),

--- a/lockfile-tests/fixtures/bun-v1-issue-13693/bun.lock
+++ b/lockfile-tests/fixtures/bun-v1-issue-13693/bun.lock
@@ -1,0 +1,34 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "repro-root",
+    },
+    "packages/backend": {
+      "name": "@repo/backend",
+      "version": "0.0.0",
+      "dependencies": {
+        "@repo/utils": "*",
+      },
+      "devDependencies": {
+        "@repo/test-recordings": "*",
+      },
+    },
+    "packages/test-recordings": {
+      "name": "@repo/test-recordings",
+      "version": "0.0.0",
+    },
+    "packages/utils": {
+      "name": "@repo/utils",
+      "version": "0.0.0",
+    },
+  },
+  "packages": {
+    "@repo/backend": ["@repo/backend@workspace:packages/backend"],
+
+    "@repo/test-recordings": ["@repo/test-recordings@workspace:packages/test-recordings"],
+
+    "@repo/utils": ["@repo/utils@workspace:packages/utils"],
+  }
+}

--- a/lockfile-tests/fixtures/bun-v1-issue-13693/meta.json
+++ b/lockfile-tests/fixtures/bun-v1-issue-13693/meta.json
@@ -1,0 +1,8 @@
+{
+  "packageManager": "bun",
+  "packageManagerVersion": "bun@1.3.13",
+  "lockfileName": "bun.lock",
+  "docker": true,
+  "production": true,
+  "pruneTargets": ["@repo/backend"]
+}

--- a/lockfile-tests/fixtures/bun-v1-issue-13693/package.json
+++ b/lockfile-tests/fixtures/bun-v1-issue-13693/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "repro-root",
+  "private": true,
+  "packageManager": "bun@1.3.13",
+  "workspaces": ["packages/*"]
+}

--- a/lockfile-tests/fixtures/bun-v1-issue-13693/packages/backend/package.json
+++ b/lockfile-tests/fixtures/bun-v1-issue-13693/packages/backend/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@repo/backend",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@repo/utils": "*"
+  },
+  "devDependencies": {
+    "@repo/test-recordings": "*"
+  }
+}

--- a/lockfile-tests/fixtures/bun-v1-issue-13693/packages/test-recordings/package.json
+++ b/lockfile-tests/fixtures/bun-v1-issue-13693/packages/test-recordings/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@repo/test-recordings",
+  "version": "0.0.0",
+  "private": true
+}

--- a/lockfile-tests/fixtures/bun-v1-issue-13693/packages/utils/package.json
+++ b/lockfile-tests/fixtures/bun-v1-issue-13693/packages/utils/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@repo/utils",
+  "version": "0.0.0",
+  "private": true
+}

--- a/lockfile-tests/fixtures/bun-v1-issue-13693/turbo.json
+++ b/lockfile-tests/fixtures/bun-v1-issue-13693/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- recognize bare `*` specifiers as workspace dependencies during production pruning
- remove excluded workspace dev dependencies from both package manifests and Bun lockfile importers
- add a scoped-package Bun fixture that validates Docker production pruning with a frozen install

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p turborepo-lib prune`
- `cargo test -p turborepo-lockfiles`
- `pnpm --filter lockfile-tests exec tsx check-lockfiles.ts --fixture bun-v1-issue-13693 --turbo-path ../target/debug/turbo`
- pre-push hooks (`turbo run format check:toml`, `cargo fmt --check`)

Closes #13693