### PR TITLE
fix: Prevent Windows process cleanup PID reuse

### DIFF
--- a/crates/turborepo-process/src/child.rs
+++ b/crates/turborepo-process/src/child.rs
@@ -57,6 +57,8 @@ pub struct Child {
     pid: Option<u32>,
     #[cfg(unix)]
     target_identity: Option<TargetIdentity>,
+    #[cfg(windows)]
+    root_identity: Option<Arc<super::job_object::ProcessIdentity>>,
     command_channel: ChildCommandChannel,
     exit_channel: watch::Receiver<Option<ChildExit>>,
     stdin: Arc<Mutex<Option<ChildInput>>>,
@@ -112,6 +114,8 @@ impl Child {
             handle: mut child,
             io: ChildIO { stdin, output },
             controller,
+            #[cfg(windows)]
+            root_identity,
         } = if let Some(size) = pty_size {
             #[cfg(unix)]
             {
@@ -167,6 +171,8 @@ impl Child {
             pid,
             #[cfg(unix)]
             target_identity,
+            #[cfg(windows)]
+            root_identity,
             command_channel: command_tx,
             exit_channel: exit_rx,
             stdin: Arc::new(Mutex::new(stdin)),
@@ -235,12 +241,15 @@ impl Child {
 
     #[cfg(windows)]
     fn cleanup_process_scope_after_success(&self) {
-        let Some(pid) = self.pid else {
+        let Some(identity) = &self.root_identity else {
             return;
         };
 
-        if let Err(err) = super::job_object::terminate_descendant_processes(pid) {
-            debug!("failed to clean up descendants after successful task {pid}: {err}");
+        if let Err(err) = super::job_object::terminate_descendant_processes(identity) {
+            debug!(
+                "failed to clean up descendants after successful task {:?}: {err}",
+                self.pid
+            );
         }
     }
 

--- a/crates/turborepo-process/src/child/handle.rs
+++ b/crates/turborepo-process/src/child/handle.rs
@@ -28,6 +28,8 @@ pub(super) struct ChildHandle {
     graceful_descendant_pids: Vec<libc::pid_t>,
     #[cfg(windows)]
     _job: Option<crate::job_object::JobObject>,
+    #[cfg(windows)]
+    root_identity: Option<std::sync::Arc<crate::job_object::ProcessIdentity>>,
     /// Shared handle to the ConPTY input pipe, used to deliver a Ctrl-C
     /// keystroke during graceful shutdown. ConPTY children are attached to a
     /// pseudoconsole rather than turbo's console, so console Ctrl-C events
@@ -293,6 +295,20 @@ impl ChildHandle {
         };
         let pid = child.id();
 
+        #[cfg(windows)]
+        let root_identity = match (pid, child.raw_handle()) {
+            (Some(pid), Some(handle)) => {
+                match crate::job_object::ProcessIdentity::duplicate_from(pid, handle) {
+                    Ok(identity) => Some(std::sync::Arc::new(identity)),
+                    Err(err) => {
+                        debug!("failed to retain process identity for child {pid}: {err}");
+                        None
+                    }
+                }
+            }
+            _ => None,
+        };
+
         #[cfg(unix)]
         let target_identity = capture_target_identity(pid);
 
@@ -339,6 +355,8 @@ impl ChildHandle {
                 #[cfg(windows)]
                 _job: job,
                 #[cfg(windows)]
+                root_identity: root_identity.clone(),
+                #[cfg(windows)]
                 pty_input: None,
             },
             io: ChildIO {
@@ -346,6 +364,8 @@ impl ChildHandle {
                 output: Some(ChildOutput::Std { stdout, stderr }),
             },
             controller: None,
+            #[cfg(windows)]
+            root_identity,
         })
     }
 
@@ -402,6 +422,20 @@ impl ChildHandle {
             })?;
 
         let pid = child.process_id();
+
+        #[cfg(windows)]
+        let root_identity = match (pid, child.as_raw_handle()) {
+            (Some(pid), Some(handle)) => {
+                match crate::job_object::ProcessIdentity::duplicate_from(pid, handle) {
+                    Ok(identity) => Some(std::sync::Arc::new(identity)),
+                    Err(err) => {
+                        debug!("failed to retain process identity for PTY child {pid}: {err}");
+                        None
+                    }
+                }
+            }
+            _ => None,
+        };
 
         #[cfg(unix)]
         let target_identity = capture_target_identity(pid);
@@ -474,10 +508,14 @@ impl ChildHandle {
                 #[cfg(windows)]
                 _job: job,
                 #[cfg(windows)]
+                root_identity: root_identity.clone(),
+                #[cfg(windows)]
                 pty_input,
             },
             io: ChildIO { stdin, output },
             controller: Some(controller),
+            #[cfg(windows)]
+            root_identity,
         })
     }
 
@@ -819,8 +857,8 @@ impl ChildHandle {
 
     #[cfg(windows)]
     fn has_running_windows_descendants(&self) -> bool {
-        match self.pid {
-            Some(pid) => match crate::job_object::has_descendant_processes(pid) {
+        match &self.root_identity {
+            Some(identity) => match crate::job_object::has_descendant_processes(identity) {
                 Ok(has_descendants) => has_descendants,
                 Err(err) => {
                     debug!("failed to query descendant processes: {err}");
@@ -839,8 +877,8 @@ impl ChildHandle {
             debug!("failed to terminate job object: {err}");
         }
 
-        if let Some(pid) = self.pid
-            && let Err(err) = crate::job_object::terminate_descendant_processes(pid)
+        if let Some(identity) = &self.root_identity
+            && let Err(err) = crate::job_object::terminate_descendant_processes(identity)
         {
             debug!("failed to terminate descendant process tree: {err}");
         }
@@ -979,4 +1017,6 @@ pub(super) struct SpawnResult {
     pub(super) handle: ChildHandle,
     pub(super) io: ChildIO,
     pub(super) controller: Option<Box<dyn PtyController + Send>>,
+    #[cfg(windows)]
+    pub(super) root_identity: Option<std::sync::Arc<crate::job_object::ProcessIdentity>>,
 }

--- a/crates/turborepo-process/src/job_object.rs
+++ b/crates/turborepo-process/src/job_object.rs
@@ -6,11 +6,18 @@
 // `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`, we ensure the entire process tree
 // is terminated when the job handle is closed.
 
-use std::{collections::HashSet, io, os::windows::io::RawHandle};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt, io,
+    os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle, RawHandle},
+};
 
 use tracing::debug;
 use windows_sys::Win32::{
-    Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE},
+    Foundation::{
+        CloseHandle, DuplicateHandle, FILETIME, HANDLE, INVALID_HANDLE_VALUE, WAIT_OBJECT_0,
+        WAIT_TIMEOUT,
+    },
     System::{
         Diagnostics::ToolHelp::{
             CreateToolhelp32Snapshot, PROCESSENTRY32, Process32First, Process32Next,
@@ -23,14 +30,67 @@ use windows_sys::Win32::{
             QueryInformationJobObject, SetInformationJobObject, TerminateJobObject,
         },
         Threading::{
-            GetProcessId, OpenProcess, OpenThread, PROCESS_SET_QUOTA, PROCESS_TERMINATE,
-            ResumeThread, THREAD_SUSPEND_RESUME, TerminateProcess,
+            GetCurrentProcess, GetProcessId, GetProcessTimes, OpenProcess, OpenThread,
+            PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SET_QUOTA, PROCESS_TERMINATE, ResumeThread,
+            THREAD_SUSPEND_RESUME, TerminateProcess, WaitForSingleObject,
         },
     },
 };
 
+use crate::process_tree::{ProcessEntry, ProcessTimes, descendants};
+
+const PROCESS_SYNCHRONIZE: u32 = 0x0010_0000;
+
 pub struct JobObject {
     handle: HANDLE,
+}
+
+/// A query-only handle retained from spawn so the root PID cannot be reused
+/// while descendant cleanup is still pending.
+pub(crate) struct ProcessIdentity {
+    pid: u32,
+    handle: OwnedHandle,
+}
+
+// OwnedHandle closes the handle on drop and is Send + Sync. Windows process
+// handles are valid in every thread of the owning process.
+
+impl fmt::Debug for ProcessIdentity {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProcessIdentity")
+            .field("pid", &self.pid)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ProcessIdentity {
+    pub(crate) fn duplicate_from(pid: u32, handle: RawHandle) -> io::Result<Self> {
+        let current_process = unsafe { GetCurrentProcess() };
+        let mut duplicate = std::ptr::null_mut();
+        let result = unsafe {
+            DuplicateHandle(
+                current_process,
+                handle as HANDLE,
+                current_process,
+                &mut duplicate,
+                PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_SYNCHRONIZE,
+                0,
+                0,
+            )
+        };
+        if result == 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        // SAFETY: DuplicateHandle returned a new owned process handle.
+        let handle = unsafe { OwnedHandle::from_raw_handle(duplicate as RawHandle) };
+        Ok(Self { pid, handle })
+    }
+
+    fn times(&self) -> io::Result<ProcessTimes> {
+        process_times(self.handle.as_raw_handle() as HANDLE)
+    }
 }
 
 // SAFETY: Job object handles can be sent between threads.
@@ -143,17 +203,20 @@ impl JobObject {
     }
 }
 
-pub fn has_descendant_processes(root_pid: u32) -> io::Result<bool> {
-    Ok(!descendant_processes(root_pid)?.is_empty())
+pub fn has_descendant_processes(root: &ProcessIdentity) -> io::Result<bool> {
+    Ok(!descendant_processes(root)?.0.is_empty())
 }
 
-pub fn terminate_descendant_processes(root_pid: u32) -> io::Result<()> {
+pub fn terminate_descendant_processes(root: &ProcessIdentity) -> io::Result<()> {
     let mut first_error = None;
-    let mut descendants = descendant_processes(root_pid)?;
-    descendants.reverse();
+    let (mut descendant_pids, mut candidates) = descendant_processes(root)?;
+    descendant_pids.reverse();
 
-    for pid in descendants {
-        if let Err(err) = terminate_process(pid) {
+    for pid in descendant_pids {
+        let Some(candidate) = candidates.remove(&pid) else {
+            continue;
+        };
+        if let Err(err) = candidate.terminate() {
             debug!("failed to terminate descendant process {pid}: {err}");
             first_error.get_or_insert(err);
         }
@@ -191,24 +254,92 @@ fn resume_threads(process_handle: HANDLE) -> io::Result<()> {
     result
 }
 
-pub fn descendant_processes(root_pid: u32) -> io::Result<Vec<u32>> {
-    let entries = process_entries()?;
+struct CandidateProcess {
+    handle: OwnedHandle,
+}
+
+impl CandidateProcess {
+    fn open(pid: u32) -> io::Result<Self> {
+        let handle = unsafe {
+            OpenProcess(
+                PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_TERMINATE | PROCESS_SYNCHRONIZE,
+                0,
+                pid,
+            )
+        };
+        if handle.is_null() {
+            return Err(io::Error::last_os_error());
+        }
+
+        // SAFETY: OpenProcess returned a new owned process handle.
+        let handle = unsafe { OwnedHandle::from_raw_handle(handle as RawHandle) };
+        Ok(Self { handle })
+    }
+
+    fn times(&self) -> io::Result<ProcessTimes> {
+        process_times(self.handle.as_raw_handle() as HANDLE)
+    }
+
+    fn terminate(self) -> io::Result<()> {
+        if unsafe { TerminateProcess(self.handle.as_raw_handle() as HANDLE, 1) } == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+}
+
+fn descendant_processes(
+    root: &ProcessIdentity,
+) -> io::Result<(Vec<u32>, HashMap<u32, CandidateProcess>)> {
+    let initial_entries = process_entries()?;
+    let mut candidates = HashMap::new();
+
+    for pid in candidate_pids(root.pid, &initial_entries) {
+        match CandidateProcess::open(pid) {
+            Ok(candidate) => {
+                candidates.insert(pid, candidate);
+            }
+            Err(err) => debug!("failed to pin descendant candidate {pid}: {err}"),
+        }
+    }
+
+    // Re-snapshot after candidates are pinned. Entries absent from the first
+    // snapshot have no retained handle and cannot participate in traversal.
+    let entries = process_entries()?
+        .into_iter()
+        .map(|(pid, parent_pid)| ProcessEntry {
+            pid,
+            parent_pid,
+            times: candidates.get(&pid).and_then(|candidate| {
+                candidate
+                    .times()
+                    .map_err(|err| debug!("failed to query descendant candidate {pid}: {err}"))
+                    .ok()
+            }),
+        })
+        .collect::<Vec<_>>();
+    let descendant_pids = descendants(root.pid, root.times()?, &entries);
+
+    Ok((descendant_pids, candidates))
+}
+
+fn candidate_pids(root_pid: u32, entries: &[(u32, u32)]) -> Vec<u32> {
     let mut visited = HashSet::from([root_pid]);
     let mut current_generation = vec![root_pid];
-    let mut descendants = Vec::new();
+    let mut candidates = Vec::new();
 
     while !current_generation.is_empty() {
         let mut next_generation = Vec::new();
-        for (pid, parent_pid) in &entries {
+        for (pid, parent_pid) in entries {
             if current_generation.contains(parent_pid) && visited.insert(*pid) {
-                descendants.push(*pid);
+                candidates.push(*pid);
                 next_generation.push(*pid);
             }
         }
         current_generation = next_generation;
     }
 
-    Ok(descendants)
+    candidates
 }
 
 fn process_entries() -> io::Result<Vec<(u32, u32)>> {
@@ -248,24 +379,37 @@ fn process_entries_from_snapshot(snapshot: HANDLE) -> io::Result<Vec<(u32, u32)>
     Ok(entries)
 }
 
-fn terminate_process(pid: u32) -> io::Result<()> {
-    let process_handle = unsafe { OpenProcess(PROCESS_TERMINATE, 0, pid) };
-    if process_handle.is_null() {
+fn process_times(handle: HANDLE) -> io::Result<ProcessTimes> {
+    let mut creation = FILETIME {
+        dwLowDateTime: 0,
+        dwHighDateTime: 0,
+    };
+    let mut exit = creation;
+    let mut kernel = creation;
+    let mut user = creation;
+    if unsafe { GetProcessTimes(handle, &mut creation, &mut exit, &mut kernel, &mut user) } == 0 {
         return Err(io::Error::last_os_error());
     }
 
-    let terminate_result = unsafe { TerminateProcess(process_handle, 1) };
-    let terminate_error = (terminate_result == 0).then(io::Error::last_os_error);
-    let close_result = unsafe { CloseHandle(process_handle) };
-
-    if let Some(err) = terminate_error {
-        return Err(err);
-    }
-    if close_result == 0 {
+    let exited = match unsafe { WaitForSingleObject(handle, 0) } {
+        WAIT_OBJECT_0 => true,
+        WAIT_TIMEOUT => false,
+        _ => return Err(io::Error::last_os_error()),
+    };
+    if exited
+        && unsafe { GetProcessTimes(handle, &mut creation, &mut exit, &mut kernel, &mut user) } == 0
+    {
         return Err(io::Error::last_os_error());
     }
 
-    Ok(())
+    Ok(ProcessTimes {
+        creation: filetime_to_u64(creation),
+        exit: exited.then(|| filetime_to_u64(exit)),
+    })
+}
+
+fn filetime_to_u64(time: FILETIME) -> u64 {
+    (u64::from(time.dwHighDateTime) << 32) | u64::from(time.dwLowDateTime)
 }
 
 fn resume_threads_from_snapshot(snapshot: HANDLE, process_id: u32) -> io::Result<()> {

--- a/crates/turborepo-process/src/lib.rs
+++ b/crates/turborepo-process/src/lib.rs
@@ -16,6 +16,8 @@ mod child;
 mod command;
 #[cfg(windows)]
 mod job_object;
+#[cfg(any(windows, test))]
+mod process_tree;
 
 use std::{
     collections::HashMap,

--- a/crates/turborepo-process/src/process_tree.rs
+++ b/crates/turborepo-process/src/process_tree.rs
@@ -37,7 +37,7 @@ pub(crate) fn descendants(
                 continue;
             };
 
-            if child_times.creation <= parent_times.creation
+            if child_times.creation < parent_times.creation
                 || parent_times
                     .exit
                     .is_some_and(|exit| child_times.creation > exit)

--- a/crates/turborepo-process/src/process_tree.rs
+++ b/crates/turborepo-process/src/process_tree.rs
@@ -1,0 +1,191 @@
+use std::collections::{HashMap, HashSet};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ProcessTimes {
+    pub(crate) creation: u64,
+    pub(crate) exit: Option<u64>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ProcessEntry {
+    pub(crate) pid: u32,
+    pub(crate) parent_pid: u32,
+    pub(crate) times: Option<ProcessTimes>,
+}
+
+pub(crate) fn descendants(
+    root_pid: u32,
+    root_times: ProcessTimes,
+    entries: &[ProcessEntry],
+) -> Vec<u32> {
+    let mut accepted = HashMap::from([(root_pid, root_times)]);
+    let mut visited = HashSet::from([root_pid]);
+    let mut current_generation = vec![root_pid];
+    let mut descendants = Vec::new();
+
+    while !current_generation.is_empty() {
+        let mut next_generation = Vec::new();
+        for entry in entries {
+            if !current_generation.contains(&entry.parent_pid) || !visited.insert(entry.pid) {
+                continue;
+            }
+
+            let Some(child_times) = entry.times else {
+                continue;
+            };
+            let Some(parent_times) = accepted.get(&entry.parent_pid) else {
+                continue;
+            };
+
+            if child_times.creation <= parent_times.creation
+                || parent_times
+                    .exit
+                    .is_some_and(|exit| child_times.creation > exit)
+            {
+                continue;
+            }
+
+            accepted.insert(entry.pid, child_times);
+            descendants.push(entry.pid);
+            next_generation.push(entry.pid);
+        }
+        current_generation = next_generation;
+    }
+
+    descendants
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ProcessEntry, ProcessTimes, descendants};
+
+    fn times(creation: u64, exit: Option<u64>) -> Option<ProcessTimes> {
+        Some(ProcessTimes { creation, exit })
+    }
+
+    #[test]
+    fn rejects_dangling_old_parent() {
+        let entries = [ProcessEntry {
+            pid: 2,
+            parent_pid: 1,
+            times: times(50, None),
+        }];
+
+        assert!(
+            descendants(
+                1,
+                ProcessTimes {
+                    creation: 100,
+                    exit: Some(200)
+                },
+                &entries
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn rejects_children_of_reused_root_pid() {
+        let entries = [ProcessEntry {
+            pid: 2,
+            parent_pid: 1,
+            times: times(201, None),
+        }];
+
+        assert!(
+            descendants(
+                1,
+                ProcessTimes {
+                    creation: 100,
+                    exit: Some(200)
+                },
+                &entries
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn rejects_children_of_reused_intermediate_pid() {
+        let entries = [
+            ProcessEntry {
+                pid: 2,
+                parent_pid: 1,
+                times: times(120, Some(150)),
+            },
+            ProcessEntry {
+                pid: 3,
+                parent_pid: 2,
+                times: times(151, None),
+            },
+        ];
+
+        assert_eq!(
+            descendants(
+                1,
+                ProcessTimes {
+                    creation: 100,
+                    exit: Some(200)
+                },
+                &entries
+            ),
+            vec![2]
+        );
+    }
+
+    #[test]
+    fn accepts_valid_descendants_after_root_exit() {
+        let entries = [
+            ProcessEntry {
+                pid: 2,
+                parent_pid: 1,
+                times: times(120, None),
+            },
+            ProcessEntry {
+                pid: 3,
+                parent_pid: 2,
+                times: times(250, None),
+            },
+        ];
+
+        assert_eq!(
+            descendants(
+                1,
+                ProcessTimes {
+                    creation: 100,
+                    exit: Some(200)
+                },
+                &entries
+            ),
+            vec![2, 3]
+        );
+    }
+
+    #[test]
+    fn rejected_candidates_do_not_extend_traversal() {
+        let entries = [
+            ProcessEntry {
+                pid: 2,
+                parent_pid: 1,
+                times: None,
+            },
+            ProcessEntry {
+                pid: 3,
+                parent_pid: 2,
+                times: times(150, None),
+            },
+        ];
+
+        assert!(
+            descendants(
+                1,
+                ProcessTimes {
+                    creation: 100,
+                    exit: None
+                },
+                &entries
+            )
+            .is_empty()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Retain the root process identity handle through descendant cleanup.
- Pin descendant handles before termination and validate creation/exit times for every process-tree edge.
- Add regression coverage for dangling parent PIDs and root/intermediate PID reuse.

## Testing

- `cargo test -p turborepo-process`
- `cargo check -p turborepo-process`
- `cargo check -p turborepo-process --tests --target x86_64-pc-windows-gnu`
- Pre-push formatting and TOML checks

Closes #13692