### PR TITLE
feat: Support nub.lock files

### DIFF
--- a/crates/turborepo-devtools/src/watcher.rs
+++ b/crates/turborepo-devtools/src/watcher.rs
@@ -42,6 +42,8 @@ const RELEVANT_FILES: &[&str] = &[
     "package-lock.json",
     "yarn.lock",
     "pnpm-lock.yaml",
+    "nub.lock",
+    "lock.yaml",
     "bun.lockb",
     "Cargo.toml",
     "Cargo.lock",
@@ -221,6 +223,8 @@ mod tests {
         assert!(is_relevant_file(Path::new("turbo.json")));
         assert!(is_relevant_file(Path::new("turbo.jsonc")));
         assert!(is_relevant_file(Path::new("pnpm-workspace.yaml")));
+        assert!(is_relevant_file(Path::new("nub.lock")));
+        assert!(is_relevant_file(Path::new("lock.yaml")));
         assert!(is_relevant_file(Path::new("crates/app/Cargo.toml")));
         assert!(is_relevant_file(Path::new("Cargo.lock")));
         assert!(!is_relevant_file(Path::new("index.ts")));

--- a/crates/turborepo-filewatch/src/package_watcher.rs
+++ b/crates/turborepo-filewatch/src/package_watcher.rs
@@ -192,6 +192,7 @@ const INVALIDATION_PATHS: &[&str] = &[
     package_manager::aube::LOCKFILE,
     "pnpm-workspace.yaml",
     package_manager::nub::LOCKFILE,
+    package_manager::nub::LEGACY_LOCKFILE,
     package_manager::pnpm::LOCKFILE,
     package_manager::npm::LOCKFILE,
     package_manager::yarn::LOCKFILE,

--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -991,11 +991,10 @@ impl PackageManager {
                 });
         // nub is recognized ONLY through the `packageManager` field /
         // `devEngines.packageManager` (handled in `get_package_manager`), never
-        // from the presence of its `lock.yaml`: nub's lockfile name is
-        // deliberately neutral and nub is lockfile-compatible with whatever the
-        // project already uses, so the file's presence is not a reliable nub
-        // signal. Lockfile parsing still happens once nub is detected via the
-        // field — only the name-based *detection* is dropped here.
+        // from the presence of its lockfile: nub is lockfile-compatible with
+        // whatever the project already uses, so a file alone is not a reliable
+        // nub signal. Lockfile parsing still happens once nub is detected via
+        // the field — only name-based *detection* is excluded here.
         let detected_package_managers = native_aube
             .into_iter()
             .map(Ok)
@@ -1097,14 +1096,19 @@ impl PackageManager {
         root_path: &AbsoluteSystemPath,
         root_package_json: &PackageJson,
     ) -> Result<Box<dyn Lockfile>, Error> {
-        if let PackageManager::Nub { lockfile } | PackageManager::Aube { lockfile } = self {
-            let native_lockfile = match self {
-                PackageManager::Nub { .. } => nub::LOCKFILE,
-                PackageManager::Aube { .. } => aube::LOCKFILE,
-                _ => unreachable!(),
-            };
-            if root_path.join_component(native_lockfile).exists() {
-                let contents = root_path.join_component(native_lockfile).read()?;
+        if let PackageManager::Nub { lockfile } = self {
+            if lockfile.is_pnpm_family()
+                && let Some(native_lockfile) = nub::native_lockfile_path(root_path)
+            {
+                let contents = native_lockfile.read()?;
+                return lockfile.parse_lockfile(root_package_json, &contents, None);
+            }
+            return lockfile.read_lockfile(root_path, root_package_json);
+        }
+        if let PackageManager::Aube { lockfile } = self {
+            let native_lockfile = root_path.join_component(aube::LOCKFILE);
+            if native_lockfile.exists() {
+                let contents = native_lockfile.read()?;
                 return lockfile.parse_lockfile(root_package_json, &contents, None);
             }
             return lockfile.read_lockfile(root_path, root_package_json);
@@ -1277,10 +1281,10 @@ impl PackageManager {
     }
 
     pub fn lockfile_path(&self, turbo_root: &AbsoluteSystemPath) -> AbsoluteSystemPathBuf {
-        if matches!(self, PackageManager::Nub { .. })
-            && turbo_root.join_component(nub::LOCKFILE).exists()
+        if matches!(self, PackageManager::Nub { lockfile } if lockfile.is_pnpm_family())
+            && let Some(native_lockfile) = nub::native_lockfile_path(turbo_root)
         {
-            return turbo_root.join_component(nub::LOCKFILE);
+            return native_lockfile;
         }
         if matches!(self, PackageManager::Aube { .. })
             && turbo_root.join_component(aube::LOCKFILE).exists()
@@ -1966,7 +1970,7 @@ mod tests {
     #[test]
     fn test_native_nub_lockfile_is_ignored_by_detection() -> Result<(), Error> {
         let (_dir, repo_root) = temp_repo_root()?;
-        // A native `lock.yaml` does not participate in detection (nub is
+        // A native `nub.lock` does not participate in detection (nub is
         // field-only), so a co-present `pnpm-lock.yaml` resolves cleanly to pnpm
         // rather than producing an ambiguous multi-manager result.
         std::fs::write(
@@ -2139,6 +2143,31 @@ mod tests {
             repo_root.join_component(nub::LOCKFILE)
         );
         package_manager.read_lockfile(&repo_root, &package_json)?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_dev_engines_nub_prefers_selected_bun_lockfile_over_native_lockfile() -> Result<(), Error>
+    {
+        let (_dir, repo_root) = temp_repo_root()?;
+        repo_root.join_component(bun::LOCKFILE).create()?;
+        repo_root
+            .join_component(nub::LOCKFILE)
+            .create_with_contents("lockfileVersion: '9.0'\n")?;
+        let package_json = dev_engines_package_manager(json!("nub"), json!("0.6.0"));
+
+        let package_manager = PackageManager::read_package_manager(&repo_root, &package_json)?;
+
+        assert_eq!(
+            package_manager,
+            PackageManager::Nub {
+                lockfile: Box::new(PackageManager::Bun)
+            }
+        );
+        assert_eq!(
+            package_manager.lockfile_path(&repo_root),
+            repo_root.join_component(bun::LOCKFILE)
+        );
         Ok(())
     }
 

--- a/crates/turborepo-repository/src/package_manager/nub.rs
+++ b/crates/turborepo-repository/src/package_manager/nub.rs
@@ -2,13 +2,12 @@
 //!
 //! nub (<https://nub.dev>) is a Rust CLI that augments the user's installed
 //! Node and ships a pnpm-compatible package-manager command surface. Unlike the
-//! other supported package managers, nub does not define its own lockfile
-//! format: it is lockfile-compatible with whatever the project already uses
-//! (npm, pnpm, yarn, or bun). For that reason nub is recognized ONLY through
-//! the `packageManager` field in `package.json` (`"nub@x.y.z"`) or
-//! `devEngines.packageManager` — never from the presence of a lockfile. nub's
-//! `lock.yaml` name is deliberately neutral, so its presence is not a reliable
-//! nub signal; a bare lockfile (nub's or any other) alone does not imply nub.
+//! other supported package managers, nub's native `nub.lock` uses the pnpm v9
+//! format, and nub is also lockfile-compatible with whatever package manager
+//! the project already uses (npm, pnpm, yarn, or bun). For that reason nub is
+//! recognized ONLY through the `packageManager` field in `package.json`
+//! (`"nub@x.y.z"`) or `devEngines.packageManager` — never from the presence of
+//! a lockfile. A bare lockfile (nub's or any other) alone does not imply nub.
 //!
 //! Because Turborepo needs a parsed lockfile for pruning and cache hashing, the
 //! [`PackageManager::Nub`] variant carries the concrete package manager whose
@@ -16,11 +15,21 @@
 //! delegate to it. That parsing happens once nub is detected via the field;
 //! the lockfile name is never itself a detection signal.
 
-use turbopath::AbsoluteSystemPath;
+use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 
 use crate::package_manager::{PackageManager, bun, pnpm, yarn, yarn::YarnDetector};
 
-pub const LOCKFILE: &str = "lock.yaml";
+pub const LOCKFILE: &str = "nub.lock";
+pub const LEGACY_LOCKFILE: &str = "lock.yaml";
+
+/// Returns the native nub lockfile present in the repository, preferring the
+/// current filename over the legacy filename.
+pub fn native_lockfile_path(repo_root: &AbsoluteSystemPath) -> Option<AbsoluteSystemPathBuf> {
+    [LOCKFILE, LEGACY_LOCKFILE]
+        .into_iter()
+        .map(|lockfile| repo_root.join_component(lockfile))
+        .find(|lockfile| lockfile.exists())
+}
 
 /// Determine which package manager's lockfile is present in the repository
 /// root, in priority order. Defaults to npm when no lockfile is found yet (e.g.
@@ -29,9 +38,8 @@ pub const LOCKFILE: &str = "lock.yaml";
 pub fn underlying_lockfile_manager(repo_root: &AbsoluteSystemPath) -> PackageManager {
     if repo_root.join_component(bun::LOCKFILE).exists() {
         PackageManager::Bun
-    } else if repo_root.join_component(LOCKFILE).exists() {
-        repo_root
-            .join_component(LOCKFILE)
+    } else if let Some(lockfile_path) = native_lockfile_path(repo_root) {
+        lockfile_path
             .read()
             .map(|contents| pnpm::detect_from_lockfile_contents(&contents))
             .unwrap_or(PackageManager::Pnpm)
@@ -83,7 +91,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let repo_root = AbsoluteSystemPathBuf::try_from(dir.path()).unwrap();
 
-        // A native `lock.yaml` with NO `packageManager` field must NOT be
+        // A native `nub.lock` with NO `packageManager` field must NOT be
         // detected as nub: nub is recognized only via the field. With no other
         // recognized lockfile present, detection finds no package manager.
         repo_root
@@ -93,7 +101,7 @@ mod tests {
         let detected = PackageManager::detect_package_manager(&repo_root);
         assert!(
             !matches!(detected, Ok(PackageManager::Nub { .. })),
-            "a bare lock.yaml must not be detected as nub, got {detected:?}"
+            "a bare nub.lock must not be detected as nub, got {detected:?}"
         );
 
         // The same repo IS nub once the field is present.
@@ -172,6 +180,36 @@ mod tests {
         assert_eq!(
             underlying_lockfile_manager(&repo_root),
             PackageManager::Pnpm9
+        );
+    }
+
+    #[test]
+    fn test_nub_underlying_legacy_lockfile_detects_pnpm9() {
+        let dir = tempdir().unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(dir.path()).unwrap();
+
+        repo_root
+            .join_component(LEGACY_LOCKFILE)
+            .create_with_contents("lockfileVersion: '9.0'\n")
+            .unwrap();
+
+        assert_eq!(
+            underlying_lockfile_manager(&repo_root),
+            PackageManager::Pnpm9
+        );
+    }
+
+    #[test]
+    fn test_native_lockfile_path_prefers_current_filename() {
+        let dir = tempdir().unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(dir.path()).unwrap();
+
+        repo_root.join_component(LEGACY_LOCKFILE).create().unwrap();
+        repo_root.join_component(LOCKFILE).create().unwrap();
+
+        assert_eq!(
+            native_lockfile_path(&repo_root),
+            Some(repo_root.join_component(LOCKFILE))
         );
     }
 }

--- a/packages/turbo-workspaces/__tests__/aube.test.ts
+++ b/packages/turbo-workspaces/__tests__/aube.test.ts
@@ -79,6 +79,19 @@ describe("aube", () => {
       );
     });
 
+    it("prefers its native lockfile over a co-present nub lockfile", () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": { packageManager: "aube@0.1.0" },
+        "aube-lock.yaml": "lockfileVersion: '9.0'\n",
+        "nub.lock": "lockfileVersion: '9.0'\n"
+      });
+
+      expect(getUnderlyingLockfileManager({ workspaceRoot })).toEqual("pnpm");
+      expect(getUnderlyingLockfileName({ workspaceRoot })).toEqual(
+        "aube-lock.yaml"
+      );
+    });
+
     it("prefers bun over non-native foreign lockfiles", () => {
       const workspaceRoot = makeWorkspace({
         "package.json": { packageManager: "aube@0.1.0" },

--- a/packages/turbo-workspaces/__tests__/nub.test.ts
+++ b/packages/turbo-workspaces/__tests__/nub.test.ts
@@ -88,6 +88,26 @@ describe("nub", () => {
 
       expect(getUnderlyingLockfileManager({ workspaceRoot })).toEqual("pnpm");
     });
+
+    it("uses nub.lock as a pnpm-compatible native lockfile", () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": { packageManager: "nub@0.6.0" },
+        "nub.lock": "lockfileVersion: '9.0'\n"
+      });
+
+      expect(getUnderlyingLockfileManager({ workspaceRoot })).toEqual("pnpm");
+      expect(getUnderlyingLockfileName({ workspaceRoot })).toEqual("nub.lock");
+    });
+
+    it("continues to support the legacy lock.yaml filename", () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": { packageManager: "nub@0.1.0" },
+        "lock.yaml": "lockfileVersion: '9.0'\n"
+      });
+
+      expect(getUnderlyingLockfileManager({ workspaceRoot })).toEqual("pnpm");
+      expect(getUnderlyingLockfileName({ workspaceRoot })).toEqual("lock.yaml");
+    });
   });
 
   describe("detection", () => {
@@ -118,6 +138,25 @@ describe("nub", () => {
   });
 
   describe("getWorkspaceDetails", () => {
+    it("returns nub.lock for a native nub project", async () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": {
+          name: "nub-project",
+          packageManager: "nub@0.6.0",
+          workspaces: ["packages/*"]
+        },
+        "nub.lock": "lockfileVersion: '9.0'\n"
+      });
+
+      const project = await getWorkspaceDetails({ root: workspaceRoot });
+
+      expect(project.packageManager).toEqual("nub");
+      expect(project.paths.lockfile).toEqual(
+        path.join(workspaceRoot, "nub.lock")
+      );
+      expect(project.workspaceData.globs).toEqual(["packages/*"]);
+    });
+
     it("returns nub as the package manager", async () => {
       const workspaceRoot = makeWorkspace({
         "package.json": {

--- a/packages/turbo-workspaces/src/managers/nub.ts
+++ b/packages/turbo-workspaces/src/managers/nub.ts
@@ -35,7 +35,7 @@ import { bun } from "./bun";
 
 const PACKAGE_MANAGER_DETAILS: Manager = {
   name: "nub",
-  lock: "package-lock.json"
+  lock: "nub.lock"
 };
 
 const UNDERLYING_MANAGERS = {

--- a/packages/turbo-workspaces/src/utils.ts
+++ b/packages/turbo-workspaces/src/utils.ts
@@ -465,22 +465,54 @@ function expandWorkspaces({
 
 type LockfilePackageManager = Exclude<PackageManager, "nub" | "aube">;
 
-const LOCKFILE_PROBE_ORDER: Array<{
+const FOREIGN_LOCKFILE_PROBE_ORDER: Array<{
   manager: LockfilePackageManager;
   lockfiles: Array<string>;
 }> = [
   { manager: "bun", lockfiles: ["bun.lock", "bun.lockb"] },
-  { manager: "pnpm", lockfiles: ["aube-lock.yaml", "pnpm-lock.yaml"] },
   { manager: "yarn", lockfiles: ["yarn.lock"] },
   { manager: "npm", lockfiles: ["package-lock.json"] }
 ];
+
+function getPnpmLockfileNames({
+  workspaceRoot
+}: {
+  workspaceRoot: string;
+}): Array<string> {
+  const packageManager = getWorkspacePackageManager({ workspaceRoot });
+
+  if (packageManager === "nub") {
+    return ["nub.lock", "lock.yaml", "aube-lock.yaml", "pnpm-lock.yaml"];
+  }
+  if (packageManager === "aube") {
+    return ["aube-lock.yaml", "nub.lock", "lock.yaml", "pnpm-lock.yaml"];
+  }
+  return ["aube-lock.yaml", "nub.lock", "lock.yaml", "pnpm-lock.yaml"];
+}
 
 function getUnderlyingLockfileManager({
   workspaceRoot
 }: {
   workspaceRoot: string;
 }): LockfilePackageManager {
-  for (const { manager, lockfiles } of LOCKFILE_PROBE_ORDER) {
+  const [bun, ...remainingManagers] = FOREIGN_LOCKFILE_PROBE_ORDER;
+  if (
+    bun.lockfiles.some((lockfile) =>
+      existsSync(path.join(workspaceRoot, lockfile))
+    )
+  ) {
+    return bun.manager;
+  }
+
+  if (
+    getPnpmLockfileNames({ workspaceRoot }).some((lockfile) =>
+      existsSync(path.join(workspaceRoot, lockfile))
+    )
+  ) {
+    return "pnpm";
+  }
+
+  for (const { manager, lockfiles } of remainingManagers) {
     if (
       lockfiles.some((lockfile) =>
         existsSync(path.join(workspaceRoot, lockfile))
@@ -508,10 +540,11 @@ function getUnderlyingLockfileName({
       return "bun.lockb";
     }
     case "pnpm": {
-      if (existsSync(path.join(workspaceRoot, "aube-lock.yaml"))) {
-        return "aube-lock.yaml";
-      }
-      return "pnpm-lock.yaml";
+      return (
+        getPnpmLockfileNames({ workspaceRoot }).find((lockfile) =>
+          existsSync(path.join(workspaceRoot, lockfile))
+        ) ?? "pnpm-lock.yaml"
+      );
     }
     case "yarn": {
       return "yarn.lock";


### PR DESCRIPTION
## Why

Nub 0.6 writes its pnpm v9-compatible lockfile as `nub.lock`, but Turborepo only recognized Nub's legacy `lock.yaml` name. As a result, Turbo fell back to npm and warned that `package-lock.json` could not be found.

Fixes #13698.

## What

- recognize `nub.lock` as Nub's current native lockfile while retaining `lock.yaml` compatibility
- use the selected native lockfile for parsing, path resolution, and watcher invalidation
- keep native lockfile precedence specific to Nub and Aube when both wrapper lockfiles are present
- update `@turbo/workspaces` lockfile reporting and add current, legacy, and mixed-lockfile regression coverage

## Impact

Nub 0.6 workspaces can run Turbo without the misleading missing `package-lock.json` warning. Existing Nub projects using `lock.yaml` or another supported underlying package-manager lockfile continue to work.

## Testing

- `cargo test -p turborepo-repository -p turborepo-filewatch -p turborepo-devtools`
- `pnpm --filter @turbo/workspaces exec jest --runInBand --silent` (990 tests)
- `cargo fmt --all --check`
- targeted `oxfmt` and `oxlint --deny-warnings`
- `cargo build -p turbo`
- manual `turbo run build --dry=json --skip-infer` against the `lazydiff` reproduction
- repository pre-push formatting and TOML checks

`cargo lint` was also attempted and reached an existing macOS-only `clippy::too_many_arguments` error in `crates/turborepo-filewatch/src/lib.rs:1633`, outside this patch.
