### PR TITLE
fix(deps): Upgrade js-yaml to 4.3.1 (GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/packages/turbo-test-utils/package.json
+++ b/packages/turbo-test-utils/package.json
@@ -18,7 +18,7 @@
   "main": "src/index.ts",
   "dependencies": {
     "fs-extra": "11.1.1",
-    "js-yaml": "4.2.0",
+    "js-yaml": "4.3.1",
     "json5": "2.2.3",
     "ts-jest": "29.4.11",
     "typescript": "npm:@typescript/typescript6@^6.0.1",

--- a/packages/turbo-utils/package.json
+++ b/packages/turbo-utils/package.json
@@ -43,7 +43,7 @@
     "fs-extra": "11.1.1",
     "gradient-string": "2.0.1",
     "jest": "30.3.0",
-    "js-yaml": "4.2.0",
+    "js-yaml": "4.3.1",
     "json5": "2.2.3",
     "ora": "4.1.1",
     "picocolors": "1.0.1",

--- a/packages/turbo-workspaces/package.json
+++ b/packages/turbo-workspaces/package.json
@@ -29,7 +29,7 @@
     "fast-glob": "3.2.12",
     "fs-extra": "10.1.0",
     "gradient-string": "2.0.1",
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "ora": "4.1.1",
     "picocolors": "1.0.1",
     "semver": "7.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -718,8 +718,8 @@ importers:
         specifier: 11.1.1
         version: 11.1.1
       js-yaml:
-        specifier: 4.2.0
-        version: 4.2.0
+        specifier: 4.3.1
+        version: 4.3.1
       json5:
         specifier: 2.2.3
         version: 2.2.3
@@ -837,8 +837,8 @@ importers:
         specifier: 30.3.0
         version: 30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.1))
       js-yaml:
-        specifier: 4.2.0
-        version: 4.2.0
+        specifier: 4.3.1
+        version: 4.3.1
       json5:
         specifier: 2.2.3
         version: 2.2.3
@@ -910,8 +910,8 @@ importers:
         specifier: 2.0.1
         version: 2.0.1
       js-yaml:
-        specifier: 4.3.0
-        version: 4.3.0
+        specifier: 4.3.1
+        version: 4.3.1
       ora:
         specifier: 4.1.1
         version: 4.1.1
@@ -7578,8 +7578,8 @@ packages:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -10813,7 +10813,7 @@ snapshots:
 
   '@fumari/json-schema-to-typescript@2.0.0(prettier@3.3.3)':
     dependencies:
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
     optionalDependencies:
       prettier: 3.3.3
 
@@ -13763,7 +13763,7 @@ snapshots:
       '@textlint/types': 15.6.0
       chalk: 4.1.2
       debug: 4.4.3
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       pluralize: 2.0.0
       string-width: 4.2.3
@@ -17157,7 +17157,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -18830,7 +18830,7 @@ snapshots:
   rc-config-loader@4.1.4:
     dependencies:
       debug: 4.4.3
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       json5: 2.2.3
       require-from-string: 2.0.2
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

Remediates **GHSA-5p4m-2wfm-xmqj** / CVE-2026-59870 (High, CWE-407) — quadratic CPU consumption in js-yaml's `!!omap` resolution.

`resolveYamlOmap()` enforces `!!omap` key uniqueness with a linear `objectKeys.indexOf()` scan inside the per-element loop, making resolution **O(n²)** in the number of entries. `!!omap` is registered in the **default schema**, so a plain `yaml.load(untrustedInput)` with no options is affected — the work happens synchronously and blocks the event loop for its whole duration.

## Scope: three packages, not one

The report flagged `@turbo/workspaces` (4.3.0), but the advisory range is `>=4.0.0 <4.3.1`, so the two `4.2.0` pins are vulnerable to the same issue. All three call `yaml.load()` with the default schema:

| Package | Was | Now | Call site |
|---|---|---|---|
| `@turbo/workspaces` | 4.3.0 | 4.3.1 | `src/utils.ts:363` — parses `pnpm-workspace.yaml` |
| `@turbo/utils` | 4.2.0 | 4.3.1 | `src/get-turbo-configs.ts:124` |
| `@turbo/test-utils` | 4.2.0 | 4.3.1 | `src/use-fixtures.ts:102` |

`@turbo/utils` matters in particular: it is consumed by `@turbo/workspaces` and several other packages, so fixing only the reported pin would have left the same vulnerable code reachable.

4.3.1 replaces the linear scan with an O(1) key lookup. Staying on the 4.x line keeps this a patch-level bump with no API change.

## Verification

**Advisory PoC** — load time now scales linearly instead of quadratically:

| n | 4.3.0 (per advisory) | 4.3.1 (this branch) |
|---|---|---|
| 10,000 | 54ms | 62ms |
| 20,000 | 169ms | 77ms |
| 40,000 | 646ms | 135ms |
| 80,000 | (worse still) | 253ms |

Correctness preserved: duplicate `!!omap` keys are still rejected (`YAMLException`), and valid omaps parse as before.

**Tests** — captured a baseline on unmodified `main`, then re-ran after the bump. Suite and test counts are byte-identical across every changed package and every consumer of `@turbo/test-utils`:

- `@turbo/workspaces` — 986 passed
- `@turbo/utils` — 89 passed
- `turbo-ignore` — 74 passed
- `turbo-codemod`, `turbo-gen`, `eslint-plugin-turbo`, `create-turbo` — unchanged from baseline

The pre-existing failures in those last four are sandbox artifacts (`Cannot find module '@turbo/workspaces'` — the `test` task `dependsOn: ["^build"]` and `dist/` was not built here). They fail identically before and after this change.

`pnpm install --frozen-lockfile` succeeds, confirming the lockfile matches the manifests. The lockfile also deduped `@fumari/json-schema-to-typescript`, `@textlint/*`, and `rc-config-loader` onto 4.3.1, since those carry `^4` ranges.

## Left out, deliberately

The docs site still resolves js-yaml 4.2.0 transitively through `fumadocs-mdx` and `fumadocs-openapi`, which pin the version exactly. Forcing those would require a `pnpm.overrides` entry pushing a version upstream has not tested against, and those packages parse only repo-owned MDX at build time — there is no untrusted-input path. Happy to add the override if you would rather have a clean `pnpm audit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)