### PR TITLE
perf: Walk the repository once when pruning

### DIFF
--- a/crates/turborepo-fs/src/lib.rs
+++ b/crates/turborepo-fs/src/lib.rs
@@ -4,14 +4,17 @@
 #![deny(clippy::all)]
 
 use std::{
-    fs::{DirBuilder, FileType, Metadata},
+    collections::{HashMap, HashSet},
+    fs::{DirBuilder, FileType, Permissions},
     io,
+    path::{Path, PathBuf},
+    sync::Arc,
 };
 
 // `fs_err` preserves paths in the error messages unlike `std::fs`
 use fs_err as fs;
 use ignore::WalkBuilder;
-use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf};
+use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -29,17 +32,118 @@ pub fn recursive_copy(
     use_gitignore: bool,
     gitignore_root: Option<&AbsoluteSystemPath>,
 ) -> Result<(), Error> {
-    let src = src.as_ref();
-    let dst = dst.as_ref();
-    let src_metadata = src.symlink_metadata()?;
+    CopyPlan::unplanned(use_gitignore, gitignore_root).copy(src, dst)
+}
 
-    if !src_metadata.is_dir() {
-        return copy_file_with_type(src, src_metadata.file_type(), dst);
+/// One path found beneath a source directory during a walk.
+struct PlannedEntry {
+    /// Path of the entry relative to the source directory.
+    suffix: AnchoredSystemPathBuf,
+    kind: PlannedEntryKind,
+}
+
+enum PlannedEntryKind {
+    /// Permissions are captured during the walk so the copy can recreate the
+    /// directory without a second `stat`.
+    Directory(Permissions),
+    File(FileType),
+}
+
+/// Copies of directories out of one repository, sharing a single walk.
+///
+/// Honoring the ignore files that live *above* a source directory means
+/// anchoring its walk at the repository root (see [`recursive_copy`]). Walking
+/// from the root once per source re-reads every directory on the way down and
+/// recompiles every ignore file above it, so the cost of copying `n` packages
+/// grows with `n * repository fan-out`. Planning the copies together walks the
+/// repository once and hands each source the entries that belong to it.
+///
+/// Sources that were not planned, or that do not resolve their ignore rules
+/// from a shared root, are walked on demand by [`CopyPlan::copy`].
+pub struct CopyPlan {
+    use_gitignore: bool,
+    gitignore_root: Option<AbsoluteSystemPathBuf>,
+    planned: HashMap<AbsoluteSystemPathBuf, Vec<PlannedEntry>>,
+}
+
+impl CopyPlan {
+    /// A plan that walks every source on demand.
+    pub fn unplanned(use_gitignore: bool, gitignore_root: Option<&AbsoluteSystemPath>) -> Self {
+        Self {
+            use_gitignore,
+            gitignore_root: gitignore_root.map(|root| root.to_owned()),
+            planned: HashMap::new(),
+        }
     }
 
-    // Parent .gitignore files need to be evaluated from their own directory so
-    // rooted patterns keep the same meaning they have to git.
-    let walk_root = match gitignore_root {
+    /// Resolve the contents of every source directory that shares a walk root
+    /// with the others, so that copying them performs one walk in total.
+    pub fn new<'a>(
+        srcs: impl IntoIterator<Item = &'a AbsoluteSystemPath>,
+        use_gitignore: bool,
+        gitignore_root: Option<&AbsoluteSystemPath>,
+    ) -> Result<Self, Error> {
+        let mut plan = Self::unplanned(use_gitignore, gitignore_root);
+        let Some(root) = gitignore_root else {
+            return Ok(plan);
+        };
+
+        // Only sources that resolve their ignore rules from the shared root
+        // benefit from a shared walk. Anything else keeps walking itself,
+        // which is what it would have done on its own anyway.
+        let shared: Vec<&AbsoluteSystemPath> = srcs
+            .into_iter()
+            .filter(|src| walk_root_for(src, use_gitignore, Some(root)) == root)
+            .filter(|src| {
+                src.symlink_metadata()
+                    .is_ok_and(|metadata| metadata.is_dir())
+            })
+            .collect();
+
+        if !shared.is_empty() {
+            collect_entries(root, &shared, use_gitignore, &mut plan.planned)?;
+        }
+
+        Ok(plan)
+    }
+
+    /// Copy `src` into `dst`, reusing the planned walk when there is one.
+    pub fn copy(
+        &self,
+        src: impl AsRef<AbsoluteSystemPath>,
+        dst: impl AsRef<AbsoluteSystemPath>,
+    ) -> Result<(), Error> {
+        let src = src.as_ref();
+        let dst = dst.as_ref();
+
+        if let Some(entries) = self.planned.get(src) {
+            return copy_entries(src, dst, entries);
+        }
+
+        let src_metadata = src.symlink_metadata()?;
+        if !src_metadata.is_dir() {
+            return copy_file_with_type(src, src_metadata.file_type(), dst);
+        }
+
+        let walk_root = walk_root_for(src, self.use_gitignore, self.gitignore_root.as_deref());
+        let mut entries = HashMap::new();
+        collect_entries(walk_root, &[src], self.use_gitignore, &mut entries)?;
+        match entries.get(src) {
+            Some(entries) => copy_entries(src, dst, entries),
+            None => Ok(()),
+        }
+    }
+}
+
+/// Where a copy of `src` has to start walking for its ignore rules to match
+/// what git would do. Parent `.gitignore` files need to be evaluated from
+/// their own directory so rooted patterns keep the same meaning.
+fn walk_root_for<'a>(
+    src: &'a AbsoluteSystemPath,
+    use_gitignore: bool,
+    gitignore_root: Option<&'a AbsoluteSystemPath>,
+) -> &'a AbsoluteSystemPath {
+    match gitignore_root {
         Some(root)
             if use_gitignore
                 && src != root
@@ -48,8 +152,18 @@ pub fn recursive_copy(
             root
         }
         _ => src,
-    };
-    let walk_from_root = walk_root != src;
+    }
+}
+
+/// Walk `walk_root` once and record the entries belonging to each source in
+/// `srcs`. Every source must be `walk_root` or live beneath it.
+fn collect_entries(
+    walk_root: &AbsoluteSystemPath,
+    srcs: &[&AbsoluteSystemPath],
+    use_gitignore: bool,
+    out: &mut HashMap<AbsoluteSystemPathBuf, Vec<PlannedEntry>>,
+) -> Result<(), Error> {
+    let walk_from_root = !(srcs.len() == 1 && srcs[0] == walk_root);
 
     let mut builder = WalkBuilder::new(walk_root.as_path());
     builder
@@ -59,23 +173,39 @@ pub fn recursive_copy(
         .git_global(false)
         .git_exclude(use_gitignore);
 
+    let sources: Arc<HashSet<PathBuf>> = Arc::new(
+        srcs.iter()
+            .map(|src| src.as_std_path().to_path_buf())
+            .collect(),
+    );
+
     if walk_from_root {
-        let src_std_path = src.as_std_path().to_path_buf();
+        // Directories that have to be descended into to reach a source.
+        let mut approaches: HashSet<PathBuf> = HashSet::new();
+        for src in srcs {
+            for ancestor in src.as_std_path().ancestors().skip(1) {
+                if !ancestor.starts_with(walk_root.as_std_path()) {
+                    break;
+                }
+                approaches.insert(ancestor.to_path_buf());
+            }
+        }
+
+        let filter_sources = sources.clone();
         builder.filter_entry(move |entry| {
             let path = entry.path();
-            if entry
+            if owning_sources(&filter_sources, path).next().is_some() {
+                return true;
+            }
+            entry
                 .file_type()
                 .is_some_and(|file_type| file_type.is_dir())
-            {
-                path.starts_with(&src_std_path) || src_std_path.starts_with(path)
-            } else {
-                path.starts_with(&src_std_path)
-            }
+                && approaches.contains(path)
         });
     }
 
     for entry in builder.build() {
-        match entry {
+        let entry = match entry {
             Err(e) => {
                 if e.io_error().is_some() {
                     // Matches go behavior where we translate path errors
@@ -85,33 +215,73 @@ pub fn recursive_copy(
                     return Err(e.into());
                 }
             }
-            Ok(entry) => {
-                let path = entry.path();
-                let path = AbsoluteSystemPath::from_std_path(path)?;
-                if path != src && !path.as_std_path().starts_with(src.as_std_path()) {
-                    continue;
-                }
+            Ok(entry) => entry,
+        };
 
-                let file_type = match entry.file_type() {
-                    Some(file_type) => file_type,
-                    None => entry.metadata()?.file_type(),
-                };
+        let path = AbsoluteSystemPath::from_std_path(entry.path())?;
+        let mut owners = owning_sources(&sources, entry.path()).peekable();
+        if owners.peek().is_none() {
+            continue;
+        }
 
-                // Note that we also don't currently copy broken symlinks
-                if file_type.is_symlink() && path.stat().is_err() {
-                    // If we have a broken link, skip this entry
-                    continue;
-                }
+        let file_type = match entry.file_type() {
+            Some(file_type) => file_type,
+            None => entry.metadata()?.file_type(),
+        };
 
-                let suffix = AnchoredSystemPathBuf::new(src, path)?;
-                let target = dst.resolve(&suffix);
-                if file_type.is_dir() {
-                    let src_metadata = entry.metadata()?;
-                    make_dir_copy(&target, &src_metadata)?;
-                } else if file_type.is_file() || file_type.is_symlink() {
-                    copy_file_with_type(path, file_type, &target)?;
+        // Note that we also don't currently copy broken symlinks
+        if file_type.is_symlink() && path.stat().is_err() {
+            // If we have a broken link, skip this entry
+            continue;
+        }
+
+        let kind = if file_type.is_dir() {
+            PlannedEntryKind::Directory(entry.metadata()?.permissions())
+        } else if file_type.is_file() || file_type.is_symlink() {
+            PlannedEntryKind::File(file_type)
+        } else {
+            // Skip special files (sockets, FIFOs, device nodes)
+            continue;
+        };
+
+        for owner in owners {
+            let owner = AbsoluteSystemPath::from_std_path(owner)?;
+            let suffix = AnchoredSystemPathBuf::new(owner, path)?;
+            let kind = match &kind {
+                PlannedEntryKind::Directory(permissions) => {
+                    PlannedEntryKind::Directory(permissions.clone())
                 }
-                // Skip special files (sockets, FIFOs, device nodes)
+                PlannedEntryKind::File(file_type) => PlannedEntryKind::File(*file_type),
+            };
+            out.entry(owner.to_owned())
+                .or_default()
+                .push(PlannedEntry { suffix, kind });
+        }
+    }
+
+    Ok(())
+}
+
+/// The sources that contain `path`, nearest first. A source contains itself.
+fn owning_sources<'a>(
+    sources: &'a HashSet<PathBuf>,
+    path: &'a Path,
+) -> impl Iterator<Item = &'a Path> {
+    path.ancestors()
+        .filter(move |ancestor| sources.contains(*ancestor))
+}
+
+fn copy_entries(
+    src: &AbsoluteSystemPath,
+    dst: &AbsoluteSystemPath,
+    entries: &[PlannedEntry],
+) -> Result<(), Error> {
+    for entry in entries {
+        let target = dst.resolve(&entry.suffix);
+        match &entry.kind {
+            PlannedEntryKind::Directory(permissions) => make_dir_copy(&target, permissions)?,
+            PlannedEntryKind::File(file_type) => {
+                copy_file_with_type(src.resolve(&entry.suffix), *file_type, &target)?
             }
         }
     }
@@ -121,14 +291,14 @@ pub fn recursive_copy(
 
 fn make_dir_copy(
     dir: impl AsRef<AbsoluteSystemPath>,
-    #[allow(unused_variables)] src_metadata: &Metadata,
+    #[allow(unused_variables)] src_permissions: &Permissions,
 ) -> Result<(), Error> {
     let dir = dir.as_ref();
     let mut builder = DirBuilder::new();
     #[cfg(not(windows))]
     {
-        use std::os::unix::{fs::DirBuilderExt, prelude::MetadataExt};
-        builder.mode(src_metadata.mode());
+        use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+        builder.mode(src_permissions.mode());
     }
     builder.recursive(true);
     builder.create(dir.as_path())?;
@@ -483,6 +653,187 @@ mod tests {
             !dst_dir.join_components(&["logs", "drop.log"]).exists(),
             use_gitignore
         );
+
+        Ok(())
+    }
+
+    /// A repository whose ignore rules exercise every place the walk root
+    /// matters: a root ignore file, a package-level ignore file, a negation
+    /// that only the nearest ignore file can express, and an anchored root
+    /// pattern that must not match the same relative path in another package.
+    fn ignore_fixture() -> Result<(tempfile::TempDir, AbsoluteSystemPathBuf), Error> {
+        let (tmp, root) = tmp_dir()?;
+        root.join_component(".git").create_dir_all()?;
+        root.join_component(".gitignore")
+            .create_with_contents("node_modules\n/apps/web/coverage\n*.log\n")?;
+
+        for package in fixture_packages() {
+            let dir = root.join_components(&package);
+            dir.create_dir_all()?;
+            dir.join_component("package.json")
+                .create_with_contents("{}")?;
+            let source = dir.join_components(&["src", "index.ts"]);
+            source.ensure_dir()?;
+            source.create_with_contents("export {}")?;
+            let dep = dir.join_components(&["node_modules", "dep", "index.js"]);
+            dep.ensure_dir()?;
+            dep.create_with_contents("dep")?;
+            let coverage = dir.join_components(&["coverage", "report.txt"]);
+            coverage.ensure_dir()?;
+            coverage.create_with_contents("report")?;
+            let keep = dir.join_components(&["logs", "keep.log"]);
+            keep.ensure_dir()?;
+            keep.create_with_contents("keep")?;
+            dir.join_components(&["logs", ".gitignore"])
+                .create_with_contents("!keep.log\n")?;
+            dir.join_components(&["logs", "drop.log"])
+                .create_with_contents("drop")?;
+        }
+
+        Ok((tmp, root))
+    }
+
+    fn fixture_packages() -> [[&'static str; 2]; 3] {
+        [["apps", "web"], ["apps", "docs"], ["packages", "ui"]]
+    }
+
+    /// Every path under `dir`, relative to it, sorted.
+    fn listing(dir: &AbsoluteSystemPath) -> Result<Vec<String>, Error> {
+        fn collect(
+            base: &AbsoluteSystemPath,
+            dir: &AbsoluteSystemPath,
+            paths: &mut Vec<String>,
+        ) -> Result<(), Error> {
+            for entry in fs::read_dir(dir.as_path())? {
+                let entry = entry?;
+                let path = AbsoluteSystemPathBuf::try_from(entry.path().as_path())?;
+                paths.push(AnchoredSystemPathBuf::new(base, &path)?.to_string());
+                if entry.file_type()?.is_dir() {
+                    collect(base, &path, paths)?;
+                }
+            }
+            Ok(())
+        }
+
+        let mut paths = Vec::new();
+        collect(dir, dir, &mut paths)?;
+        paths.sort();
+        Ok(paths)
+    }
+
+    #[test_case(true)]
+    #[test_case(false)]
+    fn test_copy_plan_matches_individual_copies(use_gitignore: bool) -> Result<(), Error> {
+        let (_root_tmp, root) = ignore_fixture()?;
+        let packages: Vec<AbsoluteSystemPathBuf> = fixture_packages()
+            .iter()
+            .map(|package| root.join_components(package))
+            .collect();
+
+        let plan = CopyPlan::new(
+            packages.iter().map(|package| package.as_ref()),
+            use_gitignore,
+            Some(&root),
+        )?;
+
+        for package in &packages {
+            let (_planned_tmp, planned_dst) = tmp_dir()?;
+            let (_single_tmp, single_dst) = tmp_dir()?;
+
+            plan.copy(package, &planned_dst)?;
+            recursive_copy(package, &single_dst, use_gitignore, Some(&root))?;
+
+            assert_eq!(
+                listing(&planned_dst)?,
+                listing(&single_dst)?,
+                "planned copy of {package} should match an individual copy"
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_copy_plan_honors_ignore_files_above_the_package() -> Result<(), Error> {
+        let (_root_tmp, root) = ignore_fixture()?;
+        let web = root.join_components(&["apps", "web"]);
+        let docs = root.join_components(&["apps", "docs"]);
+
+        let plan = CopyPlan::new([web.as_ref(), docs.as_ref()], true, Some(&root))?;
+
+        let (_web_tmp, web_dst) = tmp_dir()?;
+        plan.copy(&web, &web_dst)?;
+        let (_docs_tmp, docs_dst) = tmp_dir()?;
+        plan.copy(&docs, &docs_dst)?;
+
+        for dst in [&web_dst, &docs_dst] {
+            assert!(dst.join_components(&["src", "index.ts"]).exists());
+            // `node_modules` from the root ignore file
+            assert!(!dst.join_component("node_modules").exists());
+            // `*.log` from the root ignore file, and the nearer negation of it
+            assert!(dst.join_components(&["logs", "keep.log"]).exists());
+            assert!(!dst.join_components(&["logs", "drop.log"]).exists());
+        }
+
+        // `/apps/web/coverage` is anchored at the root, so it must not take
+        // the identically named directory in another package with it.
+        assert!(
+            !web_dst
+                .join_components(&["coverage", "report.txt"])
+                .exists()
+        );
+        assert!(
+            docs_dst
+                .join_components(&["coverage", "report.txt"])
+                .exists()
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_copy_plan_walks_unplanned_sources() -> Result<(), Error> {
+        let (_root_tmp, root) = ignore_fixture()?;
+        let web = root.join_components(&["apps", "web"]);
+        let ui = root.join_components(&["packages", "ui"]);
+
+        // Only `web` is planned; `ui` has to fall back to its own walk.
+        let plan = CopyPlan::new([web.as_ref()], true, Some(&root))?;
+
+        let (_ui_tmp, planned_dst) = tmp_dir()?;
+        plan.copy(&ui, &planned_dst)?;
+        let (_single_tmp, single_dst) = tmp_dir()?;
+        recursive_copy(&ui, &single_dst, true, Some(&root))?;
+
+        assert_eq!(listing(&planned_dst)?, listing(&single_dst)?);
+        assert!(!planned_dst.join_component("node_modules").exists());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_copy_plan_copies_nested_packages_into_both_sources() -> Result<(), Error> {
+        let (_root_tmp, root) = ignore_fixture()?;
+        let web = root.join_components(&["apps", "web"]);
+        let nested = web.join_components(&["nested", "pkg"]);
+        nested.create_dir_all()?;
+        nested
+            .join_component("package.json")
+            .create_with_contents("{}")?;
+
+        let plan = CopyPlan::new([web.as_ref(), nested.as_ref()], true, Some(&root))?;
+
+        let (_web_tmp, web_dst) = tmp_dir()?;
+        plan.copy(&web, &web_dst)?;
+        let (_nested_tmp, nested_dst) = tmp_dir()?;
+        plan.copy(&nested, &nested_dst)?;
+
+        assert!(
+            web_dst
+                .join_components(&["nested", "pkg", "package.json"])
+                .exists()
+        );
+        assert!(nested_dst.join_component("package.json").exists());
 
         Ok(())
     }

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -196,6 +196,7 @@ pub async fn prune(
     let mut workspace_paths = Vec::new();
     let mut workspace_names = Vec::new();
     let workspaces = prune.internal_dependencies()?;
+    prune.plan_package_copies(&workspaces)?;
     let retained_workspace_names: HashSet<_> = workspaces
         .iter()
         .filter_map(|workspace| match workspace {
@@ -474,6 +475,9 @@ struct Prune<'a> {
     scope: &'a [String],
     use_gitignore: bool,
     uses_per_workspace_lockfiles: bool,
+    /// The contents of the package directories being copied, resolved by a
+    /// single walk of the repository. See [`Prune::plan_package_copies`].
+    copy_plan: OnceLock<turborepo_fs::CopyPlan>,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq)]
@@ -602,7 +606,43 @@ impl<'a> Prune<'a> {
             scope,
             use_gitignore,
             uses_per_workspace_lockfiles,
+            copy_plan: OnceLock::new(),
         })
+    }
+
+    /// Resolve the contents of every package directory this prune will copy in
+    /// one walk of the repository.
+    ///
+    /// Copying a package has to honor the ignore files above it, which anchors
+    /// its walk at the repository root. Doing that once per package makes the
+    /// cost of a prune grow with `packages * repository fan-out`, which is
+    /// most of the runtime in a repository with hundreds of packages.
+    fn plan_package_copies(&self, workspaces: &[PackageName]) -> Result<(), Error> {
+        let directories: Vec<AbsoluteSystemPathBuf> = workspaces
+            .iter()
+            .filter(|workspace| !matches!(workspace, PackageName::Root))
+            .filter_map(|workspace| self.package_graph.package_task_context(workspace))
+            // A package anchored at the repository root has no directory of
+            // its own and is never copied as a unit.
+            .filter(|context| context.directory().components().next().is_some())
+            .map(|context| self.root.resolve(context.directory()))
+            .collect();
+
+        let plan = turborepo_fs::CopyPlan::new(
+            directories.iter().map(|directory| directory.as_ref()),
+            self.use_gitignore,
+            Some(&self.root),
+        )?;
+        let _ = self.copy_plan.set(plan);
+
+        Ok(())
+    }
+
+    /// The planned copies, falling back to walking each source on demand for
+    /// directories that were not known ahead of time.
+    fn copy_plan(&self) -> &turborepo_fs::CopyPlan {
+        self.copy_plan
+            .get_or_init(|| turborepo_fs::CopyPlan::unplanned(self.use_gitignore, Some(&self.root)))
     }
 
     fn docker_directory(&self) -> AbsoluteSystemPathBuf {
@@ -766,10 +806,10 @@ impl<'a> Prune<'a> {
             return Ok(());
         }
         let full_to = self.full_directory.resolve(path);
-        turborepo_fs::recursive_copy(&from_path, full_to, self.use_gitignore, Some(&self.root))?;
+        self.copy_plan().copy(&from_path, full_to)?;
         if matches!(destination, Some(CopyDestination::All)) {
             let out_to = self.out_directory.resolve(path);
-            turborepo_fs::recursive_copy(&from_path, out_to, self.use_gitignore, Some(&self.root))?;
+            self.copy_plan().copy(&from_path, out_to)?;
         }
         if self.docker
             && matches!(
@@ -778,12 +818,7 @@ impl<'a> Prune<'a> {
             )
         {
             let docker_to = self.docker_directory().resolve(path);
-            turborepo_fs::recursive_copy(
-                &from_path,
-                docker_to,
-                self.use_gitignore,
-                Some(&self.root),
-            )?;
+            self.copy_plan().copy(&from_path, docker_to)?;
         }
         Ok(())
     }
@@ -808,12 +843,7 @@ impl<'a> Prune<'a> {
         let target_dir = self.full_directory.resolve(package_directory);
         target_dir.create_dir_all_with_permissions(metadata.permissions())?;
 
-        turborepo_fs::recursive_copy(
-            &original_dir,
-            &target_dir,
-            self.use_gitignore,
-            Some(&self.root),
-        )?;
+        self.copy_plan().copy(&original_dir, &target_dir)?;
 
         if self.docker {
             let docker_package_dir = self.docker_directory().resolve(package_directory);
@@ -871,12 +901,7 @@ impl<'a> Prune<'a> {
         let target_dir = self.full_directory.resolve(workspace_directory);
         target_dir.create_dir_all_with_permissions(metadata.permissions())?;
 
-        turborepo_fs::recursive_copy(
-            &original_dir,
-            &target_dir,
-            self.use_gitignore,
-            Some(&self.root),
-        )?;
+        self.copy_plan().copy(&original_dir, &target_dir)?;
         if let Some(contents) = &pruned_package_json {
             target_dir
                 .join_component(definition_name)
@@ -1167,6 +1192,7 @@ mod tests {
     use std::{
         collections::{BTreeMap, HashMap, HashSet},
         fs,
+        sync::OnceLock,
     };
 
     use serde_json::json;
@@ -1441,6 +1467,7 @@ mod tests {
             scope: &scope,
             use_gitignore: false,
             uses_per_workspace_lockfiles: false,
+            copy_plan: OnceLock::new(),
         };
 
         assert_eq!(
@@ -1501,6 +1528,7 @@ mod tests {
             scope: &scope,
             use_gitignore: false,
             uses_per_workspace_lockfiles: false,
+            copy_plan: OnceLock::new(),
         };
 
         let context = prune.package_context(&web).unwrap();
@@ -1635,6 +1663,7 @@ mod tests {
             scope: &scope,
             use_gitignore: false,
             uses_per_workspace_lockfiles: false,
+            copy_plan: OnceLock::new(),
         };
 
         assert_eq!(
@@ -1713,6 +1742,7 @@ mod tests {
             scope: &scope,
             use_gitignore: false,
             uses_per_workspace_lockfiles: false,
+            copy_plan: OnceLock::new(),
         };
 
         assert_eq!(
@@ -1792,6 +1822,7 @@ mod tests {
             scope: &scope,
             use_gitignore: false,
             uses_per_workspace_lockfiles: false,
+            copy_plan: OnceLock::new(),
         };
 
         assert_eq!(


### PR DESCRIPTION
## Why

`turbo prune` copies each retained package with a walk anchored at the repository root. That anchoring is deliberate — it is what makes the ignore files *above* a package apply to it (#12953) — but it is paid once per package. Every copy re-reads each directory on the way down from the root and recompiles every ancestor ignore file, so the cost grows with `packages × repository fan-out`.

In a large monorepo, pruning one service copies ~440 packages, and each of those copies re-lists the same two top-level workspace directories (748 and 387 entries) and recompiles the root `.gitignore`. That overhead is ~85% of the command's runtime: the same prune with `--use-gitignore=false` (identical output, since the ignored paths are not in these packages) took 0.94s versus 3.9s.

## What

Resolve the contents of every package directory in a single walk of the repository, and hand each copy the entries that belong to it.

- `turborepo-fs` gains `CopyPlan`, which walks one root for many sources and records each source's entries. `recursive_copy` is now a plan with nothing precomputed, so the single-source path is unchanged.
- `turbo prune` builds the plan once from the package closure it is about to copy. The plan is also reused when the same directory is copied to more than one destination.
- Anything the plan does not cover — `file:` dependency directories, the additional directories, `--use-gitignore=false` — walks on demand exactly as before.

Ignore semantics are untouched: it is the same walker, rooted at the same directory, with the same options. Only the set of directories it is allowed to descend into is wider, and each entry is attributed to the sources that contain it.

## Results

Measured on two large private monorepos, referred to here as A and B — actively developed repositories rather than synthetic fixtures. To give a sense of their size without identifying them: A is the higher-fan-out of the two, its two top-level workspace directories listing 748 and 387 entries between them, with the service scope below retaining ~440 packages. B retains fewer packages per scope but carries more content in each: its largest measured scope retains 84 packages and produces 26,436 entries, against 10,157 for the largest A scope. The timings are whole-repository runs at that scale, not micro-benchmarks.

Median of 7 alternating runs, hot page cache, 4 vCPU:

| repository | scope (packages copied) | before | after | speedup |
| --- | --- | --- | --- | --- |
| A | service, `--docker` (443) | 3.957s | 0.579s | **6.8x** |
| A | service (429) | 3.875s | 0.546s | **7.1x** |
| B | app, `--docker` (84) | 1.173s | 0.984s | 1.2x |
| B | app (72) | 0.813s | 0.670s | 1.2x |
| B | library (22) | 0.412s | 0.366s | 1.1x |

The win scales with how many packages a scope retains, which is why repository A gains the most. `--use-gitignore=false` is unchanged (0.534s → 0.542s, noise), as expected: that path never shared a walk root.

## Verification

- Output equivalence on both repositories: for each scope, the full pruned tree (26,436 entries for the largest B scope, 10,157 for the largest A scope) was compared entry by entry — path, SHA-256, mode, and symlink target — against the tree produced by the current `main` binary. Everything matches.
  - One caveat worth reporting separately: in one of the two repositories, `prune` already writes `turbo.jsonc` nondeterministically (two runs of the *same* binary differ in key order). That file was the only difference between runs, and it differs between two baseline runs as well, so it is pre-existing and not from this change.
- New unit tests in `turborepo-fs` assert that a planned copy is identical to an individual `recursive_copy` for the same source, that ignore files above the package still apply (including a root-anchored pattern that must not leak into a sibling package, and a nearer negation that must win), that unplanned sources fall back correctly, and that a package nested inside another package lands in both copies.
- `cargo test -p turborepo-fs`, `cargo test -p turborepo-lib prune`, `cargo clippy --all-targets -D warnings` on both changed crates, and `cargo fmt --check` all pass. `cargo test -p turbo --test prune_test` is 25/26; `test_prune_composable_config` fails identically on unmodified `main` in this environment (its `pnpm install` step), so it is not related to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

