### PR TITLE
chore: Move pnpm overrides to pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,5 @@
   "engines": {
     "node": "24.x"
   },
-  "packageManager": "pnpm@10.28.0",
-  "pnpm": {
-    "overrides": {
-      "esbuild": "0.28.1"
-    }
-  }
+  "packageManager": "pnpm@10.28.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,3 +19,6 @@ onlyBuiltDependencies:
   - core-js-pure
   - esbuild
   - sharp
+
+overrides:
+  esbuild: 0.28.1


### PR DESCRIPTION
### Description

Running any pnpm command in this repo with pnpm 11 prints:

```
[WARN] The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: "pnpm.overrides". See https://pnpm.io/settings for the new home of each setting.
```

pnpm 11 dropped support for reading settings out of the `pnpm` field in `package.json`. The launcher emits this warning before it delegates to the version pinned in `packageManager` (pnpm 10.28.0), so the warning shows up on every command even though the override is still being applied by the delegated pnpm 10.

This moves the lone setting we had there — the `esbuild` override — to the top-level `overrides` key in `pnpm-workspace.yaml`, which is the documented home for it. `pnpm-workspace.yaml` already holds our other pnpm settings (`onlyBuiltDependencies`, `minimumReleaseAge`), and pnpm 10.28.0 reads `overrides` from there, so the pinned version keeps working unchanged.

`pnpm-lock.yaml` is untouched: it already records `overrides: esbuild: 0.28.1`, and it still resolves to exactly that after the move.

The `pnpm.overrides` entries under `lockfile-tests/fixtures/` and the other `__fixtures__` directories are deliberately left alone — those fixtures pin older pnpm versions and exist to exercise the lockfile parsers against that format.

### Testing Instructions

With pnpm 11 installed:

```sh
# Before: prints the [WARN] line. After: no warning.
pnpm install --lockfile-only --ignore-scripts
```

The lockfile is unaffected:

```sh
pnpm install --frozen-lockfile
git diff --exit-code pnpm-lock.yaml
```

And the override is still in effect:

```sh
cat node_modules/.pnpm/esbuild@*/node_modules/esbuild/package.json | grep '"version"'
# "version": "0.28.1",
```

I also sanity-checked that the setting is actually being read from the new location by temporarily changing it to `0.28.0` and confirming the lockfile's `overrides` block and resolved versions followed, then reverting.