### PR TITLE
feat: Dogfood Python workspace tasks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -101,6 +101,12 @@ jobs:
           - name: "Setup Node"
             uses: ./.github/actions/setup-node
 
+          - name: Setup uv
+            uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+            with:
+              version: "0.12.0"
+              enable-cache: false
+
       - name: Install Global Turbo
         uses: ./.github/actions/install-global-turbo
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 data/
 dist/
 node_modules/
+.venv/
 target/
 tests_output/
 vendor/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ When making changes to the codebase, check if the following docs need updates:
 ### CI task scheduling
 
 - Test and lint workflows do not pre-classify changed paths. PR jobs run consistently and use the Turborepo task graph and cache where applicable.
+- The root quality task includes the uv workspace's format and check tasks; its CI job installs the pinned uv version before running the graph.
 - Same-repository PRs authenticate to Remote Cache through OIDC; fork PRs remain local-only.
 - Rust CI restores full Cargo target state on Ubuntu, macOS, and Windows from trusted `main` snapshots; only `main` writes. Repository sccache dogfooding is disabled.
 - Linux Rust shards include `terminal-control` black-box TUI integration tests; known regressions remain explicitly ignored.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,7 @@ You will need to have these dependencies installed on your machine to work on th
 - [Rust](https://www.rust-lang.org/tools/install) (via [rustup](https://rustup.rs/), which will automatically use the [repository toolchain](https://github.com/vercel/turborepo/blob/main/rust-toolchain.toml))
 - [Node.js](https://nodejs.org/en) v22
 - [pnpm](https://pnpm.io/) v10
+- [uv](https://docs.astral.sh/uv/getting-started/installation/) for the root Python workspace and its quality tasks
 - [protoc](https://grpc.io/docs/protoc-installation/)
 - [capnp](https://capnproto.org)
 - [Zig](https://ziglang.org/download/) 0.15.2 or newer — required to build `libghostty-vt` for the TUI (`libghostty-vt-sys`). The `zig` binary must be on your `PATH` when running `cargo build`.
@@ -35,7 +36,6 @@ You will need to have these dependencies installed on your machine to work on th
 ### Optional dependencies
 
 - [Bun](https://bun.sh) is required to build `@turbo/gen` (the `turbo gen` code generator). The `@turbo/gen` package is compiled into a standalone binary using `bun build --compile`.
-- [uv](https://docs.astral.sh/uv/getting-started/installation/) is required to run the Python workspace integration tests (`crates/turborepo/tests/uv_workspace_test.rs`); tests that execute uv skip when it is not installed.
 - For running tests locally, `jq` and `zstd` are also required.
   - macOS: `brew install jq zstd`
   - Linux: `sudo apt update && sudo apt install jq zstd`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.turbo]
+name = "turborepo-python"
+
+[tool.uv.workspace]
+# Reuse the mixed-workspace fixture packages to dogfood Python support.
+members = ["turborepo-tests/integration/fixtures/uv_monorepo/python/*"]

--- a/turbo.json
+++ b/turbo.json
@@ -4,6 +4,7 @@
   "noUpdateNotifier": true,
   "futureFlags": {
     "experimentalCargoWorkspaces": true,
+    "experimentalPythonWorkspaces": true,
     "experimentalTaskCommand": true
   },
   // The following are used by tools such as pnpm, gh actions to setup pnpm, etc.
@@ -82,6 +83,8 @@
         "//#lint",
         "//#format",
         "//#check:toml",
+        "turborepo-python#format",
+        "turborepo-python#check",
         "docs#lint",
         "docs#check-types",
         "docs#check-links",

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,25 @@
+version = 1
+revision = 3
+requires-python = ">=3.9"
+
+[manifest]
+members = [
+    "py-app",
+    "py-lib",
+]
+
+[[package]]
+name = "py-app"
+version = "0.1.0"
+source = { editable = "turborepo-tests/integration/fixtures/uv_monorepo/python/py-app" }
+dependencies = [
+    { name = "py-lib" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "py-lib", editable = "turborepo-tests/integration/fixtures/uv_monorepo/python/py-lib" }]
+
+[[package]]
+name = "py-lib"
+version = "0.1.0"
+source = { editable = "turborepo-tests/integration/fixtures/uv_monorepo/python/py-lib" }


### PR DESCRIPTION
## Summary

- enable experimental Python workspace discovery at the repository root using the existing mixed uv integration fixture
- add generated Python format and check tasks to the root quality graph and install pinned uv in CI
- document uv as required contributor tooling and commit the root uv lockfile
- preserve and validate existing explicit JavaScript-to-Rust task edges while confirming uv orders `py-app#build` after `py-lib#build`

## Validation

- `PATH="$HOME/.cargo/bin:/tmp/uv-x86_64-unknown-linux-gnu:$PATH" TURBO_API= turbo run quality --env-mode=strict --output-logs=errors-only`
- `/tmp/uv-x86_64-unknown-linux-gnu/uv lock --check`
- `pnpm exec oxfmt --check AGENTS.md CONTRIBUTING.md turbo.json .github/workflows/lint.yml`
- `PATH="$HOME/.local/zig:$HOME/.cargo/bin:$PATH" cargo test -p turbo --test uv_workspace_test`
- Turbo snapshot `2.10.10-canary.2` dry-run checks for Python quality and build dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)