### PR TITLE
fix: Remove unsupported sandbox network policy

### DIFF
--- a/apps/agents/agent/sandbox.ts
+++ b/apps/agents/agent/sandbox.ts
@@ -25,24 +25,5 @@ export default defineSandbox({
       sandbox,
       `git -C ${checkout} fetch --depth=1 origin main && git -C ${checkout} reset --hard FETCH_HEAD && git -C ${checkout} clean -ffd`
     );
-    if (process.env.VERCEL) {
-      await sandbox.setNetworkPolicy({
-        allow: ["*"],
-        subnets: {
-          deny: [
-            "0.0.0.0/8",
-            "10.0.0.0/8",
-            "100.64.0.0/10",
-            "127.0.0.0/8",
-            "169.254.0.0/16",
-            "172.16.0.0/12",
-            "192.168.0.0/16",
-            "::1/128",
-            "fc00::/7",
-            "fe80::/10"
-          ]
-        }
-      });
-    }
   }
 });


### PR DESCRIPTION
## Summary

- Remove the runtime `setNetworkPolicy` call that Vercel Sandbox rejects with HTTP 400.
- Keep the sandbox checkout refresh while allowing Eve/Vercel to use the backend’s default network policy.

## Failure

Production run `wrun_01KZRG0E2D768B3SN62WJSE8BR` failed during `onSession` before model execution. The workflow retried three times and terminated with error ID `3171ce78-8d04-4004-a092-c72af655297a`.

## Verification

- `pnpm --dir apps/agents check-types`
- `pnpm --dir apps/agents build`
- Pre-push formatting and TOML checks