### PR TITLE
chore: Upgrade TypeScript to 7.0.2

### DIFF
--- a/apps/agents/package.json
+++ b/apps/agents/package.json
@@ -9,8 +9,7 @@
   "scripts": {
     "build": "eve build && next build",
     "dev": "next dev",
-    "start": "next start",
-    "check-types": "tsgo --noEmit"
+    "start": "next start"
   },
   "dependencies": {
     "@vercel/connect": "0.4.2",
@@ -26,8 +25,8 @@
     "@types/node": "24.x",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
-    "@typescript/native-preview": "7.0.0-dev.20260523.1",
-    "typescript": "^6.0.1"
+    "typescript": "^6.0.3",
+    "typescript-7": "npm:typescript@7.0.2"
   },
   "engines": {
     "node": "24.x"

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -54,7 +54,7 @@
     "postcss": "^8.5.10",
     "tailwindcss": "^4.1.17",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^6.0.1",
-    "typescript-7": "npm:typescript@7.0.1-rc"
+    "typescript": "^6.0.3",
+    "typescript-7": "npm:typescript@7.0.2"
   }
 }

--- a/docs/link-checker/package.json
+++ b/docs/link-checker/package.json
@@ -22,6 +22,6 @@
   },
   "devDependencies": {
     "@types/node": "22.7.8",
-    "typescript": "5.5.4"
+    "typescript-7": "npm:typescript@7.0.2"
   }
 }

--- a/docs/link-checker/tsconfig.json
+++ b/docs/link-checker/tsconfig.json
@@ -2,8 +2,11 @@
   "compilerOptions": {
     "noEmit": true,
     "target": "esnext",
-    "moduleResolution": "node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "rootDir": "src",
+    "types": ["node"],
+    "skipLibCheck": true,
     "strict": true,
     "noImplicitAny": true,
     "allowSyntheticDefaultImports": true,

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "oxfmt": "^0.34.0",
     "oxlint": "^1.49.0",
     "semver": "7.5.2",
-    "typescript": "npm:@typescript/typescript6@^6.0.1",
-    "typescript-7": "npm:typescript@7.0.1-rc",
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
+    "typescript-7": "npm:typescript@7.0.2",
     "ultracite": "7.4.3"
   },
   "lint-staged": {

--- a/packages/create-turbo/package.json
+++ b/packages/create-turbo/package.json
@@ -38,7 +38,7 @@
     "@types/semver": "7.3.12",
     "jest": "30.3.0",
     "tsdown": "0.12.0",
-    "typescript": "npm:@typescript/typescript6@^6.0.1",
-    "typescript-7": "npm:typescript@7.0.1-rc"
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
+    "typescript-7": "npm:typescript@7.0.2"
   }
 }

--- a/packages/eslint-config-turbo/package.json
+++ b/packages/eslint-config-turbo/package.json
@@ -57,7 +57,7 @@
     "@types/node": "20.11.30",
     "bunchee": "6.9.4",
     "eslint": "10.2.0",
-    "typescript": "npm:@typescript/typescript6@^6.0.1"
+    "typescript": "npm:@typescript/typescript6@^6.0.2"
   },
   "peerDependencies": {
     "eslint": ">6.6.0",

--- a/packages/eslint-plugin-turbo/package.json
+++ b/packages/eslint-plugin-turbo/package.json
@@ -40,8 +40,8 @@
     "jest": "30.3.0",
     "json5": "2.2.3",
     "tsdown": "0.12.0",
-    "typescript": "npm:@typescript/typescript6@^6.0.1",
-    "typescript-7": "npm:typescript@7.0.1-rc"
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
+    "typescript-7": "npm:typescript@7.0.2"
   },
   "peerDependencies": {
     "eslint": ">6.6.0",

--- a/packages/turbo-codemod/package.json
+++ b/packages/turbo-codemod/package.json
@@ -52,7 +52,7 @@
     "jest": "30.3.0",
     "semver": "7.5.2",
     "tsdown": "0.12.0",
-    "typescript": "npm:@typescript/typescript6@^6.0.1",
-    "typescript-7": "npm:typescript@7.0.1-rc"
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
+    "typescript-7": "npm:typescript@7.0.2"
   }
 }

--- a/packages/turbo-gen/package.json
+++ b/packages/turbo-gen/package.json
@@ -44,8 +44,8 @@
     "picocolors": "1.0.1",
     "proxy-agent": "8.0.2",
     "tsdown": "0.12.0",
-    "typescript": "npm:@typescript/typescript6@^6.0.1",
-    "typescript-7": "npm:typescript@7.0.1-rc",
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
+    "typescript-7": "npm:typescript@7.0.2",
     "update-check": "1.5.4",
     "validate-npm-package-name": "5.0.0"
   }

--- a/packages/turbo-ignore/package.json
+++ b/packages/turbo-ignore/package.json
@@ -32,7 +32,7 @@
     "commander": "11.0.0",
     "jest": "30.3.0",
     "tsdown": "0.12.0",
-    "typescript": "npm:@typescript/typescript6@^6.0.1",
-    "typescript-7": "npm:typescript@7.0.1-rc"
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
+    "typescript-7": "npm:typescript@7.0.2"
   }
 }

--- a/packages/turbo-releaser/package.json
+++ b/packages/turbo-releaser/package.json
@@ -23,7 +23,7 @@
     "@types/semver": "7.3.12",
     "tsdown": "0.12.0",
     "tsx": "4.21.0",
-    "typescript": "npm:@typescript/typescript6@^6.0.1",
-    "typescript-7": "npm:typescript@7.0.1-rc"
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
+    "typescript-7": "npm:typescript@7.0.2"
   }
 }

--- a/packages/turbo-telemetry/package.json
+++ b/packages/turbo-telemetry/package.json
@@ -32,8 +32,8 @@
     "@types/node": "20.11.30",
     "dirs-next": "0.0.1-canary.1",
     "tsx": "4.21.0",
-    "typescript": "npm:@typescript/typescript6@^6.0.1",
-    "typescript-7": "npm:typescript@7.0.1-rc"
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
+    "typescript-7": "npm:typescript@7.0.2"
   },
   "peerDependencies": {
     "commander": "^11.0.0"

--- a/packages/turbo-test-utils/package.json
+++ b/packages/turbo-test-utils/package.json
@@ -21,8 +21,8 @@
     "js-yaml": "4.3.1",
     "json5": "2.2.3",
     "ts-jest": "29.4.11",
-    "typescript": "npm:@typescript/typescript6@^6.0.1",
-    "typescript-7": "npm:typescript@7.0.1-rc"
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
+    "typescript-7": "npm:typescript@7.0.2"
   },
   "devDependencies": {
     "@jest/globals": "30.3.0",

--- a/packages/turbo-types/package.json
+++ b/packages/turbo-types/package.json
@@ -28,7 +28,7 @@
     "@types/node": "20.11.30",
     "ts-json-schema-generator": "2.5.0",
     "tsx": "4.21.0",
-    "typescript": "npm:@typescript/typescript6@^6.0.1",
-    "typescript-7": "npm:typescript@7.0.1-rc"
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
+    "typescript-7": "npm:typescript@7.0.2"
   }
 }

--- a/packages/turbo-utils/package.json
+++ b/packages/turbo-utils/package.json
@@ -48,8 +48,8 @@
     "ora": "4.1.1",
     "picocolors": "1.0.1",
     "tar": "7.5.18",
-    "typescript": "npm:@typescript/typescript6@^6.0.1",
-    "typescript-7": "npm:typescript@7.0.1-rc",
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
+    "typescript-7": "npm:typescript@7.0.2",
     "update-check": "1.5.4"
   }
 }

--- a/packages/turbo-workspaces/package.json
+++ b/packages/turbo-workspaces/package.json
@@ -47,7 +47,7 @@
     "@types/semver": "7.5.8",
     "jest": "30.3.0",
     "tsdown": "0.12.0",
-    "typescript": "npm:@typescript/typescript6@^6.0.1",
-    "typescript-7": "npm:typescript@7.0.1-rc"
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
+    "typescript-7": "npm:typescript@7.0.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,11 +33,11 @@ importers:
         specifier: 7.5.2
         version: 7.5.2
       typescript:
-        specifier: npm:@typescript/typescript6@^6.0.1
-        version: '@typescript/typescript6@6.0.1'
+        specifier: npm:@typescript/typescript6@^6.0.2
+        version: '@typescript/typescript6@6.0.2'
       typescript-7:
-        specifier: npm:typescript@7.0.1-rc
-        version: typescript@7.0.1-rc
+        specifier: npm:typescript@7.0.2
+        version: typescript@7.0.2
       ultracite:
         specifier: 7.4.3
         version: 7.4.3(oxlint@1.51.0)
@@ -78,12 +78,12 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.13)
-      '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260523.1
-        version: 7.0.0-dev.20260523.1
       typescript:
-        specifier: ^6.0.1
+        specifier: ^6.0.3
         version: 6.0.3
+      typescript-7:
+        specifier: npm:typescript@7.0.2
+        version: typescript@7.0.2
 
   apps/docs:
     dependencies:
@@ -212,11 +212,11 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
       typescript:
-        specifier: ^6.0.1
+        specifier: ^6.0.3
         version: 6.0.3
       typescript-7:
-        specifier: npm:typescript@7.0.1-rc
-        version: typescript@7.0.1-rc
+        specifier: npm:typescript@7.0.2
+        version: typescript@7.0.2
 
   docs/link-checker:
     dependencies:
@@ -251,9 +251,9 @@ importers:
       '@types/node':
         specifier: 22.7.8
         version: 22.7.8
-      typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+      typescript-7:
+        specifier: npm:typescript@7.0.2
+        version: typescript@7.0.2
 
   examples:
     devDependencies:
@@ -320,16 +320,16 @@ importers:
         version: 7.3.12
       jest:
         specifier: 30.3.0
-        version: 30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.1))
+        version: 30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.2))
       tsdown:
         specifier: 0.12.0
-        version: 0.12.0(@typescript/native-preview@7.0.0-dev.20260523.1)(@typescript/typescript6@6.0.1)(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
+        version: 0.12.0(@typescript/native-preview@7.0.0-dev.20260523.1)(@typescript/typescript6@6.0.2)(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       typescript:
-        specifier: npm:@typescript/typescript6@^6.0.1
-        version: '@typescript/typescript6@6.0.1'
+        specifier: npm:@typescript/typescript6@^6.0.2
+        version: '@typescript/typescript6@6.0.2'
       typescript-7:
-        specifier: npm:typescript@7.0.1-rc
-        version: typescript@7.0.1-rc
+        specifier: npm:typescript@7.0.2
+        version: typescript@7.0.2
 
   packages/eslint-config-turbo:
     dependencies:
@@ -354,13 +354,13 @@ importers:
         version: 20.11.30
       bunchee:
         specifier: 6.9.4
-        version: 6.9.4(@typescript/typescript6@6.0.1)
+        version: 6.9.4(@typescript/typescript6@6.0.2)
       eslint:
         specifier: 10.2.0
         version: 10.2.0(jiti@2.6.1)
       typescript:
-        specifier: npm:@typescript/typescript6@^6.0.1
-        version: '@typescript/typescript6@6.0.1'
+        specifier: npm:@typescript/typescript6@^6.0.2
+        version: '@typescript/typescript6@6.0.2'
 
   packages/eslint-plugin-turbo:
     dependencies:
@@ -400,19 +400,19 @@ importers:
         version: 10.2.0(jiti@2.6.1)
       jest:
         specifier: 30.3.0
-        version: 30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.1))
+        version: 30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.2))
       json5:
         specifier: 2.2.3
         version: 2.2.3
       tsdown:
         specifier: 0.12.0
-        version: 0.12.0(@typescript/native-preview@7.0.0-dev.20260523.1)(@typescript/typescript6@6.0.1)(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
+        version: 0.12.0(@typescript/native-preview@7.0.0-dev.20260523.1)(@typescript/typescript6@6.0.2)(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       typescript:
-        specifier: npm:@typescript/typescript6@^6.0.1
-        version: '@typescript/typescript6@6.0.1'
+        specifier: npm:@typescript/typescript6@^6.0.2
+        version: '@typescript/typescript6@6.0.2'
       typescript-7:
-        specifier: npm:typescript@7.0.1-rc
-        version: typescript@7.0.1-rc
+        specifier: npm:typescript@7.0.2
+        version: typescript@7.0.2
 
   packages/tsconfig: {}
 
@@ -502,16 +502,16 @@ importers:
         version: 4.2.2
       jest:
         specifier: 30.3.0
-        version: 30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.1))
+        version: 30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.2))
       tsdown:
         specifier: 0.12.0
-        version: 0.12.0(@typescript/native-preview@7.0.0-dev.20260523.1)(@typescript/typescript6@6.0.1)(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
+        version: 0.12.0(@typescript/native-preview@7.0.0-dev.20260523.1)(@typescript/typescript6@6.0.2)(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       typescript:
-        specifier: npm:@typescript/typescript6@^6.0.1
-        version: '@typescript/typescript6@6.0.1'
+        specifier: npm:@typescript/typescript6@^6.0.2
+        version: '@typescript/typescript6@6.0.2'
       typescript-7:
-        specifier: npm:typescript@7.0.1-rc
-        version: typescript@7.0.1-rc
+        specifier: npm:typescript@7.0.2
+        version: typescript@7.0.2
 
   packages/turbo-gen:
     dependencies:
@@ -563,7 +563,7 @@ importers:
         version: 4.7.9
       jest:
         specifier: 30.3.0
-        version: 30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.1))
+        version: 30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.2))
       minimatch:
         specifier: 9.0.7
         version: 9.0.7
@@ -578,13 +578,13 @@ importers:
         version: 8.0.2
       tsdown:
         specifier: 0.12.0
-        version: 0.12.0(@typescript/native-preview@7.0.0-dev.20260523.1)(@typescript/typescript6@6.0.1)(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
+        version: 0.12.0(@typescript/native-preview@7.0.0-dev.20260523.1)(@typescript/typescript6@6.0.2)(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       typescript:
-        specifier: npm:@typescript/typescript6@^6.0.1
-        version: '@typescript/typescript6@6.0.1'
+        specifier: npm:@typescript/typescript6@^6.0.2
+        version: '@typescript/typescript6@6.0.2'
       typescript-7:
-        specifier: npm:typescript@7.0.1-rc
-        version: typescript@7.0.1-rc
+        specifier: npm:typescript@7.0.2
+        version: typescript@7.0.2
       update-check:
         specifier: 1.5.4
         version: 1.5.4
@@ -624,16 +624,16 @@ importers:
         version: 11.0.0
       jest:
         specifier: 30.3.0
-        version: 30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.1))
+        version: 30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.2))
       tsdown:
         specifier: 0.12.0
-        version: 0.12.0(@typescript/native-preview@7.0.0-dev.20260523.1)(@typescript/typescript6@6.0.1)(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
+        version: 0.12.0(@typescript/native-preview@7.0.0-dev.20260523.1)(@typescript/typescript6@6.0.2)(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       typescript:
-        specifier: npm:@typescript/typescript6@^6.0.1
-        version: '@typescript/typescript6@6.0.1'
+        specifier: npm:@typescript/typescript6@^6.0.2
+        version: '@typescript/typescript6@6.0.2'
       typescript-7:
-        specifier: npm:typescript@7.0.1-rc
-        version: typescript@7.0.1-rc
+        specifier: npm:typescript@7.0.2
+        version: typescript@7.0.2
 
   packages/turbo-releaser:
     dependencies:
@@ -658,16 +658,16 @@ importers:
         version: 7.3.12
       tsdown:
         specifier: 0.12.0
-        version: 0.12.0(@typescript/native-preview@7.0.0-dev.20260523.1)(@typescript/typescript6@6.0.1)(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
+        version: 0.12.0(@typescript/native-preview@7.0.0-dev.20260523.1)(@typescript/typescript6@6.0.2)(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       tsx:
         specifier: 4.21.0
         version: 4.21.0
       typescript:
-        specifier: npm:@typescript/typescript6@^6.0.1
-        version: '@typescript/typescript6@6.0.1'
+        specifier: npm:@typescript/typescript6@^6.0.2
+        version: '@typescript/typescript6@6.0.2'
       typescript-7:
-        specifier: npm:typescript@7.0.1-rc
-        version: typescript@7.0.1-rc
+        specifier: npm:typescript@7.0.2
+        version: typescript@7.0.2
 
   packages/turbo-repository:
     devDependencies:
@@ -727,11 +727,11 @@ importers:
         specifier: 4.21.0
         version: 4.21.0
       typescript:
-        specifier: npm:@typescript/typescript6@^6.0.1
-        version: '@typescript/typescript6@6.0.1'
+        specifier: npm:@typescript/typescript6@^6.0.2
+        version: '@typescript/typescript6@6.0.2'
       typescript-7:
-        specifier: npm:typescript@7.0.1-rc
-        version: typescript@7.0.1-rc
+        specifier: npm:typescript@7.0.2
+        version: typescript@7.0.2
 
   packages/turbo-test-utils:
     dependencies:
@@ -746,13 +746,13 @@ importers:
         version: 2.2.3
       ts-jest:
         specifier: 29.4.11
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.3.0)(@jest/types@30.3.0)(@typescript/typescript6@6.0.1)(babel-jest@30.3.0(@babel/core@7.29.7))(jest-util@30.3.0)(jest@30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.1)))
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.3.0)(@jest/types@30.3.0)(@typescript/typescript6@6.0.2)(babel-jest@30.3.0(@babel/core@7.29.7))(jest-util@30.3.0)(jest@30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.2)))
       typescript:
-        specifier: npm:@typescript/typescript6@^6.0.1
-        version: '@typescript/typescript6@6.0.1'
+        specifier: npm:@typescript/typescript6@^6.0.2
+        version: '@typescript/typescript6@6.0.2'
       typescript-7:
-        specifier: npm:typescript@7.0.1-rc
-        version: typescript@7.0.1-rc
+        specifier: npm:typescript@7.0.2
+        version: typescript@7.0.2
     devDependencies:
       '@jest/globals':
         specifier: 30.3.0
@@ -771,7 +771,7 @@ importers:
         version: 18.17.4
       jest:
         specifier: 30.3.0
-        version: 30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.1))
+        version: 30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.2))
       jest-mock:
         specifier: 30.2.0
         version: 30.2.0
@@ -794,11 +794,11 @@ importers:
         specifier: 4.21.0
         version: 4.21.0
       typescript:
-        specifier: npm:@typescript/typescript6@^6.0.1
-        version: '@typescript/typescript6@6.0.1'
+        specifier: npm:@typescript/typescript6@^6.0.2
+        version: '@typescript/typescript6@6.0.2'
       typescript-7:
-        specifier: npm:typescript@7.0.1-rc
-        version: typescript@7.0.1-rc
+        specifier: npm:typescript@7.0.2
+        version: typescript@7.0.2
 
   packages/turbo-utils:
     dependencies:
@@ -856,7 +856,7 @@ importers:
         version: 2.0.1
       jest:
         specifier: 30.3.0
-        version: 30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.1))
+        version: 30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.2))
       js-yaml:
         specifier: 4.3.1
         version: 4.3.1
@@ -873,11 +873,11 @@ importers:
         specifier: 7.5.18
         version: 7.5.18
       typescript:
-        specifier: npm:@typescript/typescript6@^6.0.1
-        version: '@typescript/typescript6@6.0.1'
+        specifier: npm:@typescript/typescript6@^6.0.2
+        version: '@typescript/typescript6@6.0.2'
       typescript-7:
-        specifier: npm:typescript@7.0.1-rc
-        version: typescript@7.0.1-rc
+        specifier: npm:typescript@7.0.2
+        version: typescript@7.0.2
       update-check:
         specifier: 1.5.4
         version: 1.5.4
@@ -975,16 +975,16 @@ importers:
         version: 7.5.8
       jest:
         specifier: 30.3.0
-        version: 30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.1))
+        version: 30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.2))
       tsdown:
         specifier: 0.12.0
-        version: 0.12.0(@typescript/native-preview@7.0.0-dev.20260523.1)(@typescript/typescript6@6.0.1)(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
+        version: 0.12.0(@typescript/native-preview@7.0.0-dev.20260523.1)(@typescript/typescript6@6.0.2)(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       typescript:
-        specifier: npm:@typescript/typescript6@^6.0.1
-        version: '@typescript/typescript6@6.0.1'
+        specifier: npm:@typescript/typescript6@^6.0.2
+        version: '@typescript/typescript6@6.0.2'
       typescript-7:
-        specifier: npm:typescript@7.0.1-rc
-        version: typescript@7.0.1-rc
+        specifier: npm:typescript@7.0.2
+        version: typescript@7.0.2
 
 packages:
 
@@ -4967,128 +4967,128 @@ packages:
     engines: {node: '>=16.20.0'}
     hasBin: true
 
-  '@typescript/typescript-aix-ppc64@7.0.1-rc':
-    resolution: {integrity: sha512-oqq2ZfEJ7BQuufcC3QBQndZLPNyamYNHLao8lKRBeeSkZKypBqxPSgkzrcFZtbYcIaBvpiyUnQP9MT7DEYHWbw==}
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
     engines: {node: '>=16.20.0'}
     cpu: [ppc64]
     os: [aix]
 
-  '@typescript/typescript-darwin-arm64@7.0.1-rc':
-    resolution: {integrity: sha512-Slc0yTftT2F/uGDmtPst8ijydneL6uZaLEyr2UjahxZpbhTjHFBJ5agXtVz/TL4A+ldxzjzj+E8QtLZlh/5mXw==}
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/typescript-darwin-x64@7.0.1-rc':
-    resolution: {integrity: sha512-h68iFW/LbA1/BsGgSRGFw981/3s1f/rY27YrmeZNuN+ly7dI+fiDduwT9ZT9866x2onoKNRq7PTyxSKyKDzfAQ==}
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/typescript-freebsd-arm64@7.0.1-rc':
-    resolution: {integrity: sha512-DE+ppd8Ix2c6OMuRkKY4PJ4hngMGJ9M95OQUP17p9xL/1IKXof7npIeuusMN/bgL5o5JzMfSGh+N+5scTYRg0Q==}
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@typescript/typescript-freebsd-x64@7.0.1-rc':
-    resolution: {integrity: sha512-ST1ozHMw0u+CLOnWkcTyWDMV4Qn9osZ6fd1V1lnKDM1t0hZIp81mdGpdHxyHJjd7jdGrb6Gb/QXcZ1uqZ0t5zw==}
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [freebsd]
 
-  '@typescript/typescript-linux-arm64@7.0.1-rc':
-    resolution: {integrity: sha512-N46pRihK3t5zD5MUtTQcdmQUqr1WI4U2nxno1gLwOtRSsB4krFkRjPHcQNG7h2DtRkX64rQiReX6WKwg2wprMA==}
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/typescript-linux-arm@7.0.1-rc':
-    resolution: {integrity: sha512-gHmHwT5Naq5CKM8g9bbaGeEpnwQEvWCLn3fwP4K2m61VQdDKkPk0Dhab/OoZ4LV2SrMddmclYXTzpyg23YGt5g==}
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/typescript-linux-loong64@7.0.1-rc':
-    resolution: {integrity: sha512-G17Sao312rgiPBTh2F4nOpLpa3CcnBSaNhqNghZk2LNhnsp1RaMO5HMq2me21gqu9xLpc6CIgHtOzU6JBgNlfg==}
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
     engines: {node: '>=16.20.0'}
     cpu: [loong64]
     os: [linux]
 
-  '@typescript/typescript-linux-mips64el@7.0.1-rc':
-    resolution: {integrity: sha512-0FQspOb5UsQ4tQKvWgUO3pS9OIWkP7/8dPRWq+CRazJUeQZ4LBjtYK52jg5iIOrvItrVl2CwvRtrU3/9OihwJg==}
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
     engines: {node: '>=16.20.0'}
     cpu: [mips64el]
     os: [linux]
 
-  '@typescript/typescript-linux-ppc64@7.0.1-rc':
-    resolution: {integrity: sha512-SUmwfVBEv6A2Ld0eWfcvW0FqrgemfQL8jFGOmV1qYxsDqumjE5DekHXqbstgmbE4SHr4rrjHjvmuGCY+kTH/vw==}
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
     engines: {node: '>=16.20.0'}
     cpu: [ppc64]
     os: [linux]
 
-  '@typescript/typescript-linux-riscv64@7.0.1-rc':
-    resolution: {integrity: sha512-rxeqnNnGiYzv/LlPHi/3+4p0ooR1cNJLjRIHXKovtiVmxXGJq6gtw8VSpbHuWPekyFMXgIAoLCZN0SQ51rAALQ==}
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
     engines: {node: '>=16.20.0'}
     cpu: [riscv64]
     os: [linux]
 
-  '@typescript/typescript-linux-s390x@7.0.1-rc':
-    resolution: {integrity: sha512-RYWCHCiPypxajdRHM2CNK/eM22e4Ex5TTjV2pXf7PTtBowGr0xX8i8kIMknyZS0LX2QfleYHouaoMVsFDSle3g==}
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
     engines: {node: '>=16.20.0'}
     cpu: [s390x]
     os: [linux]
 
-  '@typescript/typescript-linux-x64@7.0.1-rc':
-    resolution: {integrity: sha512-PfLJSu0JzroDkqw2m4nqflPEcn8yev0m/vHFQlY9EzHorzjR6QG0wL8AJHvnD1e6h1s76AZngJ5u+z1K/D/HKw==}
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/typescript-netbsd-arm64@7.0.1-rc':
-    resolution: {integrity: sha512-FfbPxH3dTfp8yVIaNM7bdWTixXuyxpzoemluqcqMROSIz+ImpCG3Q9HO9Ptzp9/giv+P9YYEnCMSXh61migj2w==}
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@typescript/typescript-netbsd-x64@7.0.1-rc':
-    resolution: {integrity: sha512-FzdTfSzhRYb6hlav6K3cI5RVgcvCTvNAu/vc+t7B6AmZkThQ+t/1ntnvT5fnHmY1Az2RIBw7/b+qtCEG61HJTQ==}
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [netbsd]
 
-  '@typescript/typescript-openbsd-arm64@7.0.1-rc':
-    resolution: {integrity: sha512-PQGhlxfNig+0YQ9Wwzd0USPBkt6w/ZqkBQWsU7G/0JkTzunJel+jSWwhKw4947pak/m7hGSeYiI04xReDLGZww==}
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@typescript/typescript-openbsd-x64@7.0.1-rc':
-    resolution: {integrity: sha512-WJ7NYgO2mHmLUkI/tZ+hl8lFd26QPJqO8ONOHNuYbdsybLvSB6B6sep222JIVrOfPRDGvFinbGGB+l3m1FWRWA==}
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [openbsd]
 
-  '@typescript/typescript-sunos-x64@7.0.1-rc':
-    resolution: {integrity: sha512-UYjDeUxd765V9qcwlUPk4pEXyL0i3G76CJm9baK4i99u1pGO1psf3nXDw4MMmElVOPvGbZag99ZR/O59E2OX6w==}
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [sunos]
 
-  '@typescript/typescript-win32-arm64@7.0.1-rc':
-    resolution: {integrity: sha512-KzXzFSXZOm7zvEt2Aw0MsB2LbTL88znAiVqTDNAOHdlEb7brgmUQh/X2wM/8Be+N0fjEqWKl65cBKNwpWEbJiw==}
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/typescript-win32-x64@7.0.1-rc':
-    resolution: {integrity: sha512-98R3+OqDr/r0/PLWEoXu88AE0lGVLNd335Ew8ONgzK1JWkNs4ou/5BGt3Or1ij4iXjH+c7PRL+jFjCbtWze+EA==}
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
 
-  '@typescript/typescript6@6.0.1':
-    resolution: {integrity: sha512-JbesA1Y3wSOYpcw4b4XvG8KCk9AaStATxk1Vmc1qY0Y30fjovvcuRXX2fJ8eC2JRycKQi7V1VYKUljSVBJUzZA==}
+  '@typescript/typescript6@6.0.2':
+    resolution: {integrity: sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==}
     hasBin: true
 
   '@typespec/ts-http-runtime@0.3.5':
@@ -9752,11 +9752,6 @@ packages:
   typed-rest-client@1.8.11:
     resolution: {integrity: sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==}
 
-  typescript@5.5.4:
-    resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   typescript@5.6.1-rc:
     resolution: {integrity: sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==}
     engines: {node: '>=14.17'}
@@ -9772,8 +9767,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@7.0.1-rc:
-    resolution: {integrity: sha512-drEP77wK7CCDlPfXZH4e008UUQOsw1DFmHmZOZjuNA+yoDLLnSNMZRXi90NbV/1LVo7SbNLq1bs3jjvk49TEqQ==}
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
     engines: {node: '>=16.20.0'}
     hasBin: true
 
@@ -11134,7 +11129,7 @@ snapshots:
       jest-util: 30.3.0
       slash: 3.0.0
 
-  '@jest/core@30.3.0(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.1))':
+  '@jest/core@30.3.0(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.2))':
     dependencies:
       '@jest/console': 30.3.0
       '@jest/pattern': 30.0.1
@@ -11149,7 +11144,7 @@ snapshots:
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@24.10.11)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.1))
+      jest-config: 30.3.0(@types/node@24.10.11)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.2))
       jest-haste-map: 30.3.0
       jest-message-util: 30.3.0
       jest-regex-util: 30.0.1
@@ -14213,70 +14208,71 @@ snapshots:
       '@typescript/native-preview-linux-x64': 7.0.0-dev.20260523.1
       '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260523.1
       '@typescript/native-preview-win32-x64': 7.0.0-dev.20260523.1
-
-  '@typescript/typescript-aix-ppc64@7.0.1-rc':
     optional: true
 
-  '@typescript/typescript-darwin-arm64@7.0.1-rc':
+  '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true
 
-  '@typescript/typescript-darwin-x64@7.0.1-rc':
+  '@typescript/typescript-darwin-arm64@7.0.2':
     optional: true
 
-  '@typescript/typescript-freebsd-arm64@7.0.1-rc':
+  '@typescript/typescript-darwin-x64@7.0.2':
     optional: true
 
-  '@typescript/typescript-freebsd-x64@7.0.1-rc':
+  '@typescript/typescript-freebsd-arm64@7.0.2':
     optional: true
 
-  '@typescript/typescript-linux-arm64@7.0.1-rc':
+  '@typescript/typescript-freebsd-x64@7.0.2':
     optional: true
 
-  '@typescript/typescript-linux-arm@7.0.1-rc':
+  '@typescript/typescript-linux-arm64@7.0.2':
     optional: true
 
-  '@typescript/typescript-linux-loong64@7.0.1-rc':
+  '@typescript/typescript-linux-arm@7.0.2':
     optional: true
 
-  '@typescript/typescript-linux-mips64el@7.0.1-rc':
+  '@typescript/typescript-linux-loong64@7.0.2':
     optional: true
 
-  '@typescript/typescript-linux-ppc64@7.0.1-rc':
+  '@typescript/typescript-linux-mips64el@7.0.2':
     optional: true
 
-  '@typescript/typescript-linux-riscv64@7.0.1-rc':
+  '@typescript/typescript-linux-ppc64@7.0.2':
     optional: true
 
-  '@typescript/typescript-linux-s390x@7.0.1-rc':
+  '@typescript/typescript-linux-riscv64@7.0.2':
     optional: true
 
-  '@typescript/typescript-linux-x64@7.0.1-rc':
+  '@typescript/typescript-linux-s390x@7.0.2':
     optional: true
 
-  '@typescript/typescript-netbsd-arm64@7.0.1-rc':
+  '@typescript/typescript-linux-x64@7.0.2':
     optional: true
 
-  '@typescript/typescript-netbsd-x64@7.0.1-rc':
+  '@typescript/typescript-netbsd-arm64@7.0.2':
     optional: true
 
-  '@typescript/typescript-openbsd-arm64@7.0.1-rc':
+  '@typescript/typescript-netbsd-x64@7.0.2':
     optional: true
 
-  '@typescript/typescript-openbsd-x64@7.0.1-rc':
+  '@typescript/typescript-openbsd-arm64@7.0.2':
     optional: true
 
-  '@typescript/typescript-sunos-x64@7.0.1-rc':
+  '@typescript/typescript-openbsd-x64@7.0.2':
     optional: true
 
-  '@typescript/typescript-win32-arm64@7.0.1-rc':
+  '@typescript/typescript-sunos-x64@7.0.2':
     optional: true
 
-  '@typescript/typescript-win32-x64@7.0.1-rc':
+  '@typescript/typescript-win32-arm64@7.0.2':
     optional: true
 
-  '@typescript/typescript6@6.0.1':
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript6@6.0.2':
     dependencies:
-      typescript: 6.0.3
+      '@typescript/old': typescript@6.0.3
 
   '@typespec/ts-http-runtime@0.3.5':
     dependencies:
@@ -14873,7 +14869,7 @@ snapshots:
     dependencies:
       semver: 7.7.3
 
-  bunchee@6.9.4(@typescript/typescript6@6.0.1):
+  bunchee@6.9.4(@typescript/typescript6@6.0.2):
     dependencies:
       '@rollup/plugin-commonjs': 29.0.2(rollup@4.59.0)
       '@rollup/plugin-json': 6.1.0(rollup@4.59.0)
@@ -14889,14 +14885,14 @@ snapshots:
       picomatch: 4.0.4
       pretty-bytes: 5.6.0
       rollup: 4.59.0
-      rollup-plugin-dts: 6.3.0(@typescript/typescript6@6.0.1)(rollup@4.59.0)
+      rollup-plugin-dts: 6.3.0(@typescript/typescript6@6.0.2)(rollup@4.59.0)
       rollup-plugin-swc3: 0.11.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(rollup@4.59.0)
       rollup-preserve-directives: 1.1.3(rollup@4.59.0)
       tinyglobby: 0.2.15
       tslib: 2.8.1
       yargs: 17.7.2
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.1'
+      typescript: '@typescript/typescript6@6.0.2'
 
   bundle-name@4.1.0:
     dependencies:
@@ -16835,15 +16831,15 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.1)):
+  jest-cli@30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.2)):
     dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.1))
+      '@jest/core': 30.3.0(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.2))
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.1))
+      jest-config: 30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.2))
       jest-util: 30.3.0
       jest-validate: 30.3.0
       yargs: 17.7.2
@@ -16854,7 +16850,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.1)):
+  jest-config@30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.2)):
     dependencies:
       '@babel/core': 7.29.7
       '@jest/get-type': 30.1.0
@@ -16881,12 +16877,12 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 18.17.4
-      ts-node: 10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.1)
+      ts-node: 10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.3.0(@types/node@24.10.11)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.1)):
+  jest-config@30.3.0(@types/node@24.10.11)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.2)):
     dependencies:
       '@babel/core': 7.29.7
       '@jest/get-type': 30.1.0
@@ -16913,7 +16909,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 24.10.11
-      ts-node: 10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.1)
+      ts-node: 10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -17148,12 +17144,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.1)):
+  jest@30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.2)):
     dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.1))
+      '@jest/core': 30.3.0(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.2))
       '@jest/types': 30.3.0
       import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.1))
+      jest-cli: 30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.2))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -19174,7 +19170,7 @@ snapshots:
 
   robust-predicates@3.0.3: {}
 
-  rolldown-plugin-dts@0.13.14(@typescript/native-preview@7.0.0-dev.20260523.1)(@typescript/typescript6@6.0.1)(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rolldown@1.0.0-beta.9):
+  rolldown-plugin-dts@0.13.14(@typescript/native-preview@7.0.0-dev.20260523.1)(@typescript/typescript6@6.0.2)(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rolldown@1.0.0-beta.9):
     dependencies:
       '@babel/generator': 7.29.1
       '@babel/parser': 7.29.2
@@ -19187,7 +19183,7 @@ snapshots:
       rolldown: 1.0.0-beta.9
     optionalDependencies:
       '@typescript/native-preview': 7.0.0-dev.20260523.1
-      typescript: '@typescript/typescript6@6.0.1'
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - oxc-resolver
       - supports-color
@@ -19232,11 +19228,11 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.1.2
       '@rolldown/binding-win32-x64-msvc': 1.1.2
 
-  rollup-plugin-dts@6.3.0(@typescript/typescript6@6.0.1)(rollup@4.59.0):
+  rollup-plugin-dts@6.3.0(@typescript/typescript6@6.0.2)(rollup@4.59.0):
     dependencies:
       magic-string: 0.30.21
       rollup: 4.59.0
-      typescript: '@typescript/typescript6@6.0.1'
+      typescript: '@typescript/typescript6@6.0.2'
     optionalDependencies:
       '@babel/code-frame': 7.29.0
 
@@ -19810,18 +19806,18 @@ snapshots:
 
   ts-dedent@2.3.0: {}
 
-  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@30.3.0)(@jest/types@30.3.0)(@typescript/typescript6@6.0.1)(babel-jest@30.3.0(@babel/core@7.29.7))(jest-util@30.3.0)(jest@30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.1))):
+  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@30.3.0)(@jest/types@30.3.0)(@typescript/typescript6@6.0.2)(babel-jest@30.3.0(@babel/core@7.29.7))(jest-util@30.3.0)(jest@30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.2))):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.1))
+      jest: 30.3.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.2))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.8.4
       type-fest: 4.41.0
-      typescript: '@typescript/typescript6@6.0.1'
+      typescript: '@typescript/typescript6@6.0.2'
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.29.7
@@ -19845,7 +19841,7 @@ snapshots:
       '@ts-morph/common': 0.28.1
       code-block-writer: 13.0.3
 
-  ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.1):
+  ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(@typescript/typescript6@6.0.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -19859,14 +19855,14 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.4
       make-error: 1.3.6
-      typescript: '@typescript/typescript6@6.0.1'
+      typescript: '@typescript/typescript6@6.0.2'
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.15.11(@swc/helpers@0.5.18)
     optional: true
 
-  tsdown@0.12.0(@typescript/native-preview@7.0.0-dev.20260523.1)(@typescript/typescript6@6.0.1)(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)):
+  tsdown@0.12.0(@typescript/native-preview@7.0.0-dev.20260523.1)(@typescript/typescript6@6.0.2)(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)):
     dependencies:
       ansis: 4.2.0
       cac: 6.7.14
@@ -19876,13 +19872,13 @@ snapshots:
       empathic: 1.1.0
       hookable: 5.5.3
       rolldown: 1.0.0-beta.9
-      rolldown-plugin-dts: 0.13.14(@typescript/native-preview@7.0.0-dev.20260523.1)(@typescript/typescript6@6.0.1)(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rolldown@1.0.0-beta.9)
+      rolldown-plugin-dts: 0.13.14(@typescript/native-preview@7.0.0-dev.20260523.1)(@typescript/typescript6@6.0.2)(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rolldown@1.0.0-beta.9)
       semver: 7.7.3
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       unconfig: 7.5.0
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.1'
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - '@oxc-project/runtime'
       - '@typescript/native-preview'
@@ -19959,36 +19955,34 @@ snapshots:
       tunnel: 0.0.6
       underscore: 1.13.8
 
-  typescript@5.5.4: {}
-
   typescript@5.6.1-rc: {}
 
   typescript@5.9.3: {}
 
   typescript@6.0.3: {}
 
-  typescript@7.0.1-rc:
+  typescript@7.0.2:
     optionalDependencies:
-      '@typescript/typescript-aix-ppc64': 7.0.1-rc
-      '@typescript/typescript-darwin-arm64': 7.0.1-rc
-      '@typescript/typescript-darwin-x64': 7.0.1-rc
-      '@typescript/typescript-freebsd-arm64': 7.0.1-rc
-      '@typescript/typescript-freebsd-x64': 7.0.1-rc
-      '@typescript/typescript-linux-arm': 7.0.1-rc
-      '@typescript/typescript-linux-arm64': 7.0.1-rc
-      '@typescript/typescript-linux-loong64': 7.0.1-rc
-      '@typescript/typescript-linux-mips64el': 7.0.1-rc
-      '@typescript/typescript-linux-ppc64': 7.0.1-rc
-      '@typescript/typescript-linux-riscv64': 7.0.1-rc
-      '@typescript/typescript-linux-s390x': 7.0.1-rc
-      '@typescript/typescript-linux-x64': 7.0.1-rc
-      '@typescript/typescript-netbsd-arm64': 7.0.1-rc
-      '@typescript/typescript-netbsd-x64': 7.0.1-rc
-      '@typescript/typescript-openbsd-arm64': 7.0.1-rc
-      '@typescript/typescript-openbsd-x64': 7.0.1-rc
-      '@typescript/typescript-sunos-x64': 7.0.1-rc
-      '@typescript/typescript-win32-arm64': 7.0.1-rc
-      '@typescript/typescript-win32-x64': 7.0.1-rc
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   ua-parser-js@1.0.41: {}
 


### PR DESCRIPTION
## Summary

Moves the repository from the TypeScript 7 release candidate to the stable `7.0.2` release, and brings the remaining stragglers onto it.

- Bump `typescript-7` from `npm:typescript@7.0.1-rc` to `npm:typescript@7.0.2` in the root and every workspace package that declares it. `tsc` (used by the shared `check-types` command) is now the stable compiler.
- Bump the `@typescript/typescript6` compatibility shim from `^6.0.1` to `^6.0.2`. This is the package the bare `typescript` specifier still aliases to, so tooling that consumes the TypeScript JS API (`ts-jest`, `ts-json-schema-generator`, `tsdown`, `bunchee`) keeps working.
- The two Next.js apps, `apps/docs` and `apps/agents`, stay on the stable `typescript` package rather than the shim — Next.js type generation rejects the shim ([#13659](https://github.com/vercel/turborepo/pull/13659)) — and move from `^6.0.1` to `^6.0.3`.
- `apps/agents` drops `@typescript/native-preview@7.0.0-dev.20260523.1` for `typescript-7`. The preview package existed to get `tsgo` before the native compiler shipped; the `tsgo --noEmit` script goes with it, so the app type checks through the repository-wide `pnpm exec tsc --noEmit` like every other workspace.
- `@repo/docs-link-checker` was the last workspace package on TypeScript 5.5.4. It now uses `typescript-7`, which required switching `moduleResolution` from the removed `node10` mode to `nodenext` and adding the `node` types and `skipLibCheck` that its dependency type declarations need.

### One thing to know about `apps/agents`

In `apps/docs` and `apps/agents`, `pnpm exec tsc` is **6.0.3**, not 7.0.2. Both apps depend on the real `typescript` package for Next.js, and because their `typescript-7` matches the root's, pnpm dedupes it and links only `typescript` into the app — whose `tsc` bin then shadows the root's 7.0.2. For `apps/docs` that is already the behaviour on `main`; for `apps/agents` it is a change from `tsgo` (7.0.0-dev), which this PR removes.

I left it that way so both Next.js apps behave the same and neither needs a bespoke task command. `apps/agents` type checks clean under both compilers (I ran each). If you'd rather pin it to 7.x, a scoped override in the root `turbo.json` does it:

```jsonc
"examples-agent#check-types": {
  "command": ["pnpm", "-w", "exec", "tsc", "--noEmit", "-p", "apps/agents"]
}
```

### Out of scope

- `examples/**` and `lockfile-tests/fixtures/**` are untouched. Examples are maintained by their own update flow with per-package-manager lockfiles, and the fixture lockfiles are semantic test data.
- The `@repo/docs-link-checker#check-types` opt-out in the root `turbo.json` is left in place, though the package now type checks cleanly under `7.0.2`. Removing the opt-out is a reasonable follow-up.

## Testing

Re-run after rebasing onto `main` (which added the Eve operator dashboard to `apps/agents`):

- `corepack pnpm@10.28.0 install --ignore-scripts` (lockfile reported up to date against the resolved `package.json` files)
- `turbo run check-types --filter='./packages/*' --filter='./apps/*' --filter='./docs/*' --filter='!turbo-vsc'` (20 tasks passed, including `docs` and `examples-agent`)
- `turbo run check-types --only --filter=turbo-vsc` (passed; excluded from the run above only because its `^build` needs the Rust LSP toolchain, which this environment lacks)
- `apps/agents` type checked explicitly with both compilers: `tsc@7.0.2 --noEmit -p apps/agents` and the app-local `tsc@6.0.3 --noEmit`
- `cd docs/link-checker && tsc --noEmit` (7.0.2)
- `pnpm exec oxfmt --check`
- `turbo run test --filter='./packages/*' --filter='!turbo-vsc'` — all pass except `eslint-plugin-turbo#test`, which shells out to `npm install eslint` inside its fixtures and fails on `SELF_SIGNED_CERT_IN_CHAIN` behind this sandbox's TLS-inspecting proxy. Unrelated to the change.

Not run here: `docs#build` and the Rust workspace builds, which need Zig and a full Cargo toolchain this environment does not have.

## CI

The first CI run on this branch had three red checks. None of them were caused by the TypeScript bump, but all three are now resolved:

- **Formatting** — `turbo run quality` failed on four `oxlint --deny-warnings` errors in `apps/agents/agent/**` (`unicorn/consistent-existence-index-check` ×2, `unicorn/prefer-type-error`, `no-unmodified-loop-condition`). They came from `main`, which is never linted directly because the Lint workflow only runs on `pull_request`, so every branch cut from it inherited a red Formatting check. Fixed on `main` in #13716 and merged in here. `turbo run quality --env-mode=strict` is now 10/10 green locally and the job passes.
- **JS Package Tests (macos, Node 18)** — the job hit its 15-minute timeout with `@turbo/codemod#test` (normally ~50s) stalled and no output for 12.5 minutes. The other 36 tasks finished, and the same task passed on ubuntu Node 18 and on macOS Node 20/22/24 with the identical dependency tree, so this was a runner stall rather than a compiler-version problem. It passed on the re-run.
- **Cleanup / cleanup** — `gh api .../actions/caches` failed with `x509: certificate is not valid for any names`. A transient runner TLS failure; passed on the re-run.

The second run then hit the same class of TLS failure in **@turbo/types codegen check**, where the `libghostty-vt-sys` build script clones `ghostty-org/ghostty` and got `server certificate verification failed`. Also transient — that job passed on the first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

