### PR TITLE
feat(agents): Update one stale example per workflow run

### DIFF
--- a/apps/agents/agent/instructions.md
+++ b/apps/agents/agent/instructions.md
@@ -5,13 +5,18 @@ You are the Turborepo examples maintenance agent. Your job is to keep the exampl
 # Standing Rules
 
 - Load the `examples_maintenance` skill whenever the user asks to inspect, update, modernize, validate, or repair examples.
-- When the user asks to update examples without narrowing scope, update all examples and all versioned values. Do not ask for a scoping decision.
+- Never update every example in one run. A broad update request is a fan-out request: split it into one workflow run per stale example.
+- When the user asks to update examples without narrowing scope, call `find_stale_examples`, then dispatch one `tools.agent` call per entry of the returned `updateQueue` with the `Workflow` tool. Do not ask for a scoping decision.
+- An example is stale when `examples/<name>` has had no commit in the last week. That is the `find_stale_examples` default; only use a different window when the user names one.
+- Never open a second pull request for an example that already has one open. `find_stale_examples` reports those under `skipped` with reason `open-pull-request`; leave them alone and report them as skipped.
+- One example per run, one pull request per example, on the branch `agents/examples/<example>`.
+- When your assignment names a single example, you are the run for that example: update only that example, open at most one pull request for it, and never fan out again.
 - Focus on `examples/` unless the user explicitly asks for broader repository changes.
 - Write example files directly when maintenance requires it. Do not ask for approval for routine file writes.
 - Never manually edit lockfiles. Update them by running the example's package manager.
 - Keep changes minimal except where latest-version migrations require broader code, config, or tooling changes. Exact latest pins are the invariant; fix breakage caused by those updates before reporting completion.
-- Do not use questions to avoid large or risky updates. Proceed in batches, fix breakage, and report progress.
+- Do not use questions to avoid large or risky updates. Proceed with the assigned example, fix breakage, and report progress.
 - Never ask the user questions during examples maintenance. If continuing is impossible because of missing credentials, unavailable services, or external product direction, report the blocker and stop.
 - Do not downgrade or hold a direct dependency below the latest stable registry version because of compatibility concerns. If latest breaks, migrate the example until latest works.
 - Version bumps are not enough. When upgrading a framework, toolchain, or library, migrate the example to that ecosystem's current best-practice configuration and APIs instead of preserving deprecated patterns.
-- Do not stop with checkpoint summaries, partial progress reports, or "I'll continue" messages. For broad examples updates, keep working until every example has been updated, lockfiles are regenerated, and relevant non-persistent validation tasks have passed or produced a concrete external blocker.
+- Do not stop with checkpoint summaries, partial progress reports, or "I'll continue" messages. A fan-out run ends once every stale example has been dispatched; a single-example run ends once that example is updated, its lockfile is regenerated, its relevant non-persistent validation tasks have passed or produced a concrete external blocker, and its pull request is open.

--- a/apps/agents/agent/lib/github.ts
+++ b/apps/agents/agent/lib/github.ts
@@ -1,0 +1,314 @@
+import { createSign } from "node:crypto";
+
+export interface RepositoryReference {
+  owner: string;
+  repo: string;
+}
+
+export interface PullRequestSummary {
+  number: number;
+  title: string;
+  url: string;
+  headRef: string;
+  baseRef: string;
+  updatedAt: string | null;
+}
+
+export interface CommitSummary {
+  sha: string;
+  committedAt: string | null;
+}
+
+interface InstallationTokenResponse {
+  expires_at?: string;
+  token?: string;
+}
+
+interface PullRequestListEntry {
+  number?: number;
+  title?: string;
+  html_url?: string;
+  updated_at?: string;
+  head?: { ref?: string };
+  base?: { ref?: string };
+}
+
+interface PullRequestFileEntry {
+  filename?: string;
+  previous_filename?: string;
+}
+
+interface CommitListEntry {
+  sha?: string;
+  commit?: {
+    author?: { date?: string };
+    committer?: { date?: string };
+  };
+}
+
+const FILES_PER_PAGE = 100;
+const PULL_REQUESTS_PER_PAGE = 100;
+
+let cachedInstallationToken:
+  | { expiresAt: number; installationId: number; token: string }
+  | undefined;
+
+export class GitHubApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number
+  ) {
+    super(message);
+  }
+}
+
+export function resolveRepository(input: {
+  owner?: string;
+  repo?: string;
+}): RepositoryReference {
+  if (input.owner && input.repo) {
+    return { owner: input.owner, repo: input.repo };
+  }
+
+  const [owner, repo] = (process.env.GITHUB_REPOSITORY ?? "").split("/");
+  if (owner && repo) {
+    return { owner: input.owner ?? owner, repo: input.repo ?? repo };
+  }
+
+  throw new Error(
+    "Pass owner and repo, or set GITHUB_REPOSITORY to 'owner/repo'."
+  );
+}
+
+export async function githubRequest<T>(input: {
+  body?: unknown;
+  method: "GET" | "PATCH" | "POST";
+  owner: string;
+  path: string;
+  repo: string;
+}): Promise<T> {
+  const response = await fetch(
+    `https://api.github.com${repoPath(input.owner, input.repo, input.path)}`,
+    {
+      method: input.method,
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${await getInstallationToken()}`,
+        "content-type": "application/json",
+        "x-github-api-version": "2022-11-28"
+      },
+      body: input.body === undefined ? undefined : JSON.stringify(input.body)
+    }
+  );
+
+  if (!response.ok) {
+    throw new GitHubApiError(
+      `GitHub ${input.method} ${input.path} failed with ${response.status}: ${await response.text()}`,
+      response.status
+    );
+  }
+
+  return (await response.json()) as T;
+}
+
+export async function listOpenPullRequests(input: {
+  owner: string;
+  repo: string;
+  limit: number;
+}): Promise<PullRequestSummary[]> {
+  const pullRequests: PullRequestSummary[] = [];
+
+  for (let page = 1; pullRequests.length < input.limit; page += 1) {
+    const query = new URLSearchParams({
+      state: "open",
+      sort: "updated",
+      direction: "desc",
+      per_page: String(PULL_REQUESTS_PER_PAGE),
+      page: String(page)
+    });
+    const batch = await githubRequest<PullRequestListEntry[]>({
+      method: "GET",
+      owner: input.owner,
+      repo: input.repo,
+      path: `/pulls?${query.toString()}`
+    });
+
+    for (const entry of batch) {
+      if (typeof entry.number !== "number") {
+        continue;
+      }
+      pullRequests.push({
+        number: entry.number,
+        title: entry.title ?? "",
+        url: entry.html_url ?? "",
+        headRef: entry.head?.ref ?? "",
+        baseRef: entry.base?.ref ?? "",
+        updatedAt: entry.updated_at ?? null
+      });
+    }
+
+    if (batch.length < PULL_REQUESTS_PER_PAGE) {
+      break;
+    }
+  }
+
+  return pullRequests.slice(0, input.limit);
+}
+
+export async function listPullRequestFiles(input: {
+  owner: string;
+  repo: string;
+  pullNumber: number;
+  maxFiles: number;
+}): Promise<string[]> {
+  const files: string[] = [];
+
+  for (let page = 1; files.length < input.maxFiles; page += 1) {
+    const query = new URLSearchParams({
+      per_page: String(FILES_PER_PAGE),
+      page: String(page)
+    });
+    const batch = await githubRequest<PullRequestFileEntry[]>({
+      method: "GET",
+      owner: input.owner,
+      repo: input.repo,
+      path: `/pulls/${input.pullNumber}/files?${query.toString()}`
+    });
+
+    for (const entry of batch) {
+      if (entry.filename) {
+        files.push(entry.filename);
+      }
+      if (entry.previous_filename) {
+        files.push(entry.previous_filename);
+      }
+    }
+
+    if (batch.length < FILES_PER_PAGE) {
+      break;
+    }
+  }
+
+  return files;
+}
+
+export async function getLastCommitForPath(input: {
+  owner: string;
+  repo: string;
+  path: string;
+  ref?: string;
+}): Promise<CommitSummary | null> {
+  const query = new URLSearchParams({ path: input.path, per_page: "1" });
+  if (input.ref) {
+    query.set("sha", input.ref);
+  }
+
+  const commits = await githubRequest<CommitListEntry[]>({
+    method: "GET",
+    owner: input.owner,
+    repo: input.repo,
+    path: `/commits?${query.toString()}`
+  });
+
+  const commit = commits[0];
+  if (!commit?.sha) {
+    return null;
+  }
+
+  return {
+    sha: commit.sha,
+    committedAt:
+      commit.commit?.committer?.date ?? commit.commit?.author?.date ?? null
+  };
+}
+
+function repoPath(owner: string, repo: string, path: string) {
+  return `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}${path}`;
+}
+
+function requireEnv(name: string) {
+  const value = process.env[name];
+  if (!value) throw new Error(`Set ${name} before calling the GitHub API.`);
+  return value;
+}
+
+function installationId() {
+  const value = process.env.GITHUB_INSTALLATION_ID;
+  if (!value) {
+    throw new Error(
+      "Set GITHUB_INSTALLATION_ID before calling the GitHub API."
+    );
+  }
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed)) {
+    throw new TypeError("GITHUB_INSTALLATION_ID must be an integer.");
+  }
+
+  return parsed;
+}
+
+function base64Url(value: Buffer | string) {
+  return Buffer.from(value)
+    .toString("base64")
+    .replace(/[=]/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+function createGitHubAppJwt() {
+  const now = Math.floor(Date.now() / 1000);
+  const privateKey = requireEnv("GITHUB_APP_PRIVATE_KEY").replace(/\\n/g, "\n");
+  const payload = {
+    iat: now - 60,
+    exp: now + 9 * 60,
+    iss: requireEnv("GITHUB_APP_ID")
+  };
+  const unsigned = `${base64Url(JSON.stringify({ alg: "RS256", typ: "JWT" }))}.${base64Url(JSON.stringify(payload))}`;
+  const signature = createSign("RSA-SHA256").update(unsigned).sign(privateKey);
+
+  return `${unsigned}.${base64Url(signature)}`;
+}
+
+async function getInstallationToken() {
+  const id = installationId();
+  if (
+    cachedInstallationToken?.installationId === id &&
+    cachedInstallationToken.expiresAt > Date.now() + 60_000
+  ) {
+    return cachedInstallationToken.token;
+  }
+
+  const response = await fetch(
+    `https://api.github.com/app/installations/${id}/access_tokens`,
+    {
+      method: "POST",
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${createGitHubAppJwt()}`,
+        "x-github-api-version": "2022-11-28"
+      }
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `GitHub token request failed with ${response.status}: ${await response.text()}`
+    );
+  }
+
+  const body = (await response.json()) as InstallationTokenResponse;
+  if (!body.token || !body.expires_at) {
+    throw new Error(
+      "GitHub token response did not include token and expires_at."
+    );
+  }
+
+  cachedInstallationToken = {
+    expiresAt: Date.parse(body.expires_at),
+    installationId: id,
+    token: body.token
+  };
+
+  return body.token;
+}

--- a/apps/agents/agent/schedules/weekly_examples_audit.md
+++ b/apps/agents/agent/schedules/weekly_examples_audit.md
@@ -2,4 +2,4 @@
 cron: "0 14 * * 1"
 ---
 
-Audit the Turborepo examples for stale dependency versions, README instructions that do not match package scripts, missing or inconsistent `turbo.json` tasks, and package-manager drift. Produce a concise report with the examples inspected, findings, and recommended follow-up changes. Do not write files during the scheduled audit unless a human asks for a specific fix later.
+Audit the Turborepo examples for stale dependency versions, README instructions that do not match package scripts, missing or inconsistent `turbo.json` tasks, and package-manager drift. Start with `find_stale_examples` so the audit covers the same queue an update run would: examples with no commit in the last week and no open pull request. Produce a concise report with the examples inspected, the examples skipped because a pull request is already open, findings, and recommended follow-up changes. Do not write files or open pull requests during the scheduled audit unless a human asks for a specific fix later.

--- a/apps/agents/agent/skills/examples_maintenance.md
+++ b/apps/agents/agent/skills/examples_maintenance.md
@@ -4,7 +4,7 @@ description: "Use when maintaining Turborepo examples: auditing or updating pack
 
 # Turborepo Examples Maintenance
 
-Use this workflow for any request to inspect, update, modernize, validate, or repair files under `examples/`.
+Use this procedure for any request to inspect, update, modernize, validate, or repair files under `examples/`.
 
 ## Scope
 
@@ -12,10 +12,36 @@ Use this workflow for any request to inspect, update, modernize, validate, or re
 - Preserve package-manager intent. Do not convert an npm, pnpm, Yarn, or Berry example to another manager unless asked.
 - Keep changes minimal except where latest-version migrations require broader code, config, or tooling changes.
 - Do not add compatibility shims as a way to avoid migration. Prefer real migration, package replacement, or configuration changes that make latest versions work cleanly.
-- If the user asks broadly to update examples, update every example and every versioned value. Do not ask for scoping or risk tolerance.
-- Handle large upgrades in batches internally. Do not stop at the audit phase, after one example, after a category of examples, or after a checkpoint summary.
-- Never ask the user questions. If a decision would normally require input, choose the path that gets every example to exact latest stable pins and continue.
-- Do not produce interim reports as a substitute for finishing. Keep a private queue of remaining examples and continue until it is empty.
+- If the user asks broadly to update examples, fan the work out one example at a time instead of updating them all in one run. Do not ask for scoping or risk tolerance.
+- Within the example you own, update every versioned value. Handle a large upgrade in internal batches, and do not stop at the audit phase or at a checkpoint summary.
+- Never ask the user questions. If a decision would normally require input, choose the path that gets the example to exact latest stable pins and continue.
+- Do not produce interim reports as a substitute for finishing.
+
+## Per-Example Fan-Out
+
+A broad update request is dispatch work, not update work. One run must never walk the whole `examples/` directory.
+
+1. Call `find_stale_examples`. It returns `updateQueue` (stale, no open pull request) and `skipped` (already covered by an open pull request, updated within the window, or missing commit history).
+2. An example is stale when `examples/<name>` has no commit in the last week. Keep the default seven-day window unless the user names a different one.
+3. Use the `Workflow` tool to dispatch exactly one `tools.agent` call per `updateQueue` entry, oldest example first. Fan the calls out with `Promise.all` so they run concurrently, and keep the fan-out inside the program's subagent budget by chunking when the queue is larger than the budget.
+4. Give each call everything it needs, because a child never sees this run's history: the example name, its `lastCommitAt`, the branch to use (`agents/examples/<example>`), and the instruction to update only that example and open one pull request for it.
+5. Do not read, write, validate, or open a pull request for an example yourself in a fan-out run. Dispatch, collect the child results, and report.
+6. Report the dispatched examples, each child's outcome, and the skipped examples with their reasons.
+
+An example of the program shape, where `queue` comes from the tool result:
+
+```js
+const results = await Promise.all(
+  queue.map((entry) =>
+    tools.agent({
+      message: `Update the Turborepo example '${entry.example}' only. Last commit ${entry.lastCommitAt}. Branch: agents/examples/${entry.example}. Open exactly one pull request for this example.`
+    })
+  )
+);
+return results;
+```
+
+When you are the child, your assignment is one example. Stay inside `examples/<name>`, and never fan out again.
 
 ## Version Updates
 
@@ -59,28 +85,45 @@ Use this workflow for any request to inspect, update, modernize, validate, or re
 - Run the narrowest relevant verification commands for each changed example using `run_example_script`.
 - If a version bump breaks an example, fix the breakage in the same pass instead of leaving the example half-updated.
 
+## Pull Requests
+
+- One example, one pull request. Never bundle several examples into a single pull request.
+- Use the branch `agents/examples/<example>`. Re-running an example reuses that branch instead of creating a second one.
+- Before opening a pull request, confirm the example was in `updateQueue` and not in `skipped`. An example already carrying an open pull request is done for this cycle; skip it and say so rather than opening a duplicate.
+- Include the example name, the versions moved, and the validation results in the pull request body.
+
 ## Completion Contract
 
-- For broad requests like "update our examples", completion means all examples have been processed, all direct version pins have been moved to exact latest stable values, lockfiles have been regenerated with the declared package managers, best-practice migrations have been applied, and all relevant non-persistent validation tasks have been attempted.
-- Do not end a turn by saying there are remaining examples and that you will continue later. Continue in the same run.
+- For broad requests like "update our examples", completion means `find_stale_examples` has run, every queued example has been dispatched to its own run, and every skipped example has been reported with its reason. It does not mean this run touched the examples itself.
+- For a single-example assignment, completion means that example's direct version pins have been moved to exact latest stable values, its lockfile has been regenerated with its declared package manager, best-practice migrations have been applied, all relevant non-persistent validation tasks have been attempted, and one pull request is open.
+- Do not end a turn by saying there is remaining work on your example and that you will continue later. Continue in the same run.
 - Do not present a checkpoint, progress report, blocker analysis, or plan as the final answer unless every remaining item is blocked by a true external blocker.
 - A true external blocker is limited to unavailable registries/services, missing credentials, or an unpublished package/version. Build, lint, type, test, peer-dependency, framework, plugin, and migration failures are not blockers; they are work to fix.
 
 ## Recommended Tool Flow
 
-1. Use `list_examples` or `inspect_example` to understand the target examples.
-2. Use `audit_example_versions` to find stale `package.json`, `packageManager`, and Node engine values.
-3. Use `find_versioned_references` to find versioned references outside manifests.
+In a fan-out run:
+
+1. Use `find_stale_examples` to get the update queue and the examples to skip.
+2. Use `Workflow` to dispatch one `tools.agent` call per queued example.
+
+In a single-example run:
+
+1. Use `inspect_example` to understand the example you own.
+2. Use `audit_example_versions` with that example to find stale `package.json`, `packageManager`, and Node engine values.
+3. Use `find_versioned_references` with that example to find versioned references outside manifests.
 4. Use `audit_example_tasks` to identify validation scripts and persistent tasks.
 5. Use `read_examples_file` before modifying existing files.
 6. Use `write_examples_file` for non-lockfile example changes.
 7. Use `update_example_lockfile` after dependency or package-manager changes.
 8. Use `run_example_script` for each relevant non-persistent validation task.
+9. Use `create_pull_request` once, on `agents/examples/<example>`.
 
 ## Reporting
 
-- Summarize changed examples, exact versions selected, lockfile update commands run, and validation results.
+- In a fan-out run, summarize the dispatched examples with their outcomes and pull requests, plus the skipped examples with their reasons.
+- In a single-example run, summarize the example changed, exact versions selected, lockfile update commands run, validation results, and the pull request opened.
 - If a check cannot run because dependencies or external services are unavailable, state that clearly and include the command that failed.
-- Do not ask the user to choose safe vs full updates. The default is full latest exact pins across all examples.
+- Do not ask the user to choose safe vs full updates. The default is full latest exact pins for every example you are given.
 - Do not report “latest-compatible” fallbacks as completion. Completion requires exact latest direct pins or a true external availability blocker.
 - Report only after the completion contract is satisfied. Avoid interim status updates unless a tool or channel requires visible progress.

--- a/apps/agents/agent/tools/create_pull_request.ts
+++ b/apps/agents/agent/tools/create_pull_request.ts
@@ -1,7 +1,8 @@
-import { createSign } from "node:crypto";
 import { defineTool } from "eve/tools";
 import { always } from "eve/tools/approval";
 import { z } from "zod";
+
+import { GitHubApiError, githubRequest } from "../lib/github.js";
 
 const filePathSchema = z
   .string()
@@ -38,157 +39,21 @@ const inputSchema = z.object({
 type RefResponse = { object?: { sha?: string } };
 type CommitResponse = { tree?: { sha?: string } };
 type ShaResponse = { sha?: string };
-type InstallationTokenResponse = { expires_at?: string; token?: string };
 type PullRequestResponse = { html_url?: string; number?: number };
-
-let cachedInstallationToken:
-  | { expiresAt: number; installationId: number; token: string }
-  | undefined;
-
-class GitHubApiError extends Error {
-  constructor(
-    message: string,
-    readonly status: number
-  ) {
-    super(message);
-  }
-}
-
-function installationId() {
-  const value = process.env.GITHUB_INSTALLATION_ID;
-  if (!value) {
-    throw new Error(
-      "Set GITHUB_INSTALLATION_ID before creating pull requests."
-    );
-  }
-
-  const parsed = Number(value);
-  if (!Number.isInteger(parsed)) {
-    throw new TypeError("GITHUB_INSTALLATION_ID must be an integer.");
-  }
-
-  return parsed;
-}
-
-function repoPath(owner: string, repo: string, path: string) {
-  return `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}${path}`;
-}
 
 function requireSha(value: string | undefined, label: string) {
   if (!value) throw new Error(`GitHub response did not include ${label}.`);
   return value;
 }
 
-function requireEnv(name: string) {
-  const value = process.env[name];
-  if (!value) throw new Error(`Set ${name} before creating pull requests.`);
-  return value;
-}
-
-function base64Url(value: Buffer | string) {
-  return Buffer.from(value)
-    .toString("base64")
-    .replace(/[=]/g, "")
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_");
-}
-
-function createGitHubAppJwt() {
-  const now = Math.floor(Date.now() / 1000);
-  const privateKey = requireEnv("GITHUB_APP_PRIVATE_KEY").replace(/\\n/g, "\n");
-  const payload = {
-    iat: now - 60,
-    exp: now + 9 * 60,
-    iss: requireEnv("GITHUB_APP_ID")
-  };
-  const unsigned = `${base64Url(JSON.stringify({ alg: "RS256", typ: "JWT" }))}.${base64Url(JSON.stringify(payload))}`;
-  const signature = createSign("RSA-SHA256").update(unsigned).sign(privateKey);
-
-  return `${unsigned}.${base64Url(signature)}`;
-}
-
-async function getInstallationToken() {
-  const id = installationId();
-  if (
-    cachedInstallationToken?.installationId === id &&
-    cachedInstallationToken.expiresAt > Date.now() + 60_000
-  ) {
-    return cachedInstallationToken.token;
-  }
-
-  const response = await fetch(
-    `https://api.github.com/app/installations/${id}/access_tokens`,
-    {
-      method: "POST",
-      headers: {
-        accept: "application/vnd.github+json",
-        authorization: `Bearer ${createGitHubAppJwt()}`,
-        "x-github-api-version": "2022-11-28"
-      }
-    }
-  );
-
-  if (!response.ok) {
-    throw new Error(
-      `GitHub token request failed with ${response.status}: ${await response.text()}`
-    );
-  }
-
-  const body = (await response.json()) as InstallationTokenResponse;
-  if (!body.token || !body.expires_at) {
-    throw new Error(
-      "GitHub token response did not include token and expires_at."
-    );
-  }
-
-  cachedInstallationToken = {
-    expiresAt: Date.parse(body.expires_at),
-    installationId: id,
-    token: body.token
-  };
-
-  return body.token;
-}
-
-async function github<T>(input: {
-  body?: unknown;
-  method: "GET" | "PATCH" | "POST";
-  owner: string;
-  path: string;
-  repo: string;
-}) {
-  const response = await fetch(
-    `https://api.github.com${repoPath(input.owner, input.repo, input.path)}`,
-    {
-      method: input.method,
-      headers: {
-        accept: "application/vnd.github+json",
-        authorization: `Bearer ${await getInstallationToken()}`,
-        "content-type": "application/json",
-        "x-github-api-version": "2022-11-28"
-      },
-      body: input.body === undefined ? undefined : JSON.stringify(input.body)
-    }
-  );
-
-  if (!response.ok) {
-    throw new GitHubApiError(
-      `GitHub ${input.method} ${input.path} failed with ${response.status}: ${await response.text()}`,
-      response.status
-    );
-  }
-
-  return (await response.json()) as T;
-}
-
 export default defineTool({
   description:
-    "Create a GitHub pull request from selected sandbox files. Use only after editing files in the sandbox and choosing an agents/* branch name.",
+    "Create a GitHub pull request from selected sandbox files. Open at most one pull request per example, on the branch agents/examples/<example>. Use only after editing files in the sandbox and confirming the example has no open pull request already.",
   inputSchema,
   approval: always(),
   async execute(input, ctx) {
     const sandbox = await ctx.getSandbox();
-    const baseRef = await github<RefResponse>({
+    const baseRef = await githubRequest<RefResponse>({
       method: "GET",
       owner: input.owner,
       repo: input.repo,
@@ -198,7 +63,7 @@ export default defineTool({
 
     let branchCommitSha = baseCommitSha;
     try {
-      const branchRef = await github<RefResponse>({
+      const branchRef = await githubRequest<RefResponse>({
         method: "GET",
         owner: input.owner,
         repo: input.repo,
@@ -210,7 +75,7 @@ export default defineTool({
         throw error;
       }
 
-      await github({
+      await githubRequest<RefResponse>({
         method: "POST",
         owner: input.owner,
         repo: input.repo,
@@ -222,7 +87,7 @@ export default defineTool({
       });
     }
 
-    const branchCommit = await github<CommitResponse>({
+    const branchCommit = await githubRequest<CommitResponse>({
       method: "GET",
       owner: input.owner,
       repo: input.repo,
@@ -235,7 +100,7 @@ export default defineTool({
         const content = await sandbox.readTextFile({
           path: file.sandboxPath ?? file.path
         });
-        const blob = await github<ShaResponse>({
+        const blob = await githubRequest<ShaResponse>({
           method: "POST",
           owner: input.owner,
           repo: input.repo,
@@ -252,7 +117,7 @@ export default defineTool({
       })
     );
 
-    const newTree = await github<ShaResponse>({
+    const newTree = await githubRequest<ShaResponse>({
       method: "POST",
       owner: input.owner,
       repo: input.repo,
@@ -263,7 +128,7 @@ export default defineTool({
       }
     });
 
-    const commit = await github<ShaResponse>({
+    const commit = await githubRequest<ShaResponse>({
       method: "POST",
       owner: input.owner,
       repo: input.repo,
@@ -276,7 +141,7 @@ export default defineTool({
     });
     const newCommitSha = requireSha(commit.sha, "commit SHA");
 
-    await github({
+    await githubRequest<RefResponse>({
       method: "PATCH",
       owner: input.owner,
       repo: input.repo,
@@ -284,7 +149,7 @@ export default defineTool({
       body: { sha: newCommitSha, force: false }
     });
 
-    const pullRequest = await github<PullRequestResponse>({
+    const pullRequest = await githubRequest<PullRequestResponse>({
       method: "POST",
       owner: input.owner,
       repo: input.repo,

--- a/apps/agents/agent/tools/find_stale_examples.ts
+++ b/apps/agents/agent/tools/find_stale_examples.ts
@@ -1,0 +1,220 @@
+import { defineTool } from "eve/tools";
+import { z } from "zod";
+
+import {
+  getLastCommitForPath,
+  listOpenPullRequests,
+  listPullRequestFiles,
+  resolveRepository
+} from "../lib/github.js";
+import { listExampleNames } from "../lib/repo.js";
+
+interface PullRequestReference {
+  number: number;
+  title: string;
+  url: string;
+  headRef: string;
+}
+
+interface ExampleStatus {
+  example: string;
+  lastCommitAt: string | null;
+  lastCommitSha: string | null;
+  daysSinceUpdate: number | null;
+  openPullRequests: PullRequestReference[];
+}
+
+interface SkippedExample extends ExampleStatus {
+  reason: "open-pull-request" | "unknown-history" | "updated-recently";
+}
+
+const MILLISECONDS_PER_DAY = 86_400_000;
+const REQUEST_CONCURRENCY = 8;
+const MAX_PULL_REQUEST_FILES = 300;
+
+export default defineTool({
+  description:
+    "Find examples that are stale and not already covered by an open pull request. An example is stale when examples/<name> has had no commit within the staleness window (one week by default). Examples with an open pull request touching their directory are skipped so the agent never opens a duplicate. Use this before updating examples, and give each returned queue entry its own workflow run.",
+  inputSchema: z.object({
+    owner: z
+      .string()
+      .min(1)
+      .optional()
+      .describe("Repository owner. Defaults to GITHUB_REPOSITORY."),
+    repo: z
+      .string()
+      .min(1)
+      .optional()
+      .describe("Repository name. Defaults to GITHUB_REPOSITORY."),
+    baseBranch: z
+      .string()
+      .min(1)
+      .default("main")
+      .describe("Branch to read example commit history from."),
+    staleAfterDays: z
+      .number()
+      .int()
+      .positive()
+      .max(365)
+      .default(7)
+      .describe(
+        "How many days without a commit make an example stale. Defaults to one week."
+      ),
+    maxOpenPullRequests: z
+      .number()
+      .int()
+      .positive()
+      .max(300)
+      .default(100)
+      .describe(
+        "How many open pull requests to inspect, most recently updated first."
+      )
+  }),
+  async execute({
+    owner,
+    repo,
+    baseBranch,
+    staleAfterDays,
+    maxOpenPullRequests
+  }) {
+    const repository = resolveRepository({ owner, repo });
+    const examples = await listExampleNames();
+    const checkedAt = new Date();
+    const staleBefore = new Date(
+      checkedAt.getTime() - staleAfterDays * MILLISECONDS_PER_DAY
+    );
+
+    const pullRequests = await listOpenPullRequests({
+      ...repository,
+      limit: maxOpenPullRequests
+    });
+    const pullRequestsByExample = await mapPullRequestsToExamples(
+      repository,
+      pullRequests,
+      new Set(examples)
+    );
+
+    const statuses = await mapWithConcurrency(examples, async (example) => {
+      const commit = await getLastCommitForPath({
+        ...repository,
+        path: `examples/${example}`,
+        ref: baseBranch
+      });
+      const committedAt = commit?.committedAt
+        ? Date.parse(commit.committedAt)
+        : Number.NaN;
+
+      return {
+        example,
+        lastCommitAt: commit?.committedAt ?? null,
+        lastCommitSha: commit?.sha ?? null,
+        daysSinceUpdate: Number.isNaN(committedAt)
+          ? null
+          : Math.floor(
+              (checkedAt.getTime() - committedAt) / MILLISECONDS_PER_DAY
+            ),
+        openPullRequests: pullRequestsByExample.get(example) ?? []
+      } satisfies ExampleStatus;
+    });
+
+    const updateQueue: ExampleStatus[] = [];
+    const skipped: SkippedExample[] = [];
+
+    for (const status of statuses) {
+      if (status.openPullRequests.length > 0) {
+        skipped.push({ ...status, reason: "open-pull-request" });
+        continue;
+      }
+      if (status.lastCommitAt === null) {
+        skipped.push({ ...status, reason: "unknown-history" });
+        continue;
+      }
+      if (Date.parse(status.lastCommitAt) >= staleBefore.getTime()) {
+        skipped.push({ ...status, reason: "updated-recently" });
+        continue;
+      }
+      updateQueue.push(status);
+    }
+
+    updateQueue.sort(
+      (a, b) =>
+        Date.parse(a.lastCommitAt ?? "") - Date.parse(b.lastCommitAt ?? "")
+    );
+
+    return {
+      repository: `${repository.owner}/${repository.repo}`,
+      baseBranch,
+      staleAfterDays,
+      staleBefore: staleBefore.toISOString(),
+      checkedAt: checkedAt.toISOString(),
+      inspectedPullRequests: pullRequests.length,
+      updateQueue,
+      skipped: skipped.sort((a, b) => a.example.localeCompare(b.example))
+    };
+  }
+});
+
+async function mapPullRequestsToExamples(
+  repository: { owner: string; repo: string },
+  pullRequests: Awaited<ReturnType<typeof listOpenPullRequests>>,
+  examples: Set<string>
+): Promise<Map<string, PullRequestReference[]>> {
+  const byExample = new Map<string, PullRequestReference[]>();
+
+  await mapWithConcurrency(pullRequests, async (pullRequest) => {
+    const files = await listPullRequestFiles({
+      ...repository,
+      pullNumber: pullRequest.number,
+      maxFiles: MAX_PULL_REQUEST_FILES
+    });
+
+    for (const example of exampleNamesFromFiles(files, examples)) {
+      const references = byExample.get(example) ?? [];
+      references.push({
+        number: pullRequest.number,
+        title: pullRequest.title,
+        url: pullRequest.url,
+        headRef: pullRequest.headRef
+      });
+      byExample.set(example, references);
+    }
+  });
+
+  return byExample;
+}
+
+function exampleNamesFromFiles(
+  files: string[],
+  examples: Set<string>
+): Set<string> {
+  const names = new Set<string>();
+  for (const file of files) {
+    const [root, example] = file.split("/");
+    if (root === "examples" && example && examples.has(example)) {
+      names.add(example);
+    }
+  }
+  return names;
+}
+
+async function mapWithConcurrency<Item, Result>(
+  items: Item[],
+  handler: (item: Item) => Promise<Result>
+): Promise<Result[]> {
+  const results = Array.from<Result>({ length: items.length });
+  let cursor = 0;
+
+  async function worker() {
+    while (cursor < items.length) {
+      const index = cursor;
+      cursor += 1;
+      results[index] = await handler(items[index]);
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(REQUEST_CONCURRENCY, items.length) }, worker)
+  );
+
+  return results;
+}

--- a/apps/agents/agent/tools/workflow.ts
+++ b/apps/agents/agent/tools/workflow.ts
@@ -1,0 +1,3 @@
+// Enables the `Workflow` tool so example updates fan out into one child run
+// per stale example instead of one run that tries to update everything.
+export { ExperimentalWorkflow as default } from "eve/tools";


### PR DESCRIPTION
## Description

The examples agent read "update our examples" as one run that walks all of `examples/`. This splits that into dispatch work and update work: a fan-out run picks the stale examples, and each one gets its own child run and its own pull request.

- **`find_stale_examples` (new tool).** Reads the last commit for every `examples/<name>` from the GitHub API and marks an example stale after a week without a commit (`staleAfterDays`, default `7`). It also inspects open pull requests and attributes each one to the example directories it touches, so anything already covered comes back under `skipped` with reason `open-pull-request` instead of in `updateQueue`. The queue is sorted oldest-first, and the other skip reasons (`updated-recently`, `unknown-history`) are reported too, so nothing disappears silently.
- **`Workflow` tool enabled.** `agent/tools/workflow.ts` re-exports the `ExperimentalWorkflow` opt-in marker. A broad update request now becomes one `tools.agent` call per queued example, each scoped to a single example and a single pull request on `agents/examples/<example>`.
- **`agent/lib/github.ts` (new).** The GitHub App JWT, installation-token cache, and request helper moved out of `create_pull_request` so both tools share them, plus the open-pull-request, pull-request-files, and last-commit-for-path queries the new tool needs. `create_pull_request` keeps its existing behavior.
- **Guidance rewritten.** `instructions.md` and the `examples_maintenance` skill now describe the two roles: a fan-out run dispatches and reports, a single-example run updates one example and opens one pull request. The weekly audit stays read-only but starts from the same queue.

The fan-out uses the built-in `agent` tool rather than a declared subagent on purpose: children of `agent` share the parent's sandbox and tool surface, which `create_pull_request` depends on when it reads the edited files back out of the sandbox. A declared subagent would get its own sandbox and would need every tool re-declared under it.

Repository resolution for the new tool takes `owner`/`repo` inputs and falls back to `GITHUB_REPOSITORY`; it throws a clear error when neither is available.

## Testing Instructions

- `pnpm exec tsgo` in `apps/agents` (passes)
- `pnpm exec oxlint apps/agents/agent/` and `pnpm exec oxfmt --check apps/agents/agent/` (clean)
- `pnpm exec eve build` in `apps/agents` builds with 0 diagnostics; the compiled manifest reports `workflowEnabled: true` and lists `find_stale_examples` among the discovered tools.
- The three GitHub endpoints the tool relies on were verified against `vercel/turborepo` (commits by path, open pull requests, pull-request files) and match the response shapes the code parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
