### PR TITLE
fix: Resolve agent lint errors

### DIFF
--- a/apps/agents/agent/channels/operator.ts
+++ b/apps/agents/agent/channels/operator.ts
@@ -77,14 +77,12 @@ export default defineChannel({
         ).getReader();
         let cursor = startIndex;
         let state: "running" | "done" | "error" = "running";
-        let polling = true;
         const timeout = setTimeout(() => {
-          polling = false;
           void reader.cancel();
         }, 250);
 
         try {
-          while (polling) {
+          while (true) {
             const { done, value: event } = await reader.read();
             if (done) break;
             cursor += 1;

--- a/apps/agents/agent/lib/github.ts
+++ b/apps/agents/agent/lib/github.ts
@@ -56,7 +56,7 @@ export async function getGitHubToken(): Promise<string> {
   }
   const expiresAt = Date.parse(String(body.expires_at));
   if (Number.isNaN(expiresAt)) {
-    throw new Error(
+    throw new TypeError(
       `GitHub token exchange had invalid expires_at: ${String(body.expires_at)}`
     );
   }

--- a/apps/agents/agent/lib/repo.ts
+++ b/apps/agents/agent/lib/repo.ts
@@ -112,7 +112,7 @@ export async function resolveAutomatedSelection(
   if (typeof requested !== "string") return automatic;
 
   const index = examples.indexOf(requested);
-  if (index < 0) throw new Error(`Unknown example: ${requested}`);
+  if (index === -1) throw new Error(`Unknown example: ${requested}`);
   return { ...automatic, example: requested, index };
 }
 
@@ -127,7 +127,7 @@ export function sessionDate(sessionId: string): Date {
   let timestamp = 0;
   for (const character of encoded) {
     const value = ULID_ALPHABET.indexOf(character.toUpperCase());
-    if (value < 0) throw new Error(`Invalid Eve session id: ${sessionId}`);
+    if (value === -1) throw new Error(`Invalid Eve session id: ${sessionId}`);
     timestamp = timestamp * 32 + value;
   }
   return new Date(timestamp);


### PR DESCRIPTION
## Summary

- Use strict `indexOf` non-existence checks.
- Throw `TypeError` for an invalid token expiration value.
- Rely on stream cancellation to terminate operator status polling.

## Testing

- `pnpm exec oxlint --deny-warnings .`
- Pre-push format and TOML checks