### PR TITLE
fix: Restore source file inputs for the root lint task

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -88,8 +88,12 @@
         "docs#check-openapi"
       ]
     },
+    // oxlint reads every workspace, so the whole repository is an input.
+    // $TURBO_DEFAULT$ has to be listed explicitly: a bare exclusion replaces
+    // the default input set instead of subtracting from it, which would leave
+    // the task hashing only the root package.json and turbo.json.
     "//#lint": {
-      "inputs": ["!pnpm-lock.yaml"],
+      "inputs": ["$TURBO_DEFAULT$", "!pnpm-lock.yaml"],
       "command": ["pnpm", "exec", "oxlint", "--deny-warnings", "."]
     },
     "//#lint:fix": {


### PR DESCRIPTION
## Summary

`//#lint` declared `"inputs": ["!pnpm-lock.yaml"]`, intending "everything except the lockfile". Turbo treats an explicit `inputs` list as a *replacement* for the default set, so a list holding only an exclusion left the task hashing two files:

```
$ turbo run lint --filter=// --dry=json
//#lint      | total inputs: 2    | apps/*: 0   | packages/*: 0
//#format    | total inputs: 5602 | apps/*: 612 | packages/*: 769
//#check:toml| total inputs: 5602 | apps/*: 612 | packages/*: 769
```

The two are the root `package.json` and `turbo.json`. `oxlint` lints the whole repository, so any pull request that did not touch one of those two files replayed a cached `Found 0 warnings and 0 errors` regardless of what it did to the sources. The Formatting check was reporting on a hash that could not see the code it was linting.

That is not hypothetical — it is what happened this week:

- #13710 and #13715 added `apps/agents/agent/**` code carrying four `--deny-warnings` errors. Both got a green Formatting check: `//:lint: cache hit, replaying logs 9181a7e52fbbbe45` / `Finished in 998ms on **325** files`. oxlint never ran on the new files, and the errors landed on `main`.
- #13713 was the next pull request to touch the root `package.json`. Its hash changed, oxlint actually ran — `Finished in 1.3s on **336** files` — and the four inherited errors failed its Formatting job. They were then fixed in #13716.

`main` is never linted directly (the Lint workflow is `on: pull_request` only), so nothing else would have caught this.

## The fix

Listing `$TURBO_DEFAULT$` alongside the exclusion restores the intended meaning — the default input set, minus the lockfile:

```json
"inputs": ["$TURBO_DEFAULT$", "!pnpm-lock.yaml"]
```

`//#format` and `//#check:toml` declare no `inputs` at all and already hash the full tree, so they are unaffected. Every other `inputs` list in the repository either includes `$TURBO_DEFAULT$` or is a deliberately narrow list for a task that really does read only those files.

## Testing

- `turbo run lint --filter=// --dry=json` — inputs go from 2 to 5601 (5602 minus `pnpm-lock.yaml`), including 612 files under `apps/` and 769 under `packages/`.
- Reintroduced one of the `unicorn/consistent-existence-index-check` errors in `apps/agents/agent/lib/repo.ts`:
  - before the fix: `//:lint: cache hit, replaying logs bd41fbddd5431bc2` → `Found 0 warnings and 0 errors`, task passes.
  - after the fix: `//:lint: cache miss` → `Found 0 warnings and 1 error`, `Failed: //#lint`.
- Caching still behaves: a repeat run on a clean tree hits the cache, and appending to `pnpm-lock.yaml` still hits it, so lockfile churn does not re-lint.
- `turbo run quality --env-mode=strict` — 10/10 green on `main` with the fix applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)