### PR TITLE
chore: Enforce draft pull requests

### DIFF
--- a/apps/agents/agent/lib/pull-request.ts
+++ b/apps/agents/agent/lib/pull-request.ts
@@ -1,0 +1,10 @@
+export interface PullRequestInput {
+  title: string;
+  body: string;
+  head: string;
+  base: string;
+}
+
+export function buildDraftPullRequest(input: PullRequestInput) {
+  return { ...input, draft: true as const };
+}

--- a/apps/agents/agent/tools/create_pull_request.ts
+++ b/apps/agents/agent/tools/create_pull_request.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 
 import { requireSuccessfulValidation } from "../lib/example-validation.js";
 import { getGitHubToken } from "../lib/github.js";
+import { buildDraftPullRequest } from "../lib/pull-request.js";
 import { isAppPrincipal, resolveAutomatedSelection } from "../lib/repo.js";
 
 const owner = "vercel";
@@ -298,13 +299,12 @@ export default defineTool({
       owner,
       repo,
       path: "/pulls",
-      body: {
+      body: buildDraftPullRequest({
         title: changeTitle,
         body: input.body,
         head: branchName,
-        base: baseBranch,
-        draft: true
-      }
+        base: baseBranch
+      })
     });
 
     return {

--- a/apps/agents/tests/pull-request.test.mjs
+++ b/apps/agents/tests/pull-request.test.mjs
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildDraftPullRequest } from "../agent/lib/pull-request.ts";
+
+test("builds draft pull requests", () => {
+  assert.deepEqual(
+    buildDraftPullRequest({
+      title: "chore: Update Turborepo examples",
+      body: "Maintenance update",
+      head: "agents/examples-update",
+      base: "main"
+    }),
+    {
+      title: "chore: Update Turborepo examples",
+      body: "Maintenance update",
+      head: "agents/examples-update",
+      base: "main",
+      draft: true
+    }
+  );
+});


### PR DESCRIPTION
## Summary

- keep Eve pull request creation unconditionally in Draft state through a focused request builder
- add regression coverage that asserts every generated pull request payload includes `draft: true`
- leave Eve models, harnesses, schedules, timeouts, and workflows unchanged

## Validation

- `pnpm --dir apps/agents test`
- `pnpm --dir apps/agents exec tsc --noEmit`
- pre-push formatting and TOML checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)