### PR TITLE
fix: Expose Slack delivery diagnostics

### DIFF
--- a/apps/agents/agent/channels/operator.ts
+++ b/apps/agents/agent/channels/operator.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { defineChannel, GET, POST } from "eve/channels";
 
 import { DAILY_EXAMPLE_MAINTENANCE_PROMPT } from "../lib/daily-example-maintenance.js";
+import { deliverSlackMessage } from "../lib/slack.js";
 
 const APP_AUTH = {
   attributes: {},
@@ -11,15 +12,19 @@ const APP_AUTH = {
   principalType: "runtime"
 } as const;
 
+function isOperatorRequest(request: Request, action: string): boolean {
+  // Vercel Deployment Protection authenticates operators; this validates CSRF intent.
+  return (
+    request.headers.get("origin") === new URL(request.url).origin &&
+    request.headers.get("x-operator-action") === action &&
+    request.headers.get("content-type")?.split(";", 1)[0] === "application/json"
+  );
+}
+
 export default defineChannel({
   routes: [
     POST("/eve/v1/operator/runs", async (request, { send }) => {
-      const origin = request.headers.get("origin");
-      if (
-        origin !== new URL(request.url).origin ||
-        request.headers.get("x-operator-action") !== "run-daily-maintenance" ||
-        !request.headers.get("content-type")?.startsWith("application/json")
-      ) {
+      if (!isOperatorRequest(request, "run-daily-maintenance")) {
         return Response.json(
           { ok: false, error: "Invalid operator request." },
           {
@@ -59,6 +64,26 @@ export default defineChannel({
         { cursor: 0, sessionId: session.id, state: "running" },
         { status: 202, headers: { "cache-control": "no-store" } }
       );
+    }),
+    POST("/eve/v1/operator/slack/test", async (request) => {
+      if (!isOperatorRequest(request, "test-slack-delivery")) {
+        return Response.json(
+          { ok: false, error: "Invalid operator request." },
+          {
+            status: 403,
+            headers: { "cache-control": "no-store" }
+          }
+        );
+      }
+
+      const result = await deliverSlackMessage(
+        `Turborepo Eve operator test at ${new Date().toISOString()}.`,
+        { event: "operator_slack_test" }
+      );
+      return Response.json(result, {
+        status: result.ok ? 200 : 502,
+        headers: { "cache-control": "no-store" }
+      });
     }),
     GET(
       "/eve/v1/operator/runs/:sessionId/status",

--- a/apps/agents/agent/channels/slack.ts
+++ b/apps/agents/agent/channels/slack.ts
@@ -3,5 +3,5 @@ import { slackChannel } from "eve/channels/slack";
 import { slackCredentials } from "../lib/slack.js";
 
 export default slackChannel({
-  credentials: slackCredentials()
+  credentials: slackCredentials
 });

--- a/apps/agents/agent/lib/slack.ts
+++ b/apps/agents/agent/lib/slack.ts
@@ -1,4 +1,45 @@
 import { connectSlackCredentials } from "@vercel/connect/eve";
+import {
+  callSlackApi,
+  type SlackBotToken,
+  type SlackChannelCredentials,
+  type SlackWebhookVerifier
+} from "eve/channels/slack";
+
+const defaultTimeoutMs = 5000;
+
+interface SlackApiResponse {
+  readonly channel?: unknown;
+  readonly error?: unknown;
+  readonly ok?: boolean;
+  readonly ts?: unknown;
+}
+
+interface SlackMessageInput {
+  readonly channel: string;
+  readonly text: string;
+}
+
+interface SlackDeliveryOptions {
+  readonly channel?: string;
+  readonly event: string;
+  readonly logger?: Pick<Console, "error" | "info">;
+  readonly metadata?: Readonly<Record<string, string | number | null>>;
+  readonly send?: (input: SlackMessageInput) => Promise<SlackApiResponse>;
+  readonly timeoutMs?: number;
+}
+
+export type SlackDeliveryResult =
+  | {
+      readonly ok: true;
+      readonly channel: string;
+      readonly timestamp: string | null;
+    }
+  | {
+      readonly ok: false;
+      readonly channel: string | null;
+      readonly error: string;
+    };
 
 function requiredEnvironmentVariable(name: string): string {
   const value = process.env[name]?.trim();
@@ -8,7 +49,7 @@ function requiredEnvironmentVariable(name: string): string {
   return value;
 }
 
-export function slackCredentials() {
+function resolveSlackCredentials(): SlackChannelCredentials {
   return connectSlackCredentials(
     requiredEnvironmentVariable("SLACK_CONNECT_UID"),
     {
@@ -18,5 +59,134 @@ export function slackCredentials() {
 }
 
 export function slackDestinationChannel(): string {
-  return requiredEnvironmentVariable("SLACK_CHANNEL_ID");
+  const channel = process.env.SLACK_CHANNEL_ID?.trim();
+  if (!channel) throw new Error("Slack destination is unavailable.");
+  return channel;
+}
+
+async function resolveSlackBotToken(): Promise<string> {
+  try {
+    const botToken: SlackBotToken | undefined =
+      resolveSlackCredentials().botToken;
+    if (typeof botToken === "function") return await botToken();
+    if (botToken) return botToken;
+  } catch {
+    throw new Error("Slack credentials are unavailable.");
+  }
+  throw new Error("Slack credentials are unavailable.");
+}
+
+const verifySlackWebhook: SlackWebhookVerifier = async (request, body) => {
+  try {
+    const verifier = resolveSlackCredentials().webhookVerifier;
+    return verifier ? await verifier(request, body) : null;
+  } catch {
+    console.warn("Slack webhook verification failed.");
+    return null;
+  }
+};
+
+export const slackCredentials: SlackChannelCredentials = {
+  botToken: resolveSlackBotToken,
+  webhookVerifier: verifySlackWebhook
+};
+
+async function sendSlackMessage({ channel, text }: SlackMessageInput) {
+  return callSlackApi({
+    botToken: slackCredentials.botToken,
+    operation: "chat.postMessage",
+    body: { channel, text }
+  });
+}
+
+function errorMessage(error: unknown): string {
+  if (
+    error instanceof Error &&
+    (error.message ===
+      "Slack delivery status is unknown because the request timed out." ||
+      error.message === "Slack credentials are unavailable." ||
+      error.message === "Slack destination is unavailable." ||
+      error.message === "Slack API rejected the message." ||
+      /^Slack API returned [a-z0-9_]+\.$/.test(error.message))
+  ) {
+    return error.message;
+  }
+  return "Slack delivery failed before the API accepted the message.";
+}
+
+function logDelivery(
+  logger: Pick<Console, "error" | "info">,
+  level: "error" | "info",
+  message: string,
+  details: Record<string, unknown>
+) {
+  try {
+    logger[level](message, details);
+  } catch {
+    // Delivery diagnostics must not change the delivery result.
+  }
+}
+
+export async function deliverSlackMessage(
+  text: string,
+  options: SlackDeliveryOptions
+): Promise<SlackDeliveryResult> {
+  const logger = options.logger ?? console;
+  let channel: string | null = null;
+  let timeout: NodeJS.Timeout | undefined;
+
+  try {
+    channel = options.channel ?? slackDestinationChannel();
+    const response = await Promise.race([
+      (options.send ?? sendSlackMessage)({ channel, text }),
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(
+          () =>
+            reject(
+              new Error(
+                "Slack delivery status is unknown because the request timed out."
+              )
+            ),
+          options.timeoutMs ?? defaultTimeoutMs
+        );
+      })
+    ]);
+
+    if (response.ok !== true) {
+      throw new Error(
+        typeof response.error === "string"
+          ? `Slack API returned ${response.error}.`
+          : "Slack API rejected the message."
+      );
+    }
+
+    const result: SlackDeliveryResult = {
+      ok: true,
+      channel:
+        typeof response.channel === "string" ? response.channel : channel,
+      timestamp: typeof response.ts === "string" ? response.ts : null
+    };
+    logDelivery(logger, "info", "Slack message delivered.", {
+      event: options.event,
+      channel: result.channel,
+      timestamp: result.timestamp,
+      ...options.metadata
+    });
+    return result;
+  } catch (error) {
+    const result: SlackDeliveryResult = {
+      ok: false,
+      channel,
+      error: errorMessage(error)
+    };
+    logDelivery(logger, "error", "Slack message delivery failed.", {
+      event: options.event,
+      channel: result.channel,
+      error: result.error,
+      ...options.metadata
+    });
+    return result;
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
 }

--- a/apps/agents/agent/tools/create_pull_request.ts
+++ b/apps/agents/agent/tools/create_pull_request.ts
@@ -1,5 +1,4 @@
 import type { SandboxSession } from "eve/sandbox";
-import { callSlackApi } from "eve/channels/slack";
 import { defineTool } from "eve/tools";
 import { z } from "zod";
 
@@ -7,13 +6,12 @@ import { requireSuccessfulValidation } from "../lib/example-validation.js";
 import { getGitHubToken } from "../lib/github.js";
 import { buildDraftPullRequest } from "../lib/pull-request.js";
 import { isAppPrincipal, resolveAutomatedSelection } from "../lib/repo.js";
-import { slackCredentials, slackDestinationChannel } from "../lib/slack.js";
+import { deliverSlackMessage } from "../lib/slack.js";
 
 const owner = "vercel";
 const repo = "turborepo";
 const baseBranch = "main";
 const checkout = "turborepo";
-const slackNotificationTimeoutMs = 5000;
 
 const inputSchema = z.object({
   branchName: z
@@ -86,41 +84,6 @@ function requirePullRequest(
   }
 
   return { number, url: expectedUrl };
-}
-
-async function notifyPullRequestCreated(pullRequest: ValidatedPullRequest) {
-  const attempt = Promise.resolve()
-    .then(() =>
-      callSlackApi({
-        botToken: slackCredentials().botToken,
-        operation: "chat.postMessage",
-        body: {
-          channel: slackDestinationChannel(),
-          text: `A new Turborepo pull request was created: #${pullRequest.number} ${pullRequest.url}`
-        }
-      })
-    )
-    .then((response) => response.ok)
-    .catch(() => false);
-  let timeout: NodeJS.Timeout | undefined;
-  const succeeded = await Promise.race([
-    attempt,
-    new Promise<false>((resolve) => {
-      timeout = setTimeout(resolve, slackNotificationTimeoutMs, false);
-    })
-  ]);
-  if (timeout) clearTimeout(timeout);
-
-  if (!succeeded) {
-    logSlackNotificationFailure(pullRequest.number);
-  }
-}
-
-function logSlackNotificationFailure(pullRequestNumber: number) {
-  console.warn("Slack pull request notification failed.", {
-    event: "pull_request_notification_failed",
-    pullRequestNumber
-  });
 }
 
 async function findOpenPullRequests(branchName: string) {
@@ -407,14 +370,21 @@ export default defineTool({
       newCommitSha
     );
 
-    await notifyPullRequestCreated(validatedPullRequest);
+    const slackNotification = await deliverSlackMessage(
+      `A new Turborepo pull request was created: #${validatedPullRequest.number} ${validatedPullRequest.url}`,
+      {
+        event: "pull_request_notification",
+        metadata: { pullRequestNumber: validatedPullRequest.number }
+      }
+    );
 
     return {
       created: true,
       number: validatedPullRequest.number,
       url: validatedPullRequest.url,
       branch: branchName,
-      commit: newCommitSha
+      commit: newCommitSha,
+      slackNotification
     };
   }
 });

--- a/apps/agents/app/globals.css
+++ b/apps/agents/app/globals.css
@@ -248,6 +248,12 @@ button {
   cursor: pointer;
 }
 
+button.secondaryButton {
+  border-color: #596169;
+  color: var(--text);
+  background: rgb(255 255 255 / 2%);
+}
+
 .actions a {
   border: 1px solid var(--line);
   color: var(--text);

--- a/apps/agents/app/run-maintenance.tsx
+++ b/apps/agents/app/run-maintenance.tsx
@@ -3,6 +3,19 @@
 import { useState } from "react";
 
 type RunState = "starting" | "running" | "done" | "error";
+type SlackTestState =
+  | { readonly state: "idle" }
+  | { readonly state: "sending" }
+  | {
+      readonly state: "done";
+      readonly channel: string;
+      readonly timestamp: string | null;
+    }
+  | {
+      readonly state: "error";
+      readonly channel: string | null;
+      readonly error: string;
+    };
 
 interface RunStatus {
   readonly cursor?: number;
@@ -42,15 +55,89 @@ function isRunStatus(value: unknown): value is RunStatus {
   );
 }
 
+function isSlackTestResult(value: unknown): value is
+  | {
+      readonly ok: true;
+      readonly channel: string;
+      readonly timestamp: string | null;
+    }
+  | {
+      readonly ok: false;
+      readonly channel?: string | null;
+      readonly error: string;
+    } {
+  if (typeof value !== "object" || value === null || !("ok" in value)) {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  if (candidate.ok === true) {
+    return (
+      typeof candidate.channel === "string" &&
+      (candidate.timestamp === null || typeof candidate.timestamp === "string")
+    );
+  }
+  return (
+    candidate.ok === false &&
+    (candidate.channel === undefined ||
+      candidate.channel === null ||
+      typeof candidate.channel === "string") &&
+    typeof candidate.error === "string"
+  );
+}
+
 export function RunMaintenance({
   agentRunsUrl,
   examples
 }: RunMaintenanceProps) {
   const [status, setStatus] = useState<RunStatus | null>(null);
+  const [slackTest, setSlackTest] = useState<SlackTestState>({ state: "idle" });
   const [selectedExample, setSelectedExample] = useState(() =>
     dailyExample(examples)
   );
   const isBusy = status?.state === "starting" || status?.state === "running";
+
+  async function testSlackDelivery() {
+    setSlackTest({ state: "sending" });
+    try {
+      const response = await fetch("/eve/v1/operator/slack/test", {
+        body: "{}",
+        headers: {
+          "content-type": "application/json",
+          "x-operator-action": "test-slack-delivery"
+        },
+        method: "POST"
+      });
+      const result: unknown = await response
+        .json()
+        .catch(() => ({ ok: false, error: "Slack test request failed." }));
+      if (!isSlackTestResult(result)) {
+        throw new Error("Slack returned an invalid test result.");
+      }
+      setSlackTest(
+        result.ok
+          ? {
+              state: "done",
+              channel: result.channel,
+              timestamp: result.timestamp
+            }
+          : {
+              state: "error",
+              channel: result.channel ?? null,
+              error: result.error
+            }
+      );
+    } catch (error) {
+      setSlackTest({
+        state: "error",
+        channel: null,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Could not test Slack delivery."
+      });
+    }
+  }
 
   async function startRun() {
     setStatus({ state: "starting" });
@@ -132,6 +219,16 @@ export function RunMaintenance({
               ? "Running…"
               : "Run maintenance now"}
         </button>
+        <button
+          className="secondaryButton"
+          disabled={slackTest.state === "sending"}
+          onClick={() => void testSlackDelivery()}
+          type="button"
+        >
+          {slackTest.state === "sending"
+            ? "Sending Slack test…"
+            : "Send Slack test"}
+        </button>
         <a href={agentRunsUrl} rel="noreferrer" target="_blank">
           Open Agent Runs <span aria-hidden="true">↗</span>
         </a>
@@ -147,6 +244,38 @@ export function RunMaintenance({
           <div>
             <strong>{status.state}</strong>
             {status.sessionId ? <code>{status.sessionId}</code> : null}
+          </div>
+        </div>
+      ) : null}
+      {slackTest.state !== "idle" ? (
+        <div
+          aria-live={slackTest.state === "error" ? "assertive" : "polite"}
+          className={`status status-${slackTest.state === "sending" ? "running" : slackTest.state}`}
+          role={slackTest.state === "error" ? "alert" : "status"}
+        >
+          <span className="statusDot" aria-hidden="true" />
+          <div>
+            <strong>
+              {slackTest.state === "sending"
+                ? "sending Slack test"
+                : slackTest.state === "done"
+                  ? "Slack test delivered"
+                  : "Slack test failed"}
+            </strong>
+            {slackTest.state === "done" ? (
+              <code>
+                channel {slackTest.channel}
+                {slackTest.timestamp
+                  ? ` · timestamp ${slackTest.timestamp}`
+                  : ""}
+              </code>
+            ) : null}
+            {slackTest.state === "error" ? (
+              <code>
+                {slackTest.error}
+                {slackTest.channel ? ` · channel ${slackTest.channel}` : ""}
+              </code>
+            ) : null}
           </div>
         </div>
       ) : null}

--- a/apps/agents/tests/slack.test.mjs
+++ b/apps/agents/tests/slack.test.mjs
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { deliverSlackMessage } from "../agent/lib/slack.ts";
+
+const logger = { error() {}, info() {} };
+
+test("reports successful Slack delivery details", async () => {
+  const entries = [];
+  const result = await deliverSlackMessage("test", {
+    channel: "C123",
+    event: "test",
+    logger: {
+      error() {},
+      info(...entry) {
+        entries.push(entry);
+      }
+    },
+    metadata: { pullRequestNumber: 123 },
+    send: async ({ channel, text }) => {
+      assert.deepEqual({ channel, text }, { channel: "C123", text: "test" });
+      return { ok: true, channel, ts: "123.456" };
+    }
+  });
+
+  assert.deepEqual(result, {
+    ok: true,
+    channel: "C123",
+    timestamp: "123.456"
+  });
+  assert.deepEqual(entries, [
+    [
+      "Slack message delivered.",
+      {
+        event: "test",
+        channel: "C123",
+        timestamp: "123.456",
+        pullRequestNumber: 123
+      }
+    ]
+  ]);
+});
+
+test("uses configured fallback values for incomplete success responses", async () => {
+  const result = await deliverSlackMessage("test", {
+    channel: "C123",
+    event: "test",
+    logger,
+    send: async () => ({ ok: true })
+  });
+
+  assert.deepEqual(result, {
+    ok: true,
+    channel: "C123",
+    timestamp: null
+  });
+});
+
+test("reports Slack API errors", async () => {
+  const result = await deliverSlackMessage("test", {
+    channel: "C123",
+    event: "test",
+    logger,
+    send: async () => ({ ok: false, error: "channel_not_found" })
+  });
+
+  assert.deepEqual(result, {
+    ok: false,
+    channel: "C123",
+    error: "Slack API returned channel_not_found."
+  });
+});
+
+test("reports Slack API rejection without exposing the response", async () => {
+  const result = await deliverSlackMessage("test", {
+    channel: "C123",
+    event: "test",
+    logger,
+    send: async () => ({ ok: false })
+  });
+
+  assert.deepEqual(result, {
+    ok: false,
+    channel: "C123",
+    error: "Slack API rejected the message."
+  });
+});
+
+test("reports credential and transport errors", async () => {
+  const result = await deliverSlackMessage("test", {
+    channel: "C123",
+    event: "test",
+    logger,
+    send: async () => {
+      throw new Error("Slack credentials are unavailable.");
+    }
+  });
+
+  assert.deepEqual(result, {
+    ok: false,
+    channel: "C123",
+    error: "Slack credentials are unavailable."
+  });
+});
+
+test("sanitizes unexpected Slack transport errors", async () => {
+  const result = await deliverSlackMessage("test", {
+    channel: "C123",
+    event: "test",
+    logger,
+    send: async () => {
+      throw new Error("request failed with sensitive implementation details");
+    }
+  });
+
+  assert.deepEqual(result, {
+    ok: false,
+    channel: "C123",
+    error: "Slack delivery failed before the API accepted the message."
+  });
+});
+
+test("reports Slack delivery timeouts", async () => {
+  const result = await deliverSlackMessage("test", {
+    channel: "C123",
+    event: "test",
+    logger,
+    send: () => new Promise(() => {}),
+    timeoutMs: 1
+  });
+
+  assert.deepEqual(result, {
+    ok: false,
+    channel: "C123",
+    error: "Slack delivery status is unknown because the request timed out."
+  });
+});
+
+test("ignores diagnostic logger failures", async () => {
+  const result = await deliverSlackMessage("test", {
+    channel: "C123",
+    event: "test",
+    logger: {
+      error() {
+        throw new Error("logger failed");
+      },
+      info() {
+        throw new Error("logger failed");
+      }
+    },
+    send: async () => ({ ok: true })
+  });
+
+  assert.deepEqual(result, {
+    ok: true,
+    channel: "C123",
+    timestamp: null
+  });
+});


### PR DESCRIPTION
## Summary

- centralize Slack delivery for pull request notifications with structured success and sanitized failure diagnostics
- add a protected operator endpoint and dashboard button for sending an on-demand Slack test message
- resolve Slack Connect credentials lazily so builds do not require production credentials

## Testing

- `fnm exec --using=24 pnpm --filter examples-agent test`
- `fnm exec --using=24 pnpm --filter examples-agent exec tsc --noEmit`
- `fnm exec --using=24 pnpm --filter examples-agent build`
- `git diff --check`

## Security

- the test endpoint uses a fixed server-side Slack operation, destination, and message
- Vercel Deployment Protection remains the operator authentication boundary; same-origin and action headers validate CSRF intent