### PR TITLE
fix: Tolerate transient input files

### DIFF
--- a/crates/turborepo-scm/src/crlf.rs
+++ b/crates/turborepo-scm/src/crlf.rs
@@ -432,18 +432,7 @@ fn hash_file_normalized(
 /// place a crafted collision pair in the repo can already modify the build
 /// itself. Outputs are bit-identical to git for all non-colliding inputs,
 /// enforced by differential tests against `git hash-object` below.
-#[cfg(test)]
 pub(crate) fn hash_file_maybe_normalized(
-    path: &AbsoluteSystemPath,
-    attr: TextAttr,
-) -> Result<OidHash, std::io::Error> {
-    let mut file = std::fs::File::open(path)?;
-    let metadata = file.metadata()?;
-    validate_file_type(path, &metadata)?;
-    Ok(hash_file_normalized(&mut file, metadata.len(), attr)?.0)
-}
-
-pub(crate) fn hash_regular_file_maybe_normalized(
     path: &AbsoluteSystemPath,
     attr: TextAttr,
 ) -> Result<Option<OidHash>, std::io::Error> {
@@ -742,7 +731,9 @@ mod tests {
             let expected = expected.trim();
 
             let path = root.join_component(name);
-            let actual = hash_file_maybe_normalized(&path, TextAttr::Auto).unwrap();
+            let actual = hash_file_maybe_normalized(&path, TextAttr::Auto)
+                .unwrap()
+                .unwrap();
 
             assert_eq!(
                 &*actual, expected,
@@ -825,7 +816,7 @@ mod tests {
             let expected = String::from_utf8(output.stdout).unwrap();
             let expected = expected.trim();
 
-            let fast_result = hash_file_maybe_normalized(&path, *attr).unwrap();
+            let fast_result = hash_file_maybe_normalized(&path, *attr).unwrap().unwrap();
             let manual_result = manual_hash_file_maybe_normalized(&path, *attr).unwrap();
 
             assert_eq!(
@@ -874,10 +865,14 @@ mod tests {
         std::fs::write(path.as_std_path(), &content).unwrap();
 
         // With Auto, binary should be hashed raw (no normalization)
-        let auto_result = hash_file_maybe_normalized(&path, TextAttr::Auto).unwrap();
+        let auto_result = hash_file_maybe_normalized(&path, TextAttr::Auto)
+            .unwrap()
+            .unwrap();
 
         // With Unspecified, should also be raw
-        let raw_result = hash_file_maybe_normalized(&path, TextAttr::Unspecified).unwrap();
+        let raw_result = hash_file_maybe_normalized(&path, TextAttr::Unspecified)
+            .unwrap()
+            .unwrap();
 
         // Both should produce the same hash (raw bytes)
         assert_eq!(
@@ -892,14 +887,20 @@ mod tests {
         let path = root.join_component("text.txt");
         std::fs::write(path.as_std_path(), b"a\r\nb\r\n").unwrap();
 
-        let auto_hash = hash_file_maybe_normalized(&path, TextAttr::Auto).unwrap();
-        let set_hash = hash_file_maybe_normalized(&path, TextAttr::Set).unwrap();
+        let auto_hash = hash_file_maybe_normalized(&path, TextAttr::Auto)
+            .unwrap()
+            .unwrap();
+        let set_hash = hash_file_maybe_normalized(&path, TextAttr::Set)
+            .unwrap()
+            .unwrap();
 
         // Both Auto and Set should normalize CRLF for a text file
         assert_eq!(auto_hash, set_hash);
 
         // Unspecified should hash raw (different from normalized)
-        let raw_hash = hash_file_maybe_normalized(&path, TextAttr::Unspecified).unwrap();
+        let raw_hash = hash_file_maybe_normalized(&path, TextAttr::Unspecified)
+            .unwrap()
+            .unwrap();
         assert_ne!(
             auto_hash, raw_hash,
             "normalized hash should differ from raw for CRLF content"
@@ -945,7 +946,9 @@ mod tests {
         let expected = expected.trim();
 
         let path = root.join_component(name);
-        let actual = hash_file_maybe_normalized(&path, TextAttr::Auto).unwrap();
+        let actual = hash_file_maybe_normalized(&path, TextAttr::Auto)
+            .unwrap()
+            .unwrap();
 
         assert_eq!(
             &*actual, expected,

--- a/crates/turborepo-scm/src/crlf.rs
+++ b/crates/turborepo-scm/src/crlf.rs
@@ -436,8 +436,8 @@ pub(crate) fn hash_file_as_git_blob(
     path: &AbsoluteSystemPath,
     attr: TextAttr,
 ) -> Result<Option<OidHash>, std::io::Error> {
-    // Windows cannot open directories for handle-based metadata inspection.
-    #[cfg(windows)]
+    // Avoid opening sockets, FIFOs, devices, and directories. Metadata from the
+    // opened handle below remains authoritative if the path changes afterward.
     if !std::fs::metadata(path)?.is_file() {
         return Ok(None);
     }

--- a/crates/turborepo-scm/src/crlf.rs
+++ b/crates/turborepo-scm/src/crlf.rs
@@ -432,6 +432,7 @@ fn hash_file_normalized(
 /// place a crafted collision pair in the repo can already modify the build
 /// itself. Outputs are bit-identical to git for all non-colliding inputs,
 /// enforced by differential tests against `git hash-object` below.
+#[cfg(test)]
 pub(crate) fn hash_file_maybe_normalized(
     path: &AbsoluteSystemPath,
     attr: TextAttr,
@@ -442,8 +443,28 @@ pub(crate) fn hash_file_maybe_normalized(
     Ok(hash_file_normalized(&mut file, metadata.len(), attr)?.0)
 }
 
-/// Like [`hash_file_maybe_normalized`], but also reports how the hash was
-/// produced. Used by the repo-index verification pass.
+pub(crate) fn hash_regular_file_maybe_normalized(
+    path: &AbsoluteSystemPath,
+    attr: TextAttr,
+) -> Result<Option<OidHash>, std::io::Error> {
+    // Windows cannot open directories for handle-based metadata inspection.
+    #[cfg(windows)]
+    if !std::fs::metadata(path)?.is_file() {
+        return Ok(None);
+    }
+
+    let mut file = std::fs::File::open(path)?;
+    let metadata = file.metadata()?;
+    if !metadata.is_file() {
+        return Ok(None);
+    }
+    Ok(Some(
+        hash_file_normalized(&mut file, metadata.len(), attr)?.0,
+    ))
+}
+
+/// Hash a working-tree file and report how the hash was produced. Used by the
+/// repo-index verification pass.
 pub(crate) fn hash_file_for_verification(
     path: &AbsoluteSystemPath,
     attr: TextAttr,

--- a/crates/turborepo-scm/src/crlf.rs
+++ b/crates/turborepo-scm/src/crlf.rs
@@ -286,7 +286,7 @@ fn stream_normalized(reader: &mut impl Read, mut update: impl FnMut(&[u8])) -> s
 
 /// Incrementally computes a git blob oid using the `sha1` crate, which
 /// dispatches to hardware SHA extensions at runtime (SHA-NI on x86, the
-/// crypto extensions on aarch64). Both [`hash_file_maybe_normalized`] and
+/// crypto extensions on aarch64). Both [`hash_file_as_git_blob`] and
 /// [`manual_hash_file_maybe_normalized`] delegate to
 /// [`hash_file_normalized`], which drives this hasher.
 struct BlobHasher(Sha1);
@@ -432,7 +432,7 @@ fn hash_file_normalized(
 /// place a crafted collision pair in the repo can already modify the build
 /// itself. Outputs are bit-identical to git for all non-colliding inputs,
 /// enforced by differential tests against `git hash-object` below.
-pub(crate) fn hash_file_maybe_normalized(
+pub(crate) fn hash_file_as_git_blob(
     path: &AbsoluteSystemPath,
     attr: TextAttr,
 ) -> Result<Option<OidHash>, std::io::Error> {
@@ -731,7 +731,7 @@ mod tests {
             let expected = expected.trim();
 
             let path = root.join_component(name);
-            let actual = hash_file_maybe_normalized(&path, TextAttr::Auto)
+            let actual = hash_file_as_git_blob(&path, TextAttr::Auto)
                 .unwrap()
                 .unwrap();
 
@@ -816,7 +816,7 @@ mod tests {
             let expected = String::from_utf8(output.stdout).unwrap();
             let expected = expected.trim();
 
-            let fast_result = hash_file_maybe_normalized(&path, *attr).unwrap().unwrap();
+            let fast_result = hash_file_as_git_blob(&path, *attr).unwrap().unwrap();
             let manual_result = manual_hash_file_maybe_normalized(&path, *attr).unwrap();
 
             assert_eq!(
@@ -855,7 +855,7 @@ mod tests {
         assert!(GitAttrs::load(&root).is_none());
     }
 
-    // -- hash_file_maybe_normalized edge-case tests --
+    // -- hash_file_as_git_blob edge-case tests --
 
     #[test]
     fn test_hash_binary_file_with_auto_is_raw() {
@@ -865,12 +865,12 @@ mod tests {
         std::fs::write(path.as_std_path(), &content).unwrap();
 
         // With Auto, binary should be hashed raw (no normalization)
-        let auto_result = hash_file_maybe_normalized(&path, TextAttr::Auto)
+        let auto_result = hash_file_as_git_blob(&path, TextAttr::Auto)
             .unwrap()
             .unwrap();
 
         // With Unspecified, should also be raw
-        let raw_result = hash_file_maybe_normalized(&path, TextAttr::Unspecified)
+        let raw_result = hash_file_as_git_blob(&path, TextAttr::Unspecified)
             .unwrap()
             .unwrap();
 
@@ -887,10 +887,10 @@ mod tests {
         let path = root.join_component("text.txt");
         std::fs::write(path.as_std_path(), b"a\r\nb\r\n").unwrap();
 
-        let auto_hash = hash_file_maybe_normalized(&path, TextAttr::Auto)
+        let auto_hash = hash_file_as_git_blob(&path, TextAttr::Auto)
             .unwrap()
             .unwrap();
-        let set_hash = hash_file_maybe_normalized(&path, TextAttr::Set)
+        let set_hash = hash_file_as_git_blob(&path, TextAttr::Set)
             .unwrap()
             .unwrap();
 
@@ -898,7 +898,7 @@ mod tests {
         assert_eq!(auto_hash, set_hash);
 
         // Unspecified should hash raw (different from normalized)
-        let raw_hash = hash_file_maybe_normalized(&path, TextAttr::Unspecified)
+        let raw_hash = hash_file_as_git_blob(&path, TextAttr::Unspecified)
             .unwrap()
             .unwrap();
         assert_ne!(
@@ -946,7 +946,7 @@ mod tests {
         let expected = expected.trim();
 
         let path = root.join_component(name);
-        let actual = hash_file_maybe_normalized(&path, TextAttr::Auto)
+        let actual = hash_file_as_git_blob(&path, TextAttr::Auto)
             .unwrap()
             .unwrap();
 

--- a/crates/turborepo-scm/src/hash_object.rs
+++ b/crates/turborepo-scm/src/hash_object.rs
@@ -46,6 +46,7 @@ pub(crate) fn hash_objects(
     pkg_path: &AbsoluteSystemPath,
     to_hash: Vec<RelativeUnixPathBuf>,
     hashes: &mut GitHashes,
+    allow_missing: bool,
     cached_attrs: Option<&crate::crlf::GitAttrs>,
     slowest_files: Option<&std::sync::Arc<crate::SlowestFiles>>,
 ) -> Result<(), Error> {
@@ -95,11 +96,9 @@ pub(crate) fn hash_objects(
                         Ok(Some((package_relative_path, hash)))
                     }
                     Err(e) => {
-                        // The filesystem can change between candidate discovery and
-                        // hashing. A vanished candidate is no longer part of this
-                        // snapshot and should not force the package onto the manual
-                        // fallback path.
-                        if e.kind() == std::io::ErrorKind::NotFound {
+                        // Discovery-driven candidates can disappear before hashing.
+                        // Explicitly named files remain strict.
+                        if allow_missing && e.kind() == std::io::ErrorKind::NotFound {
                             return Ok(None);
                         }
                         // Gracefully skip non-regular files (symlinks, sockets,
@@ -184,7 +183,7 @@ mod test {
             let expected_hashes = GitHashes::from_iter(file_hashes);
             let mut hashes = GitHashes::new();
             let to_hash = expected_hashes.keys().map(|k| pkg_prefix.join(k)).collect();
-            hash_objects(&git_root, pkg_path, to_hash, &mut hashes, None, None).unwrap();
+            hash_objects(&git_root, pkg_path, to_hash, &mut hashes, false, None, None).unwrap();
             assert_eq!(hashes, expected_hashes);
         }
     }
@@ -202,8 +201,29 @@ mod test {
         candidate.remove().unwrap();
 
         let mut hashes = GitHashes::new();
-        hash_objects(&git_root, &git_root, to_hash, &mut hashes, None, None).unwrap();
+        hash_objects(&git_root, &git_root, to_hash, &mut hashes, true, None, None).unwrap();
         assert!(hashes.is_empty());
+    }
+
+    #[test]
+    fn test_missing_explicit_file_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let git_root = AbsoluteSystemPathBuf::try_from(tmp.path()).unwrap();
+        let missing = RelativeUnixPathBuf::new("missing.json").unwrap();
+
+        let mut hashes = GitHashes::new();
+        let error = hash_objects(
+            &git_root,
+            &git_root,
+            vec![missing],
+            &mut hashes,
+            false,
+            None,
+            None,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("missing.json"));
     }
 
     /// Verify that our blob hashing produces OIDs identical to `git
@@ -272,7 +292,16 @@ mod test {
             .map(|(name, _)| RelativeUnixPathBuf::new(*name).unwrap())
             .collect();
         let mut actual = GitHashes::new();
-        hash_objects(&tmp_path, &tmp_path, to_hash, &mut actual, None, None).unwrap();
+        hash_objects(
+            &tmp_path,
+            &tmp_path,
+            to_hash,
+            &mut actual,
+            false,
+            None,
+            None,
+        )
+        .unwrap();
 
         assert_eq!(actual, expected, "blob hashes must match git hash-object");
     }

--- a/crates/turborepo-scm/src/hash_object.rs
+++ b/crates/turborepo-scm/src/hash_object.rs
@@ -256,6 +256,32 @@ mod test {
         assert!(error.to_string().contains("missing.json"));
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn test_non_regular_symlink_is_skipped() {
+        use std::os::unix::net::UnixListener;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let git_root = AbsoluteSystemPathBuf::try_from(tmp.path()).unwrap();
+        let socket = git_root.join_component("server.sock");
+        let _listener = UnixListener::bind(socket.as_std_path()).unwrap();
+        let link = git_root.join_component("socket-link");
+        link.symlink_to_file(socket.to_string()).unwrap();
+
+        let mut hashes = GitHashes::new();
+        hash_objects(
+            &git_root,
+            &git_root,
+            vec![RelativeUnixPathBuf::new("socket-link").unwrap()],
+            &mut hashes,
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert!(hashes.is_empty());
+    }
+
     /// Verify that our blob hashing produces OIDs identical to `git
     /// hash-object`. This is critical because changing the hash algorithm
     /// would silently invalidate every turbo cache entry.

--- a/crates/turborepo-scm/src/hash_object.rs
+++ b/crates/turborepo-scm/src/hash_object.rs
@@ -117,7 +117,7 @@ fn hash_objects_inner(
 
                 let _guard = slowest_files.map(|sf| sf.start(filename.clone()));
                 let hash_result = with_emfile_retry(|| {
-                    crate::crlf::hash_regular_file_maybe_normalized(&full_file_path, text_attr)
+                    crate::crlf::hash_file_maybe_normalized(&full_file_path, text_attr)
                 });
                 drop(_guard);
 

--- a/crates/turborepo-scm/src/hash_object.rs
+++ b/crates/turborepo-scm/src/hash_object.rs
@@ -8,6 +8,12 @@ const MAX_RETRIES: u32 = 10;
 const BASE_DELAY_MS: u64 = 10;
 const MAX_DELAY_MS: u64 = 1000;
 
+#[derive(Clone, Copy)]
+enum MissingFiles {
+    Error,
+    Ignore,
+}
+
 pub(crate) fn with_emfile_retry<T>(
     f: impl Fn() -> Result<T, std::io::Error>,
 ) -> Result<T, std::io::Error> {
@@ -46,7 +52,45 @@ pub(crate) fn hash_objects(
     pkg_path: &AbsoluteSystemPath,
     to_hash: Vec<RelativeUnixPathBuf>,
     hashes: &mut GitHashes,
-    allow_missing: bool,
+    cached_attrs: Option<&crate::crlf::GitAttrs>,
+    slowest_files: Option<&std::sync::Arc<crate::SlowestFiles>>,
+) -> Result<(), Error> {
+    hash_objects_inner(
+        git_root,
+        pkg_path,
+        to_hash,
+        hashes,
+        MissingFiles::Error,
+        cached_attrs,
+        slowest_files,
+    )
+}
+
+pub(crate) fn hash_discovered_objects(
+    git_root: &AbsoluteSystemPath,
+    pkg_path: &AbsoluteSystemPath,
+    to_hash: Vec<RelativeUnixPathBuf>,
+    hashes: &mut GitHashes,
+    cached_attrs: Option<&crate::crlf::GitAttrs>,
+    slowest_files: Option<&std::sync::Arc<crate::SlowestFiles>>,
+) -> Result<(), Error> {
+    hash_objects_inner(
+        git_root,
+        pkg_path,
+        to_hash,
+        hashes,
+        MissingFiles::Ignore,
+        cached_attrs,
+        slowest_files,
+    )
+}
+
+fn hash_objects_inner(
+    git_root: &AbsoluteSystemPath,
+    pkg_path: &AbsoluteSystemPath,
+    to_hash: Vec<RelativeUnixPathBuf>,
+    hashes: &mut GitHashes,
+    missing_files: MissingFiles,
     cached_attrs: Option<&crate::crlf::GitAttrs>,
     slowest_files: Option<&std::sync::Arc<crate::SlowestFiles>>,
 ) -> Result<(), Error> {
@@ -73,12 +117,12 @@ pub(crate) fn hash_objects(
 
                 let _guard = slowest_files.map(|sf| sf.start(filename.clone()));
                 let hash_result = with_emfile_retry(|| {
-                    crate::crlf::hash_file_maybe_normalized(&full_file_path, text_attr)
+                    crate::crlf::hash_regular_file_maybe_normalized(&full_file_path, text_attr)
                 });
                 drop(_guard);
 
                 match hash_result {
-                    Ok(hash) => {
+                    Ok(Some(hash)) => {
                         let package_relative_path = pkg_prefix
                             .as_ref()
                             .and_then(|prefix| {
@@ -95,24 +139,14 @@ pub(crate) fn hash_objects(
                             });
                         Ok(Some((package_relative_path, hash)))
                     }
-                    Err(e) => {
-                        // Discovery-driven candidates can disappear before hashing.
-                        // Explicitly named files remain strict.
-                        if allow_missing && e.kind() == std::io::ErrorKind::NotFound {
-                            return Ok(None);
-                        }
-                        // Gracefully skip non-regular files (symlinks, sockets,
-                        // FIFOs, device nodes) that can't be read as normal files.
-                        if full_file_path
-                            .symlink_metadata()
-                            .map(|md| !md.is_file())
-                            .unwrap_or(false)
-                        {
-                            Ok(None)
-                        } else {
-                            Err(Error::git_error(format!("{}: {}", full_file_path, e)))
-                        }
+                    Ok(None) => Ok(None),
+                    Err(error)
+                        if matches!(missing_files, MissingFiles::Ignore)
+                            && error.kind() == std::io::ErrorKind::NotFound =>
+                    {
+                        Ok(None)
                     }
+                    Err(error) => Err(Error::hash_file(full_file_path, error)),
                 }
             },
         )
@@ -130,7 +164,7 @@ pub(crate) fn hash_objects(
 mod test {
     use turbopath::{AbsoluteSystemPathBuf, RelativeUnixPathBuf, RelativeUnixPathBufTestExt};
 
-    use super::hash_objects;
+    use super::{hash_discovered_objects, hash_objects};
     use crate::{GitHashes, OidHash, find_git_root};
 
     #[test]
@@ -183,7 +217,7 @@ mod test {
             let expected_hashes = GitHashes::from_iter(file_hashes);
             let mut hashes = GitHashes::new();
             let to_hash = expected_hashes.keys().map(|k| pkg_prefix.join(k)).collect();
-            hash_objects(&git_root, pkg_path, to_hash, &mut hashes, false, None, None).unwrap();
+            hash_objects(&git_root, pkg_path, to_hash, &mut hashes, None, None).unwrap();
             assert_eq!(hashes, expected_hashes);
         }
     }
@@ -201,7 +235,7 @@ mod test {
         candidate.remove().unwrap();
 
         let mut hashes = GitHashes::new();
-        hash_objects(&git_root, &git_root, to_hash, &mut hashes, true, None, None).unwrap();
+        hash_discovered_objects(&git_root, &git_root, to_hash, &mut hashes, None, None).unwrap();
         assert!(hashes.is_empty());
     }
 
@@ -212,16 +246,8 @@ mod test {
         let missing = RelativeUnixPathBuf::new("missing.json").unwrap();
 
         let mut hashes = GitHashes::new();
-        let error = hash_objects(
-            &git_root,
-            &git_root,
-            vec![missing],
-            &mut hashes,
-            false,
-            None,
-            None,
-        )
-        .unwrap_err();
+        let error =
+            hash_objects(&git_root, &git_root, vec![missing], &mut hashes, None, None).unwrap_err();
 
         assert!(error.to_string().contains("missing.json"));
     }
@@ -292,16 +318,7 @@ mod test {
             .map(|(name, _)| RelativeUnixPathBuf::new(*name).unwrap())
             .collect();
         let mut actual = GitHashes::new();
-        hash_objects(
-            &tmp_path,
-            &tmp_path,
-            to_hash,
-            &mut actual,
-            false,
-            None,
-            None,
-        )
-        .unwrap();
+        hash_objects(&tmp_path, &tmp_path, to_hash, &mut actual, None, None).unwrap();
 
         assert_eq!(actual, expected, "blob hashes must match git hash-object");
     }

--- a/crates/turborepo-scm/src/hash_object.rs
+++ b/crates/turborepo-scm/src/hash_object.rs
@@ -95,6 +95,13 @@ pub(crate) fn hash_objects(
                         Ok(Some((package_relative_path, hash)))
                     }
                     Err(e) => {
+                        // The filesystem can change between candidate discovery and
+                        // hashing. A vanished candidate is no longer part of this
+                        // snapshot and should not force the package onto the manual
+                        // fallback path.
+                        if e.kind() == std::io::ErrorKind::NotFound {
+                            return Ok(None);
+                        }
                         // Gracefully skip non-regular files (symlinks, sockets,
                         // FIFOs, device nodes) that can't be read as normal files.
                         if full_file_path
@@ -180,26 +187,23 @@ mod test {
             hash_objects(&git_root, pkg_path, to_hash, &mut hashes, None, None).unwrap();
             assert_eq!(hashes, expected_hashes);
         }
+    }
 
-        // paths for files here are relative to the package path.
-        let error_tests: Vec<(Vec<&str>, &AbsoluteSystemPathBuf)> = vec![
-            // skipping test for outside of git repo, we now error earlier in the process
-            (vec!["nonexistent.json"], &fixture_path),
-        ];
+    #[test]
+    fn test_vanished_candidate_is_skipped() {
+        let tmp = tempfile::tempdir().unwrap();
+        let git_root = AbsoluteSystemPathBuf::try_from(tmp.path()).unwrap();
+        let candidate = git_root.join_component("transient.lock");
+        candidate.create_with_contents("lock").unwrap();
 
-        for (to_hash, pkg_path) in error_tests {
-            let git_to_pkg_path = git_root.anchor(pkg_path).unwrap();
-            let pkg_prefix = git_to_pkg_path.to_unix();
+        // Model a glob walk finding a transient file that disappears before
+        // the parallel blob-hashing phase starts.
+        let to_hash = vec![RelativeUnixPathBuf::new("transient.lock").unwrap()];
+        candidate.remove().unwrap();
 
-            let to_hash = to_hash
-                .into_iter()
-                .map(|k| pkg_prefix.join(&RelativeUnixPathBuf::new(k).unwrap()))
-                .collect();
-
-            let mut hashes = GitHashes::new();
-            let result = hash_objects(&git_root, pkg_path, to_hash, &mut hashes, None, None);
-            assert!(result.is_err());
-        }
+        let mut hashes = GitHashes::new();
+        hash_objects(&git_root, &git_root, to_hash, &mut hashes, None, None).unwrap();
+        assert!(hashes.is_empty());
     }
 
     /// Verify that our blob hashing produces OIDs identical to `git

--- a/crates/turborepo-scm/src/hash_object.rs
+++ b/crates/turborepo-scm/src/hash_object.rs
@@ -1,5 +1,5 @@
 use rayon::prelude::*;
-use tracing::debug;
+use tracing::{debug, info};
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf, RelativeUnixPath, RelativeUnixPathBuf};
 
 use crate::{Error, GitHashes, OidHash};
@@ -139,11 +139,15 @@ fn hash_objects_inner(
                             });
                         Ok(Some((package_relative_path, hash)))
                     }
-                    Ok(None) => Ok(None),
+                    Ok(None) => {
+                        info!(path = %full_file_path, "skipping non-regular hash candidate");
+                        Ok(None)
+                    }
                     Err(error)
                         if matches!(missing_files, MissingFiles::Ignore)
                             && error.kind() == std::io::ErrorKind::NotFound =>
                     {
+                        info!(path = %full_file_path, "discovered hash candidate disappeared");
                         Ok(None)
                     }
                     Err(error) => Err(Error::hash_file(full_file_path, error)),

--- a/crates/turborepo-scm/src/hash_object.rs
+++ b/crates/turborepo-scm/src/hash_object.rs
@@ -117,7 +117,7 @@ fn hash_objects_inner(
 
                 let _guard = slowest_files.map(|sf| sf.start(filename.clone()));
                 let hash_result = with_emfile_retry(|| {
-                    crate::crlf::hash_file_maybe_normalized(&full_file_path, text_attr)
+                    crate::crlf::hash_file_as_git_blob(&full_file_path, text_attr)
                 });
                 drop(_guard);
 

--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -55,6 +55,14 @@ pub enum Error {
     GitVersion(String),
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error, #[backtrace] backtrace::Backtrace),
+    #[error("I/O error while hashing {path}: {source}")]
+    HashFile {
+        path: AbsoluteSystemPathBuf,
+        #[source]
+        source: std::io::Error,
+        #[backtrace]
+        backtrace: backtrace::Backtrace,
+    },
     #[error("Path error: {0}")]
     Path(#[from] PathError, #[backtrace] backtrace::Backtrace),
     #[error("Could not find git binary")]
@@ -128,6 +136,7 @@ impl Error {
     pub fn is_resource_exhaustion(&self) -> bool {
         match self {
             Error::Io(e, _) => is_os_resource_error(e),
+            Error::HashFile { source, .. } => is_os_resource_error(source),
             Error::Walk(e) => walk_error_is_resource_exhaustion(e),
             _ => false,
         }

--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -131,6 +131,14 @@ impl Error {
         Error::Git(s.into(), Backtrace::capture())
     }
 
+    pub(crate) fn hash_file(path: AbsoluteSystemPathBuf, source: std::io::Error) -> Self {
+        Error::HashFile {
+            path,
+            source,
+            backtrace: Backtrace::capture(),
+        }
+    }
+
     /// Returns true if this error indicates OS resource exhaustion (e.g. too
     /// many open files) where a fallback to manual hashing would also fail.
     pub fn is_resource_exhaustion(&self) -> bool {

--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -132,6 +132,7 @@ impl Error {
     }
 
     pub(crate) fn hash_file(path: AbsoluteSystemPathBuf, source: std::io::Error) -> Self {
+        tracing::info!(%path, error = %source, "file hashing failed");
         Error::HashFile {
             path,
             source,

--- a/crates/turborepo-scm/src/manual.rs
+++ b/crates/turborepo-scm/src/manual.rs
@@ -141,6 +141,7 @@ pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
     let mut hashes = GitHashes::new();
 
     let effective_attrs_root = attrs_root.unwrap_or(turbo_root);
+    let git_metadata_path = attrs_root.map(|root| root.join_component(".git"));
     let mut owned_attrs = None;
     let attrs = crate::crlf::resolve_or_load(cached_attrs, effective_attrs_root, &mut owned_attrs);
     let mut default_file_hashes = GitHashes::new();
@@ -153,6 +154,11 @@ pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
     let mut local_inputs: Vec<&str> = Vec::new();
     let mut external_inclusions = Vec::new();
     let mut external_exclusions = Vec::new();
+    if let Some(git_metadata_path) = git_metadata_path.as_ref() {
+        let relative =
+            AnchoredSystemPathBuf::relative_path_between(turbo_root, git_metadata_path).to_unix();
+        external_exclusions.push(ValidatedGlob::from_str(relative.as_str())?);
+    }
     for pattern in inputs {
         let pattern = pattern.as_ref();
         let is_exclusion = pattern.starts_with('!');
@@ -243,6 +249,11 @@ pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
         .git_ignore(local_inputs.is_empty() && external_inclusions.is_empty())
         .require_git(false)
         .hidden(false) // this results in yielding hidden files (e.g. .gitignore)
+        .filter_entry(move |entry| {
+            git_metadata_path
+                .as_ref()
+                .is_none_or(|git_metadata_path| entry.path() != git_metadata_path.as_std_path())
+        })
         .build();
 
     for dirent in walker {

--- a/crates/turborepo-scm/src/manual.rs
+++ b/crates/turborepo-scm/src/manual.rs
@@ -104,7 +104,7 @@ fn hash_discovered_file(
     let text_attr = attrs
         .map(|attrs| attrs.resolve_text_attr(attr_path))
         .unwrap_or(crate::crlf::TextAttr::Unspecified);
-    match crate::crlf::hash_regular_file_maybe_normalized(path, text_attr) {
+    match crate::crlf::hash_file_maybe_normalized(path, text_attr) {
         Ok(Some(hash)) => Ok(Some(hash)),
         Ok(None) => {
             info!(%path, "skipping non-regular hash candidate");

--- a/crates/turborepo-scm/src/manual.rs
+++ b/crates/turborepo-scm/src/manual.rs
@@ -1,4 +1,4 @@
-use std::{backtrace::Backtrace, borrow::Cow, collections::HashSet, io::ErrorKind, str::FromStr};
+use std::{borrow::Cow, collections::HashSet, io::ErrorKind, str::FromStr};
 
 use globwalk::{ValidatedGlob, fix_glob_pattern, is_glob_pattern};
 use ignore::WalkBuilder;
@@ -68,11 +68,7 @@ pub(crate) fn hash_files(
                 continue;
             }
             Err(Error::Io(io_error, _)) => {
-                return Err(Error::HashFile {
-                    path,
-                    source: io_error,
-                    backtrace: Backtrace::capture(),
-                });
+                return Err(Error::hash_file(path, io_error));
             }
             Err(e) => return Err(e),
         };
@@ -99,32 +95,35 @@ fn hash_file_with_attrs(
     crate::crlf::manual_hash_file_maybe_normalized(path, text_attr)
 }
 
-fn hash_glob_candidate(
+fn hash_discovered_file(
     path: &AbsoluteSystemPath,
     attr_path: &str,
     attrs: Option<&crate::crlf::GitAttrs>,
 ) -> Result<Option<OidHash>, Error> {
-    match hash_file_with_attrs(path, attr_path, attrs) {
-        Ok(hash) => Ok(Some(hash)),
-        Err(Error::Io(io_error, _)) if io_error.kind() == ErrorKind::NotFound => Ok(None),
-        Err(Error::Io(io_error, _)) => {
-            // Match hash_objects: file symlinks can be read and hashed, while
-            // directory symlinks and other non-regular entries are skipped.
-            if path
-                .symlink_metadata()
-                .map(|metadata| !metadata.is_file())
-                .unwrap_or(false)
-            {
-                Ok(None)
-            } else {
-                Err(Error::HashFile {
-                    path: path.to_owned(),
-                    source: io_error,
-                    backtrace: Backtrace::capture(),
-                })
-            }
+    let text_attr = attrs
+        .map(|attrs| attrs.resolve_text_attr(attr_path))
+        .unwrap_or(crate::crlf::TextAttr::Unspecified);
+    match crate::crlf::hash_regular_file_maybe_normalized(path, text_attr) {
+        Ok(hash) => Ok(hash),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(Error::hash_file(path.to_owned(), error)),
+    }
+}
+
+fn git_metadata_path(
+    turbo_root: &AbsoluteSystemPath,
+    git_root: Option<&AbsoluteSystemPath>,
+) -> turbopath::AbsoluteSystemPathBuf {
+    let mut current = git_root.unwrap_or(turbo_root).to_owned();
+    loop {
+        let dot_git = current.join_component(".git");
+        if dot_git.symlink_metadata().is_ok() {
+            return dot_git;
         }
-        Err(error) => Err(error),
+        let Some(parent) = current.parent() else {
+            return turbo_root.join_component(".git");
+        };
+        current = parent.to_owned();
     }
 }
 
@@ -133,15 +132,15 @@ pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
     package_path: &AnchoredSystemPath,
     inputs: &[S],
     include_default_files: bool,
-    attrs_root: Option<&AbsoluteSystemPath>,
+    git_root: Option<&AbsoluteSystemPath>,
     cached_attrs: Option<&crate::crlf::GitAttrs>,
 ) -> Result<GitHashes, Error> {
     let full_package_path = turbo_root.resolve(package_path);
     let package_unix_path = package_path.to_unix();
     let mut hashes = GitHashes::new();
 
-    let effective_attrs_root = attrs_root.unwrap_or(turbo_root);
-    let git_metadata_path = attrs_root.map(|root| root.join_component(".git"));
+    let effective_attrs_root = git_root.unwrap_or(turbo_root);
+    let git_metadata_path = git_metadata_path(turbo_root, git_root);
     let mut owned_attrs = None;
     let attrs = crate::crlf::resolve_or_load(cached_attrs, effective_attrs_root, &mut owned_attrs);
     let mut default_file_hashes = GitHashes::new();
@@ -154,11 +153,9 @@ pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
     let mut local_inputs: Vec<&str> = Vec::new();
     let mut external_inclusions = Vec::new();
     let mut external_exclusions = Vec::new();
-    if let Some(git_metadata_path) = git_metadata_path.as_ref() {
-        let relative =
-            AnchoredSystemPathBuf::relative_path_between(turbo_root, git_metadata_path).to_unix();
-        external_exclusions.push(ValidatedGlob::from_str(relative.as_str())?);
-    }
+    let relative =
+        AnchoredSystemPathBuf::relative_path_between(turbo_root, &git_metadata_path).to_unix();
+    external_exclusions.push(ValidatedGlob::from_str(relative.as_str())?);
     for pattern in inputs {
         let pattern = pattern.as_ref();
         let is_exclusion = pattern.starts_with('!');
@@ -193,7 +190,7 @@ pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
                     .to_unix();
             // Use attrs-root-relative path for .gitattributes pattern matching.
             let attr_path = effective_attrs_root.anchor(file_path)?.to_unix();
-            if let Some(hash) = hash_glob_candidate(file_path, attr_path.as_str(), attrs)? {
+            if let Some(hash) = hash_discovered_file(file_path, attr_path.as_str(), attrs)? {
                 hashes.insert(relative_path, hash);
             }
         }
@@ -249,11 +246,7 @@ pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
         .git_ignore(local_inputs.is_empty() && external_inclusions.is_empty())
         .require_git(false)
         .hidden(false) // this results in yielding hidden files (e.g. .gitignore)
-        .filter_entry(move |entry| {
-            git_metadata_path
-                .as_ref()
-                .is_none_or(|git_metadata_path| entry.path() != git_metadata_path.as_std_path())
-        })
+        .filter_entry(move |entry| entry.path() != git_metadata_path.as_std_path())
         .build();
 
     for dirent in walker {
@@ -295,7 +288,7 @@ pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
         }
 
         let attr_path = effective_attrs_root.anchor(path)?.to_unix();
-        if let Some(hash) = hash_glob_candidate(path, attr_path.as_str(), attrs)? {
+        if let Some(hash) = hash_discovered_file(path, attr_path.as_str(), attrs)? {
             hashes.insert(relative_path, hash);
         }
     }
@@ -349,7 +342,7 @@ pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
             }
 
             let attr_path = effective_attrs_root.anchor(path)?.to_unix();
-            if let Some(hash) = hash_glob_candidate(path, attr_path.as_str(), attrs)? {
+            if let Some(hash) = hash_discovered_file(path, attr_path.as_str(), attrs)? {
                 default_file_hashes.insert(relative_path, hash);
             }
         }
@@ -541,9 +534,6 @@ mod tests {
             .symlink_to_dir(store_dir.to_string())
             .unwrap();
 
-        // This is the manual-fallback shape of `$TURBO_ROOT$/**/*` for a
-        // package two levels below the repository root. globwalk yields the
-        // pnpm-style directory symlink as a file candidate.
         let hashes = get_package_file_hashes_without_git(
             &turbo_root,
             &pkg_path,
@@ -556,6 +546,37 @@ mod tests {
 
         assert!(!hashes.contains_key(&RelativeUnixPathBuf::new("../../node_modules/dep").unwrap()));
         assert!(hashes.contains_key(&RelativeUnixPathBuf::new("package.json").unwrap()));
+    }
+
+    #[test]
+    fn test_parent_input_excludes_ancestor_git_metadata() {
+        let (_tmp, repo_root) = tmp_dir();
+        let git_dir = repo_root.join_component(".git");
+        git_dir.create_dir_all().unwrap();
+        git_dir
+            .join_component("index.lock")
+            .create_with_contents("lock")
+            .unwrap();
+        let turbo_root = repo_root.join_component("workspace");
+        let pkg_path = AnchoredSystemPathBuf::from_raw("app").unwrap();
+        let pkg_dir = turbo_root.resolve(&pkg_path);
+        pkg_dir.create_dir_all().unwrap();
+        pkg_dir
+            .join_component("package.json")
+            .create_with_contents("{}")
+            .unwrap();
+
+        let hashes = get_package_file_hashes_without_git(
+            &turbo_root,
+            &pkg_path,
+            &["../../**/*"],
+            false,
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert!(hashes.keys().all(|path| !path.as_str().contains(".git")));
     }
 
     #[test]

--- a/crates/turborepo-scm/src/manual.rs
+++ b/crates/turborepo-scm/src/manual.rs
@@ -104,7 +104,7 @@ fn hash_discovered_file(
     let text_attr = attrs
         .map(|attrs| attrs.resolve_text_attr(attr_path))
         .unwrap_or(crate::crlf::TextAttr::Unspecified);
-    match crate::crlf::hash_file_maybe_normalized(path, text_attr) {
+    match crate::crlf::hash_file_as_git_blob(path, text_attr) {
         Ok(Some(hash)) => Ok(Some(hash)),
         Ok(None) => {
             info!(%path, "skipping non-regular hash candidate");

--- a/crates/turborepo-scm/src/manual.rs
+++ b/crates/turborepo-scm/src/manual.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashSet, io::ErrorKind, str::FromStr};
+use std::{backtrace::Backtrace, borrow::Cow, collections::HashSet, io::ErrorKind, str::FromStr};
 
 use globwalk::{ValidatedGlob, fix_glob_pattern, is_glob_pattern};
 use ignore::WalkBuilder;
@@ -67,6 +67,13 @@ pub(crate) fn hash_files(
             {
                 continue;
             }
+            Err(Error::Io(io_error, _)) => {
+                return Err(Error::HashFile {
+                    path,
+                    source: io_error,
+                    backtrace: Backtrace::capture(),
+                });
+            }
             Err(e) => return Err(e),
         };
     }
@@ -90,6 +97,35 @@ fn hash_file_with_attrs(
         .unwrap_or(crate::crlf::TextAttr::Unspecified);
 
     crate::crlf::manual_hash_file_maybe_normalized(path, text_attr)
+}
+
+fn hash_glob_candidate(
+    path: &AbsoluteSystemPath,
+    attr_path: &str,
+    attrs: Option<&crate::crlf::GitAttrs>,
+) -> Result<Option<OidHash>, Error> {
+    match hash_file_with_attrs(path, attr_path, attrs) {
+        Ok(hash) => Ok(Some(hash)),
+        Err(Error::Io(io_error, _)) if io_error.kind() == ErrorKind::NotFound => Ok(None),
+        Err(Error::Io(io_error, _)) => {
+            // Match hash_objects: file symlinks can be read and hashed, while
+            // directory symlinks and other non-regular entries are skipped.
+            if path
+                .symlink_metadata()
+                .map(|metadata| !metadata.is_file())
+                .unwrap_or(false)
+            {
+                Ok(None)
+            } else {
+                Err(Error::HashFile {
+                    path: path.to_owned(),
+                    source: io_error,
+                    backtrace: Backtrace::capture(),
+                })
+            }
+        }
+        Err(error) => Err(error),
+    }
 }
 
 pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
@@ -151,8 +187,9 @@ pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
                     .to_unix();
             // Use attrs-root-relative path for .gitattributes pattern matching.
             let attr_path = effective_attrs_root.anchor(file_path)?.to_unix();
-            let hash = hash_file_with_attrs(file_path, attr_path.as_str(), attrs)?;
-            hashes.insert(relative_path, hash);
+            if let Some(hash) = hash_glob_candidate(file_path, attr_path.as_str(), attrs)? {
+                hashes.insert(relative_path, hash);
+            }
         }
     }
 
@@ -210,7 +247,17 @@ pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
 
     for dirent in walker {
         let dirent = dirent?;
-        let metadata = dirent.metadata()?;
+        let metadata = match dirent.metadata() {
+            Ok(metadata) => metadata,
+            Err(error)
+                if error
+                    .io_error()
+                    .is_some_and(|error| error.kind() == ErrorKind::NotFound) =>
+            {
+                continue;
+            }
+            Err(error) => return Err(error.into()),
+        };
         // Skip anything that isn't a regular file (directories, symlinks,
         // sockets, FIFOs, device nodes). This must be here rather than as a
         // walker filter because the root directory is always yielded.
@@ -237,8 +284,9 @@ pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
         }
 
         let attr_path = effective_attrs_root.anchor(path)?.to_unix();
-        let hash = hash_file_with_attrs(path, attr_path.as_str(), attrs)?;
-        hashes.insert(relative_path, hash);
+        if let Some(hash) = hash_glob_candidate(path, attr_path.as_str(), attrs)? {
+            hashes.insert(relative_path, hash);
+        }
     }
 
     // If we're including default files, we need to walk again, but this time with
@@ -253,7 +301,17 @@ pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
 
         for dirent in walker {
             let dirent = dirent?;
-            let metadata = dirent.metadata()?;
+            let metadata = match dirent.metadata() {
+                Ok(metadata) => metadata,
+                Err(error)
+                    if error
+                        .io_error()
+                        .is_some_and(|error| error.kind() == ErrorKind::NotFound) =>
+                {
+                    continue;
+                }
+                Err(error) => return Err(error.into()),
+            };
             // Skip anything that isn't a regular file. Must be here rather
             // than as a walker filter because the root directory is always
             // yielded.
@@ -280,8 +338,9 @@ pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
             }
 
             let attr_path = effective_attrs_root.anchor(path)?.to_unix();
-            let hash = hash_file_with_attrs(path, attr_path.as_str(), attrs)?;
-            default_file_hashes.insert(relative_path, hash);
+            if let Some(hash) = hash_glob_candidate(path, attr_path.as_str(), attrs)? {
+                default_file_hashes.insert(relative_path, hash);
+            }
         }
     }
 
@@ -391,7 +450,10 @@ mod tests {
                 None,
             );
             match out.err().unwrap() {
-                Error::Io(io_error, _) => assert_eq!(io_error.kind(), ErrorKind::IsADirectory),
+                Error::HashFile { path, source, .. } => {
+                    assert_eq!(path, from_to_dir);
+                    assert_eq!(source.kind(), ErrorKind::IsADirectory);
+                }
                 _ => panic!("wrong error"),
             };
         }
@@ -408,7 +470,11 @@ mod tests {
         let expected_err_kind = ErrorKind::PermissionDenied;
         #[cfg(not(windows))]
         let expected_err_kind = ErrorKind::IsADirectory;
-        assert_matches!(out.unwrap_err(), Error::Io(io_error, _) if io_error.kind() == expected_err_kind);
+        assert_matches!(
+            out.unwrap_err(),
+            Error::HashFile { path, source, .. }
+                if path == from_to_dir && source.kind() == expected_err_kind
+        );
 
         // Broken symlink with allow_missing = true.
         let out = hash_files(
@@ -431,9 +497,54 @@ mod tests {
             None,
         );
         match out.err().unwrap() {
-            Error::Io(io_error, _) => assert_eq!(io_error.kind(), ErrorKind::NotFound),
+            Error::HashFile { path, source, .. } => {
+                assert_eq!(path, broken);
+                assert_eq!(source.kind(), ErrorKind::NotFound);
+            }
             _ => panic!("wrong error"),
         };
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_external_recursive_input_skips_directory_symlink() {
+        let (_tmp, turbo_root) = tmp_dir();
+        let pkg_path = AnchoredSystemPathBuf::from_raw("packages/app").unwrap();
+        let pkg_dir = turbo_root.resolve(&pkg_path);
+        pkg_dir.create_dir_all().unwrap();
+        pkg_dir
+            .join_component("package.json")
+            .create_with_contents("{}")
+            .unwrap();
+
+        let store_dir = turbo_root.join_components(&[".pnpm", "dep"]);
+        store_dir.create_dir_all().unwrap();
+        store_dir
+            .join_component("index.js")
+            .create_with_contents("module.exports = 1")
+            .unwrap();
+        let node_modules = turbo_root.join_component("node_modules");
+        node_modules.create_dir_all().unwrap();
+        node_modules
+            .join_component("dep")
+            .symlink_to_dir(store_dir.to_string())
+            .unwrap();
+
+        // This is the manual-fallback shape of `$TURBO_ROOT$/**/*` for a
+        // package two levels below the repository root. globwalk yields the
+        // pnpm-style directory symlink as a file candidate.
+        let hashes = get_package_file_hashes_without_git(
+            &turbo_root,
+            &pkg_path,
+            &["../../**/*"],
+            false,
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert!(!hashes.contains_key(&RelativeUnixPathBuf::new("../../node_modules/dep").unwrap()));
+        assert!(hashes.contains_key(&RelativeUnixPathBuf::new("package.json").unwrap()));
     }
 
     #[test]

--- a/crates/turborepo-scm/src/manual.rs
+++ b/crates/turborepo-scm/src/manual.rs
@@ -2,6 +2,7 @@ use std::{borrow::Cow, collections::HashSet, io::ErrorKind, str::FromStr};
 
 use globwalk::{ValidatedGlob, fix_glob_pattern, is_glob_pattern};
 use ignore::WalkBuilder;
+use tracing::info;
 use turbopath::{
     AbsoluteSystemPath, AnchoredSystemPath, AnchoredSystemPathBuf, IntoUnix, RelativeUnixPath,
 };
@@ -104,27 +105,38 @@ fn hash_discovered_file(
         .map(|attrs| attrs.resolve_text_attr(attr_path))
         .unwrap_or(crate::crlf::TextAttr::Unspecified);
     match crate::crlf::hash_regular_file_maybe_normalized(path, text_attr) {
-        Ok(hash) => Ok(hash),
-        Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+        Ok(Some(hash)) => Ok(Some(hash)),
+        Ok(None) => {
+            info!(%path, "skipping non-regular hash candidate");
+            Ok(None)
+        }
+        Err(error) if error.kind() == ErrorKind::NotFound => {
+            info!(%path, "discovered hash candidate disappeared");
+            Ok(None)
+        }
         Err(error) => Err(Error::hash_file(path.to_owned(), error)),
     }
 }
 
-fn git_metadata_path(
-    turbo_root: &AbsoluteSystemPath,
-    git_root: Option<&AbsoluteSystemPath>,
-) -> turbopath::AbsoluteSystemPathBuf {
-    let mut current = git_root.unwrap_or(turbo_root).to_owned();
-    loop {
-        let dot_git = current.join_component(".git");
-        if dot_git.symlink_metadata().is_ok() {
-            return dot_git;
+pub(crate) fn hash_discovered_files(
+    root_path: &AbsoluteSystemPath,
+    files: impl Iterator<Item = impl AsRef<AnchoredSystemPath>>,
+    attrs_root: Option<&AbsoluteSystemPath>,
+    cached_attrs: Option<&crate::crlf::GitAttrs>,
+) -> Result<GitHashes, Error> {
+    let effective_attrs_root = attrs_root.unwrap_or(root_path);
+    let mut owned_attrs = None;
+    let attrs = crate::crlf::resolve_or_load(cached_attrs, effective_attrs_root, &mut owned_attrs);
+    let mut hashes = GitHashes::new();
+    for file in files {
+        let anchored = file.as_ref();
+        let path = root_path.resolve(anchored);
+        let attr_path = effective_attrs_root.anchor(&path)?.to_unix();
+        if let Some(hash) = hash_discovered_file(&path, attr_path.as_str(), attrs)? {
+            hashes.insert(anchored.to_unix(), hash);
         }
-        let Some(parent) = current.parent() else {
-            return turbo_root.join_component(".git");
-        };
-        current = parent.to_owned();
     }
+    Ok(hashes)
 }
 
 pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
@@ -140,7 +152,7 @@ pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
     let mut hashes = GitHashes::new();
 
     let effective_attrs_root = git_root.unwrap_or(turbo_root);
-    let git_metadata_path = git_metadata_path(turbo_root, git_root);
+    let git_metadata_path = effective_attrs_root.join_component(".git");
     let mut owned_attrs = None;
     let attrs = crate::crlf::resolve_or_load(cached_attrs, effective_attrs_root, &mut owned_attrs);
     let mut default_file_hashes = GitHashes::new();
@@ -153,9 +165,6 @@ pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
     let mut local_inputs: Vec<&str> = Vec::new();
     let mut external_inclusions = Vec::new();
     let mut external_exclusions = Vec::new();
-    let relative =
-        AnchoredSystemPathBuf::relative_path_between(turbo_root, &git_metadata_path).to_unix();
-    external_exclusions.push(ValidatedGlob::from_str(relative.as_str())?);
     for pattern in inputs {
         let pattern = pattern.as_ref();
         let is_exclusion = pattern.starts_with('!');
@@ -176,6 +185,7 @@ pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
             local_inputs.push(pattern);
         }
     }
+    let has_local_inclusions = local_inputs.iter().any(|pattern| !pattern.starts_with('!'));
 
     if !external_inclusions.is_empty() {
         let files = globwalk::globwalk(
@@ -189,7 +199,9 @@ pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
                 AnchoredSystemPathBuf::relative_path_between(&full_package_path, file_path)
                     .to_unix();
             // Use attrs-root-relative path for .gitattributes pattern matching.
-            let attr_path = effective_attrs_root.anchor(file_path)?.to_unix();
+            let attr_path =
+                AnchoredSystemPathBuf::relative_path_between(effective_attrs_root, file_path)
+                    .to_unix();
             if let Some(hash) = hash_discovered_file(file_path, attr_path.as_str(), attrs)? {
                 hashes.insert(relative_path, hash);
             }
@@ -239,6 +251,11 @@ pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
         Some(any(excludes)?)
     };
 
+    if !has_local_inclusions {
+        let git_metadata_path = git_metadata_path.clone();
+        walker_builder.filter_entry(move |entry| entry.path() != git_metadata_path.as_std_path());
+    }
+
     let walker = walker_builder
         .follow_links(false)
         // if inputs have been provided manually, we shouldn't skip ignored files to mimic the
@@ -246,7 +263,6 @@ pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
         .git_ignore(local_inputs.is_empty() && external_inclusions.is_empty())
         .require_git(false)
         .hidden(false) // this results in yielding hidden files (e.g. .gitignore)
-        .filter_entry(move |entry| entry.path() != git_metadata_path.as_std_path())
         .build();
 
     for dirent in walker {
@@ -258,6 +274,7 @@ pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
                     .io_error()
                     .is_some_and(|error| error.kind() == ErrorKind::NotFound) =>
             {
+                info!(path = %dirent.path().display(), "discovered hash candidate disappeared");
                 continue;
             }
             Err(error) => return Err(error.into()),
@@ -296,6 +313,7 @@ pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
     // If we're including default files, we need to walk again, but this time with
     // git_ignore enabled
     if include_default_files {
+        walker_builder.filter_entry(move |entry| entry.path() != git_metadata_path.as_std_path());
         let walker = walker_builder
             .follow_links(false)
             .git_ignore(true)
@@ -312,6 +330,7 @@ pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
                         .io_error()
                         .is_some_and(|error| error.kind() == ErrorKind::NotFound) =>
                 {
+                    info!(path = %dirent.path().display(), "discovered hash candidate disappeared");
                     continue;
                 }
                 Err(error) => return Err(error.into()),
@@ -549,7 +568,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parent_input_excludes_ancestor_git_metadata() {
+    fn test_parent_input_includes_configured_ancestor_git_metadata() {
         let (_tmp, repo_root) = tmp_dir();
         let git_dir = repo_root.join_component(".git");
         git_dir.create_dir_all().unwrap();
@@ -576,7 +595,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(hashes.keys().all(|path| !path.as_str().contains(".git")));
+        assert!(hashes.contains_key(&RelativeUnixPathBuf::new("../../.git/index.lock").unwrap()));
     }
 
     #[test]

--- a/crates/turborepo-scm/src/package_deps.rs
+++ b/crates/turborepo-scm/src/package_deps.rs
@@ -119,11 +119,18 @@ impl SCM {
         turbo_root: &AbsoluteSystemPath,
         files: impl Iterator<Item = impl AsRef<AnchoredSystemPath>>,
     ) -> Result<GitHashes, Error> {
-        let (attrs_root, cached_attrs) = match self {
-            SCM::Git(git) => (Some(git.root.as_ref()), git.git_attrs()),
-            SCM::Manual => (None, None),
-        };
-        crate::manual::hash_files(turbo_root, files, true, attrs_root, cached_attrs)
+        self.hash_discovered_files(turbo_root, files)
+    }
+
+    pub fn hash_discovered_files(
+        &self,
+        turbo_root: &AbsoluteSystemPath,
+        files: impl Iterator<Item = impl AsRef<AnchoredSystemPath>>,
+    ) -> Result<GitHashes, Error> {
+        match self {
+            SCM::Manual => crate::manual::hash_discovered_files(turbo_root, files, None, None),
+            SCM::Git(git) => git.hash_discovered_files(turbo_root, files),
+        }
     }
 }
 
@@ -195,14 +202,7 @@ impl GitRepo {
         files: impl Iterator<Item = impl AsRef<AnchoredSystemPath>>,
     ) -> Result<GitHashes, Error> {
         let mut hashes = GitHashes::new();
-        let to_hash = files
-            .map(|f| {
-                Ok(self
-                    .root
-                    .anchor(process_relative_to.resolve(f.as_ref()))?
-                    .to_unix())
-            })
-            .collect::<Result<Vec<_>, PathError>>()?;
+        let to_hash = self.repo_relative_paths(process_relative_to, files)?;
         // Note: to_hash is *git repo relative*
         hash_objects(
             &self.root,
@@ -213,6 +213,39 @@ impl GitRepo {
             self.slowest_files.as_ref(),
         )?;
         Ok(hashes)
+    }
+
+    fn hash_discovered_files(
+        &self,
+        process_relative_to: &AbsoluteSystemPath,
+        files: impl Iterator<Item = impl AsRef<AnchoredSystemPath>>,
+    ) -> Result<GitHashes, Error> {
+        let mut hashes = GitHashes::new();
+        let to_hash = self.repo_relative_paths(process_relative_to, files)?;
+        hash_discovered_objects(
+            &self.root,
+            process_relative_to,
+            to_hash,
+            &mut hashes,
+            self.git_attrs(),
+            self.slowest_files.as_ref(),
+        )?;
+        Ok(hashes)
+    }
+
+    fn repo_relative_paths(
+        &self,
+        process_relative_to: &AbsoluteSystemPath,
+        files: impl Iterator<Item = impl AsRef<AnchoredSystemPath>>,
+    ) -> Result<Vec<turbopath::RelativeUnixPathBuf>, PathError> {
+        files
+            .map(|file| {
+                Ok(self
+                    .root
+                    .anchor(process_relative_to.resolve(file.as_ref()))?
+                    .to_unix())
+            })
+            .collect()
     }
 
     fn git_relative_to_package_relative(
@@ -312,7 +345,6 @@ impl GitRepo {
                 inclusions.push(ValidatedGlob::from_str(&glob_buf)?);
             }
         }
-        exclusions.push(self.git_metadata_exclusion(turbo_root)?);
         let files = globwalk::globwalk(
             turbo_root,
             &inclusions,
@@ -377,7 +409,6 @@ impl GitRepo {
             let mut glob_exclusions = Vec::new();
             let mut literal_to_hash = Vec::new();
             let mut glob_buf = String::with_capacity(package_unix_path.len() + 1 + 64);
-            let git_metadata_path = self.root.join_component(".git");
 
             // Exclusions must apply to the filesystem walk itself, not just
             // the in-memory filter below: the walk can discover files the
@@ -392,7 +423,6 @@ impl GitRepo {
                 glob_buf.push_str(exclude.trim_start_matches('/'));
                 glob_exclusions.push(ValidatedGlob::from_str(&glob_buf)?);
             }
-            glob_exclusions.push(self.git_metadata_exclusion(turbo_root)?);
 
             let all = includes.iter().copied().chain(CONFIG_FILES.iter().copied());
             for raw_glob in all {
@@ -402,12 +432,6 @@ impl GitRepo {
                     // compiling a glob and walking directories.
                     let resolved =
                         full_pkg_path.join_unix_path(turbopath::RelativeUnixPath::new(raw_glob)?);
-                    if resolved
-                        .as_std_path()
-                        .starts_with(git_metadata_path.as_std_path())
-                    {
-                        continue;
-                    }
                     match resolved.symlink_metadata() {
                         Ok(meta) if meta.is_dir() => {
                             // Directory literal — fall through to the glob
@@ -510,15 +534,6 @@ impl GitRepo {
 
         Ok(hashes)
     }
-
-    fn git_metadata_exclusion(
-        &self,
-        turbo_root: &AbsoluteSystemPath,
-    ) -> Result<ValidatedGlob, Error> {
-        let dot_git = self.root.join_component(".git");
-        let relative = AnchoredSystemPathBuf::relative_path_between(turbo_root, &dot_git).to_unix();
-        Ok(ValidatedGlob::from_str(relative.as_str())?)
-    }
 }
 
 #[cfg(test)]
@@ -594,17 +609,29 @@ mod tests {
         let missing = AnchoredSystemPathBuf::from_raw("missing-global-dependency.txt").unwrap();
 
         let error = scm
-            .get_hashes_for_files(&repo_root, &[missing], false)
+            .get_hashes_for_files(&repo_root, std::slice::from_ref(&missing), false)
             .unwrap_err();
 
         assert!(
             error.to_string().contains("missing-global-dependency.txt"),
             "missing explicit dependency should fail with path context: {error}"
         );
+
+        let hashes = scm
+            .hash_discovered_files(&repo_root, std::slice::from_ref(&missing).iter())
+            .unwrap();
+        assert!(hashes.is_empty());
+
+        let directory = AnchoredSystemPathBuf::from_raw("directory").unwrap();
+        repo_root.resolve(&directory).create_dir_all().unwrap();
+        let hashes = SCM::Manual
+            .hash_discovered_files(&repo_root, [missing, directory].iter())
+            .unwrap();
+        assert!(hashes.is_empty());
     }
 
     #[test]
-    fn test_repo_wide_inputs_exclude_git_metadata() -> Result<(), Error> {
+    fn test_repo_wide_inputs_include_configured_git_metadata() -> Result<(), Error> {
         let (_tmp, repo_root) = tmp_dir();
         repo_root
             .join_component("package.json")
@@ -639,19 +666,47 @@ mod tests {
             None,
             None,
         )?;
+        let default_manual_hashes = get_package_file_hashes_without_git::<&str>(
+            &repo_root,
+            &root_package,
+            &[],
+            false,
+            Some(&repo_root),
+            None,
+        )?;
+        let exclusion_only_hashes = get_package_file_hashes_without_git(
+            &repo_root,
+            &root_package,
+            &["!source.js"],
+            true,
+            Some(&repo_root),
+            None,
+        )?;
 
         for hashes in [&git_hashes, &fallback_hashes, &manual_hashes] {
             assert!(hashes.contains_key(&RelativeUnixPathBuf::new("source.js").unwrap()));
             assert!(
-                hashes.keys().all(|path| !path.as_str().starts_with(".git")),
-                "active Git metadata must not be hashed: {hashes:?}"
+                hashes.contains_key(&RelativeUnixPathBuf::new(".git/config").unwrap()),
+                "configured Git metadata must be hashed: {hashes:?}"
             );
         }
+        assert!(
+            default_manual_hashes
+                .keys()
+                .all(|path| !path.as_str().starts_with(".git")),
+            "default inputs must not hash Git metadata: {default_manual_hashes:?}"
+        );
+        assert!(
+            exclusion_only_hashes
+                .keys()
+                .all(|path| !path.as_str().starts_with(".git")),
+            "exclusions must not opt into Git metadata: {exclusion_only_hashes:?}"
+        );
         Ok(())
     }
 
     #[test]
-    fn test_repo_wide_inputs_exclude_linked_worktree_metadata() -> Result<(), Error> {
+    fn test_repo_wide_inputs_include_configured_worktree_metadata() -> Result<(), Error> {
         let (_tmp_main, main_root) = tmp_dir();
         let (_tmp_worktree, worktree_parent) = tmp_dir();
         main_root
@@ -703,8 +758,8 @@ mod tests {
         for hashes in [&git_hashes, &fallback_hashes, &manual_hashes] {
             assert!(hashes.contains_key(&RelativeUnixPathBuf::new("source.js").unwrap()));
             assert!(
-                !hashes.contains_key(&RelativeUnixPathBuf::new(".git").unwrap()),
-                "linked worktree .git pointer must not be hashed: {hashes:?}"
+                hashes.contains_key(&RelativeUnixPathBuf::new(".git").unwrap()),
+                "configured linked-worktree .git pointer must be hashed: {hashes:?}"
             );
         }
         Ok(())

--- a/crates/turborepo-scm/src/package_deps.rs
+++ b/crates/turborepo-scm/src/package_deps.rs
@@ -5,7 +5,10 @@ use tracing::{debug, warn};
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPath, AnchoredSystemPathBuf, PathError};
 use turborepo_telemetry::events::task::{FileHashMethod, PackageTaskEventBuilder};
 
-use crate::{Error, GitHashes, GitRepo, RepoGitIndex, SCM, hash_object::hash_objects};
+use crate::{
+    Error, GitHashes, GitRepo, RepoGitIndex, SCM,
+    hash_object::{hash_discovered_objects, hash_objects},
+};
 
 impl SCM {
     pub fn get_hashes_for_files(
@@ -175,12 +178,11 @@ impl GitRepo {
         };
 
         // Note: to_hash is *git repo relative*
-        hash_objects(
+        hash_discovered_objects(
             &self.root,
             &full_pkg_path,
             to_hash,
             &mut hashes,
-            true,
             self.git_attrs(),
             self.slowest_files.as_ref(),
         )?;
@@ -207,7 +209,6 @@ impl GitRepo {
             process_relative_to,
             to_hash,
             &mut hashes,
-            false,
             self.git_attrs(),
             self.slowest_files.as_ref(),
         )?;
@@ -257,12 +258,11 @@ impl GitRepo {
 
         if !to_hash.is_empty() {
             let mut new_hashes = GitHashes::with_capacity(to_hash.len());
-            hash_objects(
+            hash_discovered_objects(
                 &self.root,
                 full_pkg_path,
                 to_hash,
                 &mut new_hashes,
-                true,
                 self.git_attrs(),
                 self.slowest_files.as_ref(),
             )?;
@@ -377,6 +377,7 @@ impl GitRepo {
             let mut glob_exclusions = Vec::new();
             let mut literal_to_hash = Vec::new();
             let mut glob_buf = String::with_capacity(package_unix_path.len() + 1 + 64);
+            let git_metadata_path = self.root.join_component(".git");
 
             // Exclusions must apply to the filesystem walk itself, not just
             // the in-memory filter below: the walk can discover files the
@@ -401,6 +402,12 @@ impl GitRepo {
                     // compiling a glob and walking directories.
                     let resolved =
                         full_pkg_path.join_unix_path(turbopath::RelativeUnixPath::new(raw_glob)?);
+                    if resolved
+                        .as_std_path()
+                        .starts_with(git_metadata_path.as_std_path())
+                    {
+                        continue;
+                    }
                     match resolved.symlink_metadata() {
                         Ok(meta) if meta.is_dir() => {
                             // Directory literal — fall through to the glob
@@ -569,16 +576,7 @@ mod tests {
         let mut hashes = GitHashes::new();
         // FIXME: This test verifies a bug: we don't hash symlinks.
         // TODO: update this test to point at get_package_file_hashes
-        hash_objects(
-            &git_root,
-            &git_root,
-            to_hash,
-            &mut hashes,
-            false,
-            None,
-            None,
-        )
-        .unwrap();
+        hash_objects(&git_root, &git_root, to_hash, &mut hashes, None, None).unwrap();
         assert!(hashes.is_empty());
 
         let pkg_path = git_root.anchor(&git_root).unwrap();
@@ -621,19 +619,28 @@ mod tests {
             panic!("expected git SCM");
         };
         let root_package = AnchoredSystemPathBuf::from_raw("")?;
+        let inputs = ["**/*", ".git/config"];
 
         let git_hashes =
-            git.get_package_file_hashes(&repo_root, &root_package, &["**/*"], false, None)?;
-        let manual_hashes = get_package_file_hashes_without_git(
+            git.get_package_file_hashes(&repo_root, &root_package, &inputs, true, None)?;
+        let fallback_hashes = get_package_file_hashes_without_git(
             &repo_root,
             &root_package,
-            &["**/*"],
-            false,
+            &inputs,
+            true,
             Some(&repo_root),
             None,
         )?;
+        let manual_hashes = get_package_file_hashes_without_git(
+            &repo_root,
+            &root_package,
+            &inputs,
+            true,
+            None,
+            None,
+        )?;
 
-        for hashes in [&git_hashes, &manual_hashes] {
+        for hashes in [&git_hashes, &fallback_hashes, &manual_hashes] {
             assert!(hashes.contains_key(&RelativeUnixPathBuf::new("source.js").unwrap()));
             assert!(
                 hashes.keys().all(|path| !path.as_str().starts_with(".git")),
@@ -672,19 +679,28 @@ mod tests {
             panic!("expected git SCM");
         };
         let root_package = AnchoredSystemPathBuf::from_raw("")?;
+        let inputs = ["**/*", ".git"];
 
         let git_hashes =
-            git.get_package_file_hashes(&worktree_root, &root_package, &["**/*"], false, None)?;
-        let manual_hashes = get_package_file_hashes_without_git(
+            git.get_package_file_hashes(&worktree_root, &root_package, &inputs, true, None)?;
+        let fallback_hashes = get_package_file_hashes_without_git(
             &worktree_root,
             &root_package,
-            &["**/*"],
-            false,
+            &inputs,
+            true,
             Some(&worktree_root),
             None,
         )?;
+        let manual_hashes = get_package_file_hashes_without_git(
+            &worktree_root,
+            &root_package,
+            &inputs,
+            true,
+            None,
+            None,
+        )?;
 
-        for hashes in [&git_hashes, &manual_hashes] {
+        for hashes in [&git_hashes, &fallback_hashes, &manual_hashes] {
             assert!(hashes.contains_key(&RelativeUnixPathBuf::new("source.js").unwrap()));
             assert!(
                 !hashes.contains_key(&RelativeUnixPathBuf::new(".git").unwrap()),

--- a/crates/turborepo-scm/src/package_deps.rs
+++ b/crates/turborepo-scm/src/package_deps.rs
@@ -180,6 +180,7 @@ impl GitRepo {
             &full_pkg_path,
             to_hash,
             &mut hashes,
+            true,
             self.git_attrs(),
             self.slowest_files.as_ref(),
         )?;
@@ -206,6 +207,7 @@ impl GitRepo {
             process_relative_to,
             to_hash,
             &mut hashes,
+            false,
             self.git_attrs(),
             self.slowest_files.as_ref(),
         )?;
@@ -260,6 +262,7 @@ impl GitRepo {
                 full_pkg_path,
                 to_hash,
                 &mut new_hashes,
+                true,
                 self.git_attrs(),
                 self.slowest_files.as_ref(),
             )?;
@@ -309,6 +312,7 @@ impl GitRepo {
                 inclusions.push(ValidatedGlob::from_str(&glob_buf)?);
             }
         }
+        exclusions.push(self.git_metadata_exclusion(turbo_root)?);
         let files = globwalk::globwalk(
             turbo_root,
             &inclusions,
@@ -387,6 +391,7 @@ impl GitRepo {
                 glob_buf.push_str(exclude.trim_start_matches('/'));
                 glob_exclusions.push(ValidatedGlob::from_str(&glob_buf)?);
             }
+            glob_exclusions.push(self.git_metadata_exclusion(turbo_root)?);
 
             let all = includes.iter().copied().chain(CONFIG_FILES.iter().copied());
             for raw_glob in all {
@@ -498,6 +503,15 @@ impl GitRepo {
 
         Ok(hashes)
     }
+
+    fn git_metadata_exclusion(
+        &self,
+        turbo_root: &AbsoluteSystemPath,
+    ) -> Result<ValidatedGlob, Error> {
+        let dot_git = self.root.join_component(".git");
+        let relative = AnchoredSystemPathBuf::relative_path_between(turbo_root, &dot_git).to_unix();
+        Ok(ValidatedGlob::from_str(relative.as_str())?)
+    }
 }
 
 #[cfg(test)]
@@ -555,7 +569,16 @@ mod tests {
         let mut hashes = GitHashes::new();
         // FIXME: This test verifies a bug: we don't hash symlinks.
         // TODO: update this test to point at get_package_file_hashes
-        hash_objects(&git_root, &git_root, to_hash, &mut hashes, None, None).unwrap();
+        hash_objects(
+            &git_root,
+            &git_root,
+            to_hash,
+            &mut hashes,
+            false,
+            None,
+            None,
+        )
+        .unwrap();
         assert!(hashes.is_empty());
 
         let pkg_path = git_root.anchor(&git_root).unwrap();
@@ -563,6 +586,112 @@ mod tests {
             get_package_file_hashes_without_git(&git_root, &pkg_path, &["l*"], false, None, None)
                 .unwrap();
         assert!(manual_hashes.is_empty());
+    }
+
+    #[test]
+    fn test_missing_explicit_file_errors_with_git() {
+        let (_tmp, repo_root) = tmp_dir();
+        setup_repository(&repo_root);
+        let scm = SCM::new(&repo_root);
+        let missing = AnchoredSystemPathBuf::from_raw("missing-global-dependency.txt").unwrap();
+
+        let error = scm
+            .get_hashes_for_files(&repo_root, &[missing], false)
+            .unwrap_err();
+
+        assert!(
+            error.to_string().contains("missing-global-dependency.txt"),
+            "missing explicit dependency should fail with path context: {error}"
+        );
+    }
+
+    #[test]
+    fn test_repo_wide_inputs_exclude_git_metadata() -> Result<(), Error> {
+        let (_tmp, repo_root) = tmp_dir();
+        repo_root
+            .join_component("package.json")
+            .create_with_contents("{}")?;
+        repo_root
+            .join_component("source.js")
+            .create_with_contents("export {}")?;
+        setup_repository(&repo_root);
+        commit_all(&repo_root);
+
+        let SCM::Git(git) = SCM::new(&repo_root) else {
+            panic!("expected git SCM");
+        };
+        let root_package = AnchoredSystemPathBuf::from_raw("")?;
+
+        let git_hashes =
+            git.get_package_file_hashes(&repo_root, &root_package, &["**/*"], false, None)?;
+        let manual_hashes = get_package_file_hashes_without_git(
+            &repo_root,
+            &root_package,
+            &["**/*"],
+            false,
+            Some(&repo_root),
+            None,
+        )?;
+
+        for hashes in [&git_hashes, &manual_hashes] {
+            assert!(hashes.contains_key(&RelativeUnixPathBuf::new("source.js").unwrap()));
+            assert!(
+                hashes.keys().all(|path| !path.as_str().starts_with(".git")),
+                "active Git metadata must not be hashed: {hashes:?}"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_repo_wide_inputs_exclude_linked_worktree_metadata() -> Result<(), Error> {
+        let (_tmp_main, main_root) = tmp_dir();
+        let (_tmp_worktree, worktree_parent) = tmp_dir();
+        main_root
+            .join_component("package.json")
+            .create_with_contents("{}")?;
+        main_root
+            .join_component("source.js")
+            .create_with_contents("export {}")?;
+        setup_repository(&main_root);
+        commit_all(&main_root);
+
+        let worktree_root = worktree_parent.join_component("linked");
+        require_git_cmd(
+            &main_root,
+            &[
+                "worktree",
+                "add",
+                worktree_root.as_str(),
+                "-b",
+                "repo-wide-input-test",
+            ],
+        );
+
+        let SCM::Git(git) = SCM::new(&worktree_root) else {
+            panic!("expected git SCM");
+        };
+        let root_package = AnchoredSystemPathBuf::from_raw("")?;
+
+        let git_hashes =
+            git.get_package_file_hashes(&worktree_root, &root_package, &["**/*"], false, None)?;
+        let manual_hashes = get_package_file_hashes_without_git(
+            &worktree_root,
+            &root_package,
+            &["**/*"],
+            false,
+            Some(&worktree_root),
+            None,
+        )?;
+
+        for hashes in [&git_hashes, &manual_hashes] {
+            assert!(hashes.contains_key(&RelativeUnixPathBuf::new("source.js").unwrap()));
+            assert!(
+                !hashes.contains_key(&RelativeUnixPathBuf::new(".git").unwrap()),
+                "linked worktree .git pointer must not be hashed: {hashes:?}"
+            );
+        }
+        Ok(())
     }
 
     #[test]

--- a/crates/turborepo-task-hash/src/global_hash.rs
+++ b/crates/turborepo-task-hash/src/global_hash.rs
@@ -156,31 +156,37 @@ pub fn collect_global_file_hash_inputs<'a>(
         global_hashable_env_vars.all.names()
     );
 
-    let mut global_deps =
+    let mut discovered_global_deps =
         collect_global_deps(package_manager, root_path, global_file_dependencies)?;
-
-    for path in resolution_file_fallback {
-        global_deps.insert(path.clone());
-    }
 
     // .gitattributes drives CRLF→LF normalization which affects file hashes.
     // Including it in the global hash ensures cache invalidation when
     // normalization rules change.
     let gitattributes_path = root_path.join_component(".gitattributes");
     if gitattributes_path.exists() {
-        global_deps.insert(gitattributes_path);
+        discovered_global_deps.insert(gitattributes_path);
     }
 
-    let global_deps_paths = global_deps
+    let discovered_global_deps_paths = discovered_global_deps
+        .iter()
+        .map(|p| root_path.anchor(p).map_err(Error::from))
+        .collect::<Result<Vec<_>, _>>()?;
+    let resolution_file_fallback_paths = resolution_file_fallback
         .iter()
         .map(|p| root_path.anchor(p).map_err(Error::from))
         .collect::<Result<Vec<_>, _>>()?;
 
-    let global_file_hash_map = hasher
-        .get_hashes_for_files(root_path, &global_deps_paths, false)?
+    let mut global_file_hash_map = hasher
+        .hash_discovered_files(root_path, discovered_global_deps_paths.iter())?
         .into_iter()
         .map(|(k, v)| (k, String::from(v)))
-        .collect();
+        .collect::<HashMap<_, _>>();
+    global_file_hash_map.extend(
+        hasher
+            .hash_files(root_path, resolution_file_fallback_paths.iter())?
+            .into_iter()
+            .map(|(k, v)| (k, String::from(v))),
+    );
 
     Ok(GlobalFileHashInputs {
         global_file_hash_map,

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -1020,6 +1020,14 @@ Creates a "content identifier" for a specific task depending on current state of
 - **Global Hash**: Package manager lockfile, global dependencies, environment variables
 - **Task Hash**: Task definition, package dependencies, input files, environment variables
 - **File Hashing**: Uses git for tracking file changes efficiently
+- **Discovery Races**: Files requiring content hashing after repo-index or glob
+  discovery, including `globalDependencies`, are omitted if they disappear
+  before hashing. Required resolution fallback files remain strict. Verbose
+  tracing records final-stage candidates that disappear or are rejected as
+  non-regular, plus path-specific hashing failures.
+- **Configured Git Metadata**: Input patterns are respected literally. If a
+  configured task or global input matches `.git`, that metadata participates in
+  the hash and transient entries use the same discovery-race behavior.
 - **Explicit Inputs**: When tasks use custom `inputs`, glob matches still walk the
   filesystem, but clean tracked matches reuse blob OIDs from the repo index
   instead of re-hashing file contents


### PR DESCRIPTION
## Summary
- Tolerate `ENOENT` for task inputs and `globalDependencies` files that disappear between discovery and hashing.
- Keep required resolution fallback files strict and report path-specific `HashFile` errors.
- Respect configured inputs literally, including `.git` metadata and linked-worktree pointer files.
- Classify regular files from opened handles where supported and skip non-regular discovery candidates consistently across Git and manual SCM.
- Record vanished candidates, non-regular candidates, and hashing failures when verbosity is enabled.

Closes #13732

## Testing
- `cargo test -p turborepo-scm`
- `cargo test -p turborepo-task-hash`
- `cargo clippy -p turborepo-scm -p turborepo-task-hash --all-targets -- -D warnings`
- `cargo fmt --all -- --check`