### PR TITLE
fix: Scope musl library dependency installation

### DIFF
--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -87,7 +87,7 @@ jobs:
               export PATH=/usr/local/cargo/bin/rustup:/root/.cargo/bin:${PATH}
               rustup show active-toolchain
               dirname $(rustup which cargo) >> ${GITHUB_PATH}
-              pnpm install --frozen-lockfile
+              pnpm install --filter @turbo/repository --frozen-lockfile
 
           - host: ubuntu-24.04
             target: aarch64-unknown-linux-musl
@@ -104,7 +104,7 @@ jobs:
               rustup show active-toolchain
               rustup target add aarch64-unknown-linux-musl
               dirname $(rustup which cargo) >> ${GITHUB_PATH}
-              pnpm install --frozen-lockfile
+              pnpm install --filter @turbo/repository --frozen-lockfile
             rust_env: CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc RUSTFLAGS="-Ctarget-feature=-crt-static"
 
           - host: windows-2022


### PR DESCRIPTION
## Summary

- Limit musl library release dependency installation to `@turbo/repository`.
- Avoid unrelated workspace postinstall scripts that require Node 24 while the pinned musl build image uses Node 18.
- Fix the failing x86_64 and aarch64 musl release jobs from https://github.com/vercel/turborepo/actions/runs/31731546522/job/94553012282.

## Testing

- Built `@turbo/repository` for `x86_64-unknown-linux-musl` in the exact pinned release container.
- Ran `pnpm exec oxfmt --check .github/workflows/turborepo-library-release.yml`.
- Parsed the workflow with Ruby YAML.
- Passed pre-push formatting and TOML checks.