### PR TITLE
feat: Add estimatedUncachedDuration to run summary and dry-run JSON

### DIFF
--- a/crates/turborepo-run-summary/src/estimated_duration.rs
+++ b/crates/turborepo-run-summary/src/estimated_duration.rs
@@ -1,0 +1,303 @@
+//! Estimate of the uncached wall-clock duration of a run.
+//!
+//! `estimatedUncachedDuration` answers: "how long would this run have taken
+//! if the cache had not existed?" It walks the task dependency graph and
+//! computes the critical path (longest dependency chain) using per-task
+//! uncached durations, so parallel branches are not summed.
+//!
+//! Per-task uncached duration (milliseconds):
+//! - Cache hit: `cache.timeSaved` from the cache artifact metadata, i.e. the
+//!   duration of the execution that originally produced the artifact. When that
+//!   metadata is missing or zero, the task contributes 0.
+//! - Executed cache miss (real runs): the task's measured wall-clock execution
+//!   duration (`endTime - startTime`).
+//! - Anything else (dry-run cache misses, tasks that never ran): 0, because the
+//!   task has never been executed by this repository and Turbo has no timing
+//!   information for it.
+//!
+//! Dry runs therefore produce a *partial* estimate: it accounts only for the
+//! cache-hit portion of the graph, since misses have no observed timing.
+//!
+//! The estimate ignores scheduling constraints (concurrency limits,
+//! scheduling overhead) and models an ideal machine with unlimited
+//! parallelism: it is the wall-clock time of the longest dependency chain,
+//! which is the lower bound of any uncached execution.
+
+use std::collections::HashMap;
+
+use turborepo_task_id::TaskId;
+
+use crate::task::{CacheStatus, TaskSummary};
+
+/// Computes the estimated uncached wall-clock duration, in milliseconds, of
+/// the critical path through the task DAG.
+///
+/// `tasks` must contain every task in the run; `dependencies` on each
+/// `TaskSummary` are used as the graph edges. Dependencies that point outside
+/// `tasks` are ignored (they are not part of this run).
+pub fn estimated_uncached_duration(tasks: &[TaskSummary]) -> u64 {
+    let by_id: HashMap<&TaskId<'static>, usize> = tasks
+        .iter()
+        .enumerate()
+        .map(|(index, task)| (&task.task_id, index))
+        .collect();
+
+    let mut memo: HashMap<usize, u64> = HashMap::with_capacity(tasks.len());
+    let mut max_finish = 0u64;
+    for index in 0..tasks.len() {
+        // Cycle guard: task graphs are validated acyclic at engine
+        // construction, but guard anyway so a malformed input yields a
+        // (slightly wrong) number instead of unbounded recursion.
+        let mut visiting = vec![false; tasks.len()];
+        let finish = earliest_finish(index, tasks, &by_id, &mut memo, &mut visiting);
+        max_finish = max_finish.max(finish);
+    }
+    max_finish
+}
+
+/// Earliest finish time (ms from run start, assuming unlimited parallelism)
+/// for a task: max over dependencies of their earliest finish, plus this
+/// task's uncached duration.
+fn earliest_finish(
+    index: usize,
+    tasks: &[TaskSummary],
+    by_id: &HashMap<&TaskId<'static>, usize>,
+    memo: &mut HashMap<usize, u64>,
+    visiting: &mut [bool],
+) -> u64 {
+    if let Some(&finish) = memo.get(&index) {
+        return finish;
+    }
+    if visiting[index] {
+        // Cycle: stop expanding and contribute nothing further.
+        return 0;
+    }
+    visiting[index] = true;
+
+    let task = &tasks[index];
+    let mut dependency_finish = 0u64;
+    for dependency in &task.shared.dependencies {
+        let finish = match by_id.get(dependency) {
+            Some(&dependency_index) => {
+                earliest_finish(dependency_index, tasks, by_id, memo, visiting)
+            }
+            // Dependency is not part of this run (e.g. filtered out).
+            None => 0,
+        };
+        dependency_finish = dependency_finish.max(finish);
+    }
+
+    visiting[index] = false;
+
+    let finish = dependency_finish.saturating_add(task_uncached_duration_ms(task));
+    memo.insert(index, finish);
+    finish
+}
+
+/// Per-task uncached duration in milliseconds. See module docs for semantics.
+fn task_uncached_duration_ms(task: &TaskSummary) -> u64 {
+    let cache = &task.shared.cache;
+    match cache.status() {
+        // A cache hit did not execute; the best estimate of its uncached
+        // duration is the recorded duration of the run that produced the
+        // artifact. Missing/zero metadata means we cannot estimate, so the
+        // task contributes 0.
+        CacheStatus::Hit => cache.time_saved(),
+        CacheStatus::Miss => {
+            // A real run that executed this task measured its wall-clock
+            // duration directly.
+            task.shared
+                .execution
+                .as_ref()
+                .map(|execution| {
+                    execution
+                        .end_time
+                        .saturating_sub(execution.start_time)
+                        .max(0) as u64
+                })
+                // Dry runs (and tasks that never started) have no execution
+                // timing; there is nothing to estimate from.
+                .unwrap_or(0)
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{collections::BTreeMap, sync::Arc};
+
+    use turborepo_types::EnvMode;
+
+    use super::*;
+    use crate::task::{
+        SharedTaskSummary, TaskCacheSummary, TaskEnvConfiguration, TaskEnvVarSummary,
+        TaskExecutionSummary, TaskSummaryTaskDefinition,
+    };
+
+    fn task(task_id: &str, deps: &[&str]) -> TaskSummary {
+        let (package, name) = task_id.split_once('#').unwrap();
+        TaskSummary {
+            task_id: TaskId::new(package, name).into_owned(),
+            task: name.to_string(),
+            package: package.to_string(),
+            shared: SharedTaskSummary {
+                hash: Some(Arc::from("hash")),
+                hash_reason: None,
+                inputs: BTreeMap::new(),
+                hash_of_external_dependencies: String::new(),
+                cache: TaskCacheSummary::cache_miss(),
+                command: String::new(),
+                cli_arguments: Vec::new(),
+                outputs: None,
+                excluded_outputs: None,
+                log_file: None,
+                directory: None,
+                dependencies: deps
+                    .iter()
+                    .map(|dep| {
+                        let (package, name) = dep.split_once('#').unwrap();
+                        TaskId::new(package, name).into_owned()
+                    })
+                    .collect(),
+                dependents: Vec::new(),
+                with: Vec::new(),
+                resolved_task_definition: TaskSummaryTaskDefinition::default(),
+                expanded_outputs: Vec::new(),
+                framework: String::new(),
+                env_mode: EnvMode::Strict,
+                environment_variables: TaskEnvVarSummary {
+                    specified: TaskEnvConfiguration {
+                        env: Vec::new(),
+                        pass_through_env: None,
+                    },
+                    configured: Vec::new(),
+                    inferred: Vec::new(),
+                    pass_through: None,
+                },
+                execution: None,
+            },
+        }
+    }
+
+    fn executed(mut task: TaskSummary, start: i64, end: i64) -> TaskSummary {
+        task.shared.execution = Some(TaskExecutionSummary {
+            start_time: start,
+            end_time: end,
+            error: None,
+            exit_code: Some(0),
+        });
+        task
+    }
+
+    fn cache_hit(mut task: TaskSummary, time_saved: u64) -> TaskSummary {
+        task.shared.cache = TaskCacheSummary::from(Some(turborepo_cache::CacheHitMetadata {
+            source: turborepo_cache::CacheSource::Local,
+            time_saved,
+            sha: None,
+            dirty_hash: None,
+        }));
+        task
+    }
+
+    #[test]
+    fn empty_run_is_zero() {
+        assert_eq!(estimated_uncached_duration(&[]), 0);
+    }
+
+    #[test]
+    fn single_executed_miss() {
+        let tasks = vec![executed(task("app#build", &[]), 1000, 3000)];
+        assert_eq!(estimated_uncached_duration(&tasks), 2000);
+    }
+
+    #[test]
+    fn dependency_chain_is_summed() {
+        // app#build -> lib#build -> util#build, each 1s: 3s total.
+        let tasks = vec![
+            executed(task("app#build", &["lib#build"]), 0, 1000),
+            executed(task("lib#build", &["util#build"]), 0, 1000),
+            executed(task("util#build", &[]), 0, 1000),
+        ];
+        assert_eq!(estimated_uncached_duration(&tasks), 3000);
+    }
+
+    #[test]
+    fn parallel_tasks_take_the_max_not_the_sum() {
+        // app#build depends on both libs; libs run in parallel.
+        let tasks = vec![
+            executed(task("app#build", &["lib-a#build", "lib-b#build"]), 0, 500),
+            executed(task("lib-a#build", &[]), 0, 2000),
+            executed(task("lib-b#build", &[]), 0, 3000),
+        ];
+        // max(2000, 3000) + 500
+        assert_eq!(estimated_uncached_duration(&tasks), 3500);
+    }
+
+    #[test]
+    fn diamond_dependencies_are_not_double_counted() {
+        let tasks = vec![
+            executed(task("app#build", &["a#build", "b#build"]), 0, 100),
+            executed(task("a#build", &["base#build"]), 0, 100),
+            executed(task("b#build", &["base#build"]), 0, 100),
+            executed(task("base#build", &[]), 0, 100),
+        ];
+        assert_eq!(estimated_uncached_duration(&tasks), 300);
+    }
+
+    #[test]
+    fn cache_hit_uses_time_saved() {
+        let tasks = vec![cache_hit(task("app#build", &[]), 42_000)];
+        assert_eq!(estimated_uncached_duration(&tasks), 42_000);
+    }
+
+    #[test]
+    fn mixed_hits_and_misses_compose_along_the_chain() {
+        // app (miss, ran 1s) depends on lib (hit, saved 10s).
+        let tasks = vec![
+            executed(task("app#build", &["lib#build"]), 10_000, 11_000),
+            cache_hit(task("lib#build", &[]), 10_000),
+        ];
+        assert_eq!(estimated_uncached_duration(&tasks), 11_000);
+    }
+
+    #[test]
+    fn cache_hit_with_zero_time_saved_contributes_nothing() {
+        let tasks = vec![cache_hit(task("app#build", &[]), 0)];
+        assert_eq!(estimated_uncached_duration(&tasks), 0);
+    }
+
+    #[test]
+    fn dry_run_misses_contribute_nothing() {
+        // Dry run: no execution timing at all, one miss and one hit.
+        let tasks = vec![
+            task("app#build", &["lib#build"]),
+            cache_hit(task("lib#build", &[]), 5_000),
+        ];
+        assert_eq!(estimated_uncached_duration(&tasks), 5_000);
+    }
+
+    #[test]
+    fn cache_hit_beats_execution_when_both_present() {
+        // A real-run cache hit has a near-zero execution (restore time);
+        // the uncached estimate must come from timeSaved.
+        let tasks = vec![cache_hit(executed(task("app#build", &[]), 0, 3), 7_000)];
+        assert_eq!(estimated_uncached_duration(&tasks), 7_000);
+    }
+
+    #[test]
+    fn dependencies_outside_the_run_are_ignored() {
+        let mut t = task("app#build", &["filtered-out#build"]);
+        t = executed(t, 0, 1000);
+        assert_eq!(estimated_uncached_duration(&[t]), 1000);
+    }
+
+    #[test]
+    fn cycles_terminate() {
+        let tasks = vec![
+            executed(task("a#build", &["b#build"]), 0, 1000),
+            executed(task("b#build", &["a#build"]), 0, 1000),
+        ];
+        // Must terminate; exact value is unspecified for malformed input.
+        assert!(estimated_uncached_duration(&tasks) <= 2000);
+    }
+}

--- a/crates/turborepo-run-summary/src/lib.rs
+++ b/crates/turborepo-run-summary/src/lib.rs
@@ -4,6 +4,7 @@
 //! and generating run summaries.
 
 mod duration;
+mod estimated_duration;
 mod execution;
 mod global_hash;
 pub mod observability;
@@ -13,6 +14,7 @@ mod task_factory;
 mod tracker;
 
 pub use duration::TurboDuration;
+pub use estimated_duration::estimated_uncached_duration;
 pub use execution::{
     ExecutionSummary, ExecutionTracker, IncrementalCacheSummary, SummaryState, TaskState,
     TaskSummaryInfo, TaskTracker,

--- a/crates/turborepo-run-summary/src/task.rs
+++ b/crates/turborepo-run-summary/src/task.rs
@@ -51,7 +51,7 @@ pub struct TaskCacheSummary {
     dirty_hash: Option<String>,
 }
 
-#[derive(Debug, Serialize, Copy, Clone)]
+#[derive(Debug, Serialize, Copy, Clone, PartialEq, Eq)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum CacheStatus {
     Hit,
@@ -171,6 +171,13 @@ impl TaskCacheSummary {
     // Used in observability/otel.rs to populate TaskMetricsPayload.cache_status
     pub(crate) fn status(&self) -> CacheStatus {
         self.status
+    }
+
+    /// Milliseconds saved by a cache hit, i.e. the duration of the execution
+    /// that originally produced the cache artifact. 0 for a cache miss and
+    /// for hits whose artifacts lack valid timing metadata.
+    pub(crate) fn time_saved(&self) -> u64 {
+        self.time_saved
     }
 
     // Used in observability/otel.rs to populate TaskMetricsPayload.cache_source

--- a/crates/turborepo-run-summary/src/tracker.rs
+++ b/crates/turborepo-run-summary/src/tracker.rs
@@ -76,6 +76,10 @@ pub struct RunSummary<'a> {
     packages: Vec<&'a PackageName>,
     env_mode: EnvMode,
     framework_inference: bool,
+    /// Estimated wall-clock duration, in milliseconds, of the critical path
+    /// through the task graph if no cache had existed. See
+    /// `estimated_duration` module docs for semantics and dry-run caveats.
+    estimated_uncached_duration: u64,
     tasks: Vec<TaskSummary>,
     user: String,
     scm: SCMState,
@@ -185,6 +189,7 @@ impl RunTracker {
             self.started_at,
             end_time,
         );
+        let estimated_uncached_duration = crate::estimated_uncached_duration(&tasks);
 
         Ok(RunSummary {
             id: Ksuid::new(None, None),
@@ -194,6 +199,7 @@ impl RunTracker {
             execution: Some(execution_summary),
             env_mode: global_env_mode,
             framework_inference: run_opts.framework_inference(),
+            estimated_uncached_duration,
             tasks,
             global_hash_summary,
             scm: scm_state,
@@ -342,6 +348,7 @@ pub struct SinglePackageRunSummary<'a> {
     global_hash_summary: &'a GlobalHashSummary<'a>,
     env_mode: EnvMode,
     framework_inference: bool,
+    estimated_uncached_duration: u64,
     tasks: Vec<SinglePackageTaskSummary>,
     user: &'a str,
     pub scm: &'a SCMState,
@@ -365,6 +372,7 @@ impl<'a> From<&'a RunSummary<'a>> for SinglePackageRunSummary<'a> {
             global_hash_summary: &run_summary.global_hash_summary,
             env_mode: run_summary.env_mode,
             framework_inference: run_summary.framework_inference,
+            estimated_uncached_duration: run_summary.estimated_uncached_duration,
             tasks,
             user: &run_summary.user,
             scm: &run_summary.scm,

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -1095,6 +1095,14 @@ The summary module is responsible for any time of summary:
 
 - Stitches together result from visitor and the task tracker
 - Constructs final summary depending on user ask e.g. `--dry=json`/`--summarize`
+- Computes `estimatedUncachedDuration`
+  (`crates/turborepo-run-summary/src/estimated_duration.rs`): the critical
+  path through the task DAG as if nothing had been cached, in milliseconds.
+  Executed cache misses contribute their measured execution duration; cache
+  hits contribute the artifact's `timeSaved` metadata (0 when absent); tasks
+  with no timing information (e.g. dry-run misses) contribute 0. Parallel
+  branches are not summed; the estimate is the longest dependency chain and
+  ignores scheduling constraints like `--concurrency`.
 
 ### 8. Query Subsystem
 

--- a/crates/turborepo/tests/dry_json.rs
+++ b/crates/turborepo/tests/dry_json.rs
@@ -158,6 +158,77 @@ fn test_monorepo_missing_task_error() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+#[test]
+fn test_monorepo_dry_json_estimated_uncached_duration_all_misses() -> Result<(), anyhow::Error> {
+    let tempdir = tempfile::tempdir()?;
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false)?;
+    let json = turbo_dry_json(tempdir.path(), &["run", "build", "--dry=json"])?;
+
+    // Dry runs never execute tasks, so cache misses have no timing signal
+    // and the estimate is 0.
+    let tasks = json["tasks"].as_array().unwrap();
+    assert!(
+        tasks.iter().all(|t| t["cache"]["status"] == "MISS"),
+        "expected all cache misses in a fresh repo"
+    );
+    assert_eq!(json["estimatedUncachedDuration"], serde_json::json!(0));
+    Ok(())
+}
+
+#[test]
+fn test_monorepo_dry_json_estimated_uncached_duration_cache_hits() -> Result<(), anyhow::Error> {
+    let tempdir = tempfile::tempdir()?;
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false)?;
+
+    // Populate the cache with a real run, then dry-run against it.
+    let output = run_turbo(tempdir.path(), &["run", "build"]);
+    assert!(output.status.success());
+
+    // Scope to the cacheable build tasks; `another` has no build script and
+    // never caches.
+    let json = turbo_dry_json(
+        tempdir.path(),
+        &[
+            "run",
+            "build",
+            "--dry=json",
+            "--filter=my-app",
+            "--filter=util",
+        ],
+    )?;
+
+    let tasks = json["tasks"].as_array().unwrap();
+    assert!(
+        tasks.iter().all(|t| t["cache"]["status"] == "HIT"),
+        "expected all cache hits after a real run, got: {tasks:?}"
+    );
+
+    // With no dependsOn wiring, my-app#build and util#build are parallel,
+    // so the estimate is the max of their timeSaved values, not the sum.
+    let max_saved = tasks
+        .iter()
+        .map(|t| t["cache"]["timeSaved"].as_u64().unwrap())
+        .max()
+        .unwrap();
+    assert!(
+        max_saved > 0,
+        "echo tasks should record a nonzero timeSaved, got: {tasks:?}"
+    );
+    let sum_saved: u64 = tasks
+        .iter()
+        .map(|t| t["cache"]["timeSaved"].as_u64().unwrap())
+        .sum();
+    assert_eq!(
+        json["estimatedUncachedDuration"].as_u64().unwrap(),
+        max_saved,
+    );
+    assert!(
+        max_saved < sum_saved,
+        "max ({max_saved}) should be less than the sum ({sum_saved}) for parallel tasks"
+    );
+    Ok(())
+}
+
 // === monorepo no changes ===
 
 #[test]

--- a/crates/turborepo/tests/run_summary.rs
+++ b/crates/turborepo/tests/run_summary.rs
@@ -123,6 +123,90 @@ fn test_run_summary_monorepo() {
     // another#build not present (no build script)
     let another = get_task(first, "another#build");
     assert!(another.is_null());
+
+    // === estimatedUncachedDuration ===
+
+    // First run: both tasks were cache misses that executed, so the
+    // estimate is derived from measured execution durations. my-app#build
+    // and util#build are independent (my-app's `util: *` dependency has no
+    // `^build` wiring in turbo.json), so the estimate is the slower of the
+    // two tasks, not the sum.
+    let estimate = first["estimatedUncachedDuration"].as_u64().unwrap();
+    let app_duration = first_app["execution"]["endTime"].as_i64().unwrap()
+        - first_app["execution"]["startTime"].as_i64().unwrap();
+    let util_duration = first_util["execution"]["endTime"].as_i64().unwrap()
+        - first_util["execution"]["startTime"].as_i64().unwrap();
+    assert_eq!(estimate, app_duration.max(util_duration) as u64);
+    let wall_clock = first["execution"]["endTime"].as_i64().unwrap()
+        - first["execution"]["startTime"].as_i64().unwrap();
+    assert!(
+        estimate as i64 <= wall_clock,
+        "critical path estimate ({estimate}) should not exceed wall clock ({wall_clock})"
+    );
+
+    // Second run: both tasks were cache hits, so the estimate comes from
+    // each artifact's recorded timeSaved (the duration of the execution
+    // that produced it), again taking the max for parallel tasks.
+    let second_util = get_task(second, "util#build");
+    let hit_estimate = second["estimatedUncachedDuration"].as_u64().unwrap();
+    let app_saved = second_app["cache"]["timeSaved"].as_u64().unwrap();
+    let util_saved = second_util["cache"]["timeSaved"].as_u64().unwrap();
+    assert_eq!(hit_estimate, app_saved.max(util_saved));
+
+    // Cache hits restore nearly instantly, so the uncached estimate must
+    // far exceed the actual wall clock of the fully cached run.
+    let hit_wall_clock = second["execution"]["endTime"].as_i64().unwrap()
+        - second["execution"]["startTime"].as_i64().unwrap();
+    assert!(
+        hit_estimate as i64 > hit_wall_clock,
+        "estimate ({hit_estimate}) should exceed cached-run wall clock ({hit_wall_clock})"
+    );
+}
+
+#[test]
+fn test_run_summary_estimated_uncached_duration_dependency_chain() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
+
+    let _ = fs::remove_dir_all(tempdir.path().join(".turbo/runs"));
+
+    // Wire my-app#build to depend on ^build so the two tasks form a chain
+    // instead of running in parallel. The fixture turbo.json contains
+    // comments, so rewrite it wholesale instead of parsing it as JSON.
+    fs::write(
+        tempdir.path().join("turbo.json"),
+        r#"{
+  "globalDependencies": ["foo.txt"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    }
+  }
+}
+"#,
+    )
+    .unwrap();
+
+    run_turbo(tempdir.path(), &["run", "build", "--summarize"]);
+
+    let summaries = read_run_summaries(tempdir.path());
+    assert_eq!(summaries.len(), 1);
+    let summary = &summaries[0];
+
+    let app = get_task(summary, "my-app#build");
+    let util = get_task(summary, "util#build");
+    assert_eq!(app["cache"]["status"], "MISS");
+    assert_eq!(util["cache"]["status"], "MISS");
+
+    let app_duration = app["execution"]["endTime"].as_i64().unwrap()
+        - app["execution"]["startTime"].as_i64().unwrap();
+    let util_duration = util["execution"]["endTime"].as_i64().unwrap()
+        - util["execution"]["startTime"].as_i64().unwrap();
+
+    // A chain sums: util must finish before my-app starts.
+    let estimate = summary["estimatedUncachedDuration"].as_u64().unwrap();
+    assert_eq!(estimate, (app_duration + util_duration) as u64);
 }
 
 #[test]

--- a/crates/turborepo/tests/snapshots/dry_json__monorepo_top_level_keys.snap
+++ b/crates/turborepo/tests/snapshots/dry_json__monorepo_top_level_keys.snap
@@ -4,6 +4,7 @@ expression: keys
 ---
 [
   "envMode",
+  "estimatedUncachedDuration",
   "frameworkInference",
   "globalCacheInputs",
   "id",

--- a/crates/turborepo/tests/snapshots/dry_json__single_package_dry_json.snap
+++ b/crates/turborepo/tests/snapshots/dry_json__single_package_dry_json.snap
@@ -28,6 +28,7 @@ expression: json
   },
   "envMode": "strict",
   "frameworkInference": true,
+  "estimatedUncachedDuration": 0,
   "tasks": [
     {
       "taskId": "build",

--- a/crates/turborepo/tests/snapshots/dry_json__single_package_no_config.snap
+++ b/crates/turborepo/tests/snapshots/dry_json__single_package_no_config.snap
@@ -27,6 +27,7 @@ expression: json
   },
   "envMode": "strict",
   "frameworkInference": true,
+  "estimatedUncachedDuration": 0,
   "tasks": [
     {
       "taskId": "build",

--- a/crates/turborepo/tests/snapshots/dry_json__single_package_with_deps.snap
+++ b/crates/turborepo/tests/snapshots/dry_json__single_package_with_deps.snap
@@ -28,6 +28,7 @@ expression: json
   },
   "envMode": "strict",
   "frameworkInference": true,
+  "estimatedUncachedDuration": 0,
   "tasks": [
     {
       "taskId": "build",


### PR DESCRIPTION
Adds a top-level `estimatedUncachedDuration` (milliseconds) to `--dry=json` output and saved run summaries: the uncached wall-clock duration of the critical path through the task DAG, for consumers (e.g. elastic build machines) that need a cache-normalized build duration.

Per-task durations: executed cache misses contribute their measured execution time; cache hits contribute the artifact's `timeSaved` (0 when missing); anything else contributes 0. The estimate is the longest dependency chain over those durations, so parallel branches take the max rather than summing. It models an unconstrained machine and ignores `--concurrency`.

Dry-run contract: dry runs never execute, so misses have no timing and contribute 0. The estimate is partial, covering the cache-hit portion of the graph: 0 on a cold cache, a real critical path on a warm one.

Compatibility: additive field, always present (0 when nothing is estimable); no existing keys change shape, schema `version` stays `1`.
