### PR TITLE
fix: Respect gitignore without git metadata

### DIFF
--- a/crates/turborepo-fs/src/lib.rs
+++ b/crates/turborepo-fs/src/lib.rs
@@ -169,6 +169,7 @@ fn collect_entries(
     builder
         .hidden(false)
         .parents(false)
+        .require_git(false)
         .git_ignore(use_gitignore)
         .git_global(false)
         .git_exclude(use_gitignore);
@@ -787,6 +788,22 @@ mod tests {
                 .join_components(&["coverage", "report.txt"])
                 .exists()
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_copy_plan_honors_ignore_files_without_git_metadata() -> Result<(), Error> {
+        let (_root_tmp, root) = ignore_fixture()?;
+        root.join_component(".git").remove_dir_all()?;
+        let web = root.join_components(&["apps", "web"]);
+
+        let plan = CopyPlan::new([web.as_ref()], true, Some(&root))?;
+        let (_web_tmp, web_dst) = tmp_dir()?;
+        plan.copy(&web, &web_dst)?;
+
+        assert!(web_dst.join_components(&["src", "index.ts"]).exists());
+        assert!(!web_dst.join_component("node_modules").exists());
 
         Ok(())
     }

--- a/crates/turborepo/tests/prune_test.rs
+++ b/crates/turborepo/tests/prune_test.rs
@@ -579,8 +579,12 @@ fn test_prune_respects_root_gitignore_in_workspaces() {
         "module.exports = {};\n",
     )
     .unwrap();
+    fs::remove_dir_all(tempdir.path().join(".git")).unwrap();
 
-    let output = run_turbo(tempdir.path(), &["prune", "web", "--docker"]);
+    let output = run_turbo(
+        tempdir.path(),
+        &["prune", "web", "--docker", "--use-gitignore"],
+    );
     assert!(
         output.status.success(),
         "prune failed: {}",


### PR DESCRIPTION
## Why

`turbo prune --use-gitignore` did not honor `.gitignore` files when Git metadata was absent, as in Docker build contexts. This could copy workspace-local `node_modules` into `out/full` and leave stale or dangling package-manager links.

Fixes #13755.

## What

- Configure the shared `CopyPlan` walker with `require_git(false)` so enabled gitignore matching does not depend on a `.git` directory.
- Add focused filesystem coverage for a planned copy without Git metadata.
- Exercise `prune --docker --use-gitignore` after removing `.git` and verify workspace `node_modules` remains excluded.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p turborepo-fs`
- `cargo test -p turbo --test prune_test test_prune_respects_root_gitignore_in_workspaces`
- `cargo clippy -p turborepo-fs -p turbo --all-targets -- -D warnings`
- `cargo test -p turbo --test prune_test` (25/26 pass; pre-existing `test_prune_composable_config` fails during `pnpm install`, matching the known environment failure documented in #13705)