### PR TITLE
fix: Preserve showcase logo sizes

### DIFF
--- a/apps/docs/app/[lang]/(home)/showcase/page.tsx
+++ b/apps/docs/app/[lang]/(home)/showcase/page.tsx
@@ -21,7 +21,7 @@ function Showcase() {
         </div>
       </div>
 
-      <div className="mb-8 grid min-h-screen grid-cols-2 items-center gap-16 px-0 sm:grid-cols-3 sm:px-8 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-7">
+      <div className="mb-8 grid min-h-screen grid-cols-2 items-center gap-6 sm:gap-16 px-0 sm:grid-cols-3 sm:px-8 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-7">
         <Clients linked />
       </div>
     </main>

--- a/apps/docs/app/[lang]/(home)/showcase/page.tsx
+++ b/apps/docs/app/[lang]/(home)/showcase/page.tsx
@@ -21,7 +21,7 @@ function Showcase() {
         </div>
       </div>
 
-      <div className="mb-8 grid min-h-screen grid-cols-3 items-center gap-16 px-0 sm:grid-cols-4 sm:px-8 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-7 [&_img]:max-w-none">
+      <div className="mb-8 grid min-h-screen grid-cols-2 items-center gap-16 px-0 sm:grid-cols-3 sm:px-8 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-7">
         <Clients linked />
       </div>
     </main>

--- a/apps/docs/app/[lang]/(home)/showcase/page.tsx
+++ b/apps/docs/app/[lang]/(home)/showcase/page.tsx
@@ -21,7 +21,7 @@ function Showcase() {
         </div>
       </div>
 
-      <div className="mb-8 px-0 min-h-screen sm:px-8 grid grid-cols-3 items-center gap-16 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-7 ">
+      <div className="mb-8 grid min-h-screen grid-cols-3 items-center gap-16 px-0 sm:grid-cols-4 sm:px-8 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-7 [&_img]:max-w-none">
         <Clients linked />
       </div>
     </main>


### PR DESCRIPTION
## Summary
- prevent showcase logos from shrinking with narrow grid columns
- preserve each logo’s configured dimensions across viewport sizes
- scope the sizing override to the showcase page

## Testing
- `pnpm exec oxfmt --check`
- `git diff --check`
- pre-push format and TOML checks