### PR TITLE
fix: Refine mobile homepage interactions

### DIFF
--- a/apps/docs/app/[lang]/(home)/graphics/remote-cache-gauge.tsx
+++ b/apps/docs/app/[lang]/(home)/graphics/remote-cache-gauge.tsx
@@ -112,20 +112,27 @@ export function RemoteCacheGauge() {
     setSpringTarget(isAccelerating ? 98 : GAUGE_INDICATOR_REST);
   }, [isAccelerating]);
 
-  const resetOnMobilePointerEnd = () => {
-    if (window.matchMedia("(max-width: 767px)").matches) {
-      setIsAccelerating(false);
-    }
-  };
+  const isMobileViewport = () =>
+    window.matchMedia("(max-width: 767px)").matches;
 
   return (
     <div
       className="relative w-full max-w-[500px] aspect-[24/17] [--remote-cache-inner-end:#FF1E56] [--remote-cache-inner-start:#0196FF] [--remote-cache-tick-color:var(--ds-gray-alpha-500)] dark:[--remote-cache-inner-end:#FF5C9A] dark:[--remote-cache-inner-start:#52C7FF] dark:[--remote-cache-tick-color:var(--ds-gray-alpha-600)]"
-      onClick={resetOnMobilePointerEnd}
-      onMouseEnter={() => setIsAccelerating(true)}
-      onMouseLeave={() => setIsAccelerating(false)}
-      onPointerCancel={resetOnMobilePointerEnd}
-      onPointerUp={resetOnMobilePointerEnd}
+      onClick={() => {
+        if (isMobileViewport()) {
+          setIsAccelerating((isActive) => !isActive);
+        }
+      }}
+      onMouseEnter={() => {
+        if (!isMobileViewport()) {
+          setIsAccelerating(true);
+        }
+      }}
+      onMouseLeave={() => {
+        if (!isMobileViewport()) {
+          setIsAccelerating(false);
+        }
+      }}
     >
       <svg
         aria-hidden="true"

--- a/apps/docs/app/[lang]/(home)/graphics/remote-cache-gauge.tsx
+++ b/apps/docs/app/[lang]/(home)/graphics/remote-cache-gauge.tsx
@@ -112,11 +112,20 @@ export function RemoteCacheGauge() {
     setSpringTarget(isAccelerating ? 98 : GAUGE_INDICATOR_REST);
   }, [isAccelerating]);
 
+  const resetOnMobilePointerEnd = () => {
+    if (window.matchMedia("(max-width: 767px)").matches) {
+      setIsAccelerating(false);
+    }
+  };
+
   return (
     <div
       className="relative w-full max-w-[500px] aspect-[24/17] [--remote-cache-inner-end:#FF1E56] [--remote-cache-inner-start:#0196FF] [--remote-cache-tick-color:var(--ds-gray-alpha-500)] dark:[--remote-cache-inner-end:#FF5C9A] dark:[--remote-cache-inner-start:#52C7FF] dark:[--remote-cache-tick-color:var(--ds-gray-alpha-600)]"
+      onClick={resetOnMobilePointerEnd}
       onMouseEnter={() => setIsAccelerating(true)}
       onMouseLeave={() => setIsAccelerating(false)}
+      onPointerCancel={resetOnMobilePointerEnd}
+      onPointerUp={resetOnMobilePointerEnd}
     >
       <svg
         aria-hidden="true"

--- a/apps/docs/app/[lang]/(home)/showcase/page.tsx
+++ b/apps/docs/app/[lang]/(home)/showcase/page.tsx
@@ -21,7 +21,7 @@ function Showcase() {
         </div>
       </div>
 
-      <div className="mb-8 px-0 min-h-screen sm:px-8 grid grid-cols-3 items-center gap-16 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-7 ">
+      <div className="mb-8 grid min-h-screen grid-cols-2 items-center gap-6 sm:gap-16 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 xl:grid-cols-7">
         <Clients linked />
       </div>
     </main>


### PR DESCRIPTION
## Summary
- toggle the cache gauge between accelerated and resting states on successive mobile taps, preserve the existing desktop hover behavior
- fix logo scale on mobile view in /showcase

## Testing
- `pnpm exec oxfmt --check`
- `git diff --check`
- pre-push format and TOML checks