### PR TITLE
fix: Prevent homepage KPI overflow

### DIFF
--- a/apps/docs/app/[lang]/(home)/open-source-metrics.tsx
+++ b/apps/docs/app/[lang]/(home)/open-source-metrics.tsx
@@ -26,7 +26,7 @@ const getOpenIssuesLabel = (count: number): string => {
 
 const fetchDownloads = async (): Promise<string> => {
   const response = await fetch(
-    "https://api.npmjs.org/downloads/range/last-month/turbo",
+    "https://api.npmjs.org/downloads/range/last-month/turbo"
   );
 
   if (!response.ok) {
@@ -45,7 +45,7 @@ const fetchDownloads = async (): Promise<string> => {
   const weeklyTotals = [0, 7, 14].map((start) =>
     recentDownloads
       .slice(start, start + 7)
-      .reduce((total, day) => total + day.downloads, 0),
+      .reduce((total, day) => total + day.downloads, 0)
   );
 
   return formatNumber(Math.max(...weeklyTotals));
@@ -54,9 +54,7 @@ const fetchDownloads = async (): Promise<string> => {
 const fetchRepositoryMetrics = async (): Promise<{
   stars: string;
 }> => {
-  const response = await fetch(
-    "https://api.github.com/repos/vercel/turborepo",
-  );
+  const response = await fetch("https://api.github.com/repos/vercel/turborepo");
 
   if (!response.ok) {
     throw new Error(`Failed to fetch GitHub stars: ${response.status}`);
@@ -73,7 +71,7 @@ const fetchRepositoryMetrics = async (): Promise<{
 
 const fetchOpenIssues = async (): Promise<number> => {
   const response = await fetch(
-    "https://api.github.com/search/issues?q=repo%3Avercel%2Fturborepo+type%3Aissue+state%3Aopen",
+    "https://api.github.com/search/issues?q=repo%3Avercel%2Fturborepo+type%3Aissue+state%3Aopen"
   );
 
   if (!response.ok) {
@@ -119,7 +117,10 @@ export async function OpenSourceMetrics() {
         const isFeatured = index === 0;
 
         return (
-          <div className="min-w-0" key={metric.id}>
+          <div
+            className={isFeatured ? "min-w-0" : "min-w-0 text-right"}
+            key={metric.id}
+          >
             <dt
               className={
                 isFeatured

--- a/apps/docs/app/[lang]/(home)/open-source-metrics.tsx
+++ b/apps/docs/app/[lang]/(home)/open-source-metrics.tsx
@@ -118,7 +118,9 @@ export async function OpenSourceMetrics() {
 
         return (
           <div
-            className={isFeatured ? "min-w-0" : "min-w-0 lg:translate-x-28"}
+            className={
+              isFeatured ? "min-w-0" : "min-w-0 lg:justify-self-end"
+            }
             key={metric.id}
           >
             <dt

--- a/apps/docs/app/[lang]/(home)/open-source-metrics.tsx
+++ b/apps/docs/app/[lang]/(home)/open-source-metrics.tsx
@@ -26,7 +26,7 @@ const getOpenIssuesLabel = (count: number): string => {
 
 const fetchDownloads = async (): Promise<string> => {
   const response = await fetch(
-    "https://api.npmjs.org/downloads/range/last-month/turbo"
+    "https://api.npmjs.org/downloads/range/last-month/turbo",
   );
 
   if (!response.ok) {
@@ -45,7 +45,7 @@ const fetchDownloads = async (): Promise<string> => {
   const weeklyTotals = [0, 7, 14].map((start) =>
     recentDownloads
       .slice(start, start + 7)
-      .reduce((total, day) => total + day.downloads, 0)
+      .reduce((total, day) => total + day.downloads, 0),
   );
 
   return formatNumber(Math.max(...weeklyTotals));
@@ -71,7 +71,7 @@ const fetchRepositoryMetrics = async (): Promise<{
 
 const fetchOpenIssues = async (): Promise<number> => {
   const response = await fetch(
-    "https://api.github.com/search/issues?q=repo%3Avercel%2Fturborepo+type%3Aissue+state%3Aopen"
+    "https://api.github.com/search/issues?q=repo%3Avercel%2Fturborepo+type%3Aissue+state%3Aopen",
   );
 
   if (!response.ok) {
@@ -118,7 +118,7 @@ export async function OpenSourceMetrics() {
 
         return (
           <div
-            className={isFeatured ? "min-w-0" : "min-w-0 lg:translate-x-4"}
+            className={isFeatured ? "min-w-0" : "min-w-0 lg:translate-x-28"}
             key={metric.id}
           >
             <dt

--- a/apps/docs/app/[lang]/(home)/open-source-metrics.tsx
+++ b/apps/docs/app/[lang]/(home)/open-source-metrics.tsx
@@ -118,7 +118,7 @@ export async function OpenSourceMetrics() {
 
         return (
           <div
-            className={isFeatured ? "min-w-0" : "min-w-0 text-right"}
+            className={isFeatured ? "min-w-0" : "min-w-0 lg:translate-x-4"}
             key={metric.id}
           >
             <dt


### PR DESCRIPTION
## Summary
- align KPI cells normally

| **Before**  | **After** |
| ------------- | ------------- |
| <img width="2560" height="1294" alt="image" src="https://github.com/user-attachments/assets/d763a1b0-c0f7-4ed3-a99a-7fffa8740582" /> | <img width="2560" height="1295" alt="image" src="https://github.com/user-attachments/assets/f4fdda90-e98f-4349-83cd-1cfd89f2f81d" />  |