### PR TITLE
feat: Add security.txt endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@ Follow [@turborepo](https://x.com/turborepo) on X for project updates.
 
 If you believe you have found a security vulnerability in Turborepo, we encourage you to responsibly disclose this and not open a public issue. We will investigate all legitimate reports. Email `security@vercel.com` to disclose any security vulnerabilities.
 
-https://vercel.com/security
+https://security.vercel.com/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,1 +1,1 @@
-Visit https://vercel.com/security to view the disclosure policy.
+Visit https://security.vercel.com/ to view the disclosure policy.

--- a/apps/docs/proxy.ts
+++ b/apps/docs/proxy.ts
@@ -9,7 +9,7 @@ const proxy = createProxy({
 
 export const config = {
   matcher: [
-    "/((?!api(?:/|$)|_next/static|_next/image|favicon.ico|feed.xml|sitemap.xml|robots.txt|schema\\.json|schema\\.v\\d+\\.json|microfrontends/schema\\.json).*)"
+    "/((?!api(?:/|$)|_next/static|_next/image|favicon.ico|feed.xml|sitemap.xml|robots.txt|schema\\.json|schema\\.v\\d+\\.json|microfrontends/schema\\.json|\\.well-known/security\\.txt).*)"
   ]
 };
 

--- a/apps/docs/public/.well-known/security.txt
+++ b/apps/docs/public/.well-known/security.txt
@@ -1,0 +1,7 @@
+Contact: https://hackerone.com/vercel-open-source
+Contact: mailto:responsible.disclosure@vercel.com
+Expires: 2027-08-19T00:00:00.000Z
+Preferred-Languages: en
+Policy: https://security.vercel.com/
+Canonical: https://turborepo.dev/.well-known/security.txt
+Hiring: https://vercel.com/careers?function=Security+%26+IT#positions

--- a/packages/turbo/README.md
+++ b/packages/turbo/README.md
@@ -45,4 +45,4 @@ Follow [@turborepo](https://x.com/turborepo) on X for project updates.
 
 If you believe you have found a security vulnerability in Turborepo, we encourage you to responsibly disclose this and not open a public issue. We will investigate all legitimate reports. Email `security@vercel.com` to disclose any security vulnerabilities.
 
-https://vercel.com/security
+https://security.vercel.com/


### PR DESCRIPTION
## Description

Adds an RFC 9116-compatible security disclosure file at `https://turborepo.dev/.well-known/security.txt`, based on the existing Vercel security metadata.

The route is excluded from the docs locale proxy so it is served directly as plain text.

The existing documentation links pointed to the general Vercel security page. They now use `https://security.vercel.com/`, the Trust Center and policy URL advertised by the Vercel `security.txt`, keeping the human-readable documentation and machine-readable metadata aligned.

## Testing

- Ran formatting checks
- Ran the docs TypeScript check
- Built the docs site
- Verified the endpoint returns `200` with `Content-Type: text/plain; charset=UTF-8`