### PR TITLE
feat: Add SSH command affordance for factory sandboxes

### DIFF
--- a/apps/factory/agent/lib/sandbox-ssh.ts
+++ b/apps/factory/agent/lib/sandbox-ssh.ts
@@ -1,0 +1,3 @@
+export function sandboxSshCommand(name: string): string {
+  return `sandbox ssh ${name}`;
+}

--- a/apps/factory/app/globals.css
+++ b/apps/factory/app/globals.css
@@ -420,6 +420,34 @@ h3 {
   font-size: 0.75rem;
 }
 
+.copyCommand {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 12px;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--background);
+}
+
+.copyCommand code {
+  overflow: hidden;
+  color: var(--foreground);
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 0.75rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.copyCommandButton {
+  flex: none;
+  height: auto;
+  padding: 2px 8px;
+  font-size: 0.75rem;
+}
+
 .runDetails {
   display: inline-block;
   margin-top: 20px;

--- a/apps/factory/app/run-observatory.tsx
+++ b/apps/factory/app/run-observatory.tsx
@@ -106,7 +106,7 @@ function RunTicket({ run }: { readonly run: AgentRunRecord }) {
           <span aria-hidden="true">→</span>
           <span>{run.sandbox?.status ?? run.status}</span>
         </div>
-        {run.sandbox ? (
+        {run.sandbox && run.sandbox.provider !== "eve" ? (
           <CopyCommand
             command={sandboxSshCommand(run.sandbox.id)}
             label="SSH command for this sandbox"

--- a/apps/factory/app/run-observatory.tsx
+++ b/apps/factory/app/run-observatory.tsx
@@ -8,11 +8,13 @@ import {
   useState
 } from "react";
 
+import { sandboxSshCommand } from "../agent/lib/sandbox-ssh";
 import type {
   AgentRunRecord,
   ControlPlaneSnapshot,
   SandboxResource
 } from "../agent/lib/run-types";
+import { CopyCommand } from "../components/copy-command";
 import { Button } from "../components/ui/button";
 
 const AGENT_RUNS_URL =
@@ -104,6 +106,12 @@ function RunTicket({ run }: { readonly run: AgentRunRecord }) {
           <span aria-hidden="true">→</span>
           <span>{run.sandbox?.status ?? run.status}</span>
         </div>
+        {run.sandbox ? (
+          <CopyCommand
+            command={sandboxSshCommand(run.sandbox.id)}
+            label="SSH command for this sandbox"
+          />
+        ) : null}
         <a
           className="runDetails"
           href={detailsUrl}
@@ -142,6 +150,10 @@ function SandboxCard({ sandbox }: { readonly sandbox: SandboxResource }) {
           <dd>{sandbox.region ?? "automatic"}</dd>
         </div>
       </dl>
+      <CopyCommand
+        command={sandboxSshCommand(sandbox.name)}
+        label="SSH command for this sandbox"
+      />
     </li>
   );
 }

--- a/apps/factory/components/copy-command.tsx
+++ b/apps/factory/components/copy-command.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+import { Button } from "./ui/button";
+
+interface CopyCommandProps {
+  readonly command: string;
+  readonly label?: string;
+}
+
+export function CopyCommand({ command, label }: CopyCommandProps) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Ignore clipboard failures; the user can still select the text manually.
+    }
+  }, [command]);
+
+  return (
+    <div className="copyCommand">
+      <code aria-label={label ?? "Terminal command"}>{command}</code>
+      <Button
+        aria-label={copied ? "Copied" : `Copy ${label ?? "command"}`}
+        className="copyCommandButton"
+        onClick={() => void copy()}
+        size="sm"
+        type="button"
+        variant="ghost"
+      >
+        {copied ? "Copied" : "Copy"}
+      </Button>
+    </div>
+  );
+}

--- a/apps/factory/tests/sandbox-ssh.test.mjs
+++ b/apps/factory/tests/sandbox-ssh.test.mjs
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { sandboxSshCommand } from "../agent/lib/sandbox-ssh.ts";
+
+test("produces a sandbox ssh command for a given sandbox name", () => {
+  assert.equal(sandboxSshCommand("my-sandbox"), "sandbox ssh my-sandbox");
+  assert.equal(
+    sandboxSshCommand("ai-sdk-harness-session-abc123"),
+    "sandbox ssh ai-sdk-harness-session-abc123"
+  );
+});
+
+test("preserves special characters in sandbox names", () => {
+  assert.equal(sandboxSshCommand("a-b_c.d"), "sandbox ssh a-b_c.d");
+});


### PR DESCRIPTION
Adds an easy-to-copy terminal SSH command to factory sandboxes.

- New sandboxSshCommand() helper in agent/lib/sandbox-ssh.ts generates the command sandbox ssh <name>.
- New CopyCommand React component copies the command to the clipboard and shows a copied confirmation.
- Integrated into both RunTicket (when a run has a sandbox) and SandboxCard (in the sandbox inventory).
- Added unit tests for the SSH command helper.