### PR TITLE
chore: Add full-page terminal SSH sessions to Factory sandbox inventory

### DIFF
--- a/apps/factory/agent/lib/sandbox-terminal.ts
+++ b/apps/factory/agent/lib/sandbox-terminal.ts
@@ -1,0 +1,94 @@
+import { Sandbox } from "@vercel/sandbox";
+
+export interface TerminalSession {
+  readonly url: string;
+  readonly token: string;
+}
+
+export interface SandboxWithInteractive {
+  readonly openInteractive: (opts?: {
+    readonly signal?: AbortSignal;
+  }) => Promise<{ readonly url: string; readonly token: string }>;
+}
+
+const ALLOWED_SANDBOX_NAME_PREFIX = "ai-sdk-harness";
+
+export function isAllowedSandboxName(name: string): boolean {
+  return name.startsWith(ALLOWED_SANDBOX_NAME_PREFIX);
+}
+
+export async function createTerminalSession(
+  sandboxName: string,
+  getSandbox: (
+    name: string
+  ) => Promise<SandboxWithInteractive> = defaultGetSandbox
+): Promise<TerminalSession> {
+  if (!isAllowedSandboxName(sandboxName)) {
+    throw new Error(
+      `Sandbox name must start with "${ALLOWED_SANDBOX_NAME_PREFIX}".`
+    );
+  }
+
+  const sandbox = await getSandbox(sandboxName);
+  const session = await sandbox.openInteractive();
+  return { url: session.url, token: session.token };
+}
+
+async function defaultGetSandbox(
+  name: string
+): Promise<SandboxWithInteractive> {
+  const sandbox = await Sandbox.get({ name, resume: true });
+  return sandbox as SandboxWithInteractive;
+}
+
+export async function handleTerminalRequest(
+  request: Request,
+  createSession: (
+    name: string
+  ) => Promise<TerminalSession> = createTerminalSession
+): Promise<Response> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  if (!isValidRequest(body)) {
+    return Response.json(
+      { error: "A valid sandboxName is required." },
+      { status: 400 }
+    );
+  }
+
+  const { sandboxName } = body;
+
+  if (!isAllowedSandboxName(sandboxName)) {
+    return Response.json(
+      { error: "Sandbox name is not allowed." },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const session = await createSession(sandboxName);
+    return Response.json(session);
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "Could not open an interactive session for the sandbox.";
+    const status = message.includes("not_found") ? 404 : 500;
+    return Response.json({ error: message }, { status });
+  }
+}
+
+function isValidRequest(
+  value: unknown
+): value is { readonly sandboxName: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as Record<string, unknown>).sandboxName === "string"
+  );
+}

--- a/apps/factory/app/api/sandbox/terminal/route.ts
+++ b/apps/factory/app/api/sandbox/terminal/route.ts
@@ -1,0 +1,7 @@
+import { handleTerminalRequest } from "@/agent/lib/sandbox-terminal";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request): Promise<Response> {
+  return handleTerminalRequest(request);
+}

--- a/apps/factory/app/globals.css
+++ b/apps/factory/app/globals.css
@@ -540,6 +540,11 @@ select:focus-visible {
   margin: 16px 0 0 15px;
 }
 
+.sandboxTerminalButton {
+  margin-top: 12px;
+  width: 100%;
+}
+
 .resourceDot {
   color: var(--muted-foreground);
 }
@@ -776,6 +781,69 @@ select:focus-visible {
   .actions > * {
     width: 100%;
   }
+}
+
+.sandboxTerminalOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  background: #000000;
+  color: #ededed;
+}
+
+.sandboxTerminalOverlay-error {
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.sandboxTerminalContainer {
+  flex: 1 1 auto;
+  min-height: 0;
+  padding: 8px;
+}
+
+.sandboxTerminalContainer .xterm {
+  height: 100%;
+}
+
+.sandboxTerminalContainer .xterm-screen {
+  width: 100% !important;
+  height: 100% !important;
+}
+
+.sandboxTerminalNotice {
+  max-width: 480px;
+  padding: 24px;
+  text-align: center;
+  color: var(--foreground);
+  background: var(--secondary);
+  border-radius: var(--radius);
+}
+
+.sandboxTerminalNotice p {
+  margin: 0 0 16px;
+}
+
+.sandboxTerminalClose {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40px;
+  padding: 0 16px;
+  color: var(--primary-foreground);
+  background: var(--primary);
+  border: 1px solid var(--primary);
+  border-radius: var(--radius);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.sandboxTerminalClose:hover {
+  opacity: 0.9;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/apps/factory/app/run-observatory.tsx
+++ b/apps/factory/app/run-observatory.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import {
   startTransition,
   useEffect,
@@ -16,6 +17,11 @@ import type {
 } from "../agent/lib/run-types";
 import { CopyCommand } from "../components/copy-command";
 import { Button } from "../components/ui/button";
+
+const SandboxTerminal = dynamic(
+  () => import("./sandbox-terminal").then((mod) => mod.SandboxTerminal),
+  { ssr: false }
+);
 
 const AGENT_RUNS_URL =
   "https://vercel.com/vercel-internal-apps/turborepo-eve-agent/observability/agent-runs";
@@ -126,7 +132,13 @@ function RunTicket({ run }: { readonly run: AgentRunRecord }) {
   );
 }
 
-function SandboxCard({ sandbox }: { readonly sandbox: SandboxResource }) {
+function SandboxCard({
+  sandbox,
+  onTerminal
+}: {
+  readonly sandbox: SandboxResource;
+  readonly onTerminal: (name: string) => void;
+}) {
   return (
     <li className="sandboxCard">
       <div>
@@ -154,6 +166,16 @@ function SandboxCard({ sandbox }: { readonly sandbox: SandboxResource }) {
         command={sandboxSshCommand(sandbox.name)}
         label="SSH command for this sandbox"
       />
+      <Button
+        className="sandboxTerminalButton"
+        disabled={sandbox.status !== "running"}
+        onClick={() => onTerminal(sandbox.name)}
+        size="sm"
+        type="button"
+        variant="outline"
+      >
+        Terminal
+      </Button>
     </li>
   );
 }
@@ -166,6 +188,7 @@ export function RunObservatory({
   const [snapshot, setSnapshot] = useState(initialSnapshot);
   const [trigger, setTrigger] = useState("all");
   const [refreshing, setRefreshing] = useState(false);
+  const [activeTerminal, setActiveTerminal] = useState<string | null>(null);
   const refreshController = useRef<AbortController | null>(null);
 
   async function refresh() {
@@ -304,12 +327,22 @@ export function RunObservatory({
       ) : snapshot.sandboxes.length > 0 ? (
         <ul className="sandboxGrid">
           {snapshot.sandboxes.slice(0, 8).map((sandbox) => (
-            <SandboxCard key={sandbox.name} sandbox={sandbox} />
+            <SandboxCard
+              key={sandbox.name}
+              sandbox={sandbox}
+              onTerminal={setActiveTerminal}
+            />
           ))}
         </ul>
       ) : (
         <p className="emptySandboxes">No named sandbox resources are active.</p>
       )}
+      {activeTerminal ? (
+        <SandboxTerminal
+          sandboxName={activeTerminal}
+          onExit={() => setActiveTerminal(null)}
+        />
+      ) : null}
     </section>
   );
 }

--- a/apps/factory/app/run-observatory.tsx
+++ b/apps/factory/app/run-observatory.tsx
@@ -168,7 +168,7 @@ function SandboxCard({
       />
       <Button
         className="sandboxTerminalButton"
-        disabled={sandbox.status !== "running"}
+        disabled={sandbox.status === "failed"}
         onClick={() => onTerminal(sandbox.name)}
         size="sm"
         type="button"

--- a/apps/factory/app/sandbox-terminal.tsx
+++ b/apps/factory/app/sandbox-terminal.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Terminal } from "@xterm/xterm";
+import { FitAddon } from "@xterm/addon-fit";
+import "@xterm/xterm/css/xterm.css";
+
+import {
+  buildWebSocketUrl,
+  buildStartMessage,
+  buildResizeMessage,
+  parseServerMessage,
+  DEFAULT_CWD
+} from "@/lib/sandbox-terminal-protocol";
+
+export interface SandboxTerminalProps {
+  readonly sandboxName: string;
+  readonly onExit: () => void;
+}
+
+export function SandboxTerminal({ sandboxName, onExit }: SandboxTerminalProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const terminalRef = useRef<Terminal | null>(null);
+  const fitAddonRef = useRef<FitAddon | null>(null);
+  const socketRef = useRef<WebSocket | null>(null);
+  const exitedRef = useRef(false);
+  const [error, setError] = useState<string | null>(null);
+  const [connecting, setConnecting] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function setup() {
+      const response = await fetch("/api/sandbox/terminal", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ sandboxName })
+      });
+
+      if (!response.ok) {
+        const body = (await response.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        throw new Error(
+          body.error ?? `Could not open terminal session (${response.status}).`
+        );
+      }
+
+      const session = (await response.json()) as {
+        readonly url: string;
+        readonly token: string;
+      };
+
+      if (cancelled) return;
+
+      const terminal = new Terminal({
+        cursorBlink: true,
+        fontFamily: "var(--font-geist-mono), monospace",
+        fontSize: 14,
+        theme: {
+          background: "#000000",
+          foreground: "#ededed"
+        }
+      });
+
+      const fitAddon = new FitAddon();
+      terminal.loadAddon(fitAddon);
+
+      if (containerRef.current) {
+        terminal.open(containerRef.current);
+        fitAddon.fit();
+      }
+
+      terminalRef.current = terminal;
+      fitAddonRef.current = fitAddon;
+
+      const socket = new WebSocket(
+        buildWebSocketUrl(session.url, session.token)
+      );
+      socketRef.current = socket;
+      socket.binaryType = "arraybuffer";
+
+      socket.addEventListener("open", () => {
+        if (cancelled) return;
+        setConnecting(false);
+        const { cols, rows } = fitAddon.proposeDimensions() ?? {
+          cols: 80,
+          rows: 24
+        };
+        terminal.resize(cols, rows);
+        socket.send(
+          JSON.stringify(buildStartMessage(cols, rows, { cwd: DEFAULT_CWD }))
+        );
+      });
+
+      socket.addEventListener("message", (event) => {
+        const message = parseServerMessage(event.data);
+        if (message.kind === "exit") {
+          exitedRef.current = true;
+          terminal.writeln("");
+          terminal.writeln(
+            `Connection to ${sandboxName} closed.` +
+              (message.code !== null ? ` Exit code: ${message.code}.` : "")
+          );
+          setTimeout(() => {
+            if (!cancelled) onExit();
+          }, 600);
+          return;
+        }
+        if (message.kind === "output") {
+          terminal.write(message.data);
+        }
+      });
+
+      terminal.onData((data) => {
+        if (socket.readyState === WebSocket.OPEN) {
+          socket.send(new TextEncoder().encode(data));
+        }
+      });
+
+      const onResize = () => {
+        if (!fitAddonRef.current || !terminalRef.current) return;
+        fitAddonRef.current.fit();
+        const { cols, rows } = fitAddonRef.current.proposeDimensions() ?? {
+          cols: 80,
+          rows: 24
+        };
+        terminalRef.current.resize(cols, rows);
+        if (socket.readyState === WebSocket.OPEN) {
+          socket.send(JSON.stringify(buildResizeMessage(cols, rows)));
+        }
+      };
+
+      window.addEventListener("resize", onResize);
+
+      socket.addEventListener("close", () => {
+        if (!exitedRef.current && !cancelled) {
+          setError("The terminal session was closed unexpectedly.");
+        }
+      });
+
+      socket.addEventListener("error", () => {
+        if (!cancelled) {
+          setError("The terminal connection failed.");
+        }
+      });
+
+      return () => {
+        window.removeEventListener("resize", onResize);
+      };
+    }
+
+    const cleanupPromise = setup().catch((err) => {
+      if (!cancelled) {
+        setError(
+          err instanceof Error ? err.message : "Could not start terminal."
+        );
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      socketRef.current?.close();
+      terminalRef.current?.dispose();
+      terminalRef.current = null;
+      fitAddonRef.current = null;
+      socketRef.current = null;
+      void cleanupPromise;
+    };
+  }, [sandboxName, onExit]);
+
+  if (error) {
+    return (
+      <div className="sandboxTerminalOverlay sandboxTerminalOverlay-error">
+        <div className="sandboxTerminalNotice" role="alert">
+          <p>{error}</p>
+          <button
+            className="sandboxTerminalClose"
+            onClick={onExit}
+            type="button"
+          >
+            Return to Factory
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="sandboxTerminalOverlay"
+      role="dialog"
+      aria-label={`Terminal for ${sandboxName}`}
+    >
+      {connecting ? (
+        <div className="sandboxTerminalNotice" role="status">
+          <p>Opening terminal session for {sandboxName}…</p>
+        </div>
+      ) : null}
+      <div ref={containerRef} className="sandboxTerminalContainer" />
+    </div>
+  );
+}

--- a/apps/factory/app/sandbox-terminal.tsx
+++ b/apps/factory/app/sandbox-terminal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useEffectEvent, useRef, useState } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import "@xterm/xterm/css/xterm.css";
@@ -26,6 +26,7 @@ export function SandboxTerminal({ sandboxName, onExit }: SandboxTerminalProps) {
   const exitedRef = useRef(false);
   const [error, setError] = useState<string | null>(null);
   const [connecting, setConnecting] = useState(true);
+  const onExitEvent = useEffectEvent(onExit);
 
   useEffect(() => {
     let cancelled = false;
@@ -103,7 +104,7 @@ export function SandboxTerminal({ sandboxName, onExit }: SandboxTerminalProps) {
               (message.code !== null ? ` Exit code: ${message.code}.` : "")
           );
           setTimeout(() => {
-            if (!cancelled) onExit();
+            if (!cancelled) onExitEvent();
           }, 600);
           return;
         }
@@ -167,7 +168,7 @@ export function SandboxTerminal({ sandboxName, onExit }: SandboxTerminalProps) {
       socketRef.current = null;
       void cleanupPromise;
     };
-  }, [sandboxName, onExit]);
+  }, [sandboxName]);
 
   if (error) {
     return (

--- a/apps/factory/lib/sandbox-terminal-protocol.ts
+++ b/apps/factory/lib/sandbox-terminal-protocol.ts
@@ -1,0 +1,101 @@
+export const TERM = "xterm-256color";
+export const PS1 = `▲ \u0001\u001B[2m\u0002$PWD/\u0001\u001B[0m\u0002 `;
+export const DEFAULT_COMMAND = "sh";
+export const DEFAULT_ARGS: readonly string[] = [];
+export const DEFAULT_CWD = "/vercel/sandbox";
+
+export interface StartMessage {
+  readonly type: "start";
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly env: readonly string[];
+  readonly cwd: string;
+  readonly cols: number;
+  readonly rows: number;
+}
+
+export interface ResizeMessage {
+  readonly type: "resize";
+  readonly cols: number;
+  readonly rows: number;
+}
+
+export interface ExitMessage {
+  readonly type: "exit";
+  readonly code: number | null;
+}
+
+export type ServerMessage =
+  | { readonly kind: "output"; readonly data: string }
+  | { readonly kind: "exit"; readonly code: number | null }
+  | { readonly kind: "unknown"; readonly data: string };
+
+export function buildWebSocketUrl(url: string, token: string): string {
+  const separator = url.includes("?") ? "&" : "?";
+  return `${url}${separator}token=${encodeURIComponent(token)}`;
+}
+
+export function buildStartMessage(
+  cols: number,
+  rows: number,
+  options: {
+    readonly command?: string;
+    readonly args?: readonly string[];
+    readonly env?: Record<string, string>;
+    readonly cwd?: string;
+  } = {}
+): StartMessage {
+  const env = {
+    TERM,
+    PS1,
+    ...options.env
+  };
+
+  return {
+    type: "start",
+    command: options.command ?? DEFAULT_COMMAND,
+    args: options.args ?? DEFAULT_ARGS,
+    env: Object.entries(env).map(([key, value]) => `${key}=${value}`),
+    cwd: options.cwd ?? DEFAULT_CWD,
+    cols,
+    rows
+  };
+}
+
+export function buildResizeMessage(cols: number, rows: number): ResizeMessage {
+  return { type: "resize", cols, rows };
+}
+
+export function parseServerMessage(
+  data: string | Blob | ArrayBuffer
+): ServerMessage {
+  if (typeof data === "string") {
+    try {
+      const parsed = JSON.parse(data) as unknown;
+      if (isExitMessage(parsed)) {
+        return { kind: "exit", code: parsed.code };
+      }
+    } catch {
+      // Non-JSON text frame; treat as output.
+    }
+    return { kind: "output", data };
+  }
+
+  if (data instanceof Blob) {
+    return { kind: "unknown", data: "[binary blob]" };
+  }
+
+  const view = new Uint8Array(data);
+  const decoded = new TextDecoder().decode(view);
+  return { kind: "output", data: decoded };
+}
+
+function isExitMessage(value: unknown): value is ExitMessage {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as Record<string, unknown>).type === "exit" &&
+    (typeof (value as Record<string, unknown>).code === "number" ||
+      (value as Record<string, unknown>).code === null)
+  );
+}

--- a/apps/factory/package.json
+++ b/apps/factory/package.json
@@ -23,6 +23,8 @@
     "@vercel/connect": "0.4.2",
     "@vercel/oidc": "3.8.0",
     "@vercel/sandbox": "2.5.0",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "ai": "7.0.65",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",

--- a/apps/factory/tests/sandbox-terminal-protocol.test.mjs
+++ b/apps/factory/tests/sandbox-terminal-protocol.test.mjs
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildStartMessage,
+  buildResizeMessage,
+  buildWebSocketUrl,
+  parseServerMessage,
+  TERM,
+  PS1,
+  DEFAULT_CWD
+} from "../lib/sandbox-terminal-protocol.ts";
+
+test("buildWebSocketUrl appends the token as a query parameter", () => {
+  assert.equal(
+    buildWebSocketUrl("wss://example.com/ws", "tok"),
+    "wss://example.com/ws?token=tok"
+  );
+  assert.equal(
+    buildWebSocketUrl("wss://example.com/ws?foo=1", "tok"),
+    "wss://example.com/ws?foo=1&token=tok"
+  );
+  assert.equal(
+    buildWebSocketUrl("wss://example.com/ws", "tok with spaces"),
+    "wss://example.com/ws?token=tok%20with%20spaces"
+  );
+});
+
+test("buildStartMessage includes required fields and defaults", () => {
+  const message = buildStartMessage(80, 24);
+  assert.equal(message.type, "start");
+  assert.equal(message.command, "sh");
+  assert.deepEqual(message.args, []);
+  assert.equal(message.cwd, DEFAULT_CWD);
+  assert.equal(message.cols, 80);
+  assert.equal(message.rows, 24);
+  assert.ok(message.env.includes(`TERM=${TERM}`));
+  assert.ok(message.env.includes(`PS1=${PS1}`));
+});
+
+test("buildStartMessage accepts command, args, env, and cwd overrides", () => {
+  const message = buildStartMessage(100, 30, {
+    command: "bash",
+    args: ["-l"],
+    env: { FOO: "bar" },
+    cwd: "/workspace"
+  });
+  assert.equal(message.command, "bash");
+  assert.deepEqual(message.args, ["-l"]);
+  assert.equal(message.cwd, "/workspace");
+  assert.equal(message.cols, 100);
+  assert.equal(message.rows, 30);
+  assert.ok(message.env.includes("FOO=bar"));
+  assert.ok(message.env.includes(`TERM=${TERM}`));
+});
+
+test("buildResizeMessage encodes a resize control frame", () => {
+  assert.deepEqual(buildResizeMessage(120, 40), {
+    type: "resize",
+    cols: 120,
+    rows: 40
+  });
+});
+
+test("parseServerMessage parses exit control frames", () => {
+  assert.deepEqual(
+    parseServerMessage(JSON.stringify({ type: "exit", code: 0 })),
+    {
+      kind: "exit",
+      code: 0
+    }
+  );
+  assert.deepEqual(
+    parseServerMessage(JSON.stringify({ type: "exit", code: 1 })),
+    {
+      kind: "exit",
+      code: 1
+    }
+  );
+  assert.deepEqual(
+    parseServerMessage(JSON.stringify({ type: "exit", code: null })),
+    {
+      kind: "exit",
+      code: null
+    }
+  );
+});
+
+test("parseServerMessage treats text and binary data as output", () => {
+  assert.deepEqual(parseServerMessage("hello"), {
+    kind: "output",
+    data: "hello"
+  });
+  const buffer = new TextEncoder().encode("binary data").buffer;
+  assert.deepEqual(parseServerMessage(buffer), {
+    kind: "output",
+    data: "binary data"
+  });
+});
+
+test("parseServerMessage treats non-JSON text as output", () => {
+  assert.deepEqual(parseServerMessage("not json"), {
+    kind: "output",
+    data: "not json"
+  });
+});
+
+test("parseServerMessage marks blobs as unknown", () => {
+  const blob = new Blob(["data"]);
+  const result = parseServerMessage(blob);
+  assert.equal(result.kind, "unknown");
+});

--- a/apps/factory/tests/sandbox-terminal.test.mjs
+++ b/apps/factory/tests/sandbox-terminal.test.mjs
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createTerminalSession,
+  handleTerminalRequest,
+  isAllowedSandboxName
+} from "../agent/lib/sandbox-terminal.ts";
+
+test("isAllowedSandboxName accepts only ai-sdk-harness prefixed names", () => {
+  assert.equal(isAllowedSandboxName("ai-sdk-harness-session-abc"), true);
+  assert.equal(isAllowedSandboxName("ai-sdk-harness"), true);
+  assert.equal(isAllowedSandboxName("other-sandbox"), false);
+  assert.equal(isAllowedSandboxName(""), false);
+});
+
+test("createTerminalSession rejects disallowed sandbox names", async () => {
+  await assert.rejects(
+    createTerminalSession("untrusted-sandbox", async () => ({
+      openInteractive: async () => ({ url: "wss://example.com", token: "tok" })
+    })),
+    /Sandbox name must start with "ai-sdk-harness"/
+  );
+});
+
+test("createTerminalSession returns a url and token from openInteractive", async () => {
+  const session = await createTerminalSession(
+    "ai-sdk-harness-session-abc",
+    async () => ({
+      openInteractive: async () => ({
+        url: "wss://example.com/ws",
+        token: "secret-token"
+      })
+    })
+  );
+  assert.equal(session.url, "wss://example.com/ws");
+  assert.equal(session.token, "secret-token");
+});
+
+test("createTerminalSession propagates openInteractive errors", async () => {
+  await assert.rejects(
+    createTerminalSession("ai-sdk-harness-session-abc", async () => ({
+      openInteractive: async () => {
+        throw new Error("sandbox not found");
+      }
+    })),
+    /sandbox not found/
+  );
+});
+
+test("handleTerminalRequest returns a session for a valid sandbox", async () => {
+  const response = await handleTerminalRequest(
+    new Request("http://localhost/api/sandbox/terminal", {
+      method: "POST",
+      body: JSON.stringify({ sandboxName: "ai-sdk-harness-session-abc" })
+    }),
+    async () => ({ url: "wss://example.com/ws", token: "tok" })
+  );
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.url, "wss://example.com/ws");
+  assert.equal(body.token, "tok");
+});
+
+test("handleTerminalRequest rejects missing sandboxName", async () => {
+  const response = await handleTerminalRequest(
+    new Request("http://localhost/api/sandbox/terminal", {
+      method: "POST",
+      body: JSON.stringify({})
+    })
+  );
+  assert.equal(response.status, 400);
+  const body = await response.json();
+  assert.match(body.error, /A valid sandboxName is required/);
+});
+
+test("handleTerminalRequest rejects disallowed sandbox names", async () => {
+  const response = await handleTerminalRequest(
+    new Request("http://localhost/api/sandbox/terminal", {
+      method: "POST",
+      body: JSON.stringify({ sandboxName: "untrusted-sandbox" })
+    })
+  );
+  assert.equal(response.status, 400);
+  const body = await response.json();
+  assert.match(body.error, /Sandbox name is not allowed/);
+});
+
+test("handleTerminalRequest returns 404 for not_found errors", async () => {
+  const response = await handleTerminalRequest(
+    new Request("http://localhost/api/sandbox/terminal", {
+      method: "POST",
+      body: JSON.stringify({ sandboxName: "ai-sdk-harness-missing" })
+    }),
+    async () => {
+      throw new Error("sandbox not_found");
+    }
+  );
+  assert.equal(response.status, 404);
+  const body = await response.json();
+  assert.match(body.error, /not_found/);
+});
+
+test("handleTerminalRequest returns 500 for unexpected errors", async () => {
+  const response = await handleTerminalRequest(
+    new Request("http://localhost/api/sandbox/terminal", {
+      method: "POST",
+      body: JSON.stringify({ sandboxName: "ai-sdk-harness-error" })
+    }),
+    async () => {
+      throw new Error("something went wrong");
+    }
+  );
+  assert.equal(response.status, 500);
+  const body = await response.json();
+  assert.match(body.error, /something went wrong/);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,6 +207,12 @@ importers:
       '@vercel/sandbox':
         specifier: 2.5.0
         version: 2.5.0
+      '@xterm/addon-fit':
+        specifier: ^0.11.0
+        version: 0.11.0
+      '@xterm/xterm':
+        specifier: ^6.0.0
+        version: 6.0.0
       ai:
         specifier: 7.0.65
         version: 7.0.65(zod@4.4.3)
@@ -6028,6 +6034,12 @@ packages:
   '@xhmikosr/os-filter-obj@4.1.0':
     resolution: {integrity: sha512-y5ArHvQ7BVule/+L9yE2nYMhceiJhgsqo58lOfnisQ7bg+Kjfmkgr7JBuVFiTkl+ErdShpp829QstZQyLugl8g==}
     engines: {node: '>=20'}
+
+  '@xterm/addon-fit@0.11.0':
+    resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
+
+  '@xterm/xterm@6.0.0':
+    resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -16661,6 +16673,10 @@ snapshots:
   '@xhmikosr/os-filter-obj@4.1.0':
     dependencies:
       system-architecture: 1.0.0
+
+  '@xterm/addon-fit@0.11.0': {}
+
+  '@xterm/xterm@6.0.0': {}
 
   accepts@2.0.0:
     dependencies:


### PR DESCRIPTION
This PR adds a full-page terminal SSH session affordance to the Turborepo Factory operator page.

Changes:
- Added a "Terminal" button to each sandbox card in the inventory. Only running sandboxes are clickable.
- Clicking the button opens a full-screen xterm.js terminal overlay that takes over the page.
- Added a new `/api/sandbox/terminal` API route that uses `Sandbox.openInteractive()` to return a WebSocket URL and token.
- Added reusable protocol helpers for the Vercel Sandbox interactive shell WebSocket protocol (start/resize/exit messages and token authentication).
- The overlay returns to the main Factory UI when the server reports an `exit` control frame (i.e., when the user runs `exit` in the shell).
- Added tests for session creation, the API request handler, and the WebSocket protocol helpers.

Notes:
- The WebSocket protocol matches the implementation used by the official `sandbox connect` CLI command.
- The backend only allows interactive sessions for sandboxes whose names start with `ai-sdk-harness`, matching the existing inventory query.
