### PR TITLE
chore: Allow SSH terminal for completed-run sandboxes in Factory

### DIFF
--- a/apps/factory/agent/lib/sandbox-ssh.ts
+++ b/apps/factory/agent/lib/sandbox-ssh.ts
@@ -1,3 +1,9 @@
 export function sandboxSshCommand(name: string): string {
   return `sandbox ssh ${name}`;
 }
+
+const SSHABLE_STATUSES = new Set(["running", "stopped"]);
+
+export function isSandboxSSHable(status: string): boolean {
+  return SSHABLE_STATUSES.has(status);
+}

--- a/apps/factory/app/api/sandbox/terminal/route.ts
+++ b/apps/factory/app/api/sandbox/terminal/route.ts
@@ -3,5 +3,14 @@ import { handleTerminalRequest } from "@/agent/lib/sandbox-terminal";
 export const dynamic = "force-dynamic";
 
 export async function POST(request: Request): Promise<Response> {
+  if (
+    request.headers.get("origin") !== new URL(request.url).origin ||
+    request.headers.get("content-type")?.split(";", 1)[0] !== "application/json"
+  )
+    return Response.json(
+      { error: "Invalid terminal request." },
+      { status: 403 }
+    );
+
   return handleTerminalRequest(request);
 }

--- a/apps/factory/app/run-observatory.tsx
+++ b/apps/factory/app/run-observatory.tsx
@@ -9,7 +9,7 @@ import {
   useState
 } from "react";
 
-import { sandboxSshCommand } from "../agent/lib/sandbox-ssh";
+import { isSandboxSSHable, sandboxSshCommand } from "../agent/lib/sandbox-ssh";
 import type {
   AgentRunRecord,
   ControlPlaneSnapshot,
@@ -68,8 +68,16 @@ function duration(run: AgentRunRecord): string {
   return `${Math.round(milliseconds / 60_000)}m`;
 }
 
-function RunTicket({ run }: { readonly run: AgentRunRecord }) {
+function RunTicket({
+  run,
+  onTerminal
+}: {
+  readonly run: AgentRunRecord;
+  readonly onTerminal: (name: string) => void;
+}) {
   const detailsUrl = run.source === "eve" ? AGENT_RUNS_URL : WORKFLOW_RUNS_URL;
+  const sandbox = run.sandbox;
+  const sshable = sandbox ? isSandboxSSHable(sandbox.status) : false;
   return (
     <li className={`runTicket runTicket-${run.status}`}>
       <article aria-label={`${run.title}, ${run.status}`}>
@@ -112,11 +120,28 @@ function RunTicket({ run }: { readonly run: AgentRunRecord }) {
           <span aria-hidden="true">→</span>
           <span>{run.sandbox?.status ?? run.status}</span>
         </div>
-        {run.sandbox && run.sandbox.provider !== "eve" ? (
-          <CopyCommand
-            command={sandboxSshCommand(run.sandbox.id)}
-            label="SSH command for this sandbox"
-          />
+        {sandbox && sandbox.provider !== "eve" ? (
+          <>
+            <CopyCommand
+              command={sandboxSshCommand(sandbox.id)}
+              label="SSH command for this sandbox"
+            />
+            <Button
+              className="sandboxTerminalButton"
+              disabled={!sshable}
+              onClick={() => onTerminal(sandbox.id)}
+              size="sm"
+              title={
+                sshable
+                  ? "Open a terminal session for this sandbox"
+                  : "This sandbox is not currently reachable for a terminal session"
+              }
+              type="button"
+              variant="outline"
+            >
+              Terminal
+            </Button>
+          </>
         ) : null}
         <a
           className="runDetails"
@@ -168,9 +193,14 @@ function SandboxCard({
       />
       <Button
         className="sandboxTerminalButton"
-        disabled={sandbox.status === "failed"}
+        disabled={!isSandboxSSHable(sandbox.status)}
         onClick={() => onTerminal(sandbox.name)}
         size="sm"
+        title={
+          isSandboxSSHable(sandbox.status)
+            ? "Open a terminal session for this sandbox"
+            : "This sandbox is not currently reachable for a terminal session"
+        }
         type="button"
         variant="outline"
       >
@@ -304,7 +334,11 @@ export function RunObservatory({
                 {runs.length > 0 ? (
                   <ol className="runList">
                     {runs.map((run) => (
-                      <RunTicket key={run.id} run={run} />
+                      <RunTicket
+                        key={run.id}
+                        run={run}
+                        onTerminal={setActiveTerminal}
+                      />
                     ))}
                   </ol>
                 ) : (

--- a/apps/factory/app/sandbox-terminal.tsx
+++ b/apps/factory/app/sandbox-terminal.tsx
@@ -166,7 +166,7 @@ export function SandboxTerminal({ sandboxName, onExit }: SandboxTerminalProps) {
       terminalRef.current = null;
       fitAddonRef.current = null;
       socketRef.current = null;
-      void cleanupPromise;
+      void cleanupPromise.then((cleanup) => cleanup?.());
     };
   }, [sandboxName]);
 

--- a/apps/factory/tests/sandbox-ssh.test.mjs
+++ b/apps/factory/tests/sandbox-ssh.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { sandboxSshCommand } from "../agent/lib/sandbox-ssh.ts";
+import {
+  isSandboxSSHable,
+  sandboxSshCommand
+} from "../agent/lib/sandbox-ssh.ts";
 
 test("produces a sandbox ssh command for a given sandbox name", () => {
   assert.equal(sandboxSshCommand("my-sandbox"), "sandbox ssh my-sandbox");
@@ -13,4 +16,14 @@ test("produces a sandbox ssh command for a given sandbox name", () => {
 
 test("preserves special characters in sandbox names", () => {
   assert.equal(sandboxSshCommand("a-b_c.d"), "sandbox ssh a-b_c.d");
+});
+
+test("isSandboxSSHable recognizes running and stopped sandboxes", () => {
+  assert.equal(isSandboxSSHable("running"), true);
+  assert.equal(isSandboxSSHable("stopped"), true);
+  assert.equal(isSandboxSSHable("provisioning"), false);
+  assert.equal(isSandboxSSHable("pending"), false);
+  assert.equal(isSandboxSSHable("failed"), false);
+  assert.equal(isSandboxSSHable("aborted"), false);
+  assert.equal(isSandboxSSHable("snapshotting"), false);
 });


### PR DESCRIPTION
Updates the Factory sandbox terminal so an operator can open a terminal for a sandbox even after its run has completed.

Rebased onto `main` to resolve conflicts. Since this branch was opened, #13779 (SSH command affordance) and #13780 (full-page terminal SSH sessions) landed independently and duplicated most of what this branch carried, so the shared implementation now comes from `main` and this branch is down to what is still unique to it.

### Changes

- Adds `isSandboxSSHable()` in `agent/lib/sandbox-ssh.ts` to decide when a sandbox is reachable for an interactive session (`running` or `stopped`), matching Vercel Sandbox's resume behavior.
- `SandboxCard`: replaces `disabled={sandbox.status === "failed"}` with `disabled={!isSandboxSSHable(sandbox.status)}` plus an explanatory `title`. This is the substance of the PR — `stopped` sandboxes stay reachable, while `provisioning`/`pending`/`aborted`/`stopping`/`snapshotting` are now correctly disabled instead of only `failed`.
- `RunTicket`: adds the Terminal button alongside the existing SSH copy command, enabled for `running` and `stopped` sandboxes, so a completed run's sandbox can still be opened. Kept behind `main`'s `provider !== "eve"` guard, since the terminal is only reachable for Vercel sandboxes.
- `app/api/sandbox/terminal/route.ts`: adds an origin + content-type guard to the terminal route, mirroring the pattern in `app/api/harness/runs/route.ts`. The route mints an interactive shell session, so it should not be reachable cross-origin.
- `app/sandbox-terminal.tsx`: actually invokes the cleanup returned by the setup promise (`cleanupPromise.then((cleanup) => cleanup?.())`) instead of discarding it with `void cleanupPromise`, which left the socket and terminal teardown unrun.
- Adds tests for `isSandboxSSHable`.

### Validation

- `pnpm test` in `apps/factory` — 66 passing
- `pnpm exec tsc --noEmit` — clean
- `pnpm exec oxlint --deny-warnings .` and `pnpm exec oxfmt --check` — clean
- `next build` — succeeds
- `pnpm install --frozen-lockfile` — lockfile up to date