### PR TITLE
chore: Upgrade the factory eve agent to 0.39.3

### DIFF
--- a/apps/factory/README.md
+++ b/apps/factory/README.md
@@ -15,3 +15,5 @@ The workflow clones Turborepo into the selected sandbox and runs the chosen offi
 Connect a private Vercel Blob store to the project to enable the operator page's unified run dashboard. The recommended OIDC configuration provides `BLOB_STORE_ID` and `VERCEL_OIDC_TOKEN`; `BLOB_READ_WRITE_TOKEN` can provide local ledger access, but Harness execution and Sandbox inventory still require Vercel OIDC.
 
 Eve lifecycle hooks and Harness workflow steps write the same normalized ledger containing the latest 100 runs by start time. Collection begins after this version is deployed; it does not backfill older Agent Runs. The page polls that ledger and displays the eight most recently updated `ai-sdk-harness*` resources from the Vercel Sandbox API. Detailed transcripts remain in Agent Runs for Eve and Workflow observability for Harness.
+
+An Eve run's model is recorded when its first model step starts rather than when the session starts. The agent selects its author model dynamically, so `session.started` carries no model id and the ledger fills the field from `step.started` instead.

--- a/apps/factory/agent/agent.ts
+++ b/apps/factory/agent/agent.ts
@@ -1,14 +1,25 @@
 import { defineAgent, defineDynamic } from "eve";
 
-import { selectPerformanceModels } from "./lib/performance-models.js";
+import {
+  GPT_SOL_MODEL,
+  selectPerformanceModels
+} from "./lib/performance-models.js";
 import { sessionDate } from "./lib/repo.js";
 
 export default defineAgent({
   model: defineDynamic({
-    fallback: "openai/gpt-5.6-sol",
     events: {
-      "session.started": (_event, ctx) =>
-        selectPerformanceModels(sessionDate(ctx.session.id)).authorModel
+      // A dynamic model has no compiled default and a resolver that throws
+      // fails the turn, so keep supplying the model the removed `fallback`
+      // option used to cover when a session id cannot be parsed.
+      "session.started": (_event, ctx) => {
+        try {
+          return selectPerformanceModels(sessionDate(ctx.session.id))
+            .authorModel;
+        } catch {
+          return GPT_SOL_MODEL;
+        }
+      }
     }
   })
 });

--- a/apps/factory/agent/channels/operator.ts
+++ b/apps/factory/agent/channels/operator.ts
@@ -73,19 +73,22 @@ function isOperatorRequest(request: Request, action: string): boolean {
 
 export default defineChannel({
   routes: [
-    POST("/eve/v1/operator/runs", async (request, { send }) => {
+    POST("/eve/v1/operator/runs", async (request, { from }) => {
       const action = operatorAction(request);
       if (!action) {
         return operatorError("Invalid operator request.", 403);
       }
 
       if (action === PERFORMANCE_RUN_ACTION) {
-        const session = await send(DAILY_PERFORMANCE_IMPROVEMENT_PROMPT, {
-          auth: APP_AUTH,
-          continuationToken: randomUUID(),
-          mode: "task",
-          title: "Daily performance improvement"
-        });
+        // A fresh address is unowned, so `send` always starts a new session.
+        const session = await from(randomUUID()).send(
+          DAILY_PERFORMANCE_IMPROVEMENT_PROMPT,
+          {
+            auth: APP_AUTH,
+            mode: "task",
+            title: "Daily performance improvement"
+          }
+        );
         const { authorModel, reviewerModel } = selectPerformanceModels(
           sessionDate(session.id)
         );
@@ -98,15 +101,17 @@ export default defineChannel({
         return operatorError("A valid example is required.", 400);
       }
 
-      const session = await send(DAILY_EXAMPLE_MAINTENANCE_PROMPT, {
-        auth: {
-          ...APP_AUTH,
-          attributes: { maintenanceExample: example }
-        },
-        continuationToken: randomUUID(),
-        mode: "task",
-        title: "Daily example maintenance"
-      });
+      const session = await from(randomUUID()).send(
+        DAILY_EXAMPLE_MAINTENANCE_PROMPT,
+        {
+          auth: {
+            ...APP_AUTH,
+            attributes: { maintenanceExample: example }
+          },
+          mode: "task",
+          title: "Daily example maintenance"
+        }
+      );
 
       return startedRun(session.id);
     }),
@@ -132,7 +137,7 @@ export default defineChannel({
     }),
     GET(
       "/eve/v1/operator/runs/:sessionId/status",
-      async (request, { getSession, params }) => {
+      async (request, { attachSession, params }) => {
         const cursorValue = new URL(request.url).searchParams.get("cursor");
         const startIndex = cursorValue === null ? 0 : Number(cursorValue);
         if (!Number.isInteger(startIndex) || startIndex < 0) {
@@ -143,7 +148,7 @@ export default defineChannel({
         }
 
         const reader = (
-          await getSession(params.sessionId).getEventStream({ startIndex })
+          await attachSession(params.sessionId).getEventStream({ startIndex })
         ).getReader();
         let cursor = startIndex;
         let state: "running" | "done" | "error" = "running";

--- a/apps/factory/agent/lib/control-plane-hook.ts
+++ b/apps/factory/agent/lib/control-plane-hook.ts
@@ -1,6 +1,10 @@
 import { defineHook } from "eve/hooks";
 
-import { updateAgentRun, writeAgentRun } from "./run-registry";
+import {
+  recordAgentRunModel,
+  updateAgentRun,
+  writeAgentRun
+} from "./run-registry";
 
 async function safely(task: Promise<void>): Promise<void> {
   try {
@@ -23,7 +27,6 @@ export const controlPlaneHook = defineHook({
         writeAgentRun({
           agent,
           id: ctx.session.id,
-          model: event.data.runtime?.modelId,
           sandbox: {
             id: ctx.session.id,
             provider: "eve",
@@ -40,6 +43,12 @@ export const controlPlaneHook = defineHook({
     },
     async "turn.started"(_event, ctx) {
       await safely(updateAgentRun(ctx.session.id, { status: "running" }));
+    },
+    async "step.started"(event, ctx) {
+      // The first step of each turn is enough to catch the selected model and
+      // any later change, without touching the ledger on every model call.
+      if (event.data.stepIndex !== 0) return;
+      await safely(recordAgentRunModel(ctx.session.id, event.data.modelId));
     },
     async "session.waiting"(_event, ctx) {
       await safely(updateAgentRun(ctx.session.id, { status: "waiting" }));

--- a/apps/factory/agent/lib/run-registry.ts
+++ b/apps/factory/agent/lib/run-registry.ts
@@ -47,6 +47,26 @@ export async function updateAgentRun(
   });
 }
 
+/**
+ * Records the model a run is actually using. `session.started` carries no
+ * model id, because a dynamic model resolves only once a step begins, so the
+ * caller reports it per turn and this writes only when the model changed.
+ */
+export async function recordAgentRunModel(
+  id: string,
+  model: string
+): Promise<void> {
+  if (!isRunRegistryConfigured()) return;
+  await mutateRuns((runs) => {
+    const current = runs.find((run) => run.id === id);
+    if (!current || current.model === model) return runs;
+    return [
+      { ...current, model, updatedAt: new Date().toISOString() },
+      ...runs.filter((run) => run.id !== id)
+    ];
+  });
+}
+
 export async function getAgentRun(id: string): Promise<AgentRunRecord | null> {
   if (!isRunRegistryConfigured()) return null;
   return (await readRunIndex()).runs.find((run) => run.id === id) ?? null;
@@ -108,7 +128,10 @@ async function mutateRuns(
 ): Promise<void> {
   for (let attempt = 0; attempt < MAX_WRITE_ATTEMPTS; attempt += 1) {
     const current = await readRunIndex();
-    const runs = mutation(current.runs)
+    const mutated = mutation(current.runs);
+    // A mutation that returns its input changed nothing worth writing.
+    if (mutated === current.runs) return;
+    const runs = mutated
       .sort((left, right) => right.startedAt.localeCompare(left.startedAt))
       .slice(0, MAX_RUNS);
     try {

--- a/apps/factory/package.json
+++ b/apps/factory/package.json
@@ -26,7 +26,7 @@
     "ai": "7.0.65",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
-    "eve": "^0.22.5",
+    "eve": "^0.39.3",
     "next": "16.3.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,7 +200,7 @@ importers:
         version: 2.7.0
       '@vercel/connect':
         specifier: 0.4.2
-        version: 0.4.2(ai@7.0.65(zod@4.4.3))(eve@0.22.5(@azure/identity@4.13.1)(@opentelemetry/api@1.9.0)(@vercel/blob@2.7.0)(@vercel/functions@3.4.4(@aws-sdk/credential-provider-web-identity@3.972.49))(ai@7.0.65(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lru-cache@11.3.3))
+        version: 0.4.2(ai@7.0.65(zod@4.4.3))(eve@0.39.3(@azure/identity@4.13.1)(@opentelemetry/api@1.9.0)(@vercel/blob@2.7.0)(@vercel/functions@3.4.4(@aws-sdk/credential-provider-web-identity@3.972.49))(ai@7.0.65(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lru-cache@11.3.3))
       '@vercel/oidc':
         specifier: 3.8.0
         version: 3.8.0
@@ -217,8 +217,8 @@ importers:
         specifier: 2.1.1
         version: 2.1.1
       eve:
-        specifier: ^0.22.5
-        version: 0.22.5(@azure/identity@4.13.1)(@opentelemetry/api@1.9.0)(@vercel/blob@2.7.0)(@vercel/functions@3.4.4(@aws-sdk/credential-provider-web-identity@3.972.49))(ai@7.0.65(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lru-cache@11.3.3)
+        specifier: ^0.39.3
+        version: 0.39.3(@azure/identity@4.13.1)(@opentelemetry/api@1.9.0)(@vercel/blob@2.7.0)(@vercel/functions@3.4.4(@aws-sdk/credential-provider-web-identity@3.972.49))(ai@7.0.65(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lru-cache@11.3.3)
       next:
         specifier: 16.3.0
         version: 16.3.0(@opentelemetry/api@1.9.0)(@types/node@24.10.11)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1488,14 +1488,8 @@ packages:
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
-  '@emnapi/core@1.9.2':
-    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
-
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
-
-  '@emnapi/wasi-threads@1.2.1':
-    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
@@ -5130,9 +5124,6 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
-  '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
-
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
@@ -7437,13 +7428,13 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
-  eve@0.22.5:
-    resolution: {integrity: sha512-lY3qHgvVNKuTwoH/0AQpztWS53Ub/xAk2KfV38fnfNfgd8idmN9FKbT2jUgs0lNGcFwTUR1/RYWl9JzpCsImeA==}
+  eve@0.39.3:
+    resolution: {integrity: sha512-BQqxp+htxisijebDyGGcKdB00Rlw+hD+AqbDX/XzZ429/RLH/k33LRsKrTq7kKNIOQ5E9xQTY2gmph1ppCIS/A==}
     engines: {node: '>=24'}
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
-      ai: ^7.0.0
+      ai: ^7.0.58
       braintrust: ^3.0.0
       just-bash: ^3.0.0
       microsandbox: ^0.5.0
@@ -11075,6 +11066,10 @@ packages:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
+  undici@8.9.0:
+    resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
+    engines: {node: '>=22.19.0'}
+
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
@@ -12130,18 +12125,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/core@1.9.2':
-    dependencies:
-      '@emnapi/wasi-threads': 1.2.1
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/runtime@1.11.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -12953,9 +12937,9 @@ snapshots:
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
-      '@emnapi/core': 1.9.2
+      '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
-      '@tybys/wasm-util': 0.10.1
+      '@tybys/wasm-util': 0.10.2
     optional: true
 
   '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
@@ -15612,11 +15596,6 @@ snapshots:
   '@tsconfig/node16@1.0.4':
     optional: true
 
-  '@tybys/wasm-util@0.10.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
@@ -16118,12 +16097,12 @@ snapshots:
     dependencies:
       execa: 5.1.1
 
-  '@vercel/connect@0.4.2(ai@7.0.65(zod@4.4.3))(eve@0.22.5(@azure/identity@4.13.1)(@opentelemetry/api@1.9.0)(@vercel/blob@2.7.0)(@vercel/functions@3.4.4(@aws-sdk/credential-provider-web-identity@3.972.49))(ai@7.0.65(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lru-cache@11.3.3))':
+  '@vercel/connect@0.4.2(ai@7.0.65(zod@4.4.3))(eve@0.39.3(@azure/identity@4.13.1)(@opentelemetry/api@1.9.0)(@vercel/blob@2.7.0)(@vercel/functions@3.4.4(@aws-sdk/credential-provider-web-identity@3.972.49))(ai@7.0.65(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lru-cache@11.3.3))':
     dependencies:
       '@vercel/oidc': 3.8.0
     optionalDependencies:
       ai: 7.0.65(zod@4.4.3)
-      eve: 0.22.5(@azure/identity@4.13.1)(@opentelemetry/api@1.9.0)(@vercel/blob@2.7.0)(@vercel/functions@3.4.4(@aws-sdk/credential-provider-web-identity@3.972.49))(ai@7.0.65(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lru-cache@11.3.3)
+      eve: 0.39.3(@azure/identity@4.13.1)(@opentelemetry/api@1.9.0)(@vercel/blob@2.7.0)(@vercel/functions@3.4.4(@aws-sdk/credential-provider-web-identity@3.972.49))(ai@7.0.65(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lru-cache@11.3.3)
 
   '@vercel/functions@3.4.4(@aws-sdk/credential-provider-web-identity@3.972.49)':
     dependencies:
@@ -18081,10 +18060,11 @@ snapshots:
 
   etag@1.8.1: {}
 
-  eve@0.22.5(@azure/identity@4.13.1)(@opentelemetry/api@1.9.0)(@vercel/blob@2.7.0)(@vercel/functions@3.4.4(@aws-sdk/credential-provider-web-identity@3.972.49))(ai@7.0.65(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lru-cache@11.3.3):
+  eve@0.39.3(@azure/identity@4.13.1)(@opentelemetry/api@1.9.0)(@vercel/blob@2.7.0)(@vercel/functions@3.4.4(@aws-sdk/credential-provider-web-identity@3.972.49))(ai@7.0.65(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lru-cache@11.3.3):
     dependencies:
       ai: 7.0.65(zod@4.4.3)
       nitro: 3.0.260610-beta(@azure/identity@4.13.1)(@vercel/blob@2.7.0)(@vercel/functions@3.4.4(@aws-sdk/credential-provider-web-identity@3.972.49))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lru-cache@11.3.3)
+      undici: 8.9.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
     transitivePeerDependencies:
@@ -22810,6 +22790,8 @@ snapshots:
   undici@6.27.0: {}
 
   undici@7.28.0: {}
+
+  undici@8.9.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,8 @@ minimumReleaseAgeExclude:
   - next
   - "@next/*"
   - "@vercel/geistdocs"
+  # Eve security and correctness releases must be adoptable immediately.
+  - eve
 
 onlyBuiltDependencies:
   - "@swc/core"


### PR DESCRIPTION
## Why

The eve upgrade mandate requires every agent to run **0.39.1 or later**. `apps/factory` — the only eve agent in this repository — was pinned to `^0.22.5`. This takes it to `^0.39.3` (current `latest`) and migrates the authored agent across the breaking changes in between.

## Migration

| eve release | Breaking change | What changed here |
| --- | --- | --- |
| 0.33.0 | `defineDynamic` accepts only `events`; a dynamic model has no compiled default and a throwing resolver fails the turn | `agent/agent.ts` drops `fallback` and the resolver returns a concrete model, absorbing the unparseable-session-id case that `fallback` used to cover |
| 0.31.0 | Continuation-token session APIs replaced with ID-addressed handles; custom channel routes use `from(address)` / `attachSession(sessionId)` | `agent/channels/operator.ts` starts runs via `from(randomUUID()).send(message, options)` and reads run status via `attachSession(sessionId).getEventStream(...)` |
| — | `session.started` no longer carries `runtime.modelId`, since a dynamic model resolves only once a step begins | `agent/lib/control-plane-hook.ts` records the model from the first `step.started` of each turn; `recordAgentRunModel` writes only when the model changed, so the ledger is not rewritten per model call |

Nothing else in the app touched a removed API: schedules still use `defineSchedule({ cron, markdown })`, the `approval` function shorthand and `"not-applicable"` / `"user-approval"` statuses are unchanged, `defineSandbox` is unaffected by the custom-backend `stop()` requirement, `vercel.json` carries no legacy `experimentalServices` block, and the operator UI does not use the frontend bindings whose `stop()` became `cancel()`.

## Config change worth a look

`eve` is added to `minimumReleaseAgeExclude` in `pnpm-workspace.yaml`. The workspace gate is 48 hours and **every** `0.39.x` release is younger than that, so without the exclusion resolution fails outright:

```
ERR_PNPM_NO_MATURE_MATCHING_VERSION  Version 0.39.3 (released 3 hours ago) of eve
does not meet the minimumReleaseAge constraint
```

There is no compliant version that satisfies the mandate, so the gate and the mandate cannot both hold. This follows the existing precedent for first-party packages (`next`, `@next/*`, `@vercel/geistdocs`) and is scoped to `eve` alone.

Note that this is **not** the release-age rule the factory agent is bound by: `agent/instructions.md` and `agent/skills/examples_maintenance.md` forbid exclusions when upgrading **examples**, and that guardrail is enforced in `create_pull_request` only for paths under `examples/`. This change is outside it and does not weaken it. Happy to drop the exclusion in a follow-up once `0.39.1` clears 48 hours (2026-08-21 04:30 UTC) if you would rather not carry it.

## Behavior change to be aware of

eve 0.33.0 made `turnPolicy: "steer"` the channel default, so a follow-up Slack or GitHub message now cancels and replaces an active turn instead of queueing behind it. Adopted as-is: the automated paths are unaffected because scheduled runs and operator runs each get their own session, and steering is the better interactive behavior. Set `turnPolicy: "queue"` on those channels if the old wait-for-completion behavior is preferred.

## Validation

- `pnpm install --frozen-lockfile` — lockfile consistent with the manifests
- `tsc --noEmit -p apps/factory/tsconfig.json` — clean
- `eve info` — compile ready, 0 errors / 0 warnings, 16 tools, 2 subagents, 2 schedules, 2 skills discovered
- `pnpm test` — 24/24 passing
- `pnpm build` (`eve build && next build`) — succeeds
- `oxlint --deny-warnings`, `oxfmt --check` — clean; pre-push hooks passed without `--no-verify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
