### PR TITLE
docs: Fix reference links and validation

### DIFF
--- a/apps/docs/content/docs/reference/run.mdx
+++ b/apps/docs/content/docs/reference/run.mdx
@@ -183,7 +183,7 @@ To help with incremental migration or in situations where you cannot use a packa
 
 <Callout type="info">
   You may also opt out of this check using [configuration in
-  `turbo.json`](/docs/reference/configuration#dangerouslydisablepacakgemanagercheck)
+  `turbo.json`](/docs/reference/configuration#dangerouslydisablepackagemanagercheck)
   or the
   [`TURBO_DANGEROUSLY_DISABLE_PACKAGE_MANAGER_CHECK`](/docs/reference/system-environment-variables)
   environment variable for broader coverage.
@@ -358,7 +358,7 @@ turbo run build --global-deps=".env.*" --global-deps=".eslintrc" --global-deps="
 
 <Callout type="info">
   We recommend specifying file globs that you'd like to include your hashes in
-  [the `globalDependencies` key](/docs/reference/configuration#globaldeps) in
+  [the `globalDependencies` key](/docs/reference/configuration#globaldependencies) in
   `turbo.json` to make sure they are always accounted for.
 </Callout>
 
@@ -616,7 +616,7 @@ turbo run build --profile
 turbo run build --profile=my-profile
 ```
 
-### `---anon-profile`
+### `--anon-profile`
 
 This flag works the same as `--profile`, but attempts to redacts sensitive information. This is useful for sharing your profiles.
 

--- a/apps/docs/content/docs/reference/system-environment-variables.mdx
+++ b/apps/docs/content/docs/reference/system-environment-variables.mdx
@@ -52,7 +52,7 @@ System environment variables are always overridden by flag values provided direc
       </td>
       <td>
         Control reading and writing for cache sources. Uses the same syntax as
-        <code>[--cache](/docs/reference/run#--cache-options)</code>.
+        <a href="/docs/reference/run#--cache-options"><code>--cache</code></a>.
       </td>
     </tr>
     <tr id="turbo_cache_dir">
@@ -351,7 +351,7 @@ System environment variables are always overridden by flag values provided direc
         <code>TURBO_CONCURRENCY</code>
       </td>
       <td>
-        Controls [concurrency](/repo/docs/reference/run#--concurrency-number--percentage) settings in run or watch mode.
+        Controls [concurrency](/docs/reference/run#--concurrency-number--percentage) settings in run or watch mode.
       </td>
     </tr>
     <tr id="turbo_sso_login_callback_port">

--- a/docs/link-checker/package.json
+++ b/docs/link-checker/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "exports": "./dist/index.js",
   "scripts": {
-    "check-links": "cd ../../apps/docs/content && node --experimental-strip-types ../../link-checker/src/validate-docs-links.ts"
+    "check-links": "cd ../../apps/docs/content && node --experimental-strip-types ../../../docs/link-checker/src/validate-docs-links.ts"
   },
   "dependencies": {
     "github-slugger": "2.0.0",


### PR DESCRIPTION
## Summary

The command and environment reference pages contained five links or labels that pointed to nonexistent anchors, used the legacy `/repo/docs/` route, or rendered Markdown syntax as code instead of a link.

This corrects the configuration anchors for `dangerouslyDisablePackageManagerCheck` and `globalDependencies`, fixes the `--anon-profile` heading, updates the concurrency URL, and renders `--cache` as an actual link.

The standalone `@repo/docs-link-checker` command also used an incorrect relative path. It changed into `apps/docs/content` and then looked for the checker under `apps/link-checker`, causing validation to exit before checking any documentation. The corrected path now resolves the checker from `docs/link-checker`.

## Validation

`pnpm --filter @repo/docs-link-checker check-links` completes with `Link validation was successful`.

I also rendered both affected reference pages locally and checked them with Chrome. The configuration links land on the correct headings, `--cache` renders as an anchor, the concurrency link reaches the matching run option, and `--anon-profile` has the expected heading ID.

Formatting and `git diff --check` both pass.