### PR TITLE
docs: Document Nub and Aube package managers

### DIFF
--- a/apps/docs/content/docs/crafting-your-repository/structuring-a-repository.mdx
+++ b/apps/docs/content/docs/crafting-your-repository/structuring-a-repository.mdx
@@ -222,6 +222,13 @@ First, your package manager needs to describe the locations of your packages. We
 
 </PackageManagerTabs>
 
+#### Nub and Aube workspaces
+
+Turborepo also supports [Nub](https://nub.dev) and [Aube](https://aube.jdx.dev), including repositories that use their native lockfiles or preserve an existing package manager's lockfile format.
+
+- **Nub**: Declare `nub` in `devEngines.packageManager` or the legacy `packageManager` field. A Nub lockfile alone does not identify the repository as a Nub project because Nub can use npm, pnpm, Yarn, or Bun lockfiles. Turborepo recognizes `nub.lock` and the legacy `lock.yaml` as pnpm v9 lockfiles. It reads `pnpm-workspace.yaml` when the repository uses a pnpm-family lockfile and that file exists; otherwise, define workspaces in the root `package.json`.
+- **Aube**: Turborepo recognizes Aube's native `aube-lock.yaml` and can also use existing npm, pnpm, Yarn, or Bun lockfiles. When preserving another package manager's lockfile, declare `aube` in `devEngines.packageManager` or the legacy `packageManager` field. Turborepo reads workspace globs from `aube-workspace.yaml` when present, then `pnpm-workspace.yaml` for pnpm-family lockfiles, and otherwise from the root `package.json`.
+
 Using this configuration, every directory **with a `package.json`** in the `apps` or `packages` directories will be considered a package.
 
 <Callout type="error">

--- a/apps/docs/content/docs/reference/create-turbo.mdx
+++ b/apps/docs/content/docs/reference/create-turbo.mdx
@@ -131,7 +131,7 @@ bunx create-turbo@latest --example [github-url]
 ## Options
 
 ```txt title="Terminal"
--m, --package-manager to use (choices: "npm", "yarn", "pnpm", "bun")
+-m, --package-manager <package-manager>: Specify the package manager to use (choices: "npm", "yarn", "pnpm", "bun", "nub", "aube")
 
 --skip-install: Do not run a package manager install after creating the project (Default: false)
 
@@ -147,3 +147,5 @@ bunx create-turbo@latest --example [github-url]
 
 -h, --help: Display help for command
 ```
+
+For details about workspace and lockfile handling, see [Nub and Aube workspaces](/docs/crafting-your-repository/structuring-a-repository#nub-and-aube-workspaces).

--- a/apps/docs/content/docs/support-policy.mdx
+++ b/apps/docs/content/docs/support-policy.mdx
@@ -11,12 +11,14 @@ summary: Supported package managers, platforms, Node.js versions, and LTS policy
 Core `turbo` functionality depends on the package managers in the JavaScript ecosystem and their implementations of Workspaces and
 lockfile formats.
 
-| Package manager | Support                            |
-| --------------- | ---------------------------------- |
-| pnpm 8+         | Stable                             |
-| npm 8+          | Stable                             |
-| yarn 1+         | Stable (Includes Yarn Plug'n'Play) |
-| bun 1.2+        | Stable                             |
+| Package manager                  | Support                            |
+| -------------------------------- | ---------------------------------- |
+| pnpm 8+                          | Stable                             |
+| npm 8+                           | Stable                             |
+| yarn 1+                          | Stable (Includes Yarn Plug'n'Play) |
+| bun 1.2+                         | Stable                             |
+| nub                              | Stable                             |
+| aube                             | Stable                             |
 
 <Callout type="info">
   Package managers have their own release schedules, bugs, and features. While


### PR DESCRIPTION
## Summary

This updates the website documentation to reflect that `create-turbo --package-manager` supports `nub` and `aube`.

The support policy now lists both package managers as stable. The repository structure guide explains how Turborepo identifies each manager, which workspace configuration takes precedence, and how native and existing lockfile formats are handled. The `create-turbo` reference links directly to this guidance.

## Testing

`pnpm --filter docs check-links` passed. A production docs build using `OG_IMAGE_SECRET=local-docs-build pnpm --filter docs build` completed successfully. `git diff --check` also passed.