### PR TITLE
chore: Update remote cache action to v1.1.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -94,7 +94,7 @@ jobs:
       - parallel:
           - name: Set up Turborepo Remote Cache
             if: github.event.pull_request.head.repo.full_name == github.repository
-            uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7 # main
+            uses: vercel/setup-turborepo-remote-cache-action@49d7b1b46ba4c9251e1977986bfe18336feabc8f # v1.1.0
             with:
               team: ${{ vars.TURBO_TEAM }}
 

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -122,7 +122,7 @@ jobs:
       - parallel:
           - name: Set up Turborepo Remote Cache
             if: github.event.pull_request.head.repo.full_name == github.repository
-            uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7 # main
+            uses: vercel/setup-turborepo-remote-cache-action@49d7b1b46ba4c9251e1977986bfe18336feabc8f # v1.1.0
             with:
               team: ${{ vars.TURBO_TEAM }}
 

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -110,7 +110,7 @@ jobs:
       - parallel:
           - name: Set up Turborepo Remote Cache
             if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-            uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7 # main
+            uses: vercel/setup-turborepo-remote-cache-action@49d7b1b46ba4c9251e1977986bfe18336feabc8f # v1.1.0
             with:
               team: ${{ vars.TURBO_TEAM }}
 
@@ -212,7 +212,7 @@ jobs:
           # remotely; Cargo reuses state from the target-cache restore below.
           - name: Set up Turborepo Remote Cache
             if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-            uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7 # main
+            uses: vercel/setup-turborepo-remote-cache-action@49d7b1b46ba4c9251e1977986bfe18336feabc8f # v1.1.0
             with:
               team: ${{ vars.TURBO_TEAM }}
 
@@ -320,7 +320,7 @@ jobs:
           # Exchanges a GitHub OIDC token for a short-lived Remote Cache access
           # token, exported as TURBO_TOKEN/TURBO_TEAM for subsequent steps.
           - name: Set up Turborepo Remote Cache
-            uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7 # main
+            uses: vercel/setup-turborepo-remote-cache-action@49d7b1b46ba4c9251e1977986bfe18336feabc8f # v1.1.0
             with:
               team: ${{ vars.TURBO_TEAM }}
 
@@ -372,7 +372,7 @@ jobs:
           # local-only.
           - name: Set up Turborepo Remote Cache
             if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-            uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7 # main
+            uses: vercel/setup-turborepo-remote-cache-action@49d7b1b46ba4c9251e1977986bfe18336feabc8f # v1.1.0
             with:
               team: ${{ vars.TURBO_TEAM }}
 
@@ -454,7 +454,7 @@ jobs:
           # local-only.
           - name: Set up Turborepo Remote Cache
             if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-            uses: vercel/setup-turborepo-remote-cache-action@3df3d75a5268bbe2a4ee66048f56f3a86d6e21b7 # main
+            uses: vercel/setup-turborepo-remote-cache-action@49d7b1b46ba4c9251e1977986bfe18336feabc8f # v1.1.0
             with:
               team: ${{ vars.TURBO_TEAM }}
 

--- a/skills/turborepo/references/ci/github-actions.md
+++ b/skills/turborepo/references/ci/github-actions.md
@@ -96,7 +96,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: vercel/setup-turborepo-remote-cache-action@v1.0.0
+      - uses: vercel/setup-turborepo-remote-cache-action@v1.1.0
         with:
           team: ${{ vars.TURBO_TEAM }}
 ```
@@ -161,7 +161,7 @@ jobs:
           node-version: 20
           cache: "pnpm"
 
-      - uses: vercel/setup-turborepo-remote-cache-action@v1.0.0
+      - uses: vercel/setup-turborepo-remote-cache-action@v1.1.0
         with:
           team: ${{ vars.TURBO_TEAM }}
 


### PR DESCRIPTION
### Description

Update all workflow pins for `vercel/setup-turborepo-remote-cache-action` to the immutable `v1.1.0` commit so temporary Turborepo tokens are revoked after use. Update the corresponding Turborepo skill examples.

### Testing Instructions

- `git diff --check`
- Pre-push format and TOML checks