### PR TITLE
fix: Show invalid affected task glob

### DIFF
--- a/crates/turborepo-engine/src/affected.rs
+++ b/crates/turborepo-engine/src/affected.rs
@@ -23,9 +23,10 @@ use crate::{Built, Engine};
 pub enum AffectednessError {
     #[error("engine task refers to unknown package {0}")]
     UnknownTaskPackage(PackageName),
-    #[error("invalid input glob for task {task}: {error}")]
+    #[error("invalid input glob {glob:?} for task {task}: {error}")]
     InvalidGlob {
         task: TaskId<'static>,
+        glob: String,
         error: String,
     },
 }
@@ -95,7 +96,8 @@ pub fn match_tasks_against_changed_files(
             let compiled =
                 compile_globs(inputs).map_err(|error| AffectednessError::InvalidGlob {
                     task: task_id.clone(),
-                    error: error.to_string(),
+                    glob: error.glob,
+                    error: error.error.to_string(),
                 })?;
             compiled_cache.insert(cache_key.clone(), compiled);
         }

--- a/crates/turborepo-query/src/affected_tasks.rs
+++ b/crates/turborepo-query/src/affected_tasks.rs
@@ -140,7 +140,7 @@ pub fn calculate_affected_tasks(
     ) {
         Ok(matched) => matched,
         Err(error) => {
-            tracing::error!(?error, "failed to determine affected tasks");
+            tracing::error!("failed to determine affected tasks: {error}");
             return Ok(engine
                 .task_ids()
                 .map(|task_id| AffectedTask {

--- a/crates/turborepo-types/src/task_input_matching.rs
+++ b/crates/turborepo-types/src/task_input_matching.rs
@@ -43,7 +43,7 @@ pub struct CompiledGlobs {
 #[derive(Debug)]
 pub struct InvalidTaskInputGlob {
     pub glob: String,
-    pub error: wax::BuildError,
+    pub error: Box<wax::BuildError>,
 }
 
 impl std::fmt::Display for InvalidTaskInputGlob {
@@ -54,7 +54,7 @@ impl std::fmt::Display for InvalidTaskInputGlob {
 
 impl std::error::Error for InvalidTaskInputGlob {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        Some(&self.error)
+        Some(self.error.as_ref())
     }
 }
 
@@ -97,7 +97,7 @@ fn compile_patterns(
                 wax::Glob::new(stripped)
                     .map_err(|error| InvalidTaskInputGlob {
                         glob: glob_str.clone(),
-                        error,
+                        error: Box::new(error),
                     })?
                     .into_owned(),
             );
@@ -109,7 +109,7 @@ fn compile_patterns(
                 wax::Glob::new(glob_str)
                     .map_err(|error| InvalidTaskInputGlob {
                         glob: glob_str.clone(),
-                        error,
+                        error: Box::new(error),
                     })?
                     .into_owned(),
             );

--- a/crates/turborepo-types/src/task_input_matching.rs
+++ b/crates/turborepo-types/src/task_input_matching.rs
@@ -40,12 +40,30 @@ pub struct CompiledGlobs {
     jit_has_traversal_globs: bool,
 }
 
+#[derive(Debug)]
+pub struct InvalidTaskInputGlob {
+    pub glob: String,
+    pub error: wax::BuildError,
+}
+
+impl std::fmt::Display for InvalidTaskInputGlob {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "invalid glob {:?}: {}", self.glob, self.error)
+    }
+}
+
+impl std::error::Error for InvalidTaskInputGlob {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.error)
+    }
+}
+
 /// Pre-compiles a task's input globs for efficient matching against many files.
 ///
 /// When `inputs` has no globs and `default` is false (representing either
 /// `inputs: []` or a missing `inputs` key), the compiled result will match
 /// all files — see [`check_compiled_globs`] for details.
-pub fn compile_globs(inputs: &TaskInputs) -> Result<CompiledGlobs, wax::BuildError> {
+pub fn compile_globs(inputs: &TaskInputs) -> Result<CompiledGlobs, InvalidTaskInputGlob> {
     let (inclusions, exclusions, has_traversal_globs) = compile_patterns(&inputs.globs)?;
     let (jit_inclusions, jit_exclusions, jit_has_traversal_globs) =
         compile_patterns(&inputs.jit_globs)?;
@@ -65,7 +83,7 @@ pub fn compile_globs(inputs: &TaskInputs) -> Result<CompiledGlobs, wax::BuildErr
 
 fn compile_patterns(
     globs: &[String],
-) -> Result<(Vec<wax::Glob<'static>>, Vec<wax::Glob<'static>>, bool), wax::BuildError> {
+) -> Result<(Vec<wax::Glob<'static>>, Vec<wax::Glob<'static>>, bool), InvalidTaskInputGlob> {
     let mut inclusions = Vec::new();
     let mut exclusions = Vec::new();
     let mut has_traversal_globs = false;
@@ -75,12 +93,26 @@ fn compile_patterns(
             if stripped.starts_with("../") {
                 has_traversal_globs = true;
             }
-            exclusions.push(wax::Glob::new(stripped)?.into_owned());
+            exclusions.push(
+                wax::Glob::new(stripped)
+                    .map_err(|error| InvalidTaskInputGlob {
+                        glob: glob_str.clone(),
+                        error,
+                    })?
+                    .into_owned(),
+            );
         } else {
             if glob_str.starts_with("../") {
                 has_traversal_globs = true;
             }
-            inclusions.push(wax::Glob::new(glob_str)?.into_owned());
+            inclusions.push(
+                wax::Glob::new(glob_str)
+                    .map_err(|error| InvalidTaskInputGlob {
+                        glob: glob_str.clone(),
+                        error,
+                    })?
+                    .into_owned(),
+            );
         }
     }
 
@@ -494,7 +526,11 @@ mod tests {
             default: false,
             ..Default::default()
         };
-        assert!(compile_globs(&inputs).is_err());
+        let error = match compile_globs(&inputs) {
+            Ok(_) => panic!("invalid glob compiled successfully"),
+            Err(error) => error,
+        };
+        assert_eq!(error.glob, "[invalid");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Preserve the offending task input glob when compilation fails.
- Include the task, exact glob, and parser error in the affected-task fallback message.

Before:

```text
ERROR  failed to determine affected tasks
```

After:

```text
ERROR  failed to determine affected tasks: invalid input glob "[invalid" for task @pyra/jwt#build: failed to parse glob expression
```

## Testing

- `cargo test -p turborepo-types invalid_glob`
- `cargo test -p turborepo-query affected_tasks`
- `cargo clippy -p turborepo-types -p turborepo-engine -p turborepo-query --all-targets -- -D warnings`
- `cargo build -p turbo --bin turbo`
- Verified the rendered CLI error using a malformed root task input.