### PR TITLE
fix: Wire TURBO_REMOTE_CACHE_ENABLED into environment config

### DIFF
--- a/apps/docs/content/docs/reference/system-environment-variables.mdx
+++ b/apps/docs/content/docs/reference/system-environment-variables.mdx
@@ -232,6 +232,20 @@ System environment variables are always overridden by flag values provided direc
         configured.
       </td>
     </tr>
+    <tr id="turbo_remote_cache_enabled">
+      <td>
+        <code>TURBO_REMOTE_CACHE_ENABLED</code>
+      </td>
+      <td>
+        Set to <code>0</code> or <code>false</code> to disable all{" "}
+        <a href="/docs/core-concepts/remote-caching">Remote Cache</a>{" "}
+        operations, even if the repository has a valid token. Equivalent to{" "}
+        <a href="/docs/reference/configuration#enabled">
+          <code>remoteCache.enabled</code>
+        </a>{" "}
+        in <code>turbo.json</code>.
+      </td>
+    </tr>
     <tr id="turbo_remote_cache_read_only">
       <td>
         <code>TURBO_REMOTE_CACHE_READ_ONLY</code>

--- a/crates/turborepo-config/src/env.rs
+++ b/crates/turborepo-config/src/env.rs
@@ -41,6 +41,7 @@ const TURBO_MAPPING: &[(&str, &str)] = [
     ("turbo_log_order", "log_order"),
     ("turbo_remote_only", "remote_only"),
     ("turbo_remote_cache_read_only", "remote_cache_read_only"),
+    ("turbo_remote_cache_enabled", "enabled"),
     ("turbo_run_summary", "run_summary"),
     ("turbo_allow_no_turbo_json", "allow_no_turbo_json"),
     ("turbo_cache", "cache"),
@@ -141,6 +142,12 @@ impl ResolvedConfigurationOptions for EnvVars {
         let preflight = self
             .truthy_value("preflight")
             .map(|value| value.ok_or_else(|| Error::InvalidPreflight))
+            .transpose()?;
+
+        // Process remote cache enabled
+        let enabled = self
+            .truthy_value("enabled")
+            .map(|value| value.ok_or_else(|| Error::InvalidRemoteCacheEnabled))
             .transpose()?;
 
         let force = self.truthy_value("force").flatten();
@@ -315,7 +322,8 @@ impl ResolvedConfigurationOptions for EnvVars {
             // Processed booleans
             signature,
             preflight,
-            enabled: None,
+            enabled,
+            enabled_source: None,
             ui,
             allow_no_package_manager,
             daemon,
@@ -429,6 +437,7 @@ mod test {
         env.insert("turbo_log_order".into(), "grouped".into());
         env.insert("turbo_remote_only".into(), "1".into());
         env.insert("turbo_remote_cache_read_only".into(), "1".into());
+        env.insert("turbo_remote_cache_enabled".into(), "0".into());
         env.insert("turbo_run_summary".into(), "true".into());
         env.insert("turbo_allow_no_turbo_json".into(), "true".into());
         env.insert("turbo_remote_cache_upload_timeout".into(), "200".into());
@@ -443,6 +452,8 @@ mod test {
         assert_eq!(config.log_order(), LogOrder::Grouped);
         assert!(config.remote_only());
         assert!(config.remote_cache_read_only());
+        assert_eq!(config.enabled, Some(false));
+        assert!(!config.enabled());
         assert!(config.run_summary());
         assert!(config.allow_no_turbo_json());
         assert_eq!(config.upload_timeout(), 200);
@@ -496,6 +507,7 @@ mod test {
         env.insert("turbo_log_order".into(), "".into());
         env.insert("turbo_remote_only".into(), "".into());
         env.insert("turbo_remote_cache_read_only".into(), "".into());
+        env.insert("turbo_remote_cache_enabled".into(), "".into());
         env.insert("turbo_run_summary".into(), "".into());
         env.insert("turbo_allow_no_turbo_json".into(), "".into());
         env.insert("turbo_tui_scrollback_length".into(), "".into());
@@ -520,6 +532,8 @@ mod test {
         assert_eq!(config.log_order(), LogOrder::Auto);
         assert!(!config.remote_only());
         assert!(!config.remote_cache_read_only());
+        assert_eq!(config.enabled, None);
+        assert!(config.enabled());
         assert!(!config.run_summary());
         assert!(!config.allow_no_turbo_json());
         assert_eq!(
@@ -527,5 +541,29 @@ mod test {
             DEFAULT_TUI_SCROLLBACK_LENGTH
         );
         assert_eq!(config.concurrency, None);
+    }
+
+    #[test]
+    fn test_remote_cache_enabled_env_setting() {
+        for (value, expected) in [("1", true), ("true", true), ("0", false), ("false", false)] {
+            let mut env: HashMap<OsString, OsString> = HashMap::new();
+            env.insert("turbo_remote_cache_enabled".into(), value.into());
+            let config = EnvVars::new(&env)
+                .unwrap()
+                .get_configuration_options(&ConfigurationOptions::default())
+                .unwrap();
+            assert_eq!(config.enabled, Some(expected), "value {value:?}");
+        }
+    }
+
+    #[test]
+    fn test_remote_cache_enabled_invalid_env_setting() {
+        let mut env: HashMap<OsString, OsString> = HashMap::new();
+        env.insert("turbo_remote_cache_enabled".into(), "banana".into());
+        let err = EnvVars::new(&env)
+            .unwrap()
+            .get_configuration_options(&ConfigurationOptions::default())
+            .unwrap_err();
+        assert!(matches!(err, Error::InvalidRemoteCacheEnabled), "{err:?}");
     }
 }

--- a/crates/turborepo-config/src/lib.rs
+++ b/crates/turborepo-config/src/lib.rs
@@ -285,6 +285,8 @@ pub struct ConfigurationOptions {
     pub timeout: Option<u64>,
     pub upload_timeout: Option<u64>,
     pub enabled: Option<bool>,
+    #[serde(skip)]
+    pub enabled_source: Option<ConfigurationSource>,
     #[serde(rename = "ui")]
     pub ui: Option<UIMode>,
     #[serde(rename = "dangerouslyDisablePackageManagerCheck")]
@@ -339,12 +341,15 @@ pub struct TurborepoConfigBuilder {
 
 // Getters
 impl ConfigurationOptions {
-    fn with_url_sources(mut self, source: ConfigurationSource) -> Self {
+    fn with_sources(mut self, source: ConfigurationSource) -> Self {
         if self.api_url.is_some() {
             self.api_url_source = Some(source);
         }
         if self.login_url.is_some() {
             self.login_url_source = Some(source);
+        }
+        if self.enabled.is_some() {
+            self.enabled_source = Some(source);
         }
 
         self
@@ -386,6 +391,10 @@ impl ConfigurationOptions {
 
     pub fn enabled(&self) -> bool {
         self.enabled.unwrap_or(true)
+    }
+
+    pub fn enabled_source(&self) -> Option<ConfigurationSource> {
+        self.enabled_source
     }
 
     pub fn preflight(&self) -> bool {
@@ -718,7 +727,7 @@ impl TurborepoConfigBuilder {
             ConfigurationOptions::default(),
             |mut acc, (source, current_source)| {
                 let current_source_config = current_source.get_configuration_options(&acc)?;
-                let current_source_config = current_source_config.with_url_sources(source);
+                let current_source_config = current_source_config.with_sources(source);
                 acc.merge(current_source_config);
                 Ok(acc)
             },
@@ -1412,6 +1421,77 @@ mod test {
         assert_eq!(
             config.login_url_source(),
             Some(ConfigurationSource::Environment)
+        );
+    }
+
+    #[test]
+    fn test_env_remote_cache_enabled_overrides_turbo_json() {
+        let tmp_dir = TempDir::new().unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(tmp_dir.path()).unwrap();
+
+        repo_root
+            .join_component("turbo.json")
+            .create_with_contents(
+                r#"{
+                    "remoteCache": {
+                        "enabled": true
+                    }
+                }"#,
+            )
+            .unwrap();
+
+        let mut env = HashMap::new();
+        env.insert(
+            OsString::from("turbo_remote_cache_enabled"),
+            OsString::from("0"),
+        );
+
+        let config = TurborepoConfigBuilder {
+            repo_root,
+            override_config: ConfigurationOptions::default(),
+            global_config_path: None,
+            environment: Some(env),
+        }
+        .build()
+        .unwrap();
+
+        assert_eq!(config.enabled, Some(false));
+        assert!(!config.enabled());
+        assert_eq!(
+            config.enabled_source(),
+            Some(ConfigurationSource::Environment)
+        );
+    }
+
+    #[test]
+    fn test_turbo_json_remote_cache_enabled_source() {
+        let tmp_dir = TempDir::new().unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(tmp_dir.path()).unwrap();
+
+        repo_root
+            .join_component("turbo.json")
+            .create_with_contents(
+                r#"{
+                    "remoteCache": {
+                        "enabled": false
+                    }
+                }"#,
+            )
+            .unwrap();
+
+        let config = TurborepoConfigBuilder {
+            repo_root,
+            override_config: ConfigurationOptions::default(),
+            global_config_path: None,
+            environment: Some(HashMap::new()),
+        }
+        .build()
+        .unwrap();
+
+        assert_eq!(config.enabled, Some(false));
+        assert_eq!(
+            config.enabled_source(),
+            Some(ConfigurationSource::TurboJson)
         );
     }
 }

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -6,9 +6,9 @@ use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf
 use turborepo_api_client::APIAuth;
 use turborepo_cache::{CacheOpts, RemoteCacheOpts};
 use turborepo_types::{
-    APIClientOpts, ContinueMode, DryRunMode, EnvMode, GraphOpts, LogOrder, LogPrefix, RepoOpts,
-    ResolvedLogOrder, ResolvedLogPrefix, RunCacheOpts, RunOptsInfo, ScopeOpts, TaskArgs, TuiOpts,
-    UIMode,
+    APIClientOpts, ConfigurationSource, ContinueMode, DryRunMode, EnvMode, GraphOpts, LogOrder,
+    LogPrefix, RepoOpts, ResolvedLogOrder, ResolvedLogPrefix, RunCacheOpts, RunOptsInfo, ScopeOpts,
+    TaskArgs, TuiOpts, UIMode,
 };
 
 use crate::{
@@ -27,7 +27,7 @@ pub enum RemoteCacheDisabledReason {
     /// TURBO_TOKEN env var is set but no team is configured.
     /// The token gets effectively ignored because `is_linked` returns false.
     TokenWithoutTeam,
-    /// `remoteCache.enabled: false` in turbo.json.
+    /// `remoteCache.enabled: false` in turbo.json or a config file.
     InConfig,
     /// `TURBO_REMOTE_CACHE_ENABLED=0` env var.
     InEnvVar,
@@ -246,11 +246,7 @@ impl Opts {
                     Some(RemoteCacheDisabledReason::NotLinked)
                 }
             } else if config.enabled == Some(false) {
-                let disabled_by_env = std::env::var("TURBO_REMOTE_CACHE_ENABLED")
-                    .ok()
-                    .filter(|v| v == "0")
-                    .is_some();
-                if disabled_by_env {
+                if config.enabled_source() == Some(ConfigurationSource::Environment) {
                     Some(RemoteCacheDisabledReason::InEnvVar)
                 } else {
                     Some(RemoteCacheDisabledReason::InConfig)
@@ -765,7 +761,7 @@ mod test {
     };
     use turborepo_ui::ColorConfig;
 
-    use super::{APIClientOpts, RepoOpts, RunOpts};
+    use super::{APIClientOpts, RemoteCacheDisabledReason, RepoOpts, RunOpts};
     use crate::{
         cli::{Command, RunArgs},
         commands::CommandBase,
@@ -1118,6 +1114,75 @@ mod test {
                         write: true
                     }
                 }
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_remote_cache_disabled_by_env_var() -> Result<(), anyhow::Error> {
+        with_clean_turbo_env(|| {
+            temp_env::with_var("TURBO_REMOTE_CACHE_ENABLED", Some("0"), || {
+                let tmpdir = TempDir::new()?;
+                let repo_root = AbsoluteSystemPathBuf::try_from(tmpdir.path())?;
+
+                repo_root.join_component(CONFIG_FILE).create_with_contents(
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "remoteCache": { "enabled": true }
+                    }))?,
+                )?;
+
+                let mut args = Args::default();
+                args.command = Some(Command::Run {
+                    execution_args: Box::default(),
+                    run_args: Box::default(),
+                });
+                // set token and team to simulate a logged in/linked user
+                args.token = Some("token".to_string());
+                args.team = Some("team".to_string());
+
+                let base = CommandBase::new(args, repo_root, "1.0.0", ColorConfig::new(false))?;
+                let opts = base.opts();
+
+                assert!(!opts.cache_opts.cache.remote.should_use());
+                assert_eq!(
+                    opts.remote_cache_disabled_reason,
+                    Some(RemoteCacheDisabledReason::InEnvVar)
+                );
+
+                Ok(())
+            })
+        })
+    }
+
+    #[test]
+    fn test_remote_cache_disabled_by_config() -> Result<(), anyhow::Error> {
+        with_clean_turbo_env(|| {
+            let tmpdir = TempDir::new()?;
+            let repo_root = AbsoluteSystemPathBuf::try_from(tmpdir.path())?;
+
+            repo_root.join_component(CONFIG_FILE).create_with_contents(
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "remoteCache": { "enabled": false }
+                }))?,
+            )?;
+
+            let mut args = Args::default();
+            args.command = Some(Command::Run {
+                execution_args: Box::default(),
+                run_args: Box::default(),
+            });
+            args.token = Some("token".to_string());
+            args.team = Some("team".to_string());
+
+            let base = CommandBase::new(args, repo_root, "1.0.0", ColorConfig::new(false))?;
+            let opts = base.opts();
+
+            assert!(!opts.cache_opts.cache.remote.should_use());
+            assert_eq!(
+                opts.remote_cache_disabled_reason,
+                Some(RemoteCacheDisabledReason::InConfig)
             );
 
             Ok(())


### PR DESCRIPTION
### Description

Fixes #13794.

`TURBO_REMOTE_CACHE_ENABLED` was referenced by the run prelude message, `RemoteCacheDisabledReason::InEnvVar`, and the `InvalidRemoteCacheEnabled` error, but it was never added to the `TURBO_*` mapping in `turborepo-config`, and `EnvVars::get_configuration_options` hardcoded `enabled: None`. Setting the variable did nothing and invalid values were accepted silently.

Changes:

- `turborepo-config/src/env.rs`: map `turbo_remote_cache_enabled` → `enabled` and parse it strictly (`1`/`true`/`0`/`false`, otherwise `Error::InvalidRemoteCacheEnabled`), matching `TURBO_PREFLIGHT`.
- `turborepo-config/src/lib.rs`: track `enabled_source: Option<ConfigurationSource>` alongside the existing `api_url_source`/`login_url_source`, set during the same resolution fold (`with_url_sources` → `with_sources`).
- `turborepo-lib/src/opts.rs`: derive `InEnvVar` vs `InConfig` from `config.enabled_source()` instead of re-reading `std::env::var("TURBO_REMOTE_CACHE_ENABLED")` after the fact. Precedence is unchanged: env overrides `turbo.json`, CLI overrides env, via the existing `overwrite_none` merge.
- Docs: add the variable to the system environment variables reference.

Tests added: env parsing (valid values, empty, invalid), config precedence/source (`env` over `turbo.json`, `turbo.json` alone), and `Opts` resolution asserting `InEnvVar` / `InConfig`.

### Testing Instructions

```
cargo test -p turborepo-config -p turborepo-lib
```

Manual, with `cargo build -p turbo` and the repro at https://github.com/BABTUNA/turbo-remote-cache-enabled-repro:

```
$ TURBO_REMOTE_CACHE_ENABLED=0 turbo config | grep enabled
  "enabled": false,          # was: true
$ TURBO_REMOTE_CACHE_ENABLED=banana turbo config
  x TURBO_REMOTE_CACHE_ENABLED should be either 1 or 0.    # was: silently accepted
$ TURBO_REMOTE_CACHE_ENABLED=0 TURBO_TOKEN=x TURBO_TEAM=t turbo run build | grep Remote
   • Remote caching disabled (by TURBO_REMOTE_CACHE_ENABLED)    # was: Remote caching enabled
```
