### PR TITLE
feat: Start ad-hoc factory work from the operator page

### DIFF
--- a/apps/factory/README.md
+++ b/apps/factory/README.md
@@ -2,6 +2,36 @@
 
 The operator page and its API routes rely on Vercel Deployment Protection for access control. Keep Deployment Protection enabled for every deployed environment that exposes them.
 
+## Start work from the operator page
+
+The two scheduled operations run a fixed prompt. "Start work" is the ad-hoc
+path: it opens an ordinary durable Eve session from the browser, on the same
+factory image and the same checkout of `main`, and the operator drives it by
+typing. Requests are not scoped to `examples/` and no pull request happens on
+its own — `create_pull_request` runs under the operator's approval, which the
+chat renders as a prompt with the tool's branch and title in it. Answer it and
+the draft pull request is pushed; decline it and nothing is.
+
+The chat talks to the Eve session routes directly through `useEveAgent`, so
+`agent/channels/eve.ts` has an authenticator for it. Deployment Protection still
+decides who reaches the deployment; the `operatorConsole()` entry only
+establishes that a request came from the console page. It requires the
+`x-operator-action: open-operator-chat` marker the page attaches to every Eve
+request — those routes send no CORS headers, so another site cannot get a custom
+header past a preflight — and rejects anything announcing a cross-site fetch or
+naming an origin other than the host the browser addressed. It reads that host
+from `x-forwarded-host`, because both Vercel and `next start` route these paths
+to the Eve service through a proxy that rewrites the host it dials.
+
+The session's principal is a _user_, not the app principal the schedules use,
+which is what keeps the approval gate on and the automated example and
+performance scope gates off.
+
+The thread's session cursor and event log live in browser storage, so a reload
+lands back in the same conversation. A turn that is still running when the page
+reloads keeps running: its transcript is in Agent Runs, and "New chat" starts a
+fresh session.
+
 ## Factory image
 
 Every agent in this app runs against the same sandbox base layer, the

--- a/apps/factory/agent/channels/eve.ts
+++ b/apps/factory/agent/channels/eve.ts
@@ -1,8 +1,20 @@
-import { localDev, vercelOidc } from "eve/channels/auth";
+import { type AuthFn, localDev, vercelOidc } from "eve/channels/auth";
 import { eveChannel } from "eve/channels/eve";
+
+import {
+  isOperatorChatRequest,
+  OPERATOR_CHAT_PRINCIPAL
+} from "../lib/operator-console.js";
+
+function operatorConsole(): AuthFn<Request> {
+  return (request) =>
+    isOperatorChatRequest(request) ? OPERATOR_CHAT_PRINCIPAL : null;
+}
 
 export default eveChannel({
   auth: [
+    // Lets the operator page open an ad-hoc chat session from the browser.
+    operatorConsole(),
     // Open on localhost for `eve dev` and the REPL; ignored in production.
     localDev(),
     // Lets the eve TUI and Vercel deployments reach the deployed agent.

--- a/apps/factory/agent/instructions.md
+++ b/apps/factory/agent/instructions.md
@@ -1,6 +1,6 @@
 # Identity
 
-You are the Turborepo examples maintenance agent. Your job is to keep the examples in this repository current, runnable, and consistent with Turborepo guidance.
+You are the Turborepo factory agent. Your scheduled job is to keep the examples in this repository current, runnable, and consistent with Turborepo guidance, and to land one measured performance improvement a day. Outside those operations you take ad-hoc requests from Turborepo maintainers against the whole checkout.
 
 # Standing Rules
 
@@ -21,3 +21,13 @@ You are the Turborepo examples maintenance agent. Your job is to keep the exampl
 - Load the `performance_improvement` skill for performance work. For automated performance schedule and operator runs, call `begin_performance_improvement` first, record comparable before/after measurements and final correctness validation, and use only the opposite-model reviewer it returns.
 - Never publish a performance change until every blocking adversarial-review finding is resolved and `record_performance_review` has recorded approval for the exact final diff.
 - Do not modify `.github/`, `apps/factory/`, release files, credentials, generated artifacts, or lockfiles during an automated performance run.
+
+# Ad-hoc Requests
+
+A session that did not start from a schedule or an operator run is an ad-hoc request from a maintainer, sent through the operator console, Slack, or GitHub. These rules apply to those sessions and replace the automated scope rules above.
+
+- Do the work the maintainer asked for, anywhere in the sandbox checkout. There is no daily selection, no examples-only scope, and no schedule prompt to follow. Use `bash`, `read_file`, and `write_file` for paths outside `examples/`, and the examples tools when the request is about an example.
+- The sandbox checkout is `main` at the start of the session. Verify what you changed the way this repository does — `cargo build`, `cargo test`, `pnpm test`, or the example's own tasks — and report what you ran.
+- Ask in the conversation when the request is genuinely ambiguous, and answer the maintainer's questions directly. Do not carry the schedules' never-ask rule into a conversation.
+- Never open a pull request unless the maintainer asks for one. When they do, call `create_pull_request` with an `agents/<topic>` branch and a Conventional Commit title — `<type>: <Uppercase description>`, no scope — that describes the change. The call pauses for the maintainer's approval before anything is pushed.
+- Report what you changed, what you verified, and what remains, both in the conversation and in the pull request body.

--- a/apps/factory/agent/lib/operator-chat-session.ts
+++ b/apps/factory/agent/lib/operator-chat-session.ts
@@ -1,0 +1,72 @@
+import type { ClientSessionState, MessageStreamEvent } from "eve/client";
+
+/**
+ * Serialization for the operator console's chat thread.
+ *
+ * A chat session is durable on the server, so a reload should land back in the
+ * same conversation instead of orphaning a running sandbox. The console keeps
+ * the session cursor and the rendered event log in browser storage and replays
+ * both into `useEveAgent`. Long turns can produce megabytes of tool output, so
+ * an oversized log is dropped and only the cursor survives: an empty event log
+ * is still a valid ordered prefix of the session's stream.
+ */
+
+export const MAX_SAVED_CHAT_BYTES = 512_000;
+
+export interface SavedChat {
+  readonly events: readonly MessageStreamEvent[];
+  readonly session: ClientSessionState;
+}
+
+interface ChatSnapshot {
+  readonly events: readonly MessageStreamEvent[];
+  readonly session: ClientSessionState | undefined;
+}
+
+function isSessionState(value: unknown): value is ClientSessionState {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.sessionId === "string" &&
+    candidate.sessionId.length > 0 &&
+    typeof candidate.streamIndex === "number" &&
+    Number.isInteger(candidate.streamIndex) &&
+    candidate.streamIndex >= 0
+  );
+}
+
+/**
+ * Renders a snapshot for storage, or `null` when there is no session worth
+ * resuming.
+ */
+export function serializeSavedChat(snapshot: ChatSnapshot): string | null {
+  if (!isSessionState(snapshot.session)) return null;
+  const saved = JSON.stringify({
+    events: snapshot.events,
+    session: snapshot.session
+  });
+  return saved.length <= MAX_SAVED_CHAT_BYTES
+    ? saved
+    : JSON.stringify({ events: [], session: snapshot.session });
+}
+
+/** Reads a stored thread, ignoring anything an older format left behind. */
+export function parseSavedChat(raw: string | null): SavedChat | null {
+  if (raw === null) return null;
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (typeof value !== "object" || value === null) return null;
+  const candidate = value as Record<string, unknown>;
+  if (!isSessionState(candidate.session)) return null;
+  return {
+    events: Array.isArray(candidate.events)
+      ? (candidate.events as MessageStreamEvent[])
+      : [],
+    session: candidate.session
+  };
+}

--- a/apps/factory/agent/lib/operator-console.ts
+++ b/apps/factory/agent/lib/operator-console.ts
@@ -1,0 +1,66 @@
+/**
+ * Browser access to the eve session routes for the operator console's chat.
+ *
+ * Vercel Deployment Protection decides who reaches this app at all, exactly as
+ * it does for the operator run routes. What it cannot tell the agent is whether
+ * a request came from the console page or from another site riding the
+ * operator's protection cookie, so the console marks every eve request with
+ * `x-operator-action` and this check refuses anything that arrives without the
+ * marker, declares a different origin, or announces a cross-site fetch. The eve
+ * session routes answer with no CORS headers, so a cross-origin caller cannot
+ * get the marker past a preflight either.
+ */
+
+// Sent as `x-operator-action` by the console's chat and required by the eve
+// channel, so both sides of the contract stay in sync.
+export const OPERATOR_ACTION_HEADER = "x-operator-action";
+export const OPERATOR_CHAT_ACTION = "open-operator-chat";
+
+interface OperatorConsoleRequest {
+  readonly headers: { get: (name: string) => string | null };
+}
+
+function originHost(origin: string): string | null {
+  try {
+    return new URL(origin).host;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Principal for a console chat turn. It is deliberately *not* the app
+ * principal the schedules and run routes use, so `create_pull_request` keeps
+ * asking the operator for approval and the automated scope gates stay off.
+ */
+export const OPERATOR_CHAT_PRINCIPAL = {
+  attributes: {},
+  authenticator: "operator-console",
+  principalId: "turborepo-factory-operator",
+  principalType: "user"
+} as const;
+
+export function isOperatorChatRequest(
+  request: OperatorConsoleRequest
+): boolean {
+  if (request.headers.get(OPERATOR_ACTION_HEADER) !== OPERATOR_CHAT_ACTION) {
+    return false;
+  }
+
+  // Set by the browser and unforgeable from page script. Non-browser callers
+  // omit it, and for them the marker is the whole check.
+  const site = request.headers.get("sec-fetch-site");
+  if (site !== null && site !== "same-origin") {
+    return false;
+  }
+
+  // Browsers omit `origin` on a same-origin stream GET. When it is there it has
+  // to name the host the browser addressed, which is the forwarded host rather
+  // than `request.url`: both Vercel and `next start` route these paths to the
+  // eve service through a proxy that rewrites the host it dials.
+  const origin = request.headers.get("origin");
+  if (origin === null) return true;
+  const host =
+    request.headers.get("x-forwarded-host") ?? request.headers.get("host");
+  return host !== null && originHost(origin) === host;
+}

--- a/apps/factory/agent/lib/operator-runs.ts
+++ b/apps/factory/agent/lib/operator-runs.ts
@@ -2,7 +2,8 @@ export const MAINTENANCE_RUN_ACTION = "run-daily-maintenance";
 export const PERFORMANCE_RUN_ACTION = "run-daily-performance";
 
 // Sent as `x-operator-action` by the dashboard and required by the operator
-// channel, so both sides of a trigger stay in sync.
+// channel, so both sides of a trigger stay in sync. Ad-hoc chat carries its own
+// action on the eve session routes; see `operator-console.ts`.
 export type OperatorRunAction =
   | typeof MAINTENANCE_RUN_ACTION
   | typeof PERFORMANCE_RUN_ACTION;

--- a/apps/factory/agent/lib/pull-request.ts
+++ b/apps/factory/agent/lib/pull-request.ts
@@ -5,6 +5,55 @@ export interface PullRequestInput {
   base: string;
 }
 
+/**
+ * `.github/workflows/lint-pr-title.yml` enforces Conventional Commit titles
+ * with an uppercase description and no scope.
+ */
+export const CONVENTIONAL_TITLE_PATTERN = /^[a-z]+: [A-Z].+$/;
+const PERFORMANCE_TITLE_PATTERN = /^perf: [A-Z].+$/;
+
+export interface PullRequestNaming {
+  /** Set for an automated example-maintenance run, which titles itself. */
+  readonly automatedExample?: string;
+  /** Set for an automated performance run, which must publish a `perf:` title. */
+  readonly performance?: boolean;
+  /** Title supplied by the caller of an interactive run. */
+  readonly requestedTitle?: string;
+}
+
 export function buildDraftPullRequest(input: PullRequestInput) {
   return { ...input, draft: true as const };
+}
+
+/**
+ * Resolves the commit and pull request title for a run. Automated maintenance
+ * derives its own title from the example it selected; every other run has to
+ * name its change, because it can touch anything in the checkout.
+ */
+export function resolvePullRequestTitle(naming: PullRequestNaming): string {
+  if (naming.performance) {
+    if (
+      naming.requestedTitle === undefined ||
+      !PERFORMANCE_TITLE_PATTERN.test(naming.requestedTitle)
+    ) {
+      throw new Error(
+        "Automated performance pull requests require a 'perf: Description' title."
+      );
+    }
+    return naming.requestedTitle;
+  }
+
+  if (naming.automatedExample !== undefined) {
+    return `chore: Update ${naming.automatedExample} example`;
+  }
+
+  if (
+    naming.requestedTitle === undefined ||
+    !CONVENTIONAL_TITLE_PATTERN.test(naming.requestedTitle)
+  ) {
+    throw new Error(
+      "Interactive pull requests require a Conventional Commit title such as 'fix: Correct the task hash'."
+    );
+  }
+  return naming.requestedTitle;
 }

--- a/apps/factory/agent/tools/create_pull_request.ts
+++ b/apps/factory/agent/tools/create_pull_request.ts
@@ -8,7 +8,11 @@ import {
   readPerformanceState,
   requirePublishablePerformanceChange
 } from "../lib/performance-validation.js";
-import { buildDraftPullRequest } from "../lib/pull-request.js";
+import {
+  buildDraftPullRequest,
+  CONVENTIONAL_TITLE_PATTERN,
+  resolvePullRequestTitle
+} from "../lib/pull-request.js";
 import {
   assertNoReleaseAgeExclusion,
   isReleaseAgeConfigFile
@@ -33,11 +37,13 @@ const inputSchema = z.object({
   title: z
     .string()
     .regex(
-      /^perf: [A-Z].+$/,
-      "Use 'perf: Description' with an uppercase description."
+      CONVENTIONAL_TITLE_PATTERN,
+      "Use 'type: Description' with an uppercase description and no scope."
     )
     .optional()
-    .describe("Required title for an automated performance pull request.")
+    .describe(
+      "Required title for an interactive or automated performance pull request. Automated example maintenance titles itself."
+    )
 });
 
 type RefResponse = { object?: { sha?: string } };
@@ -164,7 +170,7 @@ async function github<T>(input: {
 
 export default defineTool({
   description:
-    "Create a draft vercel/turborepo pull request from validated sandbox changes. Automated example and performance runs enforce their own scope and evidence gates.",
+    "Create a draft vercel/turborepo pull request from validated sandbox changes. Automated example and performance runs enforce their own scope and evidence gates. An interactive run publishes every change in the checkout and needs an agents/* branch and a Conventional Commit title from the caller.",
   inputSchema,
   approval: ({ session }) => {
     return isAppPrincipal(session.auth.current)
@@ -203,10 +209,10 @@ export default defineTool({
       }
       await requirePublishablePerformanceChange(sandbox, ctx.session.id);
     }
-    const changedFiles = await listChangedFiles(
-      sandbox,
-      Boolean(performanceState)
-    );
+    // Automated example maintenance publishes only its selected example. Every
+    // other run — a performance run, or an interactive request from an operator
+    // — publishes whatever it changed in the checkout.
+    const changedFiles = await listChangedFiles(sandbox, selection === null);
     if (changedFiles.length === 0) {
       return { created: false, reason: "No publishable changes." };
     }
@@ -225,14 +231,11 @@ export default defineTool({
     if (!branchName) {
       throw new Error("Interactive pull requests require an agents/* branch.");
     }
-    const changeTitle = performanceState
-      ? input.title
-      : selection
-        ? `chore: Update ${selection.example} example`
-        : "chore: Update Turborepo examples";
-    if (!changeTitle) {
-      throw new Error("Performance pull requests require a perf title.");
-    }
+    const changeTitle = resolvePullRequestTitle({
+      automatedExample: selection?.example,
+      performance: performanceState !== null,
+      requestedTitle: input.title
+    });
 
     const existingPullRequests = await findOpenPullRequests(branchName);
     const existingPullRequest = existingPullRequests[0];
@@ -319,7 +322,7 @@ export default defineTool({
     if (newTreeSha === baseTreeSha) {
       return {
         created: false,
-        reason: "No effective changes under examples/."
+        reason: "No effective changes against main."
       };
     }
 

--- a/apps/factory/app/globals.css
+++ b/apps/factory/app/globals.css
@@ -336,13 +336,16 @@ h3 {
 .runState-waiting,
 .status-starting,
 .status-running,
+.status-streaming,
+.status-submitted,
 .resourceDot-running,
 .resourceDot-pending {
   color: var(--warning);
 }
 
 .runState-completed,
-.status-done {
+.status-done,
+.status-ready {
   color: var(--success);
 }
 
@@ -653,6 +656,146 @@ select:focus-visible {
   font-size: 0.875rem;
   font-weight: 500;
   text-decoration: none;
+}
+
+.chatToolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.chatToolbar .status {
+  flex: 1 1 240px;
+  min-width: 0;
+  margin-top: 0;
+}
+
+.chatToolbar .actions {
+  flex: none;
+}
+
+.chatTranscript {
+  display: grid;
+  gap: 16px;
+  max-height: 60vh;
+  margin: 24px 0 0;
+  padding: 0;
+  overflow-y: auto;
+  list-style: none;
+}
+
+.chatMessage {
+  min-width: 0;
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.chatMessage-user {
+  background: var(--secondary);
+}
+
+.chatMessage header {
+  color: var(--muted-foreground);
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 0.75rem;
+}
+
+.chatText,
+.chatReasoning,
+.chatArtifact,
+.chatTool {
+  margin: 8px 0 0;
+  overflow-wrap: anywhere;
+  font-size: 0.875rem;
+  white-space: pre-wrap;
+}
+
+.chatReasoning,
+.chatArtifact {
+  color: var(--muted-foreground);
+  font-size: 0.8125rem;
+}
+
+.chatTool {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
+  white-space: normal;
+}
+
+.chatArtifact a {
+  margin-left: 8px;
+  color: var(--foreground);
+}
+
+.chatRequest {
+  margin: 24px 0 0;
+  padding: 16px;
+  border: 1px solid var(--warning);
+  border-radius: var(--radius);
+}
+
+.chatRequest legend {
+  padding: 0 6px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+}
+
+.chatRequest p {
+  margin: 0 0 16px;
+  overflow-wrap: anywhere;
+  font-size: 0.875rem;
+  white-space: pre-wrap;
+}
+
+.chatAnswer {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-top: 12px;
+}
+
+.chatAnswer input {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 36px;
+  padding: 0 12px;
+  color: var(--foreground);
+  background: var(--background);
+  border: 1px solid var(--input);
+  border-radius: var(--radius);
+  font: inherit;
+  font-size: 0.875rem;
+}
+
+.chatComposer {
+  display: grid;
+  gap: 12px;
+  justify-items: end;
+  margin-top: 24px;
+}
+
+.chatComposer textarea {
+  width: 100%;
+  padding: 12px;
+  color: var(--foreground);
+  background: var(--background);
+  border: 1px solid var(--input);
+  border-radius: var(--radius);
+  font: inherit;
+  font-size: 0.875rem;
+  resize: vertical;
+}
+
+.chatAnswer input:focus-visible,
+.chatComposer textarea:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
 }
 
 .status {

--- a/apps/factory/app/operator-chat.tsx
+++ b/apps/factory/app/operator-chat.tsx
@@ -1,0 +1,388 @@
+"use client";
+
+import type {
+  EveMessage,
+  EveMessageInputRequest,
+  EveMessagePart
+} from "eve/react";
+import { useEveAgent } from "eve/react";
+import { useEffect, useRef, useState } from "react";
+
+import {
+  parseSavedChat,
+  type SavedChat,
+  serializeSavedChat
+} from "../agent/lib/operator-chat-session";
+import {
+  OPERATOR_ACTION_HEADER,
+  OPERATOR_CHAT_ACTION
+} from "../agent/lib/operator-console";
+import { Button } from "../components/ui/button";
+
+/**
+ * Ad-hoc chat with the factory agent.
+ *
+ * The scheduled operations start a fixed prompt and report a status. This
+ * starts an ordinary durable session instead: the operator types, the agent
+ * works in the same sandbox the schedules use, and a pull request happens only
+ * when the operator approves the `create_pull_request` call this UI surfaces.
+ */
+
+const STORAGE_KEY = "turborepo-factory-operator-chat";
+// Marks every eve request as coming from this page; the eve channel's
+// operator-console auth entry requires it. See `agent/lib/operator-console.ts`.
+const CONSOLE_HEADERS = { [OPERATOR_ACTION_HEADER]: OPERATOR_CHAT_ACTION };
+
+interface PendingRequest {
+  readonly request: EveMessageInputRequest;
+  readonly toolName: string;
+}
+
+interface OperatorChatProps {
+  readonly agentRunsUrl: string;
+}
+
+function readSavedChat(): SavedChat | null {
+  try {
+    return parseSavedChat(window.localStorage.getItem(STORAGE_KEY));
+  } catch {
+    return null;
+  }
+}
+
+function writeSavedChat(snapshot: Parameters<typeof serializeSavedChat>[0]) {
+  const saved = serializeSavedChat(snapshot);
+  if (saved === null) return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, saved);
+  } catch {
+    // A full or blocked store only costs this thread its resume point.
+  }
+}
+
+/**
+ * Turn failures reach the UI through `status` and `error`, and a rejected
+ * cancel only means the turn kept running, so a rejected command needs no
+ * second reporting path — just no unhandled rejection.
+ */
+function dispatch(command: Promise<unknown>) {
+  command.catch(() => undefined);
+}
+
+function pendingRequests(
+  messages: readonly EveMessage[]
+): readonly PendingRequest[] {
+  // An unrelated turn can append newer messages while an approval stays open,
+  // so every message is scanned rather than only the last one.
+  return messages.flatMap((message) =>
+    message.parts.flatMap((part) => {
+      if (part.type !== "dynamic-tool" || part.state !== "approval-requested") {
+        return [];
+      }
+      const request = part.toolMetadata?.eve?.inputRequest;
+      return request ? [{ request, toolName: part.toolName }] : [];
+    })
+  );
+}
+
+function toolSummary(part: Extract<EveMessagePart, { type: "dynamic-tool" }>) {
+  switch (part.state) {
+    case "input-streaming":
+    case "input-available": {
+      return "running";
+    }
+    case "approval-requested": {
+      return "waiting for you";
+    }
+    case "approval-responded": {
+      return "approved";
+    }
+    case "output-available": {
+      return part.partial ? "running" : "done";
+    }
+    case "output-denied": {
+      return "declined";
+    }
+    default: {
+      return part.errorText;
+    }
+  }
+}
+
+function MessagePart({ part }: { readonly part: EveMessagePart }) {
+  if (part.type === "text") {
+    return <p className="chatText">{part.text}</p>;
+  }
+  if (part.type === "reasoning") {
+    return <p className="chatReasoning">{part.text}</p>;
+  }
+  if (part.type === "file") {
+    return <p className="chatArtifact">{part.filename ?? part.mediaType}</p>;
+  }
+  if (part.type === "authorization") {
+    return (
+      <p className="chatArtifact">
+        {part.state === "completed"
+          ? `${part.displayName} authorization ${part.outcome}.`
+          : part.description}
+        {part.state === "required" && part.authorization?.url ? (
+          <a href={part.authorization.url} rel="noreferrer" target="_blank">
+            Sign in <span aria-hidden="true">↗</span>
+          </a>
+        ) : null}
+      </p>
+    );
+  }
+  if (part.type === "dynamic-tool") {
+    return (
+      <p className="chatTool">
+        <code>{part.toolName}</code>
+        <span>{toolSummary(part)}</span>
+      </p>
+    );
+  }
+  return null;
+}
+
+function ChatMessage({ message }: { readonly message: EveMessage }) {
+  return (
+    <li className={`chatMessage chatMessage-${message.role}`}>
+      <article aria-label={`${message.role} message`}>
+        <header>{message.role === "user" ? "You" : "Factory"}</header>
+        {message.parts.map((part, index) => (
+          <MessagePart key={index} part={part} />
+        ))}
+      </article>
+    </li>
+  );
+}
+
+function ChatThread({
+  agentRunsUrl,
+  onNewChat,
+  saved
+}: {
+  readonly agentRunsUrl: string;
+  readonly onNewChat: () => void;
+  readonly saved: SavedChat | null;
+}) {
+  const savedSessionId = useRef(saved?.session.sessionId);
+  const [draft, setDraft] = useState("");
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+  const transcript = useRef<HTMLOListElement | null>(null);
+  const agent = useEveAgent({
+    headers: CONSOLE_HEADERS,
+    initialEvents: saved?.events,
+    initialSession: saved?.session,
+    onFinish: (snapshot) => writeSavedChat(snapshot),
+    onSessionChange: (session) => {
+      // Record a brand new session immediately, so reloading mid-turn still
+      // lands back in this conversation. The event log follows on `onFinish`.
+      if (session === undefined || session.sessionId === savedSessionId.current)
+        return;
+      savedSessionId.current = session.sessionId;
+      writeSavedChat({ events: [], session });
+    }
+  });
+
+  const messages = agent.data.messages;
+  const isBusy = agent.status === "submitted" || agent.status === "streaming";
+  const pending = pendingRequests(messages);
+
+  useEffect(() => {
+    // The transcript scrolls inside itself, so follow the newest message there
+    // rather than moving the page.
+    const list = transcript.current;
+    if (list) list.scrollTop = list.scrollHeight;
+  }, [messages]);
+
+  function submitDraft() {
+    const message = draft.trim();
+    if (message.length === 0 || isBusy) return;
+    setDraft("");
+    dispatch(agent.send(message));
+  }
+
+  function answer(
+    requestId: string,
+    response: { optionId?: string; text?: string }
+  ) {
+    setAnswers((current) => ({ ...current, [requestId]: "" }));
+    dispatch(agent.respond([{ requestId, ...response }]));
+  }
+
+  return (
+    <div className="chat">
+      <div className="chatToolbar">
+        <div className={`status status-${agent.status}`} role="status">
+          <span className="statusDot" aria-hidden="true" />
+          <div>
+            <strong>{isBusy ? "working" : agent.status}</strong>
+            {agent.session ? <code>{agent.session.sessionId}</code> : null}
+            {agent.error ? <code>{agent.error.message}</code> : null}
+          </div>
+        </div>
+        <div className="actions">
+          {isBusy ? (
+            <Button
+              onClick={() => dispatch(agent.cancel())}
+              size="sm"
+              type="button"
+              variant="outline"
+            >
+              Stop
+            </Button>
+          ) : null}
+          <Button
+            disabled={isBusy}
+            onClick={onNewChat}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            New chat
+          </Button>
+          <a href={agentRunsUrl} rel="noreferrer" target="_blank">
+            Open Agent Runs <span className="visuallyHidden">in a new tab</span>
+            <span aria-hidden="true">↗</span>
+          </a>
+        </div>
+      </div>
+
+      {messages.length > 0 ? (
+        <ol className="chatTranscript" ref={transcript}>
+          {messages.map((message) => (
+            <ChatMessage key={message.id} message={message} />
+          ))}
+        </ol>
+      ) : (
+        <p className="emptyRunway">
+          {agent.session
+            ? "This session's earlier messages were too large to restore. Keep going, or start a new chat."
+            : "Ask for anything in the checkout. The agent opens a pull request only when you approve it."}
+        </p>
+      )}
+
+      {pending.map(({ request, toolName }) => (
+        <fieldset className="chatRequest" key={request.requestId}>
+          <legend>
+            {request.kind === "tool-approval"
+              ? `Approve ${toolName}`
+              : request.kind === "question"
+                ? "Question"
+                : "Session limit"}
+          </legend>
+          <p>{request.prompt}</p>
+          <div className="actions">
+            {request.options?.map((option) => (
+              <Button
+                disabled={isBusy}
+                key={option.id}
+                onClick={() =>
+                  answer(request.requestId, { optionId: option.id })
+                }
+                size="sm"
+                type="button"
+                variant={option.style === "danger" ? "outline" : "default"}
+              >
+                {option.label}
+              </Button>
+            ))}
+          </div>
+          {request.allowFreeform || request.display === "text" ? (
+            <div className="chatAnswer">
+              <input
+                aria-label="Answer"
+                disabled={isBusy}
+                onChange={(event) =>
+                  setAnswers((current) => ({
+                    ...current,
+                    [request.requestId]: event.target.value
+                  }))
+                }
+                value={answers[request.requestId] ?? ""}
+              />
+              <Button
+                disabled={isBusy || !answers[request.requestId]?.trim()}
+                onClick={() =>
+                  answer(request.requestId, {
+                    text: answers[request.requestId]?.trim()
+                  })
+                }
+                size="sm"
+                type="button"
+                variant="outline"
+              >
+                Answer
+              </Button>
+            </div>
+          ) : null}
+        </fieldset>
+      ))}
+
+      <form
+        className="chatComposer"
+        onSubmit={(event) => {
+          event.preventDefault();
+          submitDraft();
+        }}
+      >
+        <label className="visuallyHidden" htmlFor="chat-message">
+          Message
+        </label>
+        <textarea
+          disabled={isBusy}
+          id="chat-message"
+          onChange={(event) => setDraft(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && !event.shiftKey) {
+              event.preventDefault();
+              submitDraft();
+            }
+          }}
+          placeholder="Land the fix for the affected-glob warning and open a PR when I say so."
+          rows={3}
+          value={draft}
+        />
+        <Button disabled={isBusy || draft.trim().length === 0} type="submit">
+          {isBusy ? "Working…" : "Send"}
+        </Button>
+      </form>
+    </div>
+  );
+}
+
+export function OperatorChat({ agentRunsUrl }: OperatorChatProps) {
+  // Browser storage is only readable after hydration, so the thread mounts on
+  // the first effect. Bumping `key` starts a fresh durable session.
+  const [thread, setThread] = useState<{
+    readonly key: number;
+    readonly saved: SavedChat | null;
+  } | null>(null);
+
+  useEffect(() => {
+    setThread({ key: 0, saved: readSavedChat() });
+  }, []);
+
+  function startNewChat() {
+    try {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // Nothing to clear.
+    }
+    setThread((current) => ({ key: (current?.key ?? 0) + 1, saved: null }));
+  }
+
+  if (thread === null) {
+    return <p className="emptyRunway">Loading the console…</p>;
+  }
+
+  return (
+    <ChatThread
+      agentRunsUrl={agentRunsUrl}
+      key={thread.key}
+      onNewChat={startNewChat}
+      saved={thread.saved}
+    />
+  );
+}

--- a/apps/factory/app/page.tsx
+++ b/apps/factory/app/page.tsx
@@ -2,6 +2,7 @@ import { listExamples } from "../agent/lib/examples";
 import { readFactoryImageView } from "../agent/lib/factory-image-registry";
 import { listControlPlaneSnapshot } from "../agent/lib/run-registry";
 import { FactoryImage } from "./factory-image";
+import { OperatorChat } from "./operator-chat";
 import { RunMaintenance } from "./run-maintenance";
 import { RunObservatory } from "./run-observatory";
 import { RunPerformance } from "./run-performance";
@@ -33,6 +34,43 @@ export default async function OperatorPage() {
       <RunObservatory initialSnapshot={snapshot} />
 
       <FactoryImage initialView={factoryImage} />
+
+      <section className="operation" aria-labelledby="chat-title">
+        <div className="operationHeader">
+          <div>
+            <h2 id="chat-title">Start work</h2>
+          </div>
+          <span className="schedule">ON DEMAND</span>
+        </div>
+
+        <p className="description">
+          Opens an ad-hoc session on the factory image, with the same sandbox
+          checkout of <code>main</code> the scheduled operations use. Ask for
+          anything in the repository; the agent opens a draft pull request only
+          when you ask for one and approve the call.
+        </p>
+
+        <dl className="facts">
+          <div>
+            <dt>Scope</dt>
+            <dd>
+              <code>whole checkout</code>
+            </dd>
+          </div>
+          <div>
+            <dt>Execution</dt>
+            <dd>Chat mode</dd>
+          </div>
+          <div>
+            <dt>Output</dt>
+            <dd>Draft PR on request</dd>
+          </div>
+        </dl>
+
+        <div className="controls">
+          <OperatorChat agentRunsUrl={AGENT_RUNS_URL} />
+        </div>
+      </section>
 
       <section className="operation" aria-labelledby="operation-title">
         <div className="operationHeader">

--- a/apps/factory/tests/operator-chat-session.test.mjs
+++ b/apps/factory/tests/operator-chat-session.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  MAX_SAVED_CHAT_BYTES,
+  parseSavedChat,
+  serializeSavedChat
+} from "../agent/lib/operator-chat-session.ts";
+
+const session = { sessionId: "ses_01JABCDEFG", streamIndex: 12 };
+
+test("round-trips a saved thread", () => {
+  const events = [{ data: { text: "hello" }, type: "message.completed" }];
+  const saved = parseSavedChat(serializeSavedChat({ events, session }));
+  assert.deepEqual(saved, { events, session });
+});
+
+test("keeps the cursor when the event log is too large to store", () => {
+  const events = [
+    {
+      data: { text: "x".repeat(MAX_SAVED_CHAT_BYTES) },
+      type: "message.completed"
+    }
+  ];
+  const saved = parseSavedChat(serializeSavedChat({ events, session }));
+  assert.deepEqual(saved, { events: [], session });
+});
+
+test("saves nothing without a session cursor", () => {
+  assert.equal(serializeSavedChat({ events: [], session: undefined }), null);
+  assert.equal(
+    serializeSavedChat({ events: [], session: { sessionId: "ses_1" } }),
+    null
+  );
+});
+
+test("ignores unreadable stored threads", () => {
+  assert.equal(parseSavedChat(null), null);
+  assert.equal(parseSavedChat("not json"), null);
+  assert.equal(parseSavedChat("[]"), null);
+  assert.equal(parseSavedChat(JSON.stringify({ events: [] })), null);
+  assert.deepEqual(
+    parseSavedChat(JSON.stringify({ events: "nope", session })),
+    { events: [], session }
+  );
+});

--- a/apps/factory/tests/operator-console.test.mjs
+++ b/apps/factory/tests/operator-console.test.mjs
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  isOperatorChatRequest,
+  OPERATOR_CHAT_PRINCIPAL
+} from "../agent/lib/operator-console.ts";
+import { isAppPrincipal } from "../agent/lib/repo.ts";
+
+const CONSOLE = "turborepo-factory.vercel.app";
+
+function request(headers) {
+  return { headers: { get: (name) => headers[name] ?? null } };
+}
+
+test("accepts a marked same-origin console request", () => {
+  assert.equal(
+    isOperatorChatRequest(
+      request({
+        host: CONSOLE,
+        origin: `https://${CONSOLE}`,
+        "sec-fetch-site": "same-origin",
+        "x-operator-action": "open-operator-chat"
+      })
+    ),
+    true
+  );
+});
+
+test("matches the forwarded host rather than the proxied one", () => {
+  assert.equal(
+    isOperatorChatRequest(
+      request({
+        host: "127.0.0.1:4274",
+        origin: `https://${CONSOLE}`,
+        "x-forwarded-host": CONSOLE,
+        "x-operator-action": "open-operator-chat"
+      })
+    ),
+    true
+  );
+});
+
+test("accepts the stream request browsers send without an origin", () => {
+  assert.equal(
+    isOperatorChatRequest(
+      request({
+        host: CONSOLE,
+        "sec-fetch-site": "same-origin",
+        "x-operator-action": "open-operator-chat"
+      })
+    ),
+    true
+  );
+});
+
+test("rejects unmarked and cross-site requests", () => {
+  assert.equal(isOperatorChatRequest(request({})), false);
+  assert.equal(
+    isOperatorChatRequest(
+      request({ "x-operator-action": "run-daily-performance" })
+    ),
+    false
+  );
+  assert.equal(
+    isOperatorChatRequest(
+      request({
+        host: CONSOLE,
+        origin: "https://attacker.example",
+        "x-operator-action": "open-operator-chat"
+      })
+    ),
+    false
+  );
+  assert.equal(
+    isOperatorChatRequest(
+      request({
+        host: CONSOLE,
+        origin: "null",
+        "x-operator-action": "open-operator-chat"
+      })
+    ),
+    false
+  );
+  assert.equal(
+    isOperatorChatRequest(
+      request({
+        host: CONSOLE,
+        origin: `https://${CONSOLE}`,
+        "sec-fetch-site": "same-site",
+        "x-operator-action": "open-operator-chat"
+      })
+    ),
+    false
+  );
+  assert.equal(
+    isOperatorChatRequest(
+      request({
+        "sec-fetch-site": "cross-site",
+        "x-operator-action": "open-operator-chat"
+      })
+    ),
+    false
+  );
+});
+
+test("chats as a user, never as the app principal", () => {
+  assert.equal(isAppPrincipal(OPERATOR_CHAT_PRINCIPAL), false);
+  assert.equal(OPERATOR_CHAT_PRINCIPAL.principalType, "user");
+});

--- a/apps/factory/tests/pull-request.test.mjs
+++ b/apps/factory/tests/pull-request.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { buildDraftPullRequest } from "../agent/lib/pull-request.ts";
+import {
+  buildDraftPullRequest,
+  resolvePullRequestTitle
+} from "../agent/lib/pull-request.ts";
 
 test("builds draft pull requests", () => {
   assert.deepEqual(
@@ -18,5 +21,50 @@ test("builds draft pull requests", () => {
       base: "main",
       draft: true
     }
+  );
+});
+
+test("titles automated example maintenance from its selection", () => {
+  assert.equal(
+    resolvePullRequestTitle({
+      automatedExample: "with-svelte",
+      requestedTitle: "feat: Ignored"
+    }),
+    "chore: Update with-svelte example"
+  );
+});
+
+test("requires a perf title for an automated performance run", () => {
+  assert.equal(
+    resolvePullRequestTitle({
+      performance: true,
+      requestedTitle: "perf: Hash tasks once per package"
+    }),
+    "perf: Hash tasks once per package"
+  );
+  assert.throws(
+    () =>
+      resolvePullRequestTitle({
+        performance: true,
+        requestedTitle: "fix: Hash tasks once per package"
+      }),
+    /perf: Description/
+  );
+  assert.throws(() => resolvePullRequestTitle({ performance: true }), /perf/);
+});
+
+test("requires a conventional title for an ad-hoc run", () => {
+  assert.equal(
+    resolvePullRequestTitle({ requestedTitle: "fix: Show invalid task globs" }),
+    "fix: Show invalid task globs"
+  );
+  assert.throws(() => resolvePullRequestTitle({}), /Conventional Commit/);
+  assert.throws(
+    () => resolvePullRequestTitle({ requestedTitle: "fix: lowercase" }),
+    /Conventional Commit/
+  );
+  assert.throws(
+    () => resolvePullRequestTitle({ requestedTitle: "fix(run): Scoped" }),
+    /Conventional Commit/
   );
 });


### PR DESCRIPTION
The factory can only run two fixed prompts today: daily example maintenance and the daily performance improvement. There is no way to just start work. This adds a **Start work** chat to the operator page that opens an ordinary durable Eve session on the same factory image and the same checkout of `main`, and opens a pull request only when the operator asks for one and approves the call.

## The chat

`app/operator-chat.tsx` drives the Eve session routes with `useEveAgent`: it streams text, reasoning, and tool activity, renders pending human-in-the-loop requests (an approval or an `ask_question`) as a prompt with buttons and a freeform answer, and offers Stop and New chat. The thread's session cursor and event log live in `localStorage`, so a reload lands back in the same conversation; an oversized event log is dropped and only the cursor survives, which is still a valid ordered prefix of the session's stream.

## Letting the browser reach the agent

The chat talks to `/eve/v1/session*` directly, so `agent/channels/eve.ts` gains an `operatorConsole()` authenticator ahead of the existing entries. Deployment Protection still decides who reaches the deployment — that has not changed. The new entry only establishes that a request came from the console page:

- it requires the `x-operator-action: open-operator-chat` marker the page attaches to every Eve request, and those routes send no CORS headers, so another site cannot get a custom header past a preflight;
- it rejects a request announcing a cross-site fetch (`sec-fetch-site`);
- it rejects a request whose `origin` names anything other than the host the browser addressed, read from `x-forwarded-host` because both Vercel and `next start` route these paths to the Eve service through a proxy that rewrites the host it dials.

Its principal is a **user**, not the app principal the schedules and run routes use. That is what keeps `create_pull_request` behind the operator's approval and keeps the automated example and performance scope gates off.

## `create_pull_request` for an ad-hoc run

Two halves of the tool assumed every non-performance run was examples maintenance:

- **Scope.** The changed-file scan was limited to `examples/` unless the run was a performance run. It is now limited to `examples/` only when there is an automated daily selection, so an ad-hoc run can publish anything it changed.
- **Title.** An interactive run got the hardcoded title `chore: Update Turborepo examples`. `resolvePullRequestTitle` now requires a Conventional Commit title from the caller instead. Automated example maintenance still derives `chore: Update <example> example`, and a performance run must still publish a `perf:` title — that check moved from the input schema to execution, so it is not weakened by the wider schema.

This is a behavior change for interactive runs that reach the tool through Slack or GitHub: they now have to pass a `title`. `agent/instructions.md` tells the agent to, alongside a new section covering ad-hoc requests — work anywhere in the checkout, verify it, answer in the conversation, and never open a pull request unasked.

## Verification

- `node --experimental-strip-types --test tests/*.test.mjs` — 78 pass, including new coverage for the console auth predicate, title resolution, and saved-thread serialization.
- `tsc --noEmit`, `oxlint --deny-warnings apps/factory`, `oxfmt --check apps/factory` — clean.
- `eve build` and `next build` both succeed; the operator page renders the new section server-side.
- The auth walk was exercised against the built Eve server, directly and through the `next start` proxy: marked same-origin POST and stream GET are accepted, and unmarked, cross-origin, and cross-site requests get `401`. The proxy case is what surfaced the `x-forwarded-host` requirement — comparing against the request URL's own origin returned `401` for every browser request in that topology.
- Not exercised end to end: a real model turn and an approved `create_pull_request`, which need AI Gateway and GitHub credentials this sandbox does not have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)