### PR TITLE
fix: Decouple graceful shutdown tests from the shell commands example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,8 @@ When making changes to the codebase, check if the following docs need updates:
 - Same-repository PRs authenticate to Remote Cache through OIDC; fork PRs remain local-only.
 - Rust CI restores full Cargo target state on Ubuntu, macOS, and Windows from trusted `main` snapshots; only `main` writes. Repository sccache dogfooding is disabled.
 - Linux Rust shards include `terminal-control` black-box TUI integration tests; known regressions remain explicitly ignored.
+- Rust test shards pin Node.js 18.20.2, so any `packageManager` version an integration fixture declares has to run on that Node.
+- Rust integration tests read fixtures from `turborepo-tests/integration/fixtures/`, never from `examples/`. Examples are version-bumped on their own cadence and are not declared inputs of the Rust test task.
 - Example validation remains push-only because it requires Vercel credentials and project state.
 
 ### PR Title Format

--- a/crates/turborepo/tests/graceful_shutdown_test.rs
+++ b/crates/turborepo/tests/graceful_shutdown_test.rs
@@ -42,6 +42,59 @@ mod unix {
             self.child.as_mut().expect("child guard consumed")
         }
 
+        /// Wait for a task to write its readiness marker, reporting turbo's
+        /// output if the run exits first or never gets there. Without this the
+        /// only signal is a bare marker-file timeout, which hides startup
+        /// failures such as an unusable package manager.
+        fn wait_for_startup_marker(&mut self, path: &Path, timeout: Duration) {
+            let start = Instant::now();
+            loop {
+                if path.exists() {
+                    return;
+                }
+                let exited = self
+                    .child_mut()
+                    .try_wait()
+                    .expect("failed waiting for child exit")
+                    .is_some();
+                if exited {
+                    // The marker may have landed in the same tick turbo exited.
+                    if path.exists() {
+                        return;
+                    }
+                    panic!(
+                        "turbo exited before {} was created\n{}",
+                        path.display(),
+                        self.collect_output()
+                    );
+                }
+                if start.elapsed() > timeout {
+                    panic!(
+                        "timed out waiting for {}\n{}",
+                        path.display(),
+                        self.collect_output()
+                    );
+                }
+                thread::sleep(Duration::from_millis(100));
+            }
+        }
+
+        /// Stop the run if it is still alive and return everything it wrote.
+        fn collect_output(&mut self) -> String {
+            let Some(mut child) = self.child.take() else {
+                return String::new();
+            };
+            let _ = child.kill();
+            match child.wait_with_output() {
+                Ok(output) => normalize_output(&format!(
+                    "{}{}",
+                    String::from_utf8_lossy(&output.stdout),
+                    String::from_utf8_lossy(&output.stderr)
+                )),
+                Err(err) => format!("failed to read turbo output: {err}"),
+            }
+        }
+
         fn into_output(mut self, timeout: Duration) -> Output {
             let _ = wait_for_process_exit(self.child_mut(), timeout);
             self.child
@@ -92,6 +145,47 @@ mod unix {
             }
         }
 
+        /// Wait for a task to write its readiness marker, reporting the pty
+        /// transcript if turbo exits first or never gets there.
+        fn wait_for_startup_marker(&mut self, path: &Path, timeout: Duration) {
+            let start = Instant::now();
+            loop {
+                if path.exists() {
+                    return;
+                }
+                let exited = self
+                    .child
+                    .as_mut()
+                    .expect("pty child guard consumed")
+                    .try_wait()
+                    .expect("failed waiting for pty child")
+                    .is_some();
+                if exited {
+                    // The marker may have landed in the same tick turbo exited.
+                    if path.exists() {
+                        return;
+                    }
+                    panic!(
+                        "turbo exited before {} was created\n{}",
+                        path.display(),
+                        self.transcript()
+                    );
+                }
+                if start.elapsed() > timeout {
+                    panic!(
+                        "timed out waiting for {}\n{}",
+                        path.display(),
+                        self.transcript()
+                    );
+                }
+                thread::sleep(Duration::from_millis(100));
+            }
+        }
+
+        fn transcript(&self) -> String {
+            normalize_output(String::from_utf8_lossy(&self.output.lock().unwrap()).as_ref())
+        }
+
         fn finish(mut self, timeout: Duration) -> String {
             let start = Instant::now();
             loop {
@@ -116,7 +210,7 @@ mod unix {
                 reader_thread.join().expect("pty reader thread panicked");
             }
 
-            normalize_output(String::from_utf8_lossy(&self.output.lock().unwrap()).as_ref())
+            self.transcript()
         }
     }
 
@@ -142,14 +236,20 @@ mod unix {
         }
     }
 
-    fn example_fixture_dir() -> PathBuf {
-        common::manifest_dir().join("../../examples/with-shell-commands")
-    }
-
-    fn setup_shutdown_example(script_name: &str, script_contents: &str) -> (TempDir, PathBuf) {
+    /// Stage the shutdown fixture with `script_name` wired up as `app-a`'s
+    /// persistent `dev` task.
+    ///
+    /// This deliberately uses a dedicated integration fixture rather than one
+    /// of the published examples: examples are version-bumped on their own
+    /// cadence, and a `packageManager` pin that outruns the Node.js version
+    /// this suite runs on takes every test here down with it. The fixture's pin
+    /// is owned by the test suite, and `turborepo-tests/integration/**` is a
+    /// declared input of the Rust test task, so changing it invalidates the
+    /// cached task.
+    fn setup_shutdown_fixture(script_name: &str, script_contents: &str) -> (TempDir, PathBuf) {
         let tempdir = tempfile::tempdir().expect("failed to create tempdir");
         let test_dir = tempdir.path().to_path_buf();
-        setup::copy_dir_all(&example_fixture_dir(), &test_dir).expect("failed to copy example");
+        setup::copy_fixture("graceful_shutdown", &test_dir).expect("failed to copy fixture");
         setup::prepare_corepack_from_package_json(&test_dir);
 
         let app_dir = test_dir.join("apps/app-a");
@@ -338,16 +438,6 @@ mod unix {
         }
     }
 
-    fn wait_for_path(path: &Path, timeout: Duration) {
-        let start = Instant::now();
-        while !path.exists() {
-            if start.elapsed() > timeout {
-                panic!("timed out waiting for {}", path.display());
-            }
-            thread::sleep(Duration::from_millis(100));
-        }
-    }
-
     fn wait_for_process_exit(child: &mut Child, timeout: Duration) -> std::process::ExitStatus {
         let start = Instant::now();
         loop {
@@ -411,7 +501,7 @@ mod unix {
 
     #[test]
     fn run_finishes_successfully_without_shutdown_banner() {
-        let (_tempdir, test_dir) = setup_shutdown_example(
+        let (_tempdir, test_dir) = setup_shutdown_fixture(
             "fast-success.sh",
             r#"#!/usr/bin/env bash
 set -eu
@@ -440,7 +530,7 @@ exit 0
 
     #[test]
     fn run_gracefully_shuts_down_on_first_sigint_in_tty() {
-        let (_tempdir, test_dir) = setup_shutdown_example(
+        let (_tempdir, test_dir) = setup_shutdown_fixture(
             "graceful.sh",
             r#"#!/usr/bin/env bash
 set -u
@@ -455,7 +545,7 @@ while true; do sleep 0.2 || true; done
         let cleanup_file = test_dir.join("apps/app-a/cleanup.done");
 
         let mut child = spawn_interactive_turbo(&test_dir);
-        wait_for_path(&ready_file, START_TIMEOUT);
+        child.wait_for_startup_marker(&ready_file, START_TIMEOUT);
 
         child.send_ctrl_c();
         let transcript = child.finish(EXIT_TIMEOUT);
@@ -488,7 +578,7 @@ while true; do sleep 0.2 || true; done
 
     #[test]
     fn run_gracefully_shuts_down_on_first_sigint_without_tty_and_exits_zero() {
-        let (_tempdir, test_dir) = setup_shutdown_example(
+        let (_tempdir, test_dir) = setup_shutdown_fixture(
             "graceful.sh",
             r#"#!/usr/bin/env bash
 set -u
@@ -503,7 +593,7 @@ while true; do sleep 0.2 || true; done
         let cleanup_file = test_dir.join("apps/app-a/cleanup.done");
 
         let mut child = spawn_noninteractive_turbo(&test_dir);
-        wait_for_path(&ready_file, START_TIMEOUT);
+        child.wait_for_startup_marker(&ready_file, START_TIMEOUT);
 
         send_signal(child.child_mut().id() as i32, Signal::SIGINT);
         let output = child.into_output(EXIT_TIMEOUT);
@@ -529,7 +619,7 @@ while true; do sleep 0.2 || true; done
 
     #[test]
     fn second_ctrl_c_force_kills_with_task_through_node_wrapper() {
-        let (_tempdir, test_dir) = setup_shutdown_example(
+        let (_tempdir, test_dir) = setup_shutdown_fixture(
             "dev-sigint.sh",
             r#"#!/usr/bin/env bash
 set -u
@@ -587,8 +677,8 @@ while true; do sleep 0.2 || true; done
         let sidecar_child_pid_file = app_dir.join("sidecar-child.pid");
 
         let mut child = spawn_interactive_turbo_via_node_wrapper(&test_dir);
-        wait_for_path(&dev_ready_file, START_TIMEOUT);
-        wait_for_path(&sidecar_ready_file, START_TIMEOUT);
+        child.wait_for_startup_marker(&dev_ready_file, START_TIMEOUT);
+        child.wait_for_startup_marker(&sidecar_ready_file, START_TIMEOUT);
         let sidecar_child_pid = wait_for_pid_file(&sidecar_child_pid_file, START_TIMEOUT);
 
         child.send_ctrl_c();
@@ -607,7 +697,7 @@ while true; do sleep 0.2 || true; done
 
     #[test]
     fn node_wrapper_waits_for_graceful_shutdown_on_sigint() {
-        let (_tempdir, test_dir) = setup_shutdown_example(
+        let (_tempdir, test_dir) = setup_shutdown_fixture(
             "slow-graceful.sh",
             r#"#!/usr/bin/env bash
 set -u
@@ -622,7 +712,7 @@ while true; do sleep 0.2 || true; done
         let cleanup_file = test_dir.join("apps/app-a/cleanup.done");
 
         let mut child = spawn_noninteractive_turbo_via_node_wrapper(&test_dir);
-        wait_for_path(&ready_file, START_TIMEOUT);
+        child.wait_for_startup_marker(&ready_file, START_TIMEOUT);
 
         let wrapper_pid = child.child_mut().id() as i32;
         send_signal_to_process_group(wrapper_pid, Signal::SIGINT);
@@ -661,7 +751,7 @@ while true; do sleep 0.2 || true; done
 
     #[test]
     fn node_wrapper_forwards_sigterm_to_turbo() {
-        let (_tempdir, test_dir) = setup_shutdown_example(
+        let (_tempdir, test_dir) = setup_shutdown_fixture(
             "slow-sigterm.sh",
             r#"#!/usr/bin/env bash
 set -u
@@ -676,7 +766,7 @@ while true; do sleep 0.2 || true; done
         let cleanup_file = test_dir.join("apps/app-a/cleanup.done");
 
         let mut child = spawn_noninteractive_turbo_via_node_wrapper(&test_dir);
-        wait_for_path(&ready_file, START_TIMEOUT);
+        child.wait_for_startup_marker(&ready_file, START_TIMEOUT);
 
         let wrapper_pid = child.child_mut().id() as i32;
         send_signal(wrapper_pid, Signal::SIGTERM);
@@ -719,7 +809,7 @@ while true; do sleep 0.2 || true; done
 
     #[test]
     fn run_force_kills_on_second_sigint_in_tty() {
-        let (_tempdir, test_dir) = setup_shutdown_example(
+        let (_tempdir, test_dir) = setup_shutdown_fixture(
             "stubborn.sh",
             r#"#!/usr/bin/env bash
 set -u
@@ -737,7 +827,7 @@ while true; do sleep 0.2 || true; done
         let child_pid_file = test_dir.join("apps/app-a/child.pid");
 
         let mut child = spawn_interactive_turbo(&test_dir);
-        wait_for_path(&ready_file, START_TIMEOUT);
+        child.wait_for_startup_marker(&ready_file, START_TIMEOUT);
         let task_child_pid = wait_for_pid_file(&child_pid_file, START_TIMEOUT);
 
         child.send_ctrl_c();
@@ -780,7 +870,7 @@ while true; do sleep 0.2 || true; done
 
     #[test]
     fn run_force_kills_after_timeout_without_tty() {
-        let (_tempdir, test_dir) = setup_shutdown_example(
+        let (_tempdir, test_dir) = setup_shutdown_fixture(
             "stubborn.sh",
             r#"#!/usr/bin/env bash
 set -u
@@ -798,7 +888,7 @@ while true; do sleep 0.2 || true; done
         let child_pid_file = test_dir.join("apps/app-a/child.pid");
 
         let mut child = spawn_noninteractive_turbo(&test_dir);
-        wait_for_path(&ready_file, START_TIMEOUT);
+        child.wait_for_startup_marker(&ready_file, START_TIMEOUT);
         let task_child_pid = wait_for_pid_file(&child_pid_file, START_TIMEOUT);
 
         let started = Instant::now();

--- a/turborepo-tests/integration/fixtures/graceful_shutdown/.gitignore
+++ b/turborepo-tests/integration/fixtures/graceful_shutdown/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.turbo

--- a/turborepo-tests/integration/fixtures/graceful_shutdown/.npmrc
+++ b/turborepo-tests/integration/fixtures/graceful_shutdown/.npmrc
@@ -1,0 +1,2 @@
+script-shell=bash
+update-notifier=false

--- a/turborepo-tests/integration/fixtures/graceful_shutdown/apps/app-a/package.json
+++ b/turborepo-tests/integration/fixtures/graceful_shutdown/apps/app-a/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "app-a",
+  "private": true,
+  "scripts": {}
+}

--- a/turborepo-tests/integration/fixtures/graceful_shutdown/package.json
+++ b/turborepo-tests/integration/fixtures/graceful_shutdown/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "graceful-shutdown-fixture",
+  "private": true,
+  "packageManager": "pnpm@10.28.0"
+}

--- a/turborepo-tests/integration/fixtures/graceful_shutdown/pnpm-lock.yaml
+++ b/turborepo-tests/integration/fixtures/graceful_shutdown/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+  .: {}
+  apps/app-a: {}

--- a/turborepo-tests/integration/fixtures/graceful_shutdown/pnpm-workspace.yaml
+++ b/turborepo-tests/integration/fixtures/graceful_shutdown/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - apps/*

--- a/turborepo-tests/integration/fixtures/graceful_shutdown/turbo.json
+++ b/turborepo-tests/integration/fixtures/graceful_shutdown/turbo.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://turborepo.dev/schema.json",
+  "tasks": {}
+}


### PR DESCRIPTION
## Summary

Rust tests have been red on `main` since #13791. All eight `#[cfg(unix)]` tests in `crates/turborepo/tests/graceful_shutdown_test.rs` fail on the Ubuntu and macOS shards; Windows stays green because the module is Unix-only.

**Root cause.** The suite copied `examples/with-shell-commands` into a tempdir and ran `turbo run dev` against it. #13791 bumped that example's pin to `packageManager: pnpm@11.22.0`, and pnpm 11 declares `engines.node: >=22.13` — but the `rust_test` job pins Node.js 18.20.2 (a "pin it for now" workaround from #8236, back in 2024). Every task launch died before writing its readiness marker:

```
app-a:dev: /home/runner/.cache/node/corepack/v1/pnpm/11.22.0/bin/pnpm.cjs:3
app-a:dev: TypeError: Invalid host defined options
app-a:dev: Node.js v18.20.2
app-a#dev:  ERROR  command (...) /opt/hostedtoolcache/node/18.20.2/x64/bin/pnpm run dev exited (1)
```

Seven of the eight tests then reported only `timed out waiting for /tmp/.tmpXXXX/apps/app-a/ready`, with turbo's output thrown away.

## Changes

- **New `graceful_shutdown` integration fixture.** The suite is the only Rust test that reached into `examples/`, and it was the wrong place to reach: examples are version-bumped on their own cadence, and `examples/**` is not a declared input of the `turborepo-crates#test` task, so an example bump could also leave a stale cached test result. `turborepo-tests/integration/**` already is a declared input, and the fixture's `packageManager` pin (`pnpm@10.28.0`, matching the existing `tui` fixture) is now owned by the test suite.
- **Diagnosable startup failures.** `ChildGuard` and `PtyTurbo` now poll the child while waiting for a readiness marker. If turbo exits early, or the wait times out, the panic carries turbo's captured output/pty transcript. On the simulated failure this turns a 15s opaque timeout into a sub-second failure that names the cause.
- **`AGENTS.md`**: record the Node 18.20.2 floor for fixture package-manager pins, and that Rust tests read fixtures, not examples.

I left the Node 18.20.2 pin alone deliberately. Other fixtures pin `pnpm@7.25.1`, `yarn@3.3.0`, and `npm@8.0.0`; raising the shards' Node version to unpin one fixture would put all of those at risk in the same change.

## Validation

- `cargo test -p turbo --test graceful_shutdown_test` — 8 passed (was 8 failing before the change, reproduced locally).
- Verified both new diagnostic paths by temporarily making a task exit non-zero before writing its marker: the failure now reports `turbo exited before .../ready was created` plus the `ELIFECYCLE` output, for the piped and pty harnesses alike.
- `cargo fmt --check`, `cargo clippy -p turbo --features rustls-tls --all-targets -- -D warnings`, `turbo run format check:toml` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)