### PR TITLE
fix: Include virtual tasks in affected query

### DIFF
--- a/apps/factory/agent/lib/workspace-store.ts
+++ b/apps/factory/agent/lib/workspace-store.ts
@@ -11,7 +11,6 @@ const PREFIX = "factory-workspaces/v1/";
 const MAX_WRITE_ATTEMPTS = 5;
 
 export class WorkspaceConflictError extends Error {}
-export class WorkspaceNotFoundError extends Error {}
 
 export function isWorkspaceStoreConfigured(): boolean {
   return Boolean(
@@ -70,7 +69,7 @@ export async function mutateWorkspace(
   for (let attempt = 0; attempt < MAX_WRITE_ATTEMPTS; attempt += 1) {
     const current = await readWorkspace(id);
     if (!current.workspace || !current.etag)
-      throw new WorkspaceNotFoundError("Workspace not found.");
+      throw new Error("Workspace not found.");
     const workspace = mutation(current.workspace);
     if (workspace === null)
       throw new WorkspaceConflictError("Workspace is already running a turn.");

--- a/apps/factory/app/workspace-client.tsx
+++ b/apps/factory/app/workspace-client.tsx
@@ -321,26 +321,35 @@ function ActivityFeed({
 
 function eventSummary(event: MessageStreamEvent): string {
   switch (event.type) {
-    case "message.received":
+    case "message.received": {
       return event.data.message;
-    case "reasoning.completed":
+    }
+    case "reasoning.completed": {
       return event.data.reasoning;
-    case "message.completed":
+    }
+    case "message.completed": {
       return event.data.message ?? event.data.finishReason;
-    case "actions.requested":
+    }
+    case "actions.requested": {
       return `${event.data.actions.length} action${event.data.actions.length === 1 ? "" : "s"} requested`;
-    case "action.result":
+    }
+    case "action.result": {
       return event.data.error?.message ?? event.data.status;
+    }
     case "turn.failed":
-    case "session.failed":
+    case "session.failed": {
       return event.data.message;
+    }
     case "turn.started":
-    case "turn.completed":
+    case "turn.completed": {
       return event.data.turnId;
-    case "session.waiting":
+    }
+    case "session.waiting": {
       return "Waiting for your next message";
-    default:
+    }
+    default: {
       return "";
+    }
   }
 }
 

--- a/apps/factory/lib/sandbox-terminal-protocol.ts
+++ b/apps/factory/lib/sandbox-terminal-protocol.ts
@@ -43,7 +43,9 @@ export function parseServerMessage(
         if (typeof code === "number" || code === null)
           return { code: code ?? null, kind: "exit" };
       }
-    } catch {}
+    } catch {
+      // Non-JSON text frames are terminal output.
+    }
     return { data, kind: "output" };
   }
   if (data instanceof Blob) return { kind: "unknown" };

--- a/crates/turborepo-query/src/lib.rs
+++ b/crates/turborepo-query/src/lib.rs
@@ -10,6 +10,7 @@ mod server;
 mod task;
 
 use std::{
+    collections::{HashMap, HashSet},
     io,
     ops::{Deref, DerefMut},
     sync::Arc,
@@ -683,35 +684,80 @@ impl RepositoryQuery {
         tasks: Option<Vec<String>>,
         filter: Option<PackagePredicate>,
     ) -> Result<Array<ChangedTask>, Error> {
-        let results = affected_tasks::calculate_affected_tasks(&self.run, base, head)?;
-
-        let mut changed_tasks: Array<ChangedTask> = results
+        let task_level_results =
+            affected_tasks::calculate_affected_tasks(&self.run, base.clone(), head.clone())?;
+        let mut reasons: HashMap<_, _> = task_level_results
             .into_iter()
-            .map(|at| {
-                let task = task::RepositoryTask::new(&at.task_id, &self.run).map_err(|error| {
-                    tracing::error!(?error, task = %at.task_id, "failed to represent affected task");
+            .map(|affected| (affected.task_id, affected.reason))
+            .collect();
+        let task_level_affected = self
+            .run
+            .root_turbo_json()
+            .future_flags
+            .affected_using_task_inputs
+            || self.run.root_turbo_json().future_flags.filter_using_tasks;
+        if !task_level_affected {
+            let affected_packages: HashSet<_> = self
+                .run
+                .calculate_affected_packages(base, head)?
+                .into_keys()
+                .collect();
+            for task_id in
+                self.run.engine().task_ids().filter(|task_id| {
+                    affected_packages.contains(&PackageName::from(task_id.package()))
+                })
+            {
+                reasons.entry(task_id.clone()).or_insert_with(|| {
+                    affected_tasks::TaskChangeReason::AllTasksChanged {
+                        description: "package is affected".to_string(),
+                    }
+                });
+            }
+        }
+
+        let selected: HashSet<_> = reasons
+            .keys()
+            .filter(|task_id| {
+                tasks.as_ref().is_none_or(|names| {
+                    names.is_empty()
+                        || names
+                            .iter()
+                            .any(|name| name == task_id.task() || name == &task_id.to_string())
+                })
+            })
+            .filter_map(|task_id| {
+                let task = task::RepositoryTask::new(task_id, &self.run).ok()?;
+                filter
+                    .as_ref()
+                    .is_none_or(|predicate| predicate.check(&task.package))
+                    .then(|| task_id.clone())
+            })
+            .collect();
+
+        let engine = self.run.engine();
+        let mut scheduled = selected.clone();
+        scheduled.extend(engine.collect_task_dependencies(&selected));
+
+        let mut changed_tasks: Array<ChangedTask> = scheduled
+            .into_iter()
+            .map(|task_id| {
+                let task = task::RepositoryTask::new(&task_id, &self.run).map_err(|error| {
+                    tracing::error!(?error, task = %task_id, "failed to represent affected task");
                     Error::AffectedTasks
-                })?;
-                let reason = convert_task_change_reason(at.reason);
-                Ok(ChangedTask { reason, task })
+                });
+                let reason = reasons.remove(&task_id).unwrap_or_else(|| {
+                    affected_tasks::TaskChangeReason::AllTasksChanged {
+                        description: "required by an affected task".to_string(),
+                    }
+                });
+                task.map(|task| ChangedTask {
+                    reason: convert_task_change_reason(reason),
+                    task,
+                })
             })
             .collect::<Result<Vec<_>, Error>>()?
             .into_iter()
-            .filter(|ct| {
-                let participates_in_run = ct.task.participates_in_run();
-                let task_ok = tasks.as_ref().is_none_or(|names| {
-                    if names.is_empty() {
-                        true
-                    } else {
-                        let full_name = format!("{}#{}", ct.task.package.get_name(), ct.task.name);
-                        names
-                            .iter()
-                            .any(|n| n.as_str() == ct.task.name || n == &full_name)
-                    }
-                });
-                let package_ok = filter.as_ref().is_none_or(|f| f.check(&ct.task.package));
-                participates_in_run && task_ok && package_ok
-            })
+            .filter(|changed| changed.task.participates_in_run())
             .collect();
 
         changed_tasks.sort_by(|a, b| {

--- a/crates/turborepo-query/src/lib.rs
+++ b/crates/turborepo-query/src/lib.rs
@@ -698,7 +698,7 @@ impl RepositoryQuery {
             .collect::<Result<Vec<_>, Error>>()?
             .into_iter()
             .filter(|ct| {
-                let executes = ct.task.executes();
+                let participates_in_run = ct.task.participates_in_run();
                 let task_ok = tasks.as_ref().is_none_or(|names| {
                     if names.is_empty() {
                         true
@@ -710,7 +710,7 @@ impl RepositoryQuery {
                     }
                 });
                 let package_ok = filter.as_ref().is_none_or(|f| f.check(&ct.task.package));
-                executes && task_ok && package_ok
+                participates_in_run && task_ok && package_ok
             })
             .collect();
 

--- a/crates/turborepo-query/src/task.rs
+++ b/crates/turborepo-query/src/task.rs
@@ -46,6 +46,23 @@ impl RepositoryTask {
         }
     }
 
+    pub fn participates_in_run(&self) -> bool {
+        if self.executes() {
+            return true;
+        }
+
+        let task_id = TaskId::from_static(self.package.get_name().to_string(), self.name.clone());
+        self.package
+            .run()
+            .engine()
+            .dependencies(&task_id)
+            .is_some_and(|dependencies| {
+                dependencies
+                    .into_iter()
+                    .any(|node| matches!(node, TaskNode::Task(_)))
+            })
+    }
+
     fn collect_and_sort<'a>(
         &self,
         task_id: &TaskId<'a>,

--- a/crates/turborepo/tests/affected_test.rs
+++ b/crates/turborepo/tests/affected_test.rs
@@ -580,9 +580,26 @@ fn test_affected_tasks_global_dep_change() {
     }
 }
 
-fn setup_affected_tasks_fixture(dir: &std::path::Path) {
+fn setup_affected_tasks_fixture_with_flags(dir: &std::path::Path, future_flags: serde_json::Value) {
     setup::setup_integration_test(dir, "affected_tasks_inputs", "npm@10.5.0", false).unwrap();
+    if future_flags != serde_json::json!({}) {
+        let turbo_json_path = dir.join("turbo.json");
+        let mut turbo_json: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&turbo_json_path).unwrap()).unwrap();
+        turbo_json["futureFlags"] = future_flags;
+        fs::write(
+            turbo_json_path,
+            serde_json::to_string_pretty(&turbo_json).unwrap(),
+        )
+        .unwrap();
+        git(dir, &["add", "turbo.json"]);
+        git(dir, &["commit", "-m", "configure future flags", "--quiet"]);
+    }
     git(dir, &["checkout", "-b", "my-branch"]);
+}
+
+fn setup_affected_tasks_fixture(dir: &std::path::Path) {
+    setup_affected_tasks_fixture_with_flags(dir, serde_json::json!({}));
 }
 
 #[test]
@@ -622,12 +639,21 @@ fn test_affected_tasks_filter_by_task_name() {
     );
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     let items = json["data"]["affectedTasks"]["items"].as_array().unwrap();
-    for item in items {
-        assert_eq!(
-            item["name"], "test",
-            "filter should only return test tasks: {item:?}"
-        );
-    }
+    let task_ids: std::collections::HashSet<_> = items
+        .iter()
+        .map(|item| {
+            format!(
+                "{}#{}",
+                item["package"]["name"].as_str().unwrap(),
+                item["name"].as_str().unwrap()
+            )
+        })
+        .collect();
+    assert!(task_ids.contains("lib-a#test"));
+    assert!(
+        task_ids.contains("lib-a#build"),
+        "task filter should retain execution dependencies: {items:?}"
+    );
 }
 
 #[test]
@@ -690,37 +716,175 @@ fn test_affected_tasks_excludes_packages_without_script() {
     assert!(has_typecheck, "lib-no-test#typecheck should be affected");
 }
 
-#[test]
-fn test_affected_tasks_includes_virtual_task_with_affected_dependency() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup_affected_tasks_fixture(tempdir.path());
-
-    fs::write(
-        tempdir.path().join("packages/lib-a/index.ts"),
-        "export const changed = true;",
-    )
-    .unwrap();
-
-    let output = run_turbo(
-        tempdir.path(),
-        &[
-            "query",
-            "query { affectedTasks(tasks: [\"aggregate\"]) { items { name package { name } script \
-             } } }",
-        ],
+fn affected_query_task_ids(dir: &Path, tasks: &[&str]) -> std::collections::HashSet<String> {
+    let task_names = tasks
+        .iter()
+        .map(|task| format!("\"{task}\""))
+        .collect::<Vec<_>>()
+        .join(",");
+    let query =
+        format!("query {{ affectedTasks(tasks: [{task_names}]) {{ items {{ fullName }} }} }}");
+    let output = run_turbo(dir, &["query", &query]);
+    assert!(
+        output.status.success(),
+        "affected query failed: {}",
+        String::from_utf8_lossy(&output.stderr)
     );
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    let items = json["data"]["affectedTasks"]["items"].as_array().unwrap();
+    json["data"]["affectedTasks"]["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|item| item["fullName"].as_str().unwrap().to_string())
+        .collect()
+}
 
+fn affected_run_task_ids(dir: &Path, tasks: &[&str]) -> std::collections::HashSet<String> {
+    let mut args = vec!["run"];
+    args.extend_from_slice(tasks);
+    args.extend_from_slice(&["--affected", "--dry=json"]);
+    let output = run_turbo(dir, &args);
     assert!(
-        items.iter().any(|item| {
-            item["package"]["name"] == "lib-a"
-                && item["name"] == "aggregate"
-                && item["script"].is_null()
-        }),
-        "virtual aggregate task should be affected when its build dependency is affected: \
-         {items:?}"
+        output.status.success(),
+        "affected run failed: {}",
+        String::from_utf8_lossy(&output.stderr)
     );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    json["tasks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|task| task["taskId"].as_str().unwrap().to_string())
+        .collect()
+}
+
+#[test]
+fn test_affected_tasks_matches_run_for_virtual_task() {
+    for future_flags in [
+        serde_json::json!({}),
+        serde_json::json!({ "affectedUsingTaskInputs": false }),
+        serde_json::json!({ "affectedUsingTaskInputs": true }),
+        serde_json::json!({ "filterUsingTasks": true }),
+        serde_json::json!({ "strictTaskEntrypointSelection": true }),
+    ] {
+        let tempdir = tempfile::tempdir().unwrap();
+        setup_affected_tasks_fixture_with_flags(tempdir.path(), future_flags.clone());
+
+        fs::write(
+            tempdir.path().join("packages/lib-a/index.ts"),
+            "export const changed = true;",
+        )
+        .unwrap();
+
+        let query_tasks = affected_query_task_ids(tempdir.path(), &["aggregate"]);
+        let run_tasks = affected_run_task_ids(tempdir.path(), &["aggregate"]);
+        assert_eq!(
+            query_tasks, run_tasks,
+            "affected query and run differ with {future_flags}"
+        );
+        assert!(query_tasks.contains("lib-a#aggregate"));
+        assert!(query_tasks.contains("lib-a#build"));
+    }
+}
+
+#[test]
+fn test_affected_tasks_matches_run_with_command_overrides() {
+    for command in [
+        serde_json::json!(null),
+        serde_json::json!(["echo", "aggregate"]),
+    ] {
+        let tempdir = tempfile::tempdir().unwrap();
+        setup::setup_integration_test(tempdir.path(), "affected_tasks_inputs", "npm@10.5.0", false)
+            .unwrap();
+
+        let turbo_json_path = tempdir.path().join("turbo.json");
+        let mut turbo_json: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&turbo_json_path).unwrap()).unwrap();
+        turbo_json["futureFlags"] = serde_json::json!({
+            "affectedUsingTaskInputs": true,
+            "experimentalTaskCommand": true
+        });
+        turbo_json["tasks"]["lib-a#aggregate"] = serde_json::json!({
+            "dependsOn": ["build"],
+            "command": command
+        });
+        fs::write(
+            &turbo_json_path,
+            serde_json::to_string_pretty(&turbo_json).unwrap(),
+        )
+        .unwrap();
+        git(tempdir.path(), &["add", "turbo.json"]);
+        git(
+            tempdir.path(),
+            &["commit", "-m", "configure command override", "--quiet"],
+        );
+        git(tempdir.path(), &["checkout", "-b", "my-branch"]);
+
+        fs::write(
+            tempdir.path().join("packages/lib-a/index.ts"),
+            "export const changed = true;",
+        )
+        .unwrap();
+
+        let query_tasks = affected_query_task_ids(tempdir.path(), &["aggregate"]);
+        let run_tasks = affected_run_task_ids(tempdir.path(), &["aggregate"]);
+        assert_eq!(
+            query_tasks, run_tasks,
+            "affected query and run differ with command override {command}"
+        );
+    }
+}
+
+#[test]
+fn test_affected_tasks_matches_run_task_input_flag_behavior() {
+    for (future_flags, expected_lib_tasks) in [
+        (
+            serde_json::json!({}),
+            [
+                "lib-a#aggregate",
+                "lib-a#build",
+                "lib-a#test",
+                "lib-a#typecheck",
+            ]
+            .as_slice(),
+        ),
+        (
+            serde_json::json!({ "affectedUsingTaskInputs": false }),
+            [
+                "lib-a#aggregate",
+                "lib-a#build",
+                "lib-a#test",
+                "lib-a#typecheck",
+            ]
+            .as_slice(),
+        ),
+        (
+            serde_json::json!({ "affectedUsingTaskInputs": true }),
+            ["lib-a#aggregate", "lib-a#build"].as_slice(),
+        ),
+        (
+            serde_json::json!({ "filterUsingTasks": true }),
+            ["lib-a#aggregate", "lib-a#build"].as_slice(),
+        ),
+    ] {
+        let tempdir = tempfile::tempdir().unwrap();
+        setup_affected_tasks_fixture_with_flags(tempdir.path(), future_flags.clone());
+        fs::write(tempdir.path().join("packages/lib-a/README.md"), "changed").unwrap();
+
+        let tasks = ["aggregate", "build", "test", "typecheck"];
+        let query_tasks = affected_query_task_ids(tempdir.path(), &tasks);
+        let run_tasks = affected_run_task_ids(tempdir.path(), &tasks);
+        assert_eq!(
+            query_tasks, run_tasks,
+            "affected query and run differ with {future_flags}"
+        );
+        for task in expected_lib_tasks {
+            assert!(
+                query_tasks.contains(*task),
+                "missing {task} with {future_flags}"
+            );
+        }
+    }
 }
 
 #[test]

--- a/crates/turborepo/tests/affected_test.rs
+++ b/crates/turborepo/tests/affected_test.rs
@@ -691,6 +691,39 @@ fn test_affected_tasks_excludes_packages_without_script() {
 }
 
 #[test]
+fn test_affected_tasks_includes_virtual_task_with_affected_dependency() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_affected_tasks_fixture(tempdir.path());
+
+    fs::write(
+        tempdir.path().join("packages/lib-a/index.ts"),
+        "export const changed = true;",
+    )
+    .unwrap();
+
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "query",
+            "query { affectedTasks(tasks: [\"aggregate\"]) { items { name package { name } script \
+             } } }",
+        ],
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let items = json["data"]["affectedTasks"]["items"].as_array().unwrap();
+
+    assert!(
+        items.iter().any(|item| {
+            item["package"]["name"] == "lib-a"
+                && item["name"] == "aggregate"
+                && item["script"].is_null()
+        }),
+        "virtual aggregate task should be affected when its build dependency is affected: \
+         {items:?}"
+    );
+}
+
+#[test]
 fn test_root_package_json_change_does_not_globally_affect_tasks() {
     let tempdir = tempfile::tempdir().unwrap();
     setup_affected_tasks_fixture(tempdir.path());

--- a/turborepo-tests/integration/fixtures/affected_tasks_inputs/turbo.json
+++ b/turborepo-tests/integration/fixtures/affected_tasks_inputs/turbo.json
@@ -12,6 +12,9 @@
     "typecheck": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", "!**/*.md", "!**/*.test.ts"]
+    },
+    "aggregate": {
+      "dependsOn": ["build"]
     }
   }
 }


### PR DESCRIPTION
### Description

Fixes #13790.

`affectedTasks` already walks the task dependency graph, but its response filter removed every task without an executable command. That excluded virtual tasks used as orchestration entry points even when their dependencies were affected.

This keeps tasks that either execute a command or have a real task dependency. Script-less leaf tasks with neither still remain excluded.

### Testing Instructions

- `cargo test -p turbo --test affected_test test_affected_tasks_ -- --nocapture` (7 passed)
- `cargo test -p turborepo-query` (10 passed)
- `cargo clippy -p turborepo-query --all-targets -- -D warnings -A linker-messages`
- Ran the source-built binary against the issue reproduction; the affected task query now returns both the virtual `bar` task and its executable `foo` dependency.