### PR TITLE
chore: Scope panic lint allows in hash crates to tests and generated code

### DIFF
--- a/crates/turborepo-hash/src/lib.rs
+++ b/crates/turborepo-hash/src/lib.rs
@@ -4,7 +4,7 @@
 //! deterministic serialization across languages and platforms, then applies
 //! xxHash64 for fast hashing.
 
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 
 mod oid_hash;
 mod traits;
@@ -19,7 +19,8 @@ pub use oid_hash::OidHash;
 pub use traits::TurboHash;
 use turborepo_types::{EnvMode, TaskOutputs};
 
-#[allow(dead_code)]
+// Generated Cap'n Proto setters use infallible unwraps.
+#[allow(dead_code, clippy::unwrap_used)]
 mod proto_capnp {
     use turborepo_types::EnvMode;
 

--- a/crates/turborepo-lockfile-hash/src/lib.rs
+++ b/crates/turborepo-lockfile-hash/src/lib.rs
@@ -1,14 +1,14 @@
 //! Byte-compatible hashing for normalized lockfile package closures.
 
-// Generated Cap'n Proto setters use infallible unwraps.
-#![allow(clippy::unwrap_used)]
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 
 use capnp::{
     message::{Builder, HeapAllocator},
     traits::{Owned, SetterInput},
 };
 
-#[allow(dead_code)]
+// Generated Cap'n Proto setters use infallible unwraps.
+#[allow(dead_code, clippy::unwrap_used)]
 mod proto_capnp {
     include!(concat!(env!("OUT_DIR"), "/src/proto_capnp.rs"));
 }


### PR DESCRIPTION
### Description

Follows the panic extraction policy in `AGENTS.md` ("remove those allows as each crate is cleaned up") and the pattern from #12818.

`turborepo-hash` and `turborepo-lockfile-hash` still carried crate-root `#![allow(clippy::unwrap_used, clippy::expect_used)]`. Neither crate has any `unwrap`/`expect` in implementation code; the only non-test call sites are the Cap'n Proto generated `Text` setters (`SetterInput::set_pointer_builder(...).unwrap()` in capnpc's codegen), which are `include!`d into `mod proto_capnp`.

This narrows the allows to where they are actually needed:

- crate root: `#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]` (same as `turborepo-task-hash`, `turborepo-signals`, `turborepo-telemetry`)
- `mod proto_capnp`: `#[allow(dead_code, clippy::unwrap_used)]` with the existing "Generated Cap'n Proto setters use infallible unwraps" comment moved next to it

Without the module-level allow, clippy reports 12 `unwrap_used` errors from the generated code in `turborepo-hash`, so that part is required rather than cosmetic. Any future `unwrap` in hand-written code in these crates is now caught by `cargo lint`.

`turborepo-repository` still has a crate-root allow but has real implementation-code violations; left out of this PR.

### Testing Instructions

```
cargo clippy -p turborepo-hash -p turborepo-lockfile-hash --all-targets -- -D warnings
cargo test -p turborepo-hash -p turborepo-lockfile-hash
```
