### PR TITLE
docs: Add missing system environment variables and run flags

### DIFF
--- a/apps/docs/content/docs/reference/run.mdx
+++ b/apps/docs/content/docs/reference/run.mdx
@@ -117,6 +117,16 @@ turbo run build --cache=local:rw
 turbo run build --cache=local:,remote:r
 ```
 
+### `--cache-workers <number>`
+
+Default: `10`
+
+Set the number of concurrent cache operations.
+
+```bash title="Terminal"
+turbo run build --cache-workers=4
+```
+
 ### `--cache-dir <path>`
 
 Default: `.turbo/cache`
@@ -645,6 +655,14 @@ Ignore the local filesystem cache for all tasks, using Remote Cache for reading 
 
 ```bash title="Terminal"
 turbo run build --remote-only
+```
+
+### `--single-package`
+
+Run `turbo` in [single-package workspace](/docs/guides/single-package-workspaces) mode, treating the repository as one package instead of discovering workspace packages.
+
+```bash title="Terminal"
+turbo run build --single-package
 ```
 
 ### `--summarize`

--- a/apps/docs/content/docs/reference/system-environment-variables.mdx
+++ b/apps/docs/content/docs/reference/system-environment-variables.mdx
@@ -122,6 +122,16 @@ System environment variables are always overridden by flag values provided direc
         if one is not found.
       </td>
     </tr>
+    <tr id="turbo_env_mode">
+      <td>
+        <code>TURBO_ENV_MODE</code>
+      </td>
+      <td>
+        <span>Sets the environment mode, similar to using the</span>{" "}
+        <code>[--env-mode](/docs/reference/run#--env-mode-option)</code>
+        <span> flag.</span>
+      </td>
+    </tr>
     <tr id="turbo_force">
       <td>
         <code>TURBO_FORCE</code>
@@ -274,6 +284,15 @@ System environment variables are always overridden by flag values provided direc
       </td>
       <td>Always ignore the local filesystem cache for all tasks.</td>
     </tr>
+    <tr id="turbo_root_turbo_json">
+      <td>
+        <code>TURBO_ROOT_TURBO_JSON</code>
+      </td>
+      <td>
+        Use the <code>turbo.json</code> located at the provided path instead of
+        the one at the root of the repository.
+      </td>
+    </tr>
     <tr id="turbo_run_summary">
       <td>
         <code>TURBO_RUN_SUMMARY</code>
@@ -338,12 +357,30 @@ System environment variables are always overridden by flag values provided direc
         <a href="/docs/core-concepts/remote-caching">Remote Cache</a>.
       </td>
     </tr>
+    <tr id="turbo_tui_scrollback_length">
+      <td>
+        <code>TURBO_TUI_SCROLLBACK_LENGTH</code>
+      </td>
+      <td>
+        Number of lines to keep in scrollback for each task in the terminal
+        UI. Defaults to <code>2048</code>.
+      </td>
+    </tr>
     <tr id="turbo_ui">
       <td>
         <code>TURBO_UI</code>
       </td>
       <td>
         Enables TUI when passed true or 1, disables when passed false or 0.
+      </td>
+    </tr>
+    <tr id="turbo_watch_startup_timeout">
+      <td>
+        <code>TURBO_WATCH_STARTUP_TIMEOUT</code>
+      </td>
+      <td>
+        Number of seconds <code>turbo watch</code> waits for the file watcher
+        to become ready before failing. Defaults to <code>120</code>.
       </td>
     </tr>
     <tr id="turbo_concurrency">


### PR DESCRIPTION
### Description

Adds reference entries for options the current binary reads but the docs do not list.

System environment variables (`system-environment-variables.mdx`):

| Variable | Source |
|---|---|
| `TURBO_ENV_MODE` | `crates/turborepo-config/src/env.rs` mapping; already mentioned in passing under `--env-mode` in `run.mdx` but had no table row |
| `TURBO_ROOT_TURBO_JSON` | `crates/turborepo-config/src/env.rs` mapping; mirrors the global `--root-turbo-json` flag |
| `TURBO_TUI_SCROLLBACK_LENGTH` | `crates/turborepo-config/src/env.rs` mapping; added in #10247, default `2048` (`DEFAULT_TUI_SCROLLBACK_LENGTH`) |
| `TURBO_WATCH_STARTUP_TIMEOUT` | `crates/turborepo-lib/src/package_changes_watcher.rs` `startup_timeout_secs()`; added in #13159, default `120` seconds |

`turbo run` flags (`run.mdx`):

| Flag | Source |
|---|---|
| `--cache-workers <number>` | `ExecutionArgs::cache_workers`, default `DEFAULT_NUM_WORKERS` (10) |
| `--single-package` | `ExecutionArgs::single_package`; the single-package guide existed but never named the flag |

Deliberately not included: `TURBO_DAEMON` and `--remote-cache-read-only` (deprecated, already covered by the support policy page), `TURBO_ALLOW_NO_TURBO_JSON` (its flag is hidden/experimental), and `TURBO_LOG_VERBOSITY` (`turborepo-log` describes tracing output as internal diagnostics).

### Testing Instructions

```
pnpm --filter docs check-links
OG_IMAGE_SECRET=local-docs-build turbo run build --filter=docs
```

Both pass locally. Flags confirmed via `turbo run --help` on a `main` build.
