### PR TITLE
fix: Update Factory session network policy

### DIFF
--- a/apps/factory/agent/lib/fx-workspace.ts
+++ b/apps/factory/agent/lib/fx-workspace.ts
@@ -20,7 +20,10 @@ import {
 import { fxEnvironment } from "./fx-environment";
 import type { FxTurnResult } from "./fx-result";
 import { getGitHubToken } from "./github";
-import { workspaceNetworkPolicy } from "./workspace-network-policy";
+import {
+  applyWorkspaceNetworkPolicy,
+  workspaceNetworkPolicy
+} from "./workspace-network-policy";
 import {
   installWorkspacePublishCommand,
   type WorkspacePublishBridge
@@ -34,9 +37,10 @@ export async function getFxWorkspaceSandbox(
   publishBridge?: WorkspacePublishBridge | null
 ): Promise<Sandbox> {
   const sandbox = await Sandbox.get({ name, resume: true });
-  await sandbox.update({
-    networkPolicy: workspaceNetworkPolicy(await getGitHubToken(), publishBridge)
-  });
+  await applyWorkspaceNetworkPolicy(
+    sandbox,
+    workspaceNetworkPolicy(await getGitHubToken(), publishBridge)
+  );
   await installWorkspacePublishCommand(sandbox, publishBridge ?? null);
   return sandbox;
 }
@@ -90,9 +94,10 @@ export async function getOrCreateFxWorkspaceSandbox(
     return Sandbox.get({ name });
   }
 
-  await sandbox.update({
-    networkPolicy: workspaceNetworkPolicy(githubToken, publishBridge)
-  });
+  await applyWorkspaceNetworkPolicy(
+    sandbox,
+    workspaceNetworkPolicy(githubToken, publishBridge)
+  );
   await initializeWorkspaceSandbox(sandbox, image !== null);
   await installWorkspacePublishCommand(sandbox, publishBridge ?? null);
   return sandbox;

--- a/apps/factory/agent/lib/workspace-network-policy.ts
+++ b/apps/factory/agent/lib/workspace-network-policy.ts
@@ -2,6 +2,19 @@ import type { NetworkPolicy } from "@vercel/sandbox";
 
 import type { WorkspacePublishBridge } from "./workspace-publish.js";
 
+interface WorkspaceNetworkPolicySandbox {
+  readonly currentSession: () => {
+    readonly update: (input: { readonly networkPolicy: NetworkPolicy }) => Promise<void>;
+  };
+}
+
+export async function applyWorkspaceNetworkPolicy(
+  sandbox: WorkspaceNetworkPolicySandbox,
+  networkPolicy: NetworkPolicy
+): Promise<void> {
+  await sandbox.currentSession().update({ networkPolicy });
+}
+
 export function workspaceNetworkPolicy(
   githubToken: string,
   publishBridge?: WorkspacePublishBridge | null

--- a/apps/factory/agent/lib/workspace-network-policy.ts
+++ b/apps/factory/agent/lib/workspace-network-policy.ts
@@ -4,7 +4,9 @@ import type { WorkspacePublishBridge } from "./workspace-publish.js";
 
 interface WorkspaceNetworkPolicySandbox {
   readonly currentSession: () => {
-    readonly update: (input: { readonly networkPolicy: NetworkPolicy }) => Promise<void>;
+    readonly update: (input: {
+      readonly networkPolicy: NetworkPolicy;
+    }) => Promise<void>;
   };
 }
 

--- a/apps/factory/agent/lib/workspace-network-policy.ts
+++ b/apps/factory/agent/lib/workspace-network-policy.ts
@@ -19,7 +19,9 @@ interface SandboxApiNetworkPolicy {
     readonly headers: Readonly<Record<string, string>>;
     readonly match: {
       readonly method: readonly string[];
-      readonly path: string | { readonly startsWith: string };
+      readonly path:
+        | { readonly exact: string }
+        | { readonly startsWith: string };
     };
   }[];
 }
@@ -53,7 +55,10 @@ export function workspaceNetworkPolicy(
             {
               domain: publishBridge.hostname,
               headers: { authorization: publishBridge.authorization },
-              match: { method: ["POST"], path: publishBridge.path }
+              match: {
+                method: ["POST"],
+                path: { exact: publishBridge.path }
+              }
             }
           ]
         : []),

--- a/apps/factory/agent/lib/workspace-network-policy.ts
+++ b/apps/factory/agent/lib/workspace-network-policy.ts
@@ -10,52 +10,69 @@ interface WorkspaceNetworkPolicySandbox {
   };
 }
 
+interface SandboxApiNetworkPolicy {
+  readonly mode: "custom";
+  readonly allowedDomains: readonly string[];
+  readonly deniedCIDRs: readonly string[];
+  readonly injectionRules: readonly {
+    readonly domain: string;
+    readonly headers: Readonly<Record<string, string>>;
+    readonly match: {
+      readonly method: readonly string[];
+      readonly path: string | { readonly startsWith: string };
+    };
+  }[];
+}
+
 export async function applyWorkspaceNetworkPolicy(
   sandbox: WorkspaceNetworkPolicySandbox,
-  networkPolicy: NetworkPolicy
+  networkPolicy: SandboxApiNetworkPolicy
 ): Promise<void> {
-  await sandbox.currentSession().update({ networkPolicy });
+  await sandbox.currentSession().update({
+    networkPolicy: networkPolicy as unknown as NetworkPolicy
+  });
 }
 
 export function workspaceNetworkPolicy(
   githubToken: string,
   publishBridge?: WorkspacePublishBridge | null
-): NetworkPolicy {
+): SandboxApiNetworkPolicy {
   const gitAuthorization = `Basic ${Buffer.from(`x-access-token:${githubToken}`).toString("base64")}`;
   return {
-    allow: {
+    mode: "custom",
+    allowedDomains: [
+      ...(publishBridge ? [publishBridge.hostname] : []),
+      "api.github.com",
+      "github.com",
+      "*"
+    ],
+    deniedCIDRs: ["169.254.169.254/32"],
+    injectionRules: [
       ...(publishBridge
-        ? {
-            [publishBridge.hostname]: [
-              {
-                match: { method: ["POST"], path: publishBridge.path },
-                transform: [
-                  { headers: { authorization: publishBridge.authorization } }
-                ]
-              }
-            ]
-          }
-        : {}),
-      "api.github.com": [
-        {
-          match: {
-            method: ["GET", "POST", "PATCH"],
-            path: { startsWith: "/repos/vercel/turborepo" }
-          },
-          transform: [{ headers: { authorization: `Bearer ${githubToken}` } }]
+        ? [
+            {
+              domain: publishBridge.hostname,
+              headers: { authorization: publishBridge.authorization },
+              match: { method: ["POST"], path: publishBridge.path }
+            }
+          ]
+        : []),
+      {
+        domain: "api.github.com",
+        headers: { authorization: `Bearer ${githubToken}` },
+        match: {
+          method: ["GET", "POST", "PATCH"],
+          path: { startsWith: "/repos/vercel/turborepo" }
         }
-      ],
-      "github.com": [
-        {
-          match: {
-            method: ["GET", "POST"],
-            path: { startsWith: "/vercel/turborepo.git" }
-          },
-          transform: [{ headers: { authorization: gitAuthorization } }]
+      },
+      {
+        domain: "github.com",
+        headers: { authorization: gitAuthorization },
+        match: {
+          method: ["GET", "POST"],
+          path: { startsWith: "/vercel/turborepo.git" }
         }
-      ],
-      "*": []
-    },
-    subnets: { deny: ["169.254.169.254/32"] }
+      }
+    ]
   };
 }

--- a/apps/factory/tests/fx-workspace.test.mjs
+++ b/apps/factory/tests/fx-workspace.test.mjs
@@ -141,7 +141,7 @@ test("workspace publication credentials are injected only for the exact route", 
     headers: { authorization: "[redacted]" },
     match: {
       method: ["POST"],
-      path: "/api/workspaces/ws_abc/publish"
+      path: { exact: "/api/workspaces/ws_abc/publish" }
     }
   });
 });

--- a/apps/factory/tests/fx-workspace.test.mjs
+++ b/apps/factory/tests/fx-workspace.test.mjs
@@ -102,7 +102,7 @@ test("the terminal runner starts fx once and injects the autonomous prompt", () 
   assert.doesNotMatch(FX_TERMINAL_RUNNER_SOURCE, /session\/cancel/);
 });
 
-test("workspace policy updates the current Sandbox session", async () => {
+test("workspace policy uses the Sandbox API custom schema", async () => {
   const updates = [];
   const policy = workspaceNetworkPolicy("github-token");
   await applyWorkspaceNetworkPolicy(
@@ -118,44 +118,30 @@ test("workspace policy updates the current Sandbox session", async () => {
     policy
   );
 
-  assert.deepEqual(updates, [{ networkPolicy: policy }]);
-});
-
-test("workspace GitHub credential rules precede the catch-all rule", () => {
-  const policy = workspaceNetworkPolicy("github-token");
-  assert.notEqual(typeof policy, "string");
-  assert.ok(policy.allow && !Array.isArray(policy.allow));
-
-  assert.deepEqual(Object.keys(policy.allow), [
+  assert.equal(policy.mode, "custom");
+  assert.deepEqual(policy.allowedDomains, [
     "api.github.com",
     "github.com",
     "*"
   ]);
-  assert.deepEqual(policy.allow["github.com"][0].transform, [
-    {
-      headers: {
-        authorization: `Basic ${Buffer.from("x-access-token:github-token").toString("base64")}`
-      }
-    }
-  ]);
+  assert.deepEqual(policy.deniedCIDRs, ["169.254.169.254/32"]);
+  assert.deepEqual(updates, [{ networkPolicy: policy }]);
 });
 
 test("workspace publication credentials are injected only for the exact route", () => {
   const policy = workspaceNetworkPolicy("github-token", {
-    authorization: "Bearer publish-token",
+    authorization: "[redacted]",
     hostname: "factory.example",
     path: "/api/workspaces/ws_abc/publish",
     url: "https://factory.example/api/workspaces/ws_abc/publish"
   });
-  assert.notEqual(typeof policy, "string");
-  assert.ok(policy.allow && !Array.isArray(policy.allow));
-  assert.deepEqual(policy.allow["factory.example"], [
-    {
-      match: {
-        method: ["POST"],
-        path: "/api/workspaces/ws_abc/publish"
-      },
-      transform: [{ headers: { authorization: "Bearer publish-token" } }]
+  assert.equal(policy.allowedDomains[0], "factory.example");
+  assert.deepEqual(policy.injectionRules[0], {
+    domain: "factory.example",
+    headers: { authorization: "[redacted]" },
+    match: {
+      method: ["POST"],
+      path: "/api/workspaces/ws_abc/publish"
     }
-  ]);
+  });
 });

--- a/apps/factory/tests/fx-workspace.test.mjs
+++ b/apps/factory/tests/fx-workspace.test.mjs
@@ -9,7 +9,10 @@ import {
   FX_TERMINAL_RUNNER_SOURCE,
   parseFxTerminalResult
 } from "../agent/lib/fx-terminal-runner.ts";
-import { workspaceNetworkPolicy } from "../agent/lib/workspace-network-policy.ts";
+import {
+  applyWorkspaceNetworkPolicy,
+  workspaceNetworkPolicy
+} from "../agent/lib/workspace-network-policy.ts";
 
 test("parseFxTerminalResult reads the completed interactive turn", () => {
   assert.deepEqual(
@@ -97,6 +100,25 @@ test("the terminal runner starts fx once and injects the autonomous prompt", () 
   assert.match(FX_TERMINAL_RUNNER_SOURCE, /fx --record/);
   assert.match(FX_TERMINAL_RUNNER_SOURCE, /\/factory\/bin:\$PATH/);
   assert.doesNotMatch(FX_TERMINAL_RUNNER_SOURCE, /session\/cancel/);
+});
+
+test("workspace policy updates the current Sandbox session", async () => {
+  const updates = [];
+  const policy = workspaceNetworkPolicy("github-token");
+  await applyWorkspaceNetworkPolicy(
+    {
+      currentSession() {
+        return {
+          async update(input) {
+            updates.push(input);
+          }
+        };
+      }
+    },
+    policy
+  );
+
+  assert.deepEqual(updates, [{ networkPolicy: policy }]);
 });
 
 test("workspace GitHub credential rules precede the catch-all rule", () => {


### PR DESCRIPTION
## Summary

- keep named sandbox creation fail-closed with `networkPolicy: "deny-all"`
- apply workspace credentials through the running session's network-policy endpoint
- use the custom policy schema accepted by the live Sandbox REST API
- retain method/path-scoped header injection for GitHub and workspace publishing

## Production and preview evidence

Production failures after #13812 reached the named-sandbox update endpoint and rejected the SDK object's `allow` property.

The first version of this PR moved the same SDK object to the documented session endpoint. Preview workspace `ws_a52900be7ac448a0ba227bc6b25d4c2d` proved that endpoint also rejects the SDK 2.5 object:

```
POST /v2/sandboxes/sessions/sbx_ZGVYSNrBKyLeI9qi4p4Gqy7bCD4B/network-policy
Invalid request: should NOT have additional property `allow`.
```

Vercel's live REST reference lists the accepted custom schema as `mode`, `allowedDomains`, `deniedCIDRs`, and `injectionRules`. This revision isolates that documented API shape at the SDK boundary while preserving the existing L7 match restrictions.

## Verification

- `node --experimental-strip-types --test tests/fx-workspace.test.mjs` (7 passed)
- `pnpm exec tsc --noEmit`
- pre-push hooks: `format`, `check:toml`
- updated Vercel preview deployed successfully at commit `4e7f6a7f6c`

## Remaining preview check

The updated preview is deployed, but the protected terminal POST was not authorized from automation. Reloading the existing workspace once will exercise the updated policy against its existing sandbox; deployment logs should then confirm whether the terminal proceeds past policy application.
