### PR TITLE
fix: Improve Factory terminal line spacing

### DIFF
--- a/apps/factory/app/workspace-terminal.tsx
+++ b/apps/factory/app/workspace-terminal.tsx
@@ -36,6 +36,7 @@ export function WorkspaceTerminal({ workspaceId }: WorkspaceTerminalProps) {
       cursorBlink: true,
       fontFamily: "var(--font-geist-mono), monospace",
       fontSize: 14,
+      lineHeight: 1.2,
       theme: { background: "#000000", foreground: "#ededed" }
     });
     const fitAddon = new FitAddon();

--- a/apps/factory/app/workspace-terminal.tsx
+++ b/apps/factory/app/workspace-terminal.tsx
@@ -36,7 +36,7 @@ export function WorkspaceTerminal({ workspaceId }: WorkspaceTerminalProps) {
       cursorBlink: true,
       fontFamily: "var(--font-geist-mono), monospace",
       fontSize: 14,
-      lineHeight: 1.2,
+      lineHeight: 1.5,
       theme: { background: "#000000", foreground: "#ededed" }
     });
     const fitAddon = new FitAddon();


### PR DESCRIPTION
## Summary

- increase the Factory workspace terminal line height to improve readability
- preserve xterm fitting and resize behavior

## Testing

- `pnpm exec tsc --noEmit --pretty false` from `apps/factory`
- pre-push hooks (`format`, `check:toml`)