### PR TITLE
fix: Install Factory publishing skill

### DIFF
--- a/apps/factory/agent/lib/workspace-publish.ts
+++ b/apps/factory/agent/lib/workspace-publish.ts
@@ -10,6 +10,10 @@ const FX_INSTRUCTIONS_PATH = "/home/vercel/.fx/AGENTS.md";
 const PUBLISH_COMMAND_PATH = "/factory/bin/factory-create-pr";
 const PUBLISH_INSTRUCTIONS = `When the maintainer asks to create or make a pull request, leave repository changes uncommitted and run \`factory-create-pr --branch agents/<topic> --title "type: Description" --body "validation results"\`. Factory creates the verified commit, branch, and draft pull request through Eve's GitHub credentials. Never run git commit, git push, gh auth setup-git, or gh pr create.\n`;
 
+export function workspacePublishPrompt(message: string): string {
+  return `${PUBLISH_INSTRUCTIONS}\nMaintainer request:\n${message}`;
+}
+
 export interface WorkspacePublishBridge {
   readonly authorization: string;
   readonly hostname: string;

--- a/apps/factory/agent/lib/workspace-publish.ts
+++ b/apps/factory/agent/lib/workspace-publish.ts
@@ -6,13 +6,20 @@ import type { SandboxSession } from "eve/sandbox";
 import type { WorkspaceRecord } from "./workspace";
 
 const CHECKOUT_PATH = "/factory/turborepo";
-const FX_INSTRUCTIONS_PATH = "/home/vercel/.fx/AGENTS.md";
+const FX_PUBLISH_SKILL_DIRECTORY = "/home/vercel/.fx/skills/factory-publish";
+const FX_PUBLISH_SKILL_PATH = `${FX_PUBLISH_SKILL_DIRECTORY}/SKILL.md`;
 const PUBLISH_COMMAND_PATH = "/factory/bin/factory-create-pr";
-const PUBLISH_INSTRUCTIONS = `When the maintainer asks to create or make a pull request, leave repository changes uncommitted and run \`factory-create-pr --branch agents/<topic> --title "type: Description" --body "validation results"\`. Factory creates the verified commit, branch, and draft pull request through Eve's GitHub credentials. Never run git commit, git push, gh auth setup-git, or gh pr create.\n`;
+const PUBLISH_SKILL = `---
+name: factory-publish
+description: Use when the maintainer asks to create, make, open, or publish a pull request.
+---
 
-export function workspacePublishPrompt(message: string): string {
-  return `${PUBLISH_INSTRUCTIONS}\nMaintainer request:\n${message}`;
-}
+# Publish a Factory pull request
+
+Leave repository changes uncommitted and run \`factory-create-pr --branch agents/<topic> --title "type: Description" --body "validation results"\`.
+
+Factory creates the verified commit, branch, and draft pull request through Eve's GitHub credentials. Never run \`git commit\`, \`git push\`, \`gh auth setup-git\`, or \`gh pr create\`.
+`;
 
 export interface WorkspacePublishBridge {
   readonly authorization: string;
@@ -79,15 +86,15 @@ try {
 }
 `;
   await sandbox.runCommand({
-    args: ["-p", "/factory/bin", "/home/vercel/.fx"],
+    args: ["-p", "/factory/bin", FX_PUBLISH_SKILL_DIRECTORY],
     cmd: "mkdir",
     timeoutMs: 10_000
   });
   await sandbox.writeFiles([
     { content: Buffer.from(source, "utf8"), path: PUBLISH_COMMAND_PATH },
     {
-      content: Buffer.from(PUBLISH_INSTRUCTIONS, "utf8"),
-      path: FX_INSTRUCTIONS_PATH
+      content: Buffer.from(PUBLISH_SKILL, "utf8"),
+      path: FX_PUBLISH_SKILL_PATH
     }
   ]);
   const command = await sandbox.runCommand({

--- a/apps/factory/tests/workspace-publish.test.mjs
+++ b/apps/factory/tests/workspace-publish.test.mjs
@@ -4,7 +4,8 @@ import test from "node:test";
 import {
   isWorkspacePublishRequest,
   parseWorkspacePublishInput,
-  workspacePublishBridge
+  workspacePublishBridge,
+  workspacePublishPrompt
 } from "../agent/lib/workspace-publish.ts";
 
 const workspace = {
@@ -41,6 +42,14 @@ test("validates workspace publication metadata", () => {
     }),
     null
   );
+});
+
+test("tells every workspace turn to publish through Eve", () => {
+  const prompt = workspacePublishPrompt("Open a PR for this fix.");
+  assert.match(prompt, /factory-create-pr/);
+  assert.match(prompt, /Eve's GitHub credentials/);
+  assert.match(prompt, /Never run git commit, git push/);
+  assert.match(prompt, /Maintainer request:\nOpen a PR for this fix\./);
 });
 
 test("requires the private workspace publication capability", () => {

--- a/apps/factory/tests/workspace-publish.test.mjs
+++ b/apps/factory/tests/workspace-publish.test.mjs
@@ -2,10 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  installWorkspacePublishCommand,
   isWorkspacePublishRequest,
   parseWorkspacePublishInput,
-  workspacePublishBridge,
-  workspacePublishPrompt
+  workspacePublishBridge
 } from "../agent/lib/workspace-publish.ts";
 
 const workspace = {
@@ -44,12 +44,39 @@ test("validates workspace publication metadata", () => {
   );
 });
 
-test("tells every workspace turn to publish through Eve", () => {
-  const prompt = workspacePublishPrompt("Open a PR for this fix.");
-  assert.match(prompt, /factory-create-pr/);
-  assert.match(prompt, /Eve's GitHub credentials/);
-  assert.match(prompt, /Never run git commit, git push/);
-  assert.match(prompt, /Maintainer request:\nOpen a PR for this fix\./);
+test("installs the Factory publishing skill for fx", async () => {
+  const writes = [];
+  const commands = [];
+  const sandbox = {
+    async runCommand(command) {
+      commands.push(command);
+      return { exitCode: 0 };
+    },
+    async writeFiles(files) {
+      writes.push(...files);
+    }
+  };
+
+  await installWorkspacePublishCommand(sandbox, {
+    authorization: "Bearer secret-token",
+    hostname: "factory.example",
+    path: "/api/workspaces/ws_abc/publish",
+    url: "https://factory.example/api/workspaces/ws_abc/publish"
+  });
+
+  const skill = writes.find(({ path }) =>
+    path.endsWith("/skills/factory-publish/SKILL.md")
+  );
+  assert.ok(skill);
+  const contents = skill.content.toString("utf8");
+  assert.match(contents, /name: factory-publish/);
+  assert.match(contents, /create, make, open, or publish a pull request/);
+  assert.match(contents, /factory-create-pr/);
+  assert.match(contents, /Never run `git commit`/);
+  assert.deepEqual(commands.at(-1).args, [
+    "+x",
+    "/factory/bin/factory-create-pr"
+  ]);
 });
 
 test("requires the private workspace publication capability", () => {

--- a/apps/factory/workflows/workspace-turn.ts
+++ b/apps/factory/workflows/workspace-turn.ts
@@ -54,7 +54,7 @@ async function runWorkspaceTurn(input: WorkspaceTurnInput): Promise<void> {
 
   try {
     if (!message) throw new Error("Workspace turn prompt is missing.");
-    const { workspacePublishBridge } =
+    const { workspacePublishBridge, workspacePublishPrompt } =
       await import("../agent/lib/workspace-publish");
     const publishBridge = workspace.publishToken
       ? workspacePublishBridge(input.workspaceId, workspace.publishToken)
@@ -65,7 +65,7 @@ async function runWorkspaceTurn(input: WorkspaceTurnInput): Promise<void> {
     );
     const result = await runFxTurn(
       sandbox,
-      message,
+      workspacePublishPrompt(message),
       workspace.sessionId,
       undefined,
       async (sessionId) => {

--- a/apps/factory/workflows/workspace-turn.ts
+++ b/apps/factory/workflows/workspace-turn.ts
@@ -54,7 +54,7 @@ async function runWorkspaceTurn(input: WorkspaceTurnInput): Promise<void> {
 
   try {
     if (!message) throw new Error("Workspace turn prompt is missing.");
-    const { workspacePublishBridge, workspacePublishPrompt } =
+    const { workspacePublishBridge } =
       await import("../agent/lib/workspace-publish");
     const publishBridge = workspace.publishToken
       ? workspacePublishBridge(input.workspaceId, workspace.publishToken)
@@ -65,7 +65,7 @@ async function runWorkspaceTurn(input: WorkspaceTurnInput): Promise<void> {
     );
     const result = await runFxTurn(
       sandbox,
-      workspacePublishPrompt(message),
+      message,
       workspace.sessionId,
       undefined,
       async (sessionId) => {


### PR DESCRIPTION
## Summary

- install the Factory pull-request workflow as an fx skill
- stop injecting publishing instructions into every workspace turn
- pass maintainer messages to fx unchanged

## Verification

- `node --experimental-strip-types --test tests/workspace-publish.test.mjs`
- `pnpm exec tsc --noEmit`
- `pnpm exec oxfmt --check apps/factory/agent/lib/workspace-publish.ts apps/factory/workflows/workspace-turn.ts apps/factory/tests/workspace-publish.test.mjs`