### PR TITLE
docs: Fix inconsistent Yarn command in basic example

### DIFF
--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -48,7 +48,7 @@ Without global `turbo`, use your package manager:
 ```sh
 cd my-turborepo
 npx turbo build
-yarn dlx turbo build
+yarn exec turbo build
 pnpm exec turbo build
 ```
 


### PR DESCRIPTION
Fixes #13813

## Summary

The `examples/basic/README.md` used `yarn dlx turbo build` in the "Without global `turbo`" build section, while every other Yarn command in the same README (`dev`, `login`, `link`, and the filtered `build`) uses `yarn exec turbo ...`. This changed `yarn dlx turbo build` to `yarn exec turbo build` to match the rest of the file and the `npx`/`pnpm exec` equivalents.

## Root cause

A single inconsistent command string in the basic example README.

## Verification

- `grep` confirmed the other five Yarn commands in the README all use `yarn exec turbo`.
- Pre-push hooks (`format`, `check:toml`) passed.