### PR TITLE
fix: Disable Factory navigation prefetching

### DIFF
--- a/apps/factory/app/navigation.tsx
+++ b/apps/factory/app/navigation.tsx
@@ -16,6 +16,7 @@ export function Navigation() {
       <Link
         className="flex items-center gap-2.5 font-semibold tracking-tight"
         href="/"
+        prefetch={false}
         aria-label="Turborepo Factory home"
       >
         <span
@@ -36,6 +37,7 @@ export function Navigation() {
                   undefined
                 }
                 href={href}
+                prefetch={false}
               >
                 {label}
               </Link>

--- a/apps/factory/app/page.tsx
+++ b/apps/factory/app/page.tsx
@@ -24,6 +24,7 @@ export default function WorkspacesPage() {
           <Link
             className="text-sm font-medium hover:underline hover:underline-offset-4"
             href="/work"
+            prefetch={false}
           >
             Start work
           </Link>


### PR DESCRIPTION
## Summary

- disable automatic Next.js prefetching for the Factory’s persistent navigation links
- prevent speculative React Server Component requests from producing repeated 404s
- preserve client-side navigation when links are clicked

## Verification

- `pnpm exec tsc --noEmit`
- `pnpm exec oxfmt --check app/navigation.tsx app/page.tsx`
- `pnpm build`
- `git diff --check`
- pre-push `format` and `check:toml` hooks