### PR TITLE
fix: Escape ampersands in RSS feed enclosure URLs

### DIFF
--- a/apps/docs/app/feed.xml/route.ts
+++ b/apps/docs/app/feed.xml/route.ts
@@ -4,6 +4,15 @@ import { createSignedOgUrl } from "@/lib/og/sign";
 
 const BASE_URL = "https://turborepo.dev";
 
+/**
+ * Escapes `&` so URLs render as valid XML attribute values.
+ * The `feed` library escapes `&` in text nodes but not in the
+ * `enclosure` URL attribute, and `xml-js` leaves attribute values raw,
+ * so signed OG image URLs with query params break feed.xml.
+ */
+const escapeXmlAmpersand = (url: string): string =>
+  url.replace(/&/g, "&amp;");
+
 export const revalidate = false;
 
 export const GET = async () => {
@@ -35,7 +44,7 @@ export const GET = async () => {
       link: `${BASE_URL}/blog/${slug}`,
       date: new Date(post.data.date),
       description: post.data.description,
-      enclosure: { url: imageUrl, length: 0, type: "image/png" }
+      enclosure: { url: escapeXmlAmpersand(imageUrl), length: 0, type: "image/png" }
     });
   }
 


### PR DESCRIPTION
## Summary

Fixes #13832 — `https://turborepo.dev/feed.xml` is not valid XML. Consumers fail with `Invalid character in entity name` because `&` characters in OG image enclosure URLs are not escaped to `&amp;`.

## Root cause

`createSignedOgUrl` returns a URL with `&` separators in its query string (`/api/og?title=...&section=Blog&sig=...`). The `feed` library escapes `&` in most fields via its internal `sanitize`, but `formatEnclosure` spreads the raw enclosure object into the `_attributes` map, bypassing `sanitize` on the `url`. The underlying `xml-js` `js2xml` escapes `&` in text nodes but **not** in attribute values, so the raw `&` ends up unescaped in the `<enclosure url="...">` attribute, breaking feed.xml.

The feed `<image>` URL renders as a text node (escaped correctly by `xml-js`), so only the `enclosure` attribute needs fixing.

## Solution

Escape `&` → `&amp;` in the enclosure URL before passing it to `feed.addItem`, mirroring the `feed` library's own `sanitize` escaping.

## Verification

Reproduced against the real `feed@5.2.0` + `xml-js@1.6.11`:

- Before: `<enclosure ... url="...&section=Blog&sig=..."/>` → invalid XML (reproduces the issue)
- After: `<enclosure ... url="...&amp;section=Blog&amp;sig=..."/>` → valid XML
