### PR TITLE
fix: Remove unsupported remote cache environment variable

### DIFF
--- a/crates/turborepo-config/src/lib.rs
+++ b/crates/turborepo-config/src/lib.rs
@@ -187,8 +187,6 @@ pub enum Error {
     Encoding(String),
     #[error("TURBO_SIGNATURE should be either 1 or 0.")]
     InvalidSignature,
-    #[error("TURBO_REMOTE_CACHE_ENABLED should be either 1 or 0.")]
-    InvalidRemoteCacheEnabled,
     #[error("TURBO_REMOTE_CACHE_TIMEOUT: Error parsing timeout.")]
     InvalidRemoteCacheTimeout(#[source] std::num::ParseIntError),
     #[error("TURBO_REMOTE_CACHE_UPLOAD_TIMEOUT: Error parsing timeout.")]

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -29,8 +29,6 @@ pub enum RemoteCacheDisabledReason {
     TokenWithoutTeam,
     /// `remoteCache.enabled: false` in turbo.json.
     InConfig,
-    /// `TURBO_REMOTE_CACHE_ENABLED=0` env var.
-    InEnvVar,
     /// CLI flags (e.g. `--cache=local:rw`, or `--no-cache` + `--force`)
     /// disabled both remote read and write.
     ByFlags,
@@ -246,15 +244,7 @@ impl Opts {
                     Some(RemoteCacheDisabledReason::NotLinked)
                 }
             } else if config.enabled == Some(false) {
-                let disabled_by_env = std::env::var("TURBO_REMOTE_CACHE_ENABLED")
-                    .ok()
-                    .filter(|v| v == "0")
-                    .is_some();
-                if disabled_by_env {
-                    Some(RemoteCacheDisabledReason::InEnvVar)
-                } else {
-                    Some(RemoteCacheDisabledReason::InConfig)
-                }
+                Some(RemoteCacheDisabledReason::InConfig)
             } else {
                 // Linked and enabled in config, but remote cache is still disabled.
                 // This means CLI flags (--no-cache + --force, or --cache=local:rw)
@@ -1066,7 +1056,6 @@ mod test {
             "TURBO_FORCE",
             "TURBO_LOGIN",
             "TURBO_PREFLIGHT",
-            "TURBO_REMOTE_CACHE_ENABLED",
             "TURBO_REMOTE_CACHE_READ_ONLY",
             "TURBO_REMOTE_ONLY",
             "TURBO_TEAM",

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -170,9 +170,6 @@ fn remote_cache_status_message(status: RemoteCacheStatus, api_url: &str) -> (Str
                 RemoteCacheDisabledReason::InConfig => {
                     "Remote caching disabled (in configuration)".to_string()
                 }
-                RemoteCacheDisabledReason::InEnvVar => {
-                    "Remote caching disabled (by TURBO_REMOTE_CACHE_ENABLED)".to_string()
-                }
                 RemoteCacheDisabledReason::ByFlags => {
                     "Remote caching disabled (by flags)".to_string()
                 }


### PR DESCRIPTION
## Summary

- remove dead `TURBO_REMOTE_CACHE_ENABLED` error and status handling
- attribute `remoteCache.enabled: false` to configuration consistently
- stop advertising an environment variable that was never wired into config or documented

Closes #13794

## Testing

- `cargo fmt --all --check`
- `cargo test -p turborepo-config --lib`
- `cargo test -p turborepo-lib opts::test --lib`
- `cargo test -p turborepo-lib remote_cache_status_messages_match_prelude_contract --lib`
