### PR TITLE
feat: Use uv workspace metadata

### DIFF
--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -252,7 +252,6 @@ jobs:
             uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
 
           - name: Setup uv
-            if: runner.os == 'Linux'
             uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
             with:
               version: "0.12.0"
@@ -474,6 +473,12 @@ jobs:
 
           - name: Setup Zig
             uses: ./.github/actions/setup-zig
+
+          - name: Setup uv
+            uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+            with:
+              version: "0.12.0"
+              enable-cache: false
 
           - name: Setup capnproto
             if: runner.os != 'macOS'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ When making changes to the codebase, check if the following docs need updates:
 - Rust CI restores full Cargo target state on Ubuntu, macOS, and Windows from trusted `main` snapshots; only `main` writes. Repository sccache dogfooding is disabled.
 - Linux Rust shards include `terminal-control` black-box TUI integration tests; known regressions remain explicitly ignored.
 - Rust test shards pin Node.js 18.20.2, so any `packageManager` version an integration fixture declares has to run on that Node.
+- Rust test shards and the `@turbo/repository` native-package matrix install the pinned uv version because Python workspace discovery invokes `uv workspace metadata`.
 - Rust integration tests read fixtures from `turborepo-tests/integration/fixtures/`, never from `examples/`. Examples are version-bumped on their own cadence and are not declared inputs of the Rust test task.
 - Example validation remains push-only because it requires Vercel credentials and project state.
 

--- a/crates/turborepo-lockfiles/src/lib.rs
+++ b/crates/turborepo-lockfiles/src/lib.rs
@@ -42,7 +42,7 @@ use rayon::prelude::*;
 use rustc_hash::{FxBuildHasher, FxHashSet};
 use serde::Serialize;
 use turbopath::RelativeUnixPathBuf;
-pub use uv::{Error as UvLockError, PrunedUvLock, uv_external_closures, uv_prune_lock};
+pub use uv::{Error as UvLockError, PrunedUvLock, UvPackageKey, uv_prune_lock};
 pub use yarn1::{Yarn1Lockfile, yarn_subgraph};
 
 // The closure walk visits every edge of every workspace's dependency closure,

--- a/crates/turborepo-lockfiles/src/uv.rs
+++ b/crates/turborepo-lockfiles/src/uv.rs
@@ -1,295 +1,72 @@
-//! uv.lock parsing for external-dependency hashing and prune.
+//! Mechanical `uv.lock` filtering for `turbo prune`.
 //!
-//! Like the Cargo module (and unlike the JS lockfile implementations), this
-//! module does not implement the [`crate::Lockfile`] trait: uv owns
-//! resolution, subgraph pruning, and installation, so Turborepo only needs
-//! two things from uv.lock — the set of external packages in each workspace
-//! member's transitive dependency closure, and a reachability-pruned
-//! lockfile for `turbo prune`.
-//!
-//! uv.lock is a flat list of `[[package]]` entries. Workspace members carry
-//! a local project source (`{ editable = "…" }`, or `{ virtual = "…" }` for
-//! packages that are not built); external packages carry a distribution
-//! source (`{ registry = "…" }`, `{ git = "…" }`, or `{ url = "…" }`).
-//! Local `path`, `directory`, `editable`, and `virtual` sources must identify
-//! workspace members; other local dependencies fail closed until Turborepo
-//! can content-hash and copy them. A package's `dependencies` (and its
-//! `optional-dependencies` / `dev-dependencies` groups) are tables of the
-//! form `{ name = "…" }`, optionally qualified with `version` and `source`
-//! when uv forked the resolution (e.g. per Python version or platform
-//! marker) and the short form would be ambiguous.
-//!
-//! Package names in uv.lock are already PEP 503-normalized by uv; callers
-//! must pass normalized member names.
+//! uv owns workspace membership and dependency-graph semantics through
+//! `uv workspace metadata`. This module does not resolve uv dependencies; it
+//! only removes `[[package]]` tables that metadata determined are unreachable.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
-
-use serde::Deserialize;
-
-use crate::Package;
+use std::collections::HashSet;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("Unable to parse uv.lock: {0}")]
-    Parse(#[from] Box<toml::de::Error>),
-    #[error("Unable to parse uv.lock: {0}")]
     ParseDocument(#[from] Box<toml_edit::TomlError>),
-    #[error(
-        "uv.lock has unsupported schema version {version}. This version of Turborepo supports \
-         uv.lock version 1; a newer Turborepo release may be required."
-    )]
-    UnsupportedLockVersion { version: i64 },
-    #[error("uv.lock dependency '{0}' does not match any package entry.")]
-    UnknownDependency(String),
-    #[error(
-        "Workspace member '{0}' not found in uv.lock; the lockfile is stale. Run `uv lock` and \
-         commit the result."
-    )]
-    MissingMember(String),
     #[error("uv.lock is malformed: the [[package]] entries are not a valid array of tables.")]
     MalformedPackageArray,
-    #[error(
-        "uv.lock contains reachable local dependency {name:?} at {source_description:?}, but only \
-         uv workspace members are supported. Add it to [tool.uv.workspace] or replace it with a \
-         non-local source."
-    )]
-    UnsupportedLocalDependency {
-        name: String,
-        source_description: String,
-    },
+    #[error("uv.lock package entry is missing a string name")]
+    MissingPackageName,
 }
 
-/// The uv.lock schema version this module understands. The `version` field
-/// tracks breaking schema changes (`revision` tracks compatible ones), so an
-/// unknown version is a hard error rather than a silent misparse.
-const SUPPORTED_LOCK_VERSION: i64 = 1;
-
-#[derive(Deserialize)]
-struct UvLock {
-    version: Option<i64>,
-    #[serde(default)]
-    package: Vec<LockPackage>,
-}
-
-#[derive(Deserialize)]
-struct LockPackage {
-    name: String,
-    version: Option<String>,
-    source: Option<PackageSource>,
-    #[serde(default)]
-    dependencies: Vec<DependencyRef>,
-    #[serde(default, rename = "optional-dependencies")]
-    optional_dependencies: BTreeMap<String, Vec<DependencyRef>>,
-    #[serde(default, rename = "dev-dependencies")]
-    dev_dependencies: BTreeMap<String, Vec<DependencyRef>>,
-    sdist: Option<Artifact>,
-    #[serde(default)]
-    wheels: Vec<Artifact>,
-}
-
-/// A package source table, kept shape-agnostic: the discriminant is the key
-/// (`registry`, `git`, `url`, `path`, `editable`, `virtual`, `directory`),
-/// and values are compared/serialized generically so schema-compatible
-/// additions do not break parsing.
-#[derive(Debug, Clone, PartialEq, Deserialize)]
-#[serde(transparent)]
-struct PackageSource(BTreeMap<String, toml::Value>);
-
-impl PackageSource {
-    /// Whether this source marks a local project (a workspace member or a
-    /// local directory dependency) rather than a fetched distribution.
-    fn is_local_project(&self) -> bool {
-        ["editable", "virtual", "directory", "path"]
-            .iter()
-            .any(|key| self.0.contains_key(*key))
-    }
-
-    fn local_path(&self) -> Option<&str> {
-        ["editable", "virtual", "directory", "path"]
-            .iter()
-            .find_map(|key| self.0.get(*key).and_then(toml::Value::as_str))
-    }
-
-    /// Canonical single-line form for hash identities: everything uv.lock
-    /// pins about where a package comes from (registry URL, git URL + rev,
-    /// direct URL, or local path).
-    fn canonical(&self) -> String {
-        self.0
-            .iter()
-            .map(|(key, value)| match value.as_str() {
-                Some(value) => format!("{key}+{value}"),
-                None => format!("{key}+{value}"),
-            })
-            .collect::<Vec<_>>()
-            .join(" ")
-    }
-}
-
-#[derive(Deserialize)]
-struct DependencyRef {
-    name: String,
-    version: Option<String>,
-    source: Option<PackageSource>,
-}
-
-#[derive(Deserialize)]
-struct Artifact {
-    hash: Option<String>,
-}
-
-impl LockPackage {
-    /// Whether this entry is an external package for hashing purposes: it is
-    /// fetched from a registry, git, or URL. Local sources are validated as
-    /// workspace members before being excluded from the external closure.
-    fn is_external(&self) -> bool {
-        self.source
-            .as_ref()
-            .is_some_and(|source| !source.is_local_project())
-    }
-
-    /// The hash identity of an external package: everything uv.lock pins
-    /// about it. Version alone is insufficient — a git dependency's rev
-    /// lives in `source`, and distribution content is pinned by the sdist
-    /// and wheel hashes.
-    fn hash_identity(&self) -> Package {
-        let mut version = self.version.clone().unwrap_or_default();
-        if let Some(source) = &self.source {
-            version.push(' ');
-            version.push_str(&source.canonical());
-        }
-        let mut hashes: Vec<&str> = self
-            .sdist
-            .iter()
-            .chain(&self.wheels)
-            .filter_map(|artifact| artifact.hash.as_deref())
-            .collect();
-        hashes.sort_unstable();
-        for hash in hashes {
-            version.push(' ');
-            version.push_str(hash);
-        }
-        Package {
-            key: self.name.clone(),
-            version,
-        }
-    }
-
-    fn dependency_refs(&self) -> impl Iterator<Item = &DependencyRef> {
-        self.dependencies
-            .iter()
-            .chain(self.optional_dependencies.values().flatten())
-            .chain(self.dev_dependencies.values().flatten())
-    }
-}
-
-fn parse_lock(contents: &str) -> Result<UvLock, Error> {
-    let lock: UvLock = toml::from_str(contents).map_err(Box::new)?;
-    let version = lock.version.unwrap_or(0);
-    if version != SUPPORTED_LOCK_VERSION {
-        return Err(Error::UnsupportedLockVersion { version });
-    }
-    Ok(lock)
-}
-
-/// For each named workspace member, compute the set of external packages in
-/// its transitive dependency closure.
+/// The lockfile-visible identity of a package selected by uv metadata.
 ///
-/// A missing member is a hard error: silently hashing an incomplete closure
-/// would allow artifacts built from different dependency resolutions to
-/// share a cache key. Optional-dependency extras and dev-dependency groups
-/// fold into the same edge set as regular dependencies — over-inclusive,
-/// which is the safe direction for hashing. Member names must be PEP
-/// 503-normalized (uv.lock entries already are).
-pub fn uv_external_closures(
-    contents: &str,
-    members: &[String],
-    workspace_paths: &HashMap<String, String>,
-) -> Result<HashMap<String, HashSet<Package>>, Error> {
-    let lock = parse_lock(contents)?;
-    let index = LockIndex::new(&lock)?;
-
-    let mut starts = Vec::with_capacity(members.len());
-    for member in members {
-        starts.push(
-            index
-                .member(member, workspace_paths)
-                .ok_or_else(|| Error::MissingMember(member.clone()))?,
-        );
-    }
-    let (external_indices, reachable) = index.external_closures(&starts);
-    for idx in reachable {
-        reject_non_workspace_local(&lock.package[idx], workspace_paths)?;
-    }
-    let closures = members
-        .iter()
-        .zip(external_indices)
-        .map(|(member, indices)| {
-            let externals = indices
-                .into_iter()
-                .map(|idx| lock.package[idx].hash_identity())
-                .collect();
-            (member.clone(), externals)
-        })
-        .collect();
-    Ok(closures)
+/// Multiple uv resolution nodes can share this identity when they are forked
+/// only by source or markers. Pruning intentionally retains every matching
+/// lockfile entry, which is conservative and leaves uv to interpret the forks.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct UvPackageKey {
+    pub name: String,
+    pub version: Option<String>,
 }
 
-/// The result of pruning a uv.lock to a set of root members.
+/// The result of mechanically filtering a uv.lock.
 #[derive(Debug)]
 pub struct PrunedUvLock {
-    /// Every workspace member in the pruned closure, sorted.
+    /// Every retained workspace member, sorted.
     pub members: Vec<String>,
-    /// The pruned lockfile, preserving retained package metadata.
+    /// The filtered lockfile, preserving retained package metadata verbatim.
     pub lockfile: String,
 }
 
-/// Prune a uv.lock to the transitive closure of the given root members.
+/// Filter a uv.lock to package identities and workspace members selected by
+/// `uv workspace metadata`.
 pub fn uv_prune_lock(
     contents: &str,
-    roots: &[String],
-    workspace_paths: &HashMap<String, String>,
+    kept_packages: &HashSet<UvPackageKey>,
+    members: &HashSet<String>,
 ) -> Result<PrunedUvLock, Error> {
-    let lock = parse_lock(contents)?;
-    let index = LockIndex::new(&lock)?;
-
-    let mut starts = Vec::with_capacity(roots.len());
-    for root in roots {
-        starts.push(
-            index
-                .member(root, workspace_paths)
-                .ok_or_else(|| Error::MissingMember(root.clone()))?,
-        );
-    }
-    let kept = index.reachable(&starts);
-
-    for &idx in &kept {
-        reject_non_workspace_local(&lock.package[idx], workspace_paths)?;
-    }
-
-    let mut members: Vec<String> = kept
-        .iter()
-        .filter(|&&idx| package_matches_workspace(&lock.package[idx], workspace_paths))
-        .map(|&idx| lock.package[idx].name.clone())
-        .collect();
-    members.sort();
-    members.dedup();
-
-    // Rewrite instead of re-serializing so artifact and metadata tables that
-    // uv validates against manifests survive unchanged.
     let mut document: toml_edit::DocumentMut = contents.parse().map_err(Box::new)?;
     let packages = document
         .get_mut("package")
         .and_then(|item| item.as_array_of_tables_mut())
         .ok_or(Error::MalformedPackageArray)?;
-    if packages.len() != lock.package.len() {
-        return Err(Error::MalformedPackageArray);
-    }
-    let mut position = 0;
-    packages.retain(|_| {
-        let keep = kept.contains(&position);
-        position += 1;
-        keep
+
+    let mut malformed = false;
+    packages.retain(|package| {
+        let Some(name) = package.get("name").and_then(|item| item.as_str()) else {
+            malformed = true;
+            return false;
+        };
+        let version = package
+            .get("version")
+            .and_then(|item| item.as_str())
+            .map(str::to_string);
+        kept_packages.contains(&UvPackageKey {
+            name: name.to_string(),
+            version,
+        })
     });
+    if malformed {
+        return Err(Error::MissingPackageName);
+    }
 
     if let Some(manifest_members) = document
         .get_mut("manifest")
@@ -297,724 +74,94 @@ pub fn uv_prune_lock(
         .and_then(|manifest| manifest.get_mut("members"))
         .and_then(|item| item.as_array_mut())
     {
-        let members: HashSet<&str> = members.iter().map(String::as_str).collect();
         manifest_members.retain(|entry| entry.as_str().is_some_and(|name| members.contains(name)));
     }
 
+    let mut members = members.iter().cloned().collect::<Vec<_>>();
+    members.sort();
     Ok(PrunedUvLock {
         members,
         lockfile: document.to_string(),
     })
 }
 
-fn reject_non_workspace_local(
-    package: &LockPackage,
-    workspace_paths: &HashMap<String, String>,
-) -> Result<(), Error> {
-    let Some(source) = package.source.as_ref() else {
-        return Ok(());
-    };
-    let matches_workspace = package_matches_workspace(package, workspace_paths);
-    if source.is_local_project() && !matches_workspace {
-        return Err(Error::UnsupportedLocalDependency {
-            name: package.name.clone(),
-            source_description: source.canonical(),
-        });
-    }
-    Ok(())
-}
-
-fn package_matches_workspace(
-    package: &LockPackage,
-    workspace_paths: &HashMap<String, String>,
-) -> bool {
-    package
-        .source
-        .as_ref()
-        .and_then(PackageSource::local_path)
-        .zip(workspace_paths.get(&package.name))
-        .is_some_and(|(actual, expected)| {
-            normalize_local_path(actual) == normalize_local_path(expected)
-        })
-}
-
-fn normalize_local_path(path: &str) -> String {
-    #[cfg(windows)]
-    let path = path.replace('\\', "/").to_ascii_lowercase();
-    #[cfg(not(windows))]
-    let path = path.to_string();
-    path.trim_start_matches("./")
-        .trim_end_matches('/')
-        .to_string()
-}
-
-/// Index over a parsed lockfile for dependency-reference resolution.
-struct LockIndex<'a> {
-    lock: &'a UvLock,
-    by_name: HashMap<&'a str, Vec<usize>>,
-    adjacency: Vec<Vec<usize>>,
-}
-
-impl<'a> LockIndex<'a> {
-    fn new(lock: &'a UvLock) -> Result<Self, Error> {
-        let mut by_name: HashMap<&str, Vec<usize>> = HashMap::new();
-        for (idx, package) in lock.package.iter().enumerate() {
-            by_name.entry(package.name.as_str()).or_default().push(idx);
-        }
-        let mut index = Self {
-            lock,
-            by_name,
-            adjacency: vec![Vec::new(); lock.package.len()],
-        };
-        for (idx, package) in lock.package.iter().enumerate() {
-            let mut dependencies = Vec::new();
-            for dependency in package.dependency_refs() {
-                dependencies.extend(index.resolve(dependency)?);
-            }
-            dependencies.sort_unstable();
-            dependencies.dedup();
-            index.adjacency[idx] = dependencies;
-        }
-        Ok(index)
-    }
-
-    /// A workspace member appears in the lock with a local project source.
-    /// Member names are unique within a uv workspace, so a local-project
-    /// entry with this name is the member.
-    fn member(&self, name: &str, workspace_paths: &HashMap<String, String>) -> Option<usize> {
-        self.by_name.get(name).and_then(|candidates| {
-            candidates
-                .iter()
-                .copied()
-                .find(|&idx| package_matches_workspace(&self.lock.package[idx], workspace_paths))
-        })
-    }
-
-    /// External package indices reachable from each requested root, plus the
-    /// union of all reachable packages. Root bitsets flow once through the SCC
-    /// DAG, avoiding both repeated graph walks and a closure set per node.
-    fn external_closures(&self, roots: &[usize]) -> (Vec<HashSet<usize>>, HashSet<usize>) {
-        let sccs = crate::closure_dp::tarjan_scc(
-            &self
-                .adjacency
-                .iter()
-                .map(|edges| edges.iter().map(|&idx| idx as u32).collect())
-                .collect::<Vec<Vec<u32>>>(),
-        );
-        let mut scc_edges = vec![HashSet::new(); sccs.components.len()];
-        for (node, edges) in self.adjacency.iter().enumerate() {
-            let from = sccs.scc_of[node] as usize;
-            for &target in edges {
-                let to = sccs.scc_of[target] as usize;
-                if from != to {
-                    scc_edges[from].insert(to);
-                }
-            }
-        }
-
-        let words = roots.len().div_ceil(64);
-        let mut reachable_by = vec![0u64; sccs.components.len() * words];
-        for (root_idx, &root) in roots.iter().enumerate() {
-            let scc = sccs.scc_of[root] as usize;
-            reachable_by[scc * words + root_idx / 64] |= 1 << (root_idx % 64);
-        }
-        // Tarjan emits dependencies first. Walk backwards so each root's bits
-        // reach its dependency SCCs after all of its dependents are known.
-        for scc_idx in (0..sccs.components.len()).rev() {
-            let row = reachable_by[scc_idx * words..][..words].to_vec();
-            for &successor in &scc_edges[scc_idx] {
-                let successor = &mut reachable_by[successor * words..][..words];
-                for (target, source) in successor.iter_mut().zip(&row) {
-                    *target |= source;
-                }
-            }
-        }
-
-        let mut externals = vec![HashSet::new(); roots.len()];
-        let mut reachable = HashSet::new();
-        for (scc_idx, members) in sccs.components.iter().enumerate() {
-            let row = &reachable_by[scc_idx * words..][..words];
-            if row.iter().all(|word| *word == 0) {
-                continue;
-            }
-            for &member in members {
-                let member = member as usize;
-                reachable.insert(member);
-                if !self.lock.package[member].is_external() {
-                    continue;
-                }
-                for (word_idx, &word) in row.iter().enumerate() {
-                    let mut word = word;
-                    while word != 0 {
-                        let bit = word.trailing_zeros() as usize;
-                        word &= word - 1;
-                        externals[word_idx * 64 + bit].insert(member);
-                    }
-                }
-            }
-        }
-        (externals, reachable)
-    }
-
-    /// Resolve a dependency reference to the package indices it can denote.
-    ///
-    /// References are qualified with `version`/`source` exactly when uv
-    /// forked the resolution (e.g. by Python version or platform marker), so
-    /// after filtering, several candidates can legitimately remain — any
-    /// environment may select either fork. All of them are returned:
-    /// over-inclusion is the safe direction for both hashing and pruning,
-    /// so ambiguity is not an error here (unlike Cargo's resolver, which
-    /// guarantees a unique match).
-    fn resolve(&self, dependency: &DependencyRef) -> Result<Vec<usize>, Error> {
-        let display = |dependency: &DependencyRef| {
-            let mut display = dependency.name.clone();
-            if let Some(version) = &dependency.version {
-                display.push(' ');
-                display.push_str(version);
-            }
-            display
-        };
-        let candidates: Vec<usize> =
-            self.by_name
-                .get(dependency.name.as_str())
-                .map(Vec::as_slice)
-                .unwrap_or_default()
-                .iter()
-                .copied()
-                .filter(|&idx| {
-                    dependency.version.as_ref().is_none_or(|version| {
-                        self.lock.package[idx].version.as_ref() == Some(version)
-                    })
-                })
-                .filter(|&idx| {
-                    dependency
-                        .source
-                        .as_ref()
-                        .is_none_or(|source| self.lock.package[idx].source.as_ref() == Some(source))
-                })
-                .collect();
-        if candidates.is_empty() {
-            return Err(Error::UnknownDependency(display(dependency)));
-        }
-        Ok(candidates)
-    }
-
-    fn reachable(&self, starts: &[usize]) -> HashSet<usize> {
-        let mut visited = HashSet::new();
-        let mut stack = starts.to_vec();
-        while let Some(idx) = stack.pop() {
-            if !visited.insert(idx) {
-                continue;
-            }
-            stack.extend(self.adjacency[idx].iter().copied());
-        }
-        visited
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
 
-    /// Shaped like real `uv lock` output (version 1): editable members, a
-    /// virtual root, registry packages with artifact hashes, dev/optional
-    /// groups, and a marker-forked package resolved at two versions.
-    const LOCK: &str = r#"
-version = 1
+    const LOCK: &str = r#"version = 1
 revision = 3
-requires-python = ">=3.11"
 
 [manifest]
-members = [
-    "py-app",
-    "py-lib",
-    "root-project",
-]
-
-[[package]]
-name = "click"
-version = "8.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://example.com/click-8.4.2.tar.gz", hash = "sha256:c11c4", size = 338000 }
-wheels = [
-    { url = "https://example.com/click-8.4.2-py3-none-any.whl", hash = "sha256:c11c4wheel", size = 119243 },
-]
-
-[[package]]
-name = "colorama"
-version = "0.4.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://example.com/colorama-0.4.6.tar.gz", hash = "sha256:c0104", size = 27697 }
-
-[[package]]
-name = "py-app"
-version = "0.1.0"
-source = { editable = "packages/py-app" }
-dependencies = [
-    { name = "click" },
-    { name = "py-lib" },
-]
-
-[package.optional-dependencies]
-color = [
-    { name = "colorama" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "click", specifier = ">=8.1" },
-    { name = "colorama", marker = "extra == 'color'", specifier = ">=0.4" },
-    { name = "py-lib", editable = "packages/py-lib" },
-]
-
-[[package]]
-name = "py-lib"
-version = "0.1.0"
-source = { editable = "packages/py-lib" }
-dependencies = [
-    { name = "six" },
-]
-
-[[package]]
-name = "pytest"
-version = "9.1.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://example.com/pytest-9.1.1.tar.gz", hash = "sha256:9e51", size = 1636369 }
-
-[[package]]
-name = "root-project"
-version = "0.1.0"
-source = { virtual = "." }
-dependencies = [
-    { name = "py-app" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "ruff" },
-]
-
-[[package]]
-name = "ruff"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://example.com/ruff-0.16.0.tar.gz", hash = "sha256:0uff", size = 4790557 }
-
-[[package]]
-name = "six"
-version = "1.17.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://example.com/six-1.17.0.tar.gz", hash = "sha256:51x", size = 34031 }
-"#;
-
-    const FORKED_LOCK: &str = r#"
-version = 1
-revision = 3
-requires-python = ">=3.10"
-resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version < '3.12'",
-]
-
-[manifest]
-members = [
-    "fork-lib",
-]
-
-[[package]]
-name = "fork-lib"
-version = "0.1.0"
-source = { editable = "packages/fork-lib" }
-dependencies = [
-    { name = "typing-extensions", version = "4.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "typing-extensions", version = "4.16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-]
-
-[[package]]
-name = "typing-extensions"
-version = "4.8.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://example.com/typing_extensions-4.8.0.tar.gz", hash = "sha256:01d", size = 71456 }
-
-[[package]]
-name = "typing-extensions"
-version = "4.16.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://example.com/typing_extensions-4.16.0.tar.gz", hash = "sha256:new", size = 113555 }
-"#;
-
-    fn names(closure: &HashSet<Package>) -> Vec<String> {
-        let mut names: Vec<_> = closure
-            .iter()
-            .map(|package| format!("{}@{}", package.key, package.version))
-            .collect();
-        names.sort();
-        names
-    }
-
-    fn workspace_paths(contents: &str) -> HashMap<String, String> {
-        parse_lock(contents)
-            .unwrap()
-            .package
-            .into_iter()
-            .filter_map(|package| {
-                let path = package.source?.local_path()?.to_string();
-                Some((package.name, path))
-            })
-            .collect()
-    }
-
-    #[test]
-    fn test_closures_are_per_member() {
-        let members = vec!["py-app".to_string(), "py-lib".to_string()];
-        let closures = uv_external_closures(LOCK, &members, &workspace_paths(LOCK)).unwrap();
-
-        // py-app's closure folds in regular deps, the `color` extra, and the
-        // `dev` group; identities capture version, source, and hashes.
-        assert_eq!(
-            names(&closures["py-app"]),
-            vec![
-                "click@8.4.2 registry+https://pypi.org/simple sha256:c11c4 sha256:c11c4wheel",
-                "colorama@0.4.6 registry+https://pypi.org/simple sha256:c0104",
-                "pytest@9.1.1 registry+https://pypi.org/simple sha256:9e51",
-                "six@1.17.0 registry+https://pypi.org/simple sha256:51x",
-            ]
-        );
-        // py-lib doesn't see click/pytest. A click bump must not invalidate
-        // it.
-        assert_eq!(
-            names(&closures["py-lib"]),
-            vec!["six@1.17.0 registry+https://pypi.org/simple sha256:51x"]
-        );
-    }
-
-    #[test]
-    fn test_virtual_root_is_a_member() {
-        let closures =
-            uv_external_closures(LOCK, &["root-project".to_string()], &workspace_paths(LOCK))
-                .unwrap();
-        // The virtual root reaches everything py-app reaches, plus its own
-        // dev group (ruff). Members never appear as externals.
-        assert_eq!(
-            names(&closures["root-project"]),
-            vec![
-                "click@8.4.2 registry+https://pypi.org/simple sha256:c11c4 sha256:c11c4wheel",
-                "colorama@0.4.6 registry+https://pypi.org/simple sha256:c0104",
-                "pytest@9.1.1 registry+https://pypi.org/simple sha256:9e51",
-                "ruff@0.16.0 registry+https://pypi.org/simple sha256:0uff",
-                "six@1.17.0 registry+https://pypi.org/simple sha256:51x",
-            ]
-        );
-    }
-
-    #[test]
-    fn test_forked_resolution_includes_both_forks() {
-        let closures = uv_external_closures(
-            FORKED_LOCK,
-            &["fork-lib".to_string()],
-            &workspace_paths(FORKED_LOCK),
-        )
-        .unwrap();
-        // Marker-forked references resolve each qualified candidate exactly.
-        assert_eq!(
-            names(&closures["fork-lib"]),
-            vec![
-                "typing-extensions@4.16.0 registry+https://pypi.org/simple sha256:new",
-                "typing-extensions@4.8.0 registry+https://pypi.org/simple sha256:01d",
-            ]
-        );
-    }
-
-    #[test]
-    fn test_unqualified_forked_reference_is_over_inclusive() {
-        let lock = r#"
-version = 1
+members = ["app", "lib"]
 
 [[package]]
 name = "app"
 version = "0.1.0"
-source = { editable = "packages/app" }
-dependencies = [
-    { name = "shared" },
-]
-
-[[package]]
-name = "shared"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-
-[[package]]
-name = "shared"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-"#;
-        // Unlike Cargo, an unqualified reference matching several forks is
-        // not an error: any environment may use either fork, so both belong
-        // in the closure.
-        let closures =
-            uv_external_closures(lock, &["app".to_string()], &workspace_paths(lock)).unwrap();
-        assert_eq!(
-            names(&closures["app"]),
-            vec![
-                "shared@1.0.0 registry+https://pypi.org/simple",
-                "shared@2.0.0 registry+https://pypi.org/simple",
-            ]
-        );
-    }
-
-    #[test]
-    fn test_missing_member_errors() {
-        let error =
-            uv_external_closures(LOCK, &["not-in-lock".to_string()], &workspace_paths(LOCK))
-                .unwrap_err();
-        assert!(matches!(error, Error::MissingMember(_)));
-    }
-
-    #[test]
-    fn test_unknown_dependency_errors() {
-        let lock = r#"
-version = 1
-
-[[package]]
-name = "app"
-version = "0.1.0"
-source = { editable = "packages/app" }
-dependencies = [
-    { name = "ghost" },
-]
-"#;
-        let error =
-            uv_external_closures(lock, &["app".to_string()], &workspace_paths(lock)).unwrap_err();
-        assert!(matches!(error, Error::UnknownDependency(_)));
-    }
-
-    #[test]
-    fn test_unsupported_lock_version_errors() {
-        let error = uv_external_closures("version = 2\n", &[], &HashMap::new()).unwrap_err();
-        assert!(matches!(
-            error,
-            Error::UnsupportedLockVersion { version: 2 }
-        ));
-        let error = uv_external_closures("", &[], &HashMap::new()).unwrap_err();
-        assert!(matches!(
-            error,
-            Error::UnsupportedLockVersion { version: 0 }
-        ));
-    }
-
-    #[test]
-    fn test_git_source_participates_in_identity() {
-        let lock = r#"
-version = 1
-
-[[package]]
-name = "app"
-version = "0.1.0"
-source = { editable = "packages/app" }
-dependencies = [
-    { name = "git-dep" },
-]
-
-[[package]]
-name = "git-dep"
-version = "0.2.0"
-source = { git = "https://example.com/dep?rev=main#deadbeef" }
-"#;
-        let closures =
-            uv_external_closures(lock, &["app".to_string()], &workspace_paths(lock)).unwrap();
-        // A git rev bump changes `source` but not `version`; the identity
-        // must capture it.
-        assert_eq!(
-            names(&closures["app"]),
-            vec!["git-dep@0.2.0 git+https://example.com/dep?rev=main#deadbeef"]
-        );
-    }
-
-    #[test]
-    fn test_non_workspace_local_dependency_errors() {
-        let lock = r#"
-version = 1
-
-[manifest]
-members = ["app"]
-
-[[package]]
-name = "app"
-version = "0.1.0"
-source = { editable = "packages/app" }
-dependencies = [{ name = "local-lib" }]
-
-[[package]]
-name = "local-lib"
-version = "0.1.0"
-source = { directory = "vendor/local-lib" }
-"#;
-        let members = ["app".to_string()];
-        let allowed = HashMap::from([("app".to_string(), "packages/app".to_string())]);
-        let error = uv_external_closures(lock, &members, &allowed).unwrap_err();
-        assert!(matches!(error, Error::UnsupportedLocalDependency { .. }));
-        let error = uv_prune_lock(lock, &members, &allowed).unwrap_err();
-        assert!(matches!(error, Error::UnsupportedLocalDependency { .. }));
-    }
-
-    #[test]
-    fn test_same_name_local_fork_must_match_workspace_path() {
-        let lock = r#"
-version = 1
-
-[[package]]
-name = "app"
-source = { editable = "packages/app" }
-dependencies = [
-    { name = "shared", source = { directory = "vendor/shared" } },
-]
-
-[[package]]
-name = "shared"
-source = { editable = "packages/shared" }
-
-[[package]]
-name = "shared"
-source = { directory = "vendor/shared" }
-"#;
-        let paths = HashMap::from([
-            ("app".to_string(), "packages/app".to_string()),
-            ("shared".to_string(), "packages/shared".to_string()),
-        ]);
-        let error = uv_external_closures(lock, &["app".to_string()], &paths).unwrap_err();
-        assert!(matches!(error, Error::UnsupportedLocalDependency { .. }));
-    }
-
-    #[test]
-    fn test_member_selection_uses_workspace_path() {
-        let lock = r#"
-version = 1
-
-[[package]]
-name = "app"
-source = { directory = "vendor/app" }
-
-[[package]]
-name = "app"
 source = { editable = "packages/app" }
 dependencies = [{ name = "dep" }]
+
+[package.metadata]
+requires-dist = [{ name = "dep", specifier = ">=1" }]
+
+[[package]]
+name = "lib"
+version = "0.1.0"
+source = { virtual = "packages/lib" }
 
 [[package]]
 name = "dep"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
-"#;
-        let paths = HashMap::from([("app".to_string(), "packages/app".to_string())]);
-        let closures = uv_external_closures(lock, &["app".to_string()], &paths).unwrap();
-        assert_eq!(
-            names(&closures["app"]),
-            vec!["dep@1.0.0 registry+https://pypi.org/simple"]
-        );
-    }
-
-    #[test]
-    fn test_prune_does_not_treat_external_same_name_as_member() {
-        let lock = r#"
-version = 1
-
-[manifest]
-members = ["app", "shared"]
+wheels = [{ hash = "sha256:abc" }]
 
 [[package]]
-name = "app"
-source = { editable = "packages/app" }
-dependencies = [
-    { name = "shared", version = "2.0.0", source = { registry = "https://pypi.org/simple" } },
-]
-
-[[package]]
-name = "shared"
-source = { editable = "packages/shared" }
-
-[[package]]
-name = "shared"
+name = "unused"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 "#;
-        let paths = HashMap::from([
-            ("app".to_string(), "packages/app".to_string()),
-            ("shared".to_string(), "packages/shared".to_string()),
+
+    #[test]
+    fn filters_packages_and_manifest_members() {
+        let kept = HashSet::from([
+            UvPackageKey {
+                name: "app".to_string(),
+                version: Some("0.1.0".to_string()),
+            },
+            UvPackageKey {
+                name: "dep".to_string(),
+                version: Some("1.0.0".to_string()),
+            },
         ]);
-        let pruned = uv_prune_lock(lock, &["app".to_string()], &paths).unwrap();
+        let members = HashSet::from(["app".to_string()]);
+        let pruned = uv_prune_lock(LOCK, &kept, &members).unwrap();
         assert_eq!(pruned.members, vec!["app"]);
-        assert!(pruned.lockfile.contains("version = \"2.0.0\""));
-    }
-
-    #[test]
-    fn test_prune_lock_keeps_reachable_closure() {
-        let pruned = uv_prune_lock(LOCK, &["py-lib".to_string()], &workspace_paths(LOCK)).unwrap();
-        assert_eq!(pruned.members, vec!["py-lib"]);
-        assert!(pruned.lockfile.contains("name = \"py-lib\""));
-        assert!(pruned.lockfile.contains("name = \"six\""));
-        assert!(!pruned.lockfile.contains("name = \"py-app\""));
-        assert!(!pruned.lockfile.contains("name = \"click\""));
-        assert!(!pruned.lockfile.contains("name = \"root-project\""));
-        assert!(!pruned.lockfile.contains("\"py-app\","));
-        assert!(pruned.lockfile.contains("requires-python = \">=3.11\""));
-        let closures = uv_external_closures(
-            &pruned.lockfile,
-            &["py-lib".to_string()],
-            &workspace_paths(LOCK),
-        )
-        .unwrap();
-        assert_eq!(
-            names(&closures["py-lib"]),
-            vec!["six@1.17.0 registry+https://pypi.org/simple sha256:51x"]
-        );
-    }
-
-    #[test]
-    fn test_prune_lock_preserves_metadata_tables_verbatim() {
-        let pruned = uv_prune_lock(LOCK, &["py-app".to_string()], &workspace_paths(LOCK)).unwrap();
+        assert!(pruned.lockfile.contains("name = \"app\""));
         assert!(pruned.lockfile.contains("[package.metadata]"));
-        assert!(
-            pruned
-                .lockfile
-                .contains(r#"{ name = "py-lib", editable = "packages/py-lib" }"#)
-        );
-        assert!(pruned.lockfile.contains("hash = \"sha256:c11c4wheel\""));
+        assert!(pruned.lockfile.contains("sha256:abc"));
+        assert!(!pruned.lockfile.contains("name = \"lib\""));
+        assert!(!pruned.lockfile.contains("name = \"unused\""));
+        assert!(!pruned.lockfile.contains("\"lib\","));
     }
 
     #[test]
-    fn test_prune_lock_retains_group_reachable_members() {
-        let pruned = uv_prune_lock(LOCK, &["py-app".to_string()], &workspace_paths(LOCK)).unwrap();
-        assert_eq!(pruned.members, vec!["py-app", "py-lib"]);
-        assert!(pruned.lockfile.contains("name = \"pytest\""));
-        assert!(pruned.lockfile.contains("name = \"colorama\""));
-        assert!(!pruned.lockfile.contains("name = \"ruff\""));
-    }
-
-    #[test]
-    fn test_prune_lock_stale_root_errors() {
-        let error =
-            uv_prune_lock(LOCK, &["not-in-lock".to_string()], &workspace_paths(LOCK)).unwrap_err();
-        assert!(matches!(error, Error::MissingMember(_)));
-    }
-
-    #[test]
-    fn test_prune_forked_lock_keeps_exact_forks() {
-        let pruned = uv_prune_lock(
-            FORKED_LOCK,
-            &["fork-lib".to_string()],
-            &workspace_paths(FORKED_LOCK),
-        )
-        .unwrap();
-        assert_eq!(pruned.members, vec!["fork-lib"]);
-        assert!(pruned.lockfile.contains("version = \"4.8.0\""));
-        assert!(pruned.lockfile.contains("version = \"4.16.0\""));
-        assert!(pruned.lockfile.contains("resolution-markers"));
+    fn keeps_all_matching_forks() {
+        let lock = r#"version = 1
+[[package]]
+name = "fork"
+version = "1.0.0"
+source = { registry = "https://one.example" }
+[[package]]
+name = "fork"
+version = "1.0.0"
+source = { registry = "https://two.example" }
+"#;
+        let kept = HashSet::from([UvPackageKey {
+            name: "fork".to_string(),
+            version: Some("1.0.0".to_string()),
+        }]);
+        let pruned = uv_prune_lock(lock, &kept, &HashSet::new()).unwrap();
+        assert!(pruned.lockfile.contains("https://one.example"));
+        assert!(pruned.lockfile.contains("https://two.example"));
     }
 }

--- a/crates/turborepo-repository/src/uv.rs
+++ b/crates/turborepo-repository/src/uv.rs
@@ -7,11 +7,11 @@
 //!
 //! Discovery parses the root `pyproject.toml`'s `[tool.uv.workspace]` table
 //! in-process: member globs are expanded against the filesystem and each
-//! member's `pyproject.toml` is parsed for its identity and dependencies.
-//! Unlike Cargo (whose membership semantics only `cargo metadata` can
-//! answer), uv workspace membership is declarative globs. Discovery probes uv
-//! and its selected Python interpreter when available so command tasks can be
-//! cached safely, but neither binary is required to construct the graph.
+//! member's `pyproject.toml` is parsed for its identity, task configuration,
+//! and internal relationships. Exact external resolution comes from
+//! `uv workspace metadata --frozen --offline`, avoiding direct interpretation
+//! of uv's unstable lockfile schema. Discovery also probes uv and its selected
+//! Python interpreter so command tasks can be cached safely.
 //!
 //! Buildable packages register `build` (`uv build --package=<name>`), and all
 //! packages register `format` and `check`. A synthetic package
@@ -29,7 +29,7 @@
 //! name = "acme"
 //! ```
 //!
-//! External dependencies hash from `uv.lock` per member (see
+//! External dependencies hash from uv's workspace metadata per member (see
 //! [`external_closures`]), scoped to each member's transitive closure, so a
 //! dependency bump only invalidates the packages that depend on it. Resolved
 //! uv and Python identities participate in every Python package hash.
@@ -41,7 +41,6 @@ use std::{
     collections::{BTreeMap, HashMap, HashSet},
     io::{self, Read},
     process::Command,
-    str::FromStr as _,
     sync::Arc,
 };
 
@@ -117,22 +116,24 @@ pub enum Error {
     MissingLockfile,
     #[error("failed to read uv.lock: {0}")]
     LockfileRead(#[source] io::Error),
+    #[error("failed to run `uv workspace metadata --frozen`: {0}")]
+    MetadataCommand(String),
+    #[error("failed to parse `uv workspace metadata` output: {0}")]
+    MetadataParse(#[source] serde_json::Error),
+    #[error("uv workspace metadata references unknown resolution node {0:?}")]
+    UnknownMetadataNode(String),
+    #[error(
+        "uv workspace metadata contains reachable local dependency {0:?}, but only uv workspace \
+         members are supported. Add it to [tool.uv.workspace] or replace it with a non-local \
+         source."
+    )]
+    UnsupportedLocalMetadataNode(String),
     #[error(transparent)]
     Lockfile(#[from] turborepo_lockfiles::UvLockError),
-    #[error("invalid uv workspace member glob: {0}")]
-    MemberGlob(#[from] globwalk::GlobError),
-    #[error("failed to walk uv workspace members: {0}")]
-    MemberWalk(#[from] globwalk::WalkError),
     #[error("uv workspace member manifest has no parent directory: {0}")]
     InvalidMemberManifestPath(String),
-    #[error("unsafe uv workspace glob {0:?}: patterns must be relative and cannot contain `..`")]
-    UnsafeWorkspaceGlob(String),
-    #[error("uv workspace declares too many member/exclude globs (maximum {0})")]
-    TooManyWorkspaceGlobs(usize),
-    #[error("uv workspace expands to too many members (maximum {0})")]
-    TooManyWorkspaceMembers(usize),
-    #[error("uv workspace glob exceeds the maximum length of {0} bytes")]
-    WorkspaceGlobTooLong(usize),
+    #[error("uv workspace metadata returned member path outside the repository: {0}")]
+    MetadataMemberOutsideRepository(String),
     #[error(transparent)]
     ResolutionPath(#[from] turbopath::PathError),
 }
@@ -212,7 +213,6 @@ struct BuildSystemTable {
 
 #[derive(Debug, Default, Deserialize)]
 struct ProjectTable {
-    name: Option<String>,
     #[serde(default)]
     dependencies: Vec<String>,
     #[serde(default, rename = "optional-dependencies")]
@@ -227,22 +227,12 @@ struct ToolTable {
 
 #[derive(Debug, Default, Deserialize)]
 struct UvToolTable {
-    workspace: Option<UvWorkspaceTable>,
-    #[serde(default)]
-    sources: BTreeMap<String, toml::Value>,
+    workspace: Option<toml::Value>,
     #[serde(default, rename = "dev-dependencies")]
     dev_dependencies: Vec<String>,
     #[serde(default, rename = "default-groups")]
     default_groups: Option<toml::Value>,
     package: Option<bool>,
-}
-
-#[derive(Debug, Default, Deserialize)]
-struct UvWorkspaceTable {
-    #[serde(default)]
-    members: Vec<String>,
-    #[serde(default)]
-    exclude: Vec<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -270,23 +260,16 @@ impl PyProjectManifest {
             })
     }
 
-    fn workspace(&self) -> Option<&UvWorkspaceTable> {
-        self.tool.as_ref()?.uv.as_ref()?.workspace.as_ref()
-    }
-
-    fn project_name(&self) -> Option<&str> {
-        self.project.as_ref()?.name.as_deref()
+    fn has_workspace(&self) -> bool {
+        self.tool
+            .as_ref()
+            .and_then(|tool| tool.uv.as_ref())
+            .and_then(|uv| uv.workspace.as_ref())
+            .is_some()
     }
 
     fn uv(&self) -> Option<&UvToolTable> {
         self.tool.as_ref()?.uv.as_ref()
-    }
-
-    fn source(&self, normalized_name: &str) -> Option<&toml::Value> {
-        self.uv()?
-            .sources
-            .iter()
-            .find_map(|(name, source)| (normalize_name(name) == normalized_name).then_some(source))
     }
 
     fn is_buildable(&self) -> bool {
@@ -679,27 +662,6 @@ impl QualityPlan {
     }
 }
 
-fn effective_source<'a>(
-    root: &'a PyProjectManifest,
-    member: &'a PyProjectManifest,
-    normalized_name: &str,
-) -> Option<&'a toml::Value> {
-    member
-        .source(normalized_name)
-        .or_else(|| root.source(normalized_name))
-}
-
-fn source_uses_current_workspace(source: &toml::Value) -> bool {
-    match source {
-        toml::Value::Table(table) => table
-            .get("workspace")
-            .and_then(toml::Value::as_bool)
-            .unwrap_or(false),
-        toml::Value::Array(sources) => sources.iter().any(source_uses_current_workspace),
-        _ => false,
-    }
-}
-
 /// Extract and validate the user-declared workspace name from the
 /// `[tool.turbo]` table.
 fn workspace_name(manifest: &PyProjectManifest) -> Result<Option<String>, Error> {
@@ -779,18 +741,12 @@ pub struct DiscoveredWorkspace {
     pytest: Option<ToolExecution>,
 }
 
-/// Discover the uv workspace rooted at `repo_root` by parsing
-/// `pyproject.toml` manifests in-process.
-///
-/// Returns an empty workspace if `repo_root` has no `pyproject.toml`, and
-/// warns (rather than errors) when one exists without a
-/// `[tool.uv.workspace]` table — the flag being enabled in a repository
-/// whose Python code is not a uv workspace should not break unrelated runs.
-///
-/// Members whose manifests live outside the repository root, resolve to the
-/// repository root itself, or have no `[project].name` are skipped with a
-/// warning.
-pub fn discover_workspace(repo_root: &AbsoluteSystemPath) -> Result<DiscoveredWorkspace, Error> {
+/// Discover the uv workspace from uv's authoritative metadata, parsing member
+/// manifests only for Turborepo task synthesis and dependency-kind labels.
+fn discover_workspace_from_metadata(
+    repo_root: &AbsoluteSystemPath,
+    metadata: &UvWorkspaceMetadata,
+) -> Result<DiscoveredWorkspace, Error> {
     let root_manifest_path = repo_root.join_component(PYPROJECT_TOML);
     let Some(root_manifest) = PyProjectManifest::load(&root_manifest_path)? else {
         return Ok(DiscoveredWorkspace {
@@ -802,7 +758,7 @@ pub fn discover_workspace(repo_root: &AbsoluteSystemPath) -> Result<DiscoveredWo
         });
     };
     let name = workspace_name(&root_manifest)?;
-    let Some(workspace) = root_manifest.workspace() else {
+    if !root_manifest.has_workspace() {
         tracing::warn!(
             "the root pyproject.toml has no [tool.uv.workspace] table; Turborepo's Python support \
              requires a uv workspace, so no Python packages were discovered"
@@ -814,65 +770,33 @@ pub fn discover_workspace(repo_root: &AbsoluteSystemPath) -> Result<DiscoveredWo
             quality_plan: QualityPlan::default(),
             pytest: None,
         });
-    };
+    }
 
-    let manifest_paths = member_manifest_paths(repo_root, workspace)?;
     let real_repo_root = repo_root.to_realpath()?;
-    let real_root_manifest = root_manifest_path.to_realpath()?;
-    let mut parsed: Vec<(String, AbsoluteSystemPathBuf, PyProjectManifest)> = Vec::new();
-    let mut seen: HashMap<String, AbsoluteSystemPathBuf> = HashMap::new();
-    for manifest_path in manifest_paths {
-        let real_manifest = manifest_path.to_realpath()?;
-        if real_manifest == real_root_manifest {
-            // The root is never a member of itself through globs; its
-            // [project] (when present) participates only through the
-            // workspace package.
+    let mut parsed = Vec::new();
+    let mut root_project_name = None;
+    for member in &metadata.members {
+        let member_path = AbsoluteSystemPathBuf::from_cwd(&member.path)?;
+        let real_member = member_path.to_realpath()?;
+        if !real_member.starts_with(&real_repo_root) {
+            return Err(Error::MetadataMemberOutsideRepository(member.path.clone()));
+        }
+        let normalized = normalize_name(&member.name);
+        if real_member == real_repo_root {
+            root_project_name = Some(normalized);
             continue;
         }
-        if !real_manifest.starts_with(&real_repo_root) {
-            tracing::warn!(
-                "skipping uv workspace member {manifest_path}: it resolves outside the repository"
-            );
-            continue;
-        }
+        let manifest_path = member_path.join_component(PYPROJECT_TOML);
         let Some(manifest) = PyProjectManifest::load(&manifest_path)? else {
             continue;
         };
-        let Some(project_name) = manifest.project_name() else {
-            tracing::warn!(
-                "skipping uv workspace member {manifest_path}: pyproject.toml has no [project] \
-                 name"
-            );
-            continue;
-        };
-        let normalized = normalize_name(project_name);
-        if normalized.is_empty() {
-            tracing::warn!(
-                "skipping uv workspace member {manifest_path}: invalid package name \
-                 {project_name:?}"
-            );
-            continue;
-        }
-        if let Some(first) = seen.get(&normalized) {
-            return Err(Error::DuplicateMemberName {
-                name: normalized,
-                first: first.to_string(),
-                second: manifest_path.to_string(),
-            });
-        }
-        seen.insert(normalized.clone(), manifest_path.clone());
         parsed.push((normalized, manifest_path, manifest));
     }
     parsed.sort_by(|left, right| left.0.cmp(&right.0));
 
-    let root_project_name = root_manifest
-        .project_name()
-        .map(normalize_name)
-        .filter(|name| !name.is_empty());
-    let member_names: HashSet<String> = parsed.iter().map(|(name, _, _)| name.clone()).collect();
     let root_tools = root_manifest.tool_declarations(DeclarationOwner::Root);
     let pytest = root_tools.execution(PythonTool::Pytest);
-    let packages = connect_packages(parsed, &member_names, &root_manifest, &root_tools);
+    let packages = connect_packages(parsed, metadata, &root_tools);
     let quality_plan = QualityPlan::homogeneous(
         &packages
             .iter()
@@ -911,83 +835,68 @@ pub fn discover_workspace(repo_root: &AbsoluteSystemPath) -> Result<DiscoveredWo
     })
 }
 
-/// Expand `[tool.uv.workspace]` member globs into member `pyproject.toml`
-/// paths, subtracting the exclude globs.
-fn member_manifest_paths(
-    repo_root: &AbsoluteSystemPath,
-    workspace: &UvWorkspaceTable,
-) -> Result<Vec<AbsoluteSystemPathBuf>, Error> {
-    const MAX_WORKSPACE_GLOBS: usize = 1024;
-    const MAX_WORKSPACE_GLOB_BYTES: usize = 4096;
-    const MAX_WORKSPACE_MEMBERS: usize = 10_000;
-
-    if workspace.members.len() + workspace.exclude.len() > MAX_WORKSPACE_GLOBS {
-        return Err(Error::TooManyWorkspaceGlobs(MAX_WORKSPACE_GLOBS));
-    }
-    for pattern in workspace.members.iter().chain(&workspace.exclude) {
-        if pattern.len() > MAX_WORKSPACE_GLOB_BYTES {
-            return Err(Error::WorkspaceGlobTooLong(MAX_WORKSPACE_GLOB_BYTES));
-        }
-        validate_workspace_pattern(pattern)?;
-    }
-    let inclusions = workspace
-        .members
-        .iter()
-        .map(|member| {
-            let mut glob = member.clone();
-            if !glob.ends_with('/') {
-                glob.push('/');
-            }
-            glob.push_str(PYPROJECT_TOML);
-            globwalk::ValidatedGlob::from_str(&glob)
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-    let exclusions = workspace
-        .exclude
-        .iter()
-        .map(|exclude| globwalk::ValidatedGlob::from_str(exclude))
-        .collect::<Result<Vec<_>, _>>()?;
-    let mut paths: Vec<_> = globwalk::globwalk_with_settings(
-        repo_root,
-        &inclusions,
-        &exclusions,
-        globwalk::WalkType::Files,
-        globwalk::Settings::default(),
-    )?
-    .into_iter()
-    .collect();
-    if paths.len() > MAX_WORKSPACE_MEMBERS {
-        return Err(Error::TooManyWorkspaceMembers(MAX_WORKSPACE_MEMBERS));
-    }
-    paths.sort();
-    Ok(paths)
-}
-
-fn validate_workspace_pattern(pattern: &str) -> Result<(), Error> {
-    let bytes = pattern.as_bytes();
-    let has_windows_drive = bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':';
-    let is_unsafe = pattern.starts_with('/')
-        || pattern.starts_with('\\')
-        || has_windows_drive
-        || pattern
-            .split(['/', '\\'])
-            .any(|component| component == "..");
-    if is_unsafe {
-        return Err(Error::UnsafeWorkspaceGlob(pattern.to_string()));
-    }
-    Ok(())
-}
-
 /// Resolve dependency edges to package names. Dependency-group
 /// (development) edges that would form a cycle remain compilation inputs
 /// but do not order tasks, since PEP 735 groups permit cycles while the
 /// task graph is a DAG.
+fn metadata_internal_dependencies(
+    metadata: &UvWorkspaceMetadata,
+) -> HashMap<String, HashSet<String>> {
+    let members_by_id = metadata
+        .members
+        .iter()
+        .map(|member| (member.id.as_str(), normalize_name(&member.name)))
+        .collect::<HashMap<_, _>>();
+    metadata
+        .members
+        .iter()
+        .map(|member| {
+            let mut dependencies = HashSet::new();
+            let mut pending = metadata
+                .resolution
+                .get(&member.id)
+                .into_iter()
+                .flat_map(|node| {
+                    node.dependencies
+                        .iter()
+                        .chain(&node.optional_dependencies)
+                        .chain(&node.dependency_groups)
+                })
+                .map(|dependency| dependency.id.as_str())
+                .collect::<Vec<_>>();
+            let mut visited = HashSet::new();
+            while let Some(id) = pending.pop() {
+                if !visited.insert(id) {
+                    continue;
+                }
+                if let Some(name) = members_by_id.get(id) {
+                    dependencies.insert(name.clone());
+                    continue;
+                }
+                let Some(node) = metadata.resolution.get(id) else {
+                    continue;
+                };
+                if node.kind.is_object() {
+                    pending.extend(
+                        node.dependencies
+                            .iter()
+                            .chain(&node.optional_dependencies)
+                            .chain(&node.dependency_groups)
+                            .map(|dependency| dependency.id.as_str()),
+                    );
+                }
+            }
+            (normalize_name(&member.name), dependencies)
+        })
+        .collect()
+}
+
 fn connect_packages(
     parsed: Vec<(String, AbsoluteSystemPathBuf, PyProjectManifest)>,
-    member_names: &HashSet<String>,
-    root_manifest: &PyProjectManifest,
+    metadata: &UvWorkspaceMetadata,
     root_tools: &ToolDeclarations,
 ) -> Vec<UvPackage> {
+    let internal_dependencies = metadata_internal_dependencies(metadata);
     let mut graph = petgraph::Graph::<(), ()>::new();
     let node_indices: HashMap<&str, petgraph::graph::NodeIndex> = parsed
         .iter()
@@ -1003,12 +912,10 @@ fn connect_packages(
                 continue;
             };
             let to = normalize_name(dependency_name);
-            // A matching name is not enough: uv only resolves the dependency
-            // to this workspace when the effective source selects it.
             if to == *from
-                || !member_names.contains(&to)
-                || !effective_source(root_manifest, manifest, &to)
-                    .is_some_and(source_uses_current_workspace)
+                || !internal_dependencies
+                    .get(from)
+                    .is_some_and(|dependencies| dependencies.contains(&to))
             {
                 continue;
             }
@@ -1640,10 +1547,10 @@ fn has_untracked_uv_configuration(environment: &toolchain::TaskIOEnvironment) ->
 /// empty for the workspace package). Globs that don't match anything (e.g.
 /// a missing `.python-version`) simply contribute nothing.
 ///
-/// uv.lock is deliberately absent: locked dependencies participate in each
-/// package task's external-dependency hash, scoped to that package's
-/// transitive closure (see [`external_closures`]), so a dependency bump
-/// only invalidates the packages that actually depend on it.
+/// uv.lock is deliberately absent: uv workspace metadata supplies each package
+/// task's external-dependency hash, scoped to that package's transitive closure
+/// (see [`external_closures`]), so a dependency bump only invalidates packages
+/// that actually depend on it.
 pub fn hash_input_globs(prefix: &str) -> Vec<String> {
     [
         PYPROJECT_TOML,
@@ -2039,29 +1946,233 @@ fn toolchain_identities(repo_root: &AbsoluteSystemPath) -> Option<UvToolchainIde
     })
 }
 
-/// Per-package external dependency closures from uv.lock, for the packages'
-/// external-dependency hashes.
-///
-/// A missing, unreadable, or unparsable lockfile is a hard error — silently
-/// hashing nothing would be unsound.
-pub fn external_closures(
-    repo_root: &AbsoluteSystemPath,
-    members: &[String],
-    workspace_paths: &HashMap<String, String>,
-) -> Result<HashMap<String, HashSet<turborepo_lockfiles::Package>>, Error> {
-    let lock_path = repo_root.join_component(UV_LOCK);
-    let contents = match lock_path.read_to_string() {
-        Ok(contents) => contents,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => {
-            return Err(Error::MissingLockfile);
-        }
-        Err(error) => return Err(Error::LockfileRead(error)),
+#[derive(Debug, Clone, Deserialize)]
+struct UvWorkspaceMetadata {
+    members: Vec<UvMetadataMember>,
+    resolution: HashMap<String, UvMetadataNode>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct UvMetadataMember {
+    name: String,
+    path: String,
+    id: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct UvMetadataNode {
+    name: Option<String>,
+    version: Option<String>,
+    #[serde(default)]
+    kind: serde_json::Value,
+    source: Option<serde_json::Value>,
+    #[serde(default)]
+    dependencies: Vec<UvMetadataDependency>,
+    #[serde(default)]
+    optional_dependencies: Vec<UvMetadataDependency>,
+    #[serde(default)]
+    dependency_groups: Vec<UvMetadataDependency>,
+    sdist: Option<UvMetadataArtifact>,
+    #[serde(default)]
+    wheels: Vec<UvMetadataArtifact>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct UvMetadataDependency {
+    id: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct UvMetadataArtifact {
+    #[serde(default)]
+    hashes: BTreeMap<String, String>,
+}
+
+fn workspace_metadata(repo_root: &AbsoluteSystemPath) -> Result<UvWorkspaceMetadata, Error> {
+    let output = Command::new("uv")
+        .args([
+            "workspace",
+            "metadata",
+            "--frozen",
+            "--offline",
+            "--preview-features",
+            "workspace-metadata",
+        ])
+        .current_dir(repo_root.as_std_path())
+        .output()
+        .map_err(|error| Error::MetadataCommand(error.to_string()))?;
+    if !output.status.success() {
+        return Err(Error::MetadataCommand(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ));
+    }
+    serde_json::from_slice(&output.stdout).map_err(Error::MetadataParse)
+}
+
+pub fn discover_workspace(repo_root: &AbsoluteSystemPath) -> Result<DiscoveredWorkspace, Error> {
+    let root_manifest_path = repo_root.join_component(PYPROJECT_TOML);
+    let Some(root_manifest) = PyProjectManifest::load(&root_manifest_path)? else {
+        return Ok(empty_workspace(None));
     };
-    Ok(turborepo_lockfiles::uv_external_closures(
-        &contents,
-        members,
-        workspace_paths,
-    )?)
+    let name = workspace_name(&root_manifest)?;
+    if !root_manifest.has_workspace() {
+        return Ok(empty_workspace(name));
+    }
+    let metadata = workspace_metadata(repo_root)?;
+    discover_workspace_from_metadata(repo_root, &metadata)
+}
+
+fn empty_workspace(name: Option<String>) -> DiscoveredWorkspace {
+    DiscoveredWorkspace {
+        name,
+        packages: Vec::new(),
+        root_project_name: None,
+        quality_plan: QualityPlan::default(),
+        pytest: None,
+    }
+}
+
+fn canonical_json(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::Null => "null".to_string(),
+        serde_json::Value::Bool(value) => value.to_string(),
+        serde_json::Value::Number(value) => value.to_string(),
+        serde_json::Value::String(value) => value.clone(),
+        serde_json::Value::Array(values) => values
+            .iter()
+            .map(canonical_json)
+            .collect::<Vec<_>>()
+            .join(","),
+        serde_json::Value::Object(values) => {
+            let mut values = values.iter().collect::<Vec<_>>();
+            values.sort_unstable_by_key(|(key, _)| *key);
+            values
+                .into_iter()
+                .map(|(key, value)| format!("{key}={}", canonical_json(value)))
+                .collect::<Vec<_>>()
+                .join(",")
+        }
+    }
+}
+
+fn metadata_package_identity(node: &UvMetadataNode) -> Option<turborepo_lockfiles::Package> {
+    let source = node.source.as_ref()?.as_object()?;
+    let name = node.name.clone()?;
+    let mut version = node.version.clone().unwrap_or_default();
+    for (key, value) in source {
+        version.push(' ');
+        version.push_str(key);
+        version.push('+');
+        version.push_str(&canonical_json(value));
+    }
+    let mut hashes = node
+        .sdist
+        .iter()
+        .chain(&node.wheels)
+        .flat_map(|artifact| &artifact.hashes)
+        .map(|(algorithm, hash)| format!("{algorithm}:{hash}"))
+        .collect::<Vec<_>>();
+    hashes.sort_unstable();
+    hashes.dedup();
+    for hash in hashes {
+        version.push(' ');
+        version.push_str(&hash);
+    }
+    Some(turborepo_lockfiles::Package { key: name, version })
+}
+
+fn collect_metadata_nodes<'a>(
+    metadata: &'a UvWorkspaceMetadata,
+    root: &'a str,
+    visited: &mut HashSet<&'a str>,
+) -> Result<(), Error> {
+    let mut pending = vec![root];
+    while let Some(id) = pending.pop() {
+        if !visited.insert(id) {
+            continue;
+        }
+        let node = metadata
+            .resolution
+            .get(id)
+            .ok_or_else(|| Error::UnknownMetadataNode(id.to_string()))?;
+        pending.extend(
+            node.dependencies
+                .iter()
+                .chain(&node.optional_dependencies)
+                .chain(&node.dependency_groups)
+                .map(|dependency| dependency.id.as_str()),
+        );
+    }
+    Ok(())
+}
+
+fn metadata_closure(
+    metadata: &UvWorkspaceMetadata,
+    root: &str,
+) -> Result<HashSet<turborepo_lockfiles::Package>, Error> {
+    let member_ids = metadata
+        .members
+        .iter()
+        .map(|member| member.id.as_str())
+        .collect::<HashSet<_>>();
+    let mut pending = vec![root];
+    let mut visited = HashSet::new();
+    let mut packages = HashSet::new();
+    while let Some(id) = pending.pop() {
+        if !visited.insert(id) {
+            continue;
+        }
+        let node = metadata
+            .resolution
+            .get(id)
+            .ok_or_else(|| Error::UnknownMetadataNode(id.to_string()))?;
+        let is_local = node
+            .source
+            .as_ref()
+            .and_then(serde_json::Value::as_object)
+            .is_some_and(|source| {
+                source.keys().any(|key| {
+                    matches!(key.as_str(), "editable" | "virtual" | "directory" | "path")
+                })
+            });
+        if is_local && node.kind == "package" && !member_ids.contains(id) {
+            return Err(Error::UnsupportedLocalMetadataNode(id.to_string()));
+        }
+        if !is_local {
+            if let Some(package) = metadata_package_identity(node) {
+                packages.insert(package);
+            }
+        }
+        pending.extend(
+            node.dependencies
+                .iter()
+                .chain(&node.optional_dependencies)
+                .chain(&node.dependency_groups)
+                .map(|dependency| dependency.id.as_str()),
+        );
+    }
+    Ok(packages)
+}
+
+/// Per-package external dependency closures from uv's supported metadata API.
+fn external_closures(
+    metadata: &UvWorkspaceMetadata,
+    members: &[String],
+) -> Result<HashMap<String, HashSet<turborepo_lockfiles::Package>>, Error> {
+    let member_ids = metadata
+        .members
+        .iter()
+        .map(|member| (normalize_name(&member.name), member.id.as_str()))
+        .collect::<HashMap<_, _>>();
+    members
+        .iter()
+        .map(|member| {
+            let id = member_ids
+                .get(member)
+                .ok_or_else(|| Error::UnknownMetadataNode(member.clone()))?;
+            Ok((member.clone(), metadata_closure(&metadata, id)?))
+        })
+        .collect()
 }
 
 fn read_lockfile(repo_root: &AbsoluteSystemPath) -> Result<String, Error> {
@@ -2163,6 +2274,7 @@ struct UvPruneKnowledge {
     root_manifest: String,
     package_directories: HashMap<String, String>,
     root_project_name: Option<String>,
+    metadata: UvWorkspaceMetadata,
 }
 
 impl UvPruneKnowledge {
@@ -2171,6 +2283,7 @@ impl UvPruneKnowledge {
         package_directories: HashMap<String, String>,
         root_project_name: Option<String>,
         lockfile: String,
+        metadata: UvWorkspaceMetadata,
     ) -> Result<Self, Error> {
         let root_manifest = repo_root
             .join_component(PYPROJECT_TOML)
@@ -2185,6 +2298,7 @@ impl UvPruneKnowledge {
             root_manifest,
             package_directories,
             root_project_name,
+            metadata,
         })
     }
 }
@@ -2202,18 +2316,48 @@ impl PruneDomain for UvPruneKnowledge {
             return Ok(None);
         }
         let failed = |error: Error| crate::prune_knowledge::Error::Failed(Box::new(error));
+        let requested_packages: HashSet<&str> = kept_packages.iter().map(String::as_str).collect();
         let mut roots = kept_packages.to_vec();
         if let Some(root_project) = &self.root_project_name {
             roots.push(root_project.clone());
         }
+        let member_ids = self
+            .metadata
+            .members
+            .iter()
+            .map(|member| (normalize_name(&member.name), member.id.as_str()))
+            .collect::<HashMap<_, _>>();
+        let mut reachable = HashSet::new();
+        for root in &roots {
+            let id = member_ids
+                .get(root)
+                .ok_or_else(|| failed(Error::UnknownMetadataNode(root.clone())))?;
+            collect_metadata_nodes(&self.metadata, id, &mut reachable).map_err(failed)?;
+        }
+        let kept_packages = reachable
+            .iter()
+            .filter_map(|id| self.metadata.resolution.get(*id))
+            .filter_map(|node| {
+                Some(turborepo_lockfiles::UvPackageKey {
+                    name: node.name.clone()?,
+                    version: node.version.clone(),
+                })
+            })
+            .collect::<HashSet<_>>();
+        let members = self
+            .metadata
+            .members
+            .iter()
+            .filter(|member| reachable.contains(member.id.as_str()))
+            .map(|member| normalize_name(&member.name))
+            .collect::<HashSet<_>>();
         let pruned_lock =
-            turborepo_lockfiles::uv_prune_lock(&self.lockfile, &roots, &self.package_directories)
+            turborepo_lockfiles::uv_prune_lock(&self.lockfile, &kept_packages, &members)
                 .map_err(|error| failed(Error::Lockfile(error)))?;
 
         let mut kept_dirs = Vec::with_capacity(pruned_lock.members.len());
         let mut kept_names = HashSet::with_capacity(pruned_lock.members.len());
         let mut extra_packages = Vec::new();
-        let requested_packages: HashSet<&str> = kept_packages.iter().map(String::as_str).collect();
         for member in &pruned_lock.members {
             if self.root_project_name.as_deref() == Some(member.as_str()) {
                 kept_names.insert(member.clone());
@@ -2293,12 +2437,14 @@ impl RepositoryContributor for UvContributor {
 
     fn discover_packages(&self) -> DiscoverPackagesFuture<'_> {
         Box::pin(async move {
-            // Discovery reads manifests and walks member globs
-            // synchronously, so keep it off the async runtime like the
-            // JavaScript manifest-parsing path.
-            let workspace =
-                turborepo_rayon_compat::block_in_place(|| discover_workspace(&self.repo_root))
-                    .map_err(|err| toolchain::Error::Failed(Box::new(err)))?;
+            // uv owns workspace membership and external resolution. Invoke its
+            // metadata command once, then parse manifests only for task details.
+            let (metadata, workspace) = turborepo_rayon_compat::block_in_place(|| {
+                let metadata = workspace_metadata(&self.repo_root)?;
+                let workspace = discover_workspace_from_metadata(&self.repo_root, &metadata)?;
+                Ok::<_, Error>((metadata, workspace))
+            })
+            .map_err(|err| toolchain::Error::Failed(Box::new(err)))?;
             let workspace_roots = self
                 .repo_root
                 .join_component(PYPROJECT_TOML)
@@ -2348,6 +2494,7 @@ impl RepositoryContributor for UvContributor {
                 package_directories.clone(),
                 workspace.root_project_name.clone(),
                 lockfile.clone(),
+                metadata.clone(),
             )
             .map_err(|error| toolchain::Error::Failed(Box::new(error)))?;
 
@@ -2365,13 +2512,8 @@ impl RepositoryContributor for UvContributor {
             if let Some(root_project) = &workspace.root_project_name {
                 closure_members.push(root_project.clone());
             }
-            let mut closures = turborepo_lockfiles::uv_external_closures(
-                &lockfile,
-                &closure_members,
-                &package_directories,
-            )
-            .map_err(Error::from)
-            .map_err(|err| toolchain::Error::Failed(Box::new(err)))?;
+            let mut closures = external_closures(&metadata, &closure_members)
+                .map_err(|err| toolchain::Error::Failed(Box::new(err)))?;
             let toolchain_identity =
                 turborepo_rayon_compat::block_in_place(|| toolchain_identities(&self.repo_root));
             let toolchain_identified = toolchain_identity.is_some();
@@ -2516,6 +2658,77 @@ mod test {
 
     use super::*;
     use crate::package_graph::{PackageName, PackageTaskContext, PackageTaskContextKind};
+
+    #[test]
+    fn test_workspace_metadata_external_closures() {
+        let metadata: UvWorkspaceMetadata = serde_json::from_value(serde_json::json!({
+            "members": [{ "name": "app", "path": "/workspace/app", "id": "app" }],
+            "resolution": {
+                "app": {
+                    "name": "app",
+                    "version": "0.1.0",
+                    "source": { "editable": "/workspace/app" },
+                    "dependencies": [{ "id": "six" }]
+                },
+                "six": {
+                    "name": "six",
+                    "version": "1.17.0",
+                    "source": { "registry": { "url": "https://pypi.org/simple" } },
+                    "dependencies": [],
+                    "sdist": { "hashes": { "sha256": "sdist" } },
+                    "wheels": [{ "hashes": { "sha256": "wheel" } }]
+                }
+            }
+        }))
+        .unwrap();
+
+        let closure = metadata_closure(&metadata, "app").unwrap();
+        assert_eq!(closure.len(), 1);
+        let package = closure.iter().next().unwrap();
+        assert_eq!(package.key, "six");
+        assert_eq!(
+            package.version,
+            "1.17.0 registry+url=https://pypi.org/simple sha256:sdist sha256:wheel"
+        );
+    }
+
+    #[test]
+    fn test_workspace_metadata_unknown_node_errors() {
+        let metadata = UvWorkspaceMetadata {
+            members: Vec::new(),
+            resolution: HashMap::new(),
+        };
+        assert!(matches!(
+            metadata_closure(&metadata, "missing"),
+            Err(Error::UnknownMetadataNode(node)) if node == "missing"
+        ));
+    }
+
+    #[test]
+    fn test_workspace_metadata_rejects_non_workspace_local_dependency() {
+        let metadata: UvWorkspaceMetadata = serde_json::from_value(serde_json::json!({
+            "members": [{ "name": "app", "path": "/workspace/app", "id": "app" }],
+            "resolution": {
+                "app": {
+                    "name": "app",
+                    "kind": "package",
+                    "source": { "editable": "/workspace/app" },
+                    "dependencies": [{ "id": "shared" }]
+                },
+                "shared": {
+                    "name": "shared",
+                    "kind": "package",
+                    "source": { "directory": "/shared" },
+                    "dependencies": []
+                }
+            }
+        }))
+        .unwrap();
+        assert!(matches!(
+            metadata_closure(&metadata, "app"),
+            Err(Error::UnsupportedLocalMetadataNode(node)) if node == "shared"
+        ));
+    }
 
     fn resolved_args(
         task: &crate::native_tasks::NativeTask,
@@ -2998,6 +3211,14 @@ version = "0.1.0"
         let tempdir = tempfile::tempdir().unwrap();
         let root = AbsoluteSystemPathBuf::try_from(tempdir.path()).unwrap();
         write_workspace(&root);
+        let locked = Command::new("uv")
+            .args(["lock", "--offline"])
+            .current_dir(root.as_std_path())
+            .status()
+            .is_ok_and(|status| status.success());
+        if !locked {
+            return;
+        }
 
         let workspace = discover_workspace(&root).unwrap();
         assert_eq!(workspace.name.as_deref(), Some("acme"));
@@ -3105,185 +3326,6 @@ version = "0.1.0"
     }
 
     #[test]
-    fn test_dev_cycle_breaks_deterministically() {
-        let tempdir = tempfile::tempdir().unwrap();
-        let root = AbsoluteSystemPathBuf::try_from(tempdir.path()).unwrap();
-        root.join_component(PYPROJECT_TOML)
-            .create_with_contents(
-                r#"
-[tool.turbo]
-name = "acme"
-
-[tool.uv.workspace]
-members = ["packages/*"]
-"#,
-            )
-            .unwrap();
-        for (name, dependencies, group) in [
-            ("pkg-a", r#"["pkg-b"]"#, "[]"),
-            ("pkg-b", "[]", r#"["pkg-a"]"#),
-        ] {
-            let source = if name == "pkg-a" { "pkg-b" } else { "pkg-a" };
-            let dir = root.join_components(&["packages", name]);
-            dir.create_dir_all().unwrap();
-            dir.join_component(PYPROJECT_TOML)
-                .create_with_contents(format!(
-                    r#"
-[project]
-name = "{name}"
-version = "0.1.0"
-dependencies = {dependencies}
-
-[dependency-groups]
-dev = {group}
-
-[tool.uv.sources]
-{source} = {{ workspace = true }}
-"#
-                ))
-                .unwrap();
-        }
-
-        let workspace = discover_workspace(&root).unwrap();
-        let pkg_a = &workspace.packages[0];
-        let pkg_b = &workspace.packages[1];
-        // a -> b is a production edge; b -> a is a dev edge that would form
-        // a cycle, so it demotes to a non-ordering input edge.
-        assert!(pkg_a.relationships[0].orders_tasks());
-        assert!(!pkg_b.relationships[0].orders_tasks());
-    }
-
-    #[test]
-    fn test_internal_edges_require_workspace_source() {
-        let tempdir = tempfile::tempdir().unwrap();
-        let root = AbsoluteSystemPathBuf::try_from(tempdir.path()).unwrap();
-        root.join_component(PYPROJECT_TOML)
-            .create_with_contents(
-                r#"
-[tool.turbo]
-name = "acme"
-
-[tool.uv.workspace]
-members = ["packages/*"]
-
-[tool.uv.sources]
-inherited = { workspace = true }
-overridden = { workspace = true }
-"#,
-            )
-            .unwrap();
-        for (name, contents) in [
-            (
-                "app",
-                r#"
-[project]
-name = "app"
-dependencies = ["inherited", "overridden", "same-name"]
-
-[tool.uv.sources]
-overridden = { index = "private" }
-"#,
-            ),
-            ("inherited", "[project]\nname = \"inherited\"\n"),
-            ("overridden", "[project]\nname = \"overridden\"\n"),
-            ("same-name", "[project]\nname = \"same-name\"\n"),
-        ] {
-            let dir = root.join_components(&["packages", name]);
-            dir.create_dir_all().unwrap();
-            dir.join_component(PYPROJECT_TOML)
-                .create_with_contents(contents)
-                .unwrap();
-        }
-
-        let workspace = discover_workspace(&root).unwrap();
-        let app = workspace
-            .packages
-            .iter()
-            .find(|package| package.name == "app")
-            .unwrap();
-        assert_eq!(app.relationships.len(), 1);
-        assert_eq!(app.relationships[0].declaration_name(), "inherited");
-    }
-
-    #[test]
-    fn test_legacy_uv_dev_dependencies_create_edges() {
-        let tempdir = tempfile::tempdir().unwrap();
-        let root = AbsoluteSystemPathBuf::try_from(tempdir.path()).unwrap();
-        root.join_component(PYPROJECT_TOML)
-            .create_with_contents(
-                "[tool.turbo]\nname = \"acme\"\n[tool.uv.workspace]\nmembers = [\"packages/*\"]\n",
-            )
-            .unwrap();
-        for (name, contents) in [
-            (
-                "app",
-                "[project]\nname = \"app\"\n[tool.uv]\ndev-dependencies = \
-                 [\"lib\"]\n[tool.uv.sources]\nlib = { workspace = true }\n",
-            ),
-            ("lib", "[project]\nname = \"lib\"\n"),
-        ] {
-            let dir = root.join_components(&["packages", name]);
-            dir.create_dir_all().unwrap();
-            dir.join_component(PYPROJECT_TOML)
-                .create_with_contents(contents)
-                .unwrap();
-        }
-        let workspace = discover_workspace(&root).unwrap();
-        assert_eq!(workspace.packages[0].relationships.len(), 1);
-        assert_eq!(
-            workspace.packages[0].relationships[0].declaration_name(),
-            "lib"
-        );
-    }
-
-    #[test]
-    fn test_unsafe_workspace_globs_are_rejected() {
-        for pattern in ["../outside", "/outside", "C:/outside", r"..\outside"] {
-            let tempdir = tempfile::tempdir().unwrap();
-            let root = AbsoluteSystemPathBuf::try_from(tempdir.path()).unwrap();
-            root.join_component(PYPROJECT_TOML)
-                .create_with_contents(format!("[tool.uv.workspace]\nmembers = [{pattern:?}]\n"))
-                .unwrap();
-            assert!(matches!(
-                discover_workspace(&root),
-                Err(Error::UnsafeWorkspaceGlob(_))
-            ));
-        }
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn test_recursive_glob_does_not_follow_external_symlink() {
-        use std::os::unix::fs::symlink;
-
-        let tempdir = tempfile::tempdir().unwrap();
-        let temp_root = AbsoluteSystemPathBuf::try_from(tempdir.path()).unwrap();
-        let root = temp_root.join_component("repo");
-        root.create_dir_all().unwrap();
-        root.join_component(PYPROJECT_TOML)
-            .create_with_contents(
-                "[tool.turbo]\nname = \"acme\"\n[tool.uv.workspace]\nmembers = [\"packages/**\"]\n",
-            )
-            .unwrap();
-        let outside = temp_root.join_component("outside");
-        outside.create_dir_all().unwrap();
-        outside
-            .join_component(PYPROJECT_TOML)
-            .create_with_contents("[project]\nname = \"outside\"\n")
-            .unwrap();
-        let packages = root.join_component("packages");
-        packages.create_dir_all().unwrap();
-        symlink(
-            outside.as_std_path(),
-            packages.join_component("external").as_std_path(),
-        )
-        .unwrap();
-
-        let workspace = discover_workspace(&root).unwrap();
-        assert!(workspace.packages.is_empty());
-    }
-
-    #[test]
     fn test_uv_path_environment_disables_automatic_inputs() {
         let environment = toolchain::TaskIOEnvironment::new(HashMap::from([(
             "UV_CONFIG_FILE".to_string(),
@@ -3351,47 +3393,6 @@ overridden = { index = "private" }
             .unwrap();
         let workspace = discover_workspace(&root).unwrap();
         assert!(workspace.packages.is_empty());
-    }
-
-    #[test]
-    fn test_duplicate_normalized_names_error() {
-        let tempdir = tempfile::tempdir().unwrap();
-        let root = AbsoluteSystemPathBuf::try_from(tempdir.path()).unwrap();
-        root.join_component(PYPROJECT_TOML)
-            .create_with_contents("[tool.uv.workspace]\nmembers = [\"packages/*\"]\n")
-            .unwrap();
-        for (dir, name) in [("one", "my_pkg"), ("two", "My-Pkg")] {
-            let package_dir = root.join_components(&["packages", dir]);
-            package_dir.create_dir_all().unwrap();
-            package_dir
-                .join_component(PYPROJECT_TOML)
-                .create_with_contents(format!(
-                    "[project]\nname = \"{name}\"\nversion = \"0.1.0\"\n"
-                ))
-                .unwrap();
-        }
-        let error = discover_workspace(&root).unwrap_err();
-        assert!(matches!(error, Error::DuplicateMemberName { .. }));
-    }
-
-    #[test]
-    fn test_workspace_name_collision_errors() {
-        let tempdir = tempfile::tempdir().unwrap();
-        let root = AbsoluteSystemPathBuf::try_from(tempdir.path()).unwrap();
-        root.join_component(PYPROJECT_TOML)
-            .create_with_contents(
-                "[tool.turbo]\nname = \"py-app\"\n\n[tool.uv.workspace]\nmembers = \
-                 [\"packages/*\"]\n",
-            )
-            .unwrap();
-        let package_dir = root.join_components(&["packages", "py-app"]);
-        package_dir.create_dir_all().unwrap();
-        package_dir
-            .join_component(PYPROJECT_TOML)
-            .create_with_contents("[project]\nname = \"py-app\"\nversion = \"0.1.0\"\n")
-            .unwrap();
-        let error = discover_workspace(&root).unwrap_err();
-        assert!(matches!(error, Error::WorkspaceNameCollision { .. }));
     }
 
     #[test]

--- a/crates/turborepo-repository/src/uv.rs
+++ b/crates/turborepo-repository/src/uv.rs
@@ -2138,10 +2138,8 @@ fn metadata_closure(
         if is_local && node.kind == "package" && !member_ids.contains(id) {
             return Err(Error::UnsupportedLocalMetadataNode(id.to_string()));
         }
-        if !is_local {
-            if let Some(package) = metadata_package_identity(node) {
-                packages.insert(package);
-            }
+        if !is_local && let Some(package) = metadata_package_identity(node) {
+            packages.insert(package);
         }
         pending.extend(
             node.dependencies
@@ -2170,7 +2168,7 @@ fn external_closures(
             let id = member_ids
                 .get(member)
                 .ok_or_else(|| Error::UnknownMetadataNode(member.clone()))?;
-            Ok((member.clone(), metadata_closure(&metadata, id)?))
+            Ok((member.clone(), metadata_closure(metadata, id)?))
         })
         .collect()
 }

--- a/crates/turborepo-repository/src/uv.rs
+++ b/crates/turborepo-repository/src/uv.rs
@@ -1753,6 +1753,8 @@ impl UvTaskContract {
 struct UvPythonIdentity {
     key: String,
     version: String,
+    #[serde(skip_serializing)]
+    path: String,
     os: String,
     variant: String,
     implementation: String,
@@ -1814,11 +1816,18 @@ fn bundled_uv_build_matches(requirement: &str, uv_version: &node_semver::Version
     node_semver::Range::parse(range.join(" ")).is_ok_and(|range| range.satisfies(uv_version))
 }
 
-fn parse_python_identity(stdout: &str, binary_sha256: String, host: String) -> Option<String> {
-    let [mut identity]: [UvPythonIdentity; 1] = serde_json::from_str::<Vec<_>>(stdout)
+fn parse_python_identity(
+    stdout: &str,
+    python_path: &std::path::Path,
+    binary_sha256: String,
+    host: String,
+) -> Option<String> {
+    let mut identity = serde_json::from_str::<Vec<UvPythonIdentity>>(stdout)
         .ok()?
-        .try_into()
-        .ok()?;
+        .into_iter()
+        .find(|identity| {
+            dunce::canonicalize(&identity.path).is_ok_and(|path| path == python_path)
+        })?;
     identity.binary_sha256 = binary_sha256;
     identity.host = host;
     serde_json::to_string(&identity).ok()
@@ -1927,11 +1936,11 @@ fn toolchain_identities(repo_root: &AbsoluteSystemPath) -> Option<UvToolchainIde
             "--only-installed",
             "--output-format",
             "json",
-            python_path.to_str()?,
         ])
         .current_dir(repo_root.as_std_path());
     let python_identity = successful_stdout(python_identity)?;
-    let python_identity = parse_python_identity(&python_identity, python_sha256, host)?;
+    let python_identity =
+        parse_python_identity(&python_identity, &python_path, python_sha256, host)?;
 
     Some(UvToolchainIdentity {
         packages: [
@@ -3345,8 +3354,13 @@ version = "0.1.0"
 
     #[test]
     fn test_python_identity_omits_installation_paths() {
+        let python_path = dunce::canonicalize(std::env::current_exe().unwrap()).unwrap();
         let identity = parse_python_identity(
-            r#"[{"key":"cpython-3.13.11-linux-x86_64-gnu","version":"3.13.11","path":"/home/user/.local/python","symlink":null,"url":null,"os":"linux","variant":"default","implementation":"cpython","arch":"x86_64","libc":"gnu"}]"#,
+            &format!(
+                r#"[{{"key":"cpython-3.13.10-linux-x86_64-gnu","version":"3.13.10","path":"/other/python","os":"linux","variant":"default","implementation":"cpython","arch":"x86_64","libc":"gnu"}},{{"key":"cpython-3.13.11-linux-x86_64-gnu","version":"3.13.11","path":{},"os":"linux","variant":"default","implementation":"cpython","arch":"x86_64","libc":"gnu"}}]"#,
+                serde_json::to_string(&python_path).unwrap()
+            ),
+            &python_path,
             "binary-hash".to_string(),
             "host-identity".to_string(),
         )

--- a/crates/turborepo-repository/src/uv.rs
+++ b/crates/turborepo-repository/src/uv.rs
@@ -1888,7 +1888,9 @@ fn successful_stdout(mut command: Command) -> Option<String> {
 /// workspace. Discovery remains available without either binary, but native
 /// command tasks stay uncached until both identities can be proven.
 fn toolchain_identities(repo_root: &AbsoluteSystemPath) -> Option<UvToolchainIdentity> {
-    let uv = std::fs::canonicalize(which::which("uv").ok()?).ok()?;
+    // Avoid Windows verbatim (`\\?\`) paths: uv does not match them against
+    // the ordinary paths returned by `uv python list`.
+    let uv = dunce::canonicalize(which::which("uv").ok()?).ok()?;
     if uv.starts_with(repo_root.as_std_path()) {
         return None;
     }
@@ -1913,7 +1915,7 @@ fn toolchain_identities(repo_root: &AbsoluteSystemPath) -> Option<UvToolchainIde
         .args(["python", "find", "--resolve-links", "--no-python-downloads"])
         .current_dir(repo_root.as_std_path());
     let python = successful_stdout(python)?;
-    let python_path = std::fs::canonicalize(&python).ok()?;
+    let python_path = dunce::canonicalize(&python).ok()?;
     let python_sha256 = file_sha256(&python_path)?;
     let host = host_compatibility_identity()?;
 

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -656,10 +656,11 @@ involved. `UvContributor` contributes pre-classified relationships, native
 tasks, external resolution, change observations, and a prune domain through
 the shared repository graph.
 
-- **Discovery** parses `[tool.uv.workspace] members` and `exclude` globs
-  in-process, so graph construction does not require the `uv` binary. When uv
-  is available, discovery probes its version and the Python interpreter selected
-  by `uv python find` for cache identity. Missing identities and repository-local
+- **Discovery** invokes `uv workspace metadata --frozen --offline` once and uses
+  its member list and resolution graph as authoritative. Turborepo parses each
+  returned `pyproject.toml` only for task/tool declarations and dependency-kind
+  labels. Discovery also probes uv and the Python interpreter selected by
+  `uv python find` for cache identity. Missing identities and repository-local
   uv executables fail closed to uncached tasks. Names are PEP 503-normalized.
   Dependencies become internal graph edges only when
   their effective `[tool.uv.sources]` entry selects `workspace = true`.
@@ -727,10 +728,13 @@ the shared repository graph.
   Quality caches, `.pytest_cache`, `.venv`, and `__pycache__` are excluded.
   Path-valued uv settings, `UV_NO_SYNC`, `UV_NO_PROJECT`, active user/system uv
   configuration, and any pass-through arguments make automatic inputs
-  untracked. Each scope also hashes its external
-  dependency closure from `uv.lock`; root-owned tools conservatively add the
-  workspace closure. Package identities include version, source, and artifact
-  hashes. Every scope also includes path-independent uv and Python identities
+  untracked. Turborepo invokes `uv workspace metadata --frozen --offline` and
+  hashes each scope's external dependency closure from uv's JSON resolution
+  graph; root-owned tools conservatively add the workspace closure. Package
+  identities include version, source, and artifact hashes. Turborepo therefore
+  does not interpret `uv.lock` for task hashing; pruning also uses metadata for
+  reachability and only parses TOML to filter selected package tables. Every scope also
+  includes path-independent uv and Python identities
   containing executable content hashes, Python implementation and version,
   operating system, architecture, libc, variant, and host compatibility. A `uv.lock` change across git refs conservatively affects
   all uv packages. Build output inference covers the bare command's matching
@@ -738,11 +742,13 @@ the shared repository graph.
 - **Watch mode** rediscoveries follow any `pyproject.toml`, the root `uv.lock`,
   `.python-version`, and `uv.toml`. Root `.venv/` and `dist/`, plus known quality-tool and Python cache
   directories at the root and member scopes, are ignored as task byproducts.
-- **Prune** walks `uv.lock` reachability, including dependency groups and
-  optional extras, and preserves retained package metadata through
-  `toml_edit`. It rewrites root workspace members, removes dangling uv source
-  entries, and copies `.python-version` and `uv.toml` when present. Reachable
-  local dependencies that are not workspace members fail closed.
+- **Prune** uses the same uv metadata graph for reachability, including
+  dependency groups and optional extras. It mechanically filters matching
+  `uv.lock` package tables with `toml_edit`, preserving retained metadata and
+  conservatively keeping all same-name/version forks. It rewrites root workspace
+  members, removes dangling uv source entries, and copies `.python-version` and
+  `uv.toml` when present. Reachable local dependencies that are not workspace
+  members fail closed.
 
 End-to-end coverage in `crates/turborepo/tests/uv_workspace_test.rs` exercises
 pure uv and mixed npm/uv repositories, graph shape, filtering, affectedness,


### PR DESCRIPTION
## Summary

- use `uv workspace metadata --frozen --offline` as the authoritative source for uv workspace membership and dependency graph semantics
- reuse one metadata snapshot for internal relationships, external dependency hashing, and prune reachability
- delete the custom uv lockfile resolver and reduce uv lockfile handling to mechanical TOML filtering for prune
- preserve same-name/version forks conservatively and keep non-workspace local dependencies fail-closed

Closes TURBO-5930.

## Tests

- `cargo test -p turborepo-lockfiles uv::test`
- `cargo test -p turborepo-repository uv::test -- --nocapture`
- `cargo check -p turborepo-repository`
- `cargo test -p turbo --test uv_workspace_test test_pure_uv_workspace_task_graph -- --nocapture`
- `cargo test -p turbo --test uv_workspace_test test_uv_packages_in_task_graph -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`

## Notes

`cargo test -p turbo --test uv_workspace_test test_uv_prune -- --nocapture` reaches the metadata-backed prune path, but uv 0.12.1 rejects the existing fixture because it applies a newer global `exclude-newer` value and considers the fixture lockfile stale.
