### PR TITLE
feat: Support Python virtual environments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8524,6 +8524,7 @@ dependencies = [
  "turborepo-task-id",
  "turborepo-turbo-json",
  "turborepo-types",
+ "wax",
  "which 4.4.0",
 ]
 

--- a/crates/turborepo-engine/Cargo.toml
+++ b/crates/turborepo-engine/Cargo.toml
@@ -29,6 +29,7 @@ turborepo-task-executor = { path = "../turborepo-task-executor" }
 turborepo-task-id = { path = "../turborepo-task-id" }
 turborepo-turbo-json = { path = "../turborepo-turbo-json" }
 turborepo-types = { workspace = true }
+wax = { workspace = true }
 which = { workspace = true }
 
 [dev-dependencies]

--- a/crates/turborepo-engine/src/builder/definitions.rs
+++ b/crates/turborepo-engine/src/builder/definitions.rs
@@ -11,6 +11,7 @@ use turborepo_turbo_json::{
     HasConfigBeyondExtends, ProcessedCommand, ProcessedTaskDefinition, RawTaskDefinition, TurboJson,
 };
 use turborepo_types::{TaskArgs, TaskCommandOverride, TaskDefinition};
+use wax::Program;
 
 use super::EngineBuilder;
 use crate::{
@@ -491,6 +492,7 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
                 wants_automatic_inputs,
                 &context,
             ) {
+                validate_forbidden_outputs(task_id.as_inner(), &task_def, &derived)?;
                 if task_io_env_exclusion_conflict(
                     &task_def.env,
                     &self.global_env,
@@ -837,6 +839,34 @@ fn task_io_env_exclusion_conflict(
         .map_or(true, |matches| !matches.exclusions.is_empty())
 }
 
+fn validate_forbidden_outputs(
+    task_id: &TaskId,
+    task_def: &TaskDefinition,
+    derived: &turborepo_repository::toolchain::DerivedTaskIO,
+) -> Result<(), BuilderError> {
+    for output in &task_def.outputs.inclusions {
+        let normalized = output.trim_start_matches("./");
+        let Some(environment) = derived
+            .forbidden_output_prefixes
+            .iter()
+            .find(|environment| {
+                wax::Glob::new(normalized).is_ok_and(|glob| {
+                    let probe = format!("{environment}/__turbo_venv_probe__");
+                    glob.is_match(environment.as_str()) || glob.is_match(probe.as_str())
+                })
+            })
+        else {
+            continue;
+        };
+        return Err(BuilderError::PythonVirtualEnvironmentOutput {
+            task_id: task_id.to_string(),
+            environment: environment.clone(),
+            output: output.clone(),
+        });
+    }
+    Ok(())
+}
+
 fn apply_derived_task_io(
     task_def: &mut TaskDefinition,
     derived: turborepo_repository::toolchain::DerivedTaskIO,
@@ -1054,9 +1084,10 @@ mod command_override_tests {
 #[cfg(test)]
 mod derived_io_tests {
     use turborepo_repository::toolchain::{DerivedInputSafety, DerivedOutputs, DerivedTaskIO};
+    use turborepo_task_id::TaskId;
     use turborepo_types::TaskDefinition;
 
-    use super::apply_derived_task_io;
+    use super::{apply_derived_task_io, validate_forbidden_outputs};
 
     #[test]
     fn unavailable_outputs_disable_only_implicit_caching() {
@@ -1116,6 +1147,24 @@ mod derived_io_tests {
             apply_derived_task_io(&mut explicit_cache, untracked(), &[], true, true);
             assert_eq!(explicit_cache.cache, cache);
         }
+    }
+
+    #[test]
+    fn virtual_environment_outputs_are_rejected() {
+        let task_id = TaskId::new("py-app", "build");
+        let derived = DerivedTaskIO {
+            forbidden_output_prefixes: vec!["../../.venv".to_string()],
+            ..Default::default()
+        };
+        for output in ["../../.venv/**", "../../**"] {
+            let mut task = TaskDefinition::default();
+            task.outputs.inclusions.push(output.to_string());
+            assert!(validate_forbidden_outputs(&task_id, &task, &derived).is_err());
+        }
+
+        let mut task = TaskDefinition::default();
+        task.outputs.inclusions.push("dist/**".to_string());
+        assert!(validate_forbidden_outputs(&task_id, &task, &derived).is_ok());
     }
 
     #[test]

--- a/crates/turborepo-engine/src/builder_error.rs
+++ b/crates/turborepo-engine/src/builder_error.rs
@@ -69,6 +69,16 @@ pub enum Error {
         task_id: String,
         alternatives: String,
     },
+    #[error(
+        "Task `{task_id}` cannot cache Python virtual environment `{environment}` as output \
+         `{output}`. Virtual environments are machine-specific; remove this output and cache \
+         portable artifacts such as `dist/**` instead."
+    )]
+    PythonVirtualEnvironmentOutput {
+        task_id: String,
+        environment: String,
+        output: String,
+    },
 }
 
 impl From<ValidateError> for Error {

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -540,6 +540,8 @@ pub struct DerivedTaskIO {
     pub package_default_inputs: Option<bool>,
     /// Env vars that participate in the task hash.
     pub env: Vec<String>,
+    /// Directory prefixes that must not be cached as task outputs.
+    pub forbidden_output_prefixes: Vec<String>,
     pub input_safety: DerivedInputSafety,
     pub outputs: DerivedOutputs,
 }

--- a/crates/turborepo-repository/src/uv.rs
+++ b/crates/turborepo-repository/src/uv.rs
@@ -1855,6 +1855,16 @@ fn bundled_uv_build_matches(requirement: &str, uv_version: &node_semver::Version
     node_semver::Range::parse(range.join(" ")).is_ok_and(|range| range.satisfies(uv_version))
 }
 
+fn paths_equal(left: &std::path::Path, right: &std::path::Path) -> bool {
+    if cfg!(windows) {
+        left.as_os_str()
+            .to_string_lossy()
+            .eq_ignore_ascii_case(&right.as_os_str().to_string_lossy())
+    } else {
+        left == right
+    }
+}
+
 fn parse_python_identity(
     stdout: &str,
     python_path: &std::path::Path,
@@ -1865,7 +1875,7 @@ fn parse_python_identity(
         .ok()?
         .into_iter()
         .find(|identity| {
-            dunce::canonicalize(&identity.path).is_ok_and(|path| path == python_path)
+            dunce::canonicalize(&identity.path).is_ok_and(|path| paths_equal(&path, python_path))
         })?;
     identity.binary_sha256 = binary_sha256;
     identity.host = host;
@@ -3403,6 +3413,13 @@ version = "0.1.0"
             "true".to_string(),
         )]));
         assert!(has_untracked_uv_configuration(&no_sync));
+    }
+
+    #[test]
+    fn test_python_paths_follow_platform_case_sensitivity() {
+        let left = std::path::Path::new("C:/Users/RunnerAdmin/Python/python.exe");
+        let right = std::path::Path::new("c:/users/runneradmin/python/python.exe");
+        assert_eq!(paths_equal(left, right), cfg!(windows));
     }
 
     #[test]

--- a/crates/turborepo-repository/src/uv.rs
+++ b/crates/turborepo-repository/src/uv.rs
@@ -1184,7 +1184,11 @@ fn declared_tool_task(
     serial_group: Option<String>,
     toolchain_identified: bool,
 ) -> crate::native_tasks::NativeTask {
-    let mut prefix = vec!["run".to_string(), "--frozen".to_string()];
+    let mut prefix = vec![
+        "run".to_string(),
+        "--active".to_string(),
+        "--frozen".to_string(),
+    ];
     match execution.owner {
         ExecutionOwner::Root => {}
         ExecutionOwner::Member => {
@@ -1477,6 +1481,7 @@ pub const HASHED_ENV_VARS: &[&str] = &[
     "PIP_EXTRA_INDEX_URL",
     "PYTHONHOME",
     "PYTHONPATH",
+    "VIRTUAL_ENV",
 ];
 
 const UV_PATH_ENV_VARS: &[&str] = &[
@@ -1487,11 +1492,41 @@ const UV_PATH_ENV_VARS: &[&str] = &[
     "UV_EXCLUDE",
     "UV_OVERRIDE",
     "UV_PROJECT",
-    "UV_PROJECT_ENVIRONMENT",
     "UV_WORKING_DIR",
     "PYTHONHOME",
     "PYTHONPATH",
 ];
+
+fn effective_virtual_environment(environment: &toolchain::TaskIOEnvironment) -> &str {
+    environment
+        .get("VIRTUAL_ENV")
+        .filter(|path| !path.is_empty())
+        .or_else(|| {
+            environment
+                .get("UV_PROJECT_ENVIRONMENT")
+                .filter(|path| !path.is_empty())
+        })
+        .unwrap_or(".venv")
+}
+
+fn virtual_environment_path(
+    package: &crate::package_graph::PackageTaskContext<'_>,
+    environment: &toolchain::TaskIOEnvironment,
+) -> Option<String> {
+    let configured = effective_virtual_environment(environment);
+    let absolute = AbsoluteSystemPathBuf::from_unknown(package.repository_root(), configured);
+    let repo_root = package.repository_root().to_realpath().ok()?;
+    let absolute = absolute.to_realpath().unwrap_or(absolute);
+    let repo_relative = repo_root.anchor(&absolute).ok()?;
+    Some(
+        turbopath::AnchoredSystemPathBuf::relative_path_between(
+            &repo_root.resolve(package.directory()),
+            &repo_root.resolve(&repo_relative),
+        )
+        .to_unix()
+        .to_string(),
+    )
+}
 
 fn environment_flag(environment: &toolchain::TaskIOEnvironment, name: &str) -> bool {
     environment.get(name).is_some_and(|value| {
@@ -1640,7 +1675,7 @@ impl UvTaskContract {
 
     pub(crate) fn derived_task_io(
         &self,
-        _package: &crate::package_graph::PackageTaskContext<'_>,
+        package: &crate::package_graph::PackageTaskContext<'_>,
         task: &str,
         path_to_root: &str,
         dependencies: &[crate::package_graph::PackageTaskContext<'_>],
@@ -1655,6 +1690,10 @@ impl UvTaskContract {
         };
         io.input_globs
             .extend(PYTHON_CACHE_GLOBS.map(|cache| format!("!{cache}")));
+        if let Some(venv) = virtual_environment_path(package, context.environment) {
+            io.input_globs.push(format!("!{venv}/**"));
+            io.forbidden_output_prefixes.push(venv);
+        }
         // These variables point at files whose contents affect uv. Until the
         // paths can be resolved against the repository safely, fail closed
         // instead of restoring an artifact hashed only by the path string.
@@ -2400,7 +2439,10 @@ impl PruneDomain for UvPruneKnowledge {
     }
 }
 
-fn uv_change_observation(package_directories: &[String]) -> ChangeObservation {
+fn uv_change_observation(
+    repo_root: &AbsoluteSystemPath,
+    package_directories: &[String],
+) -> ChangeObservation {
     let mut observation = ChangeObservation::new()
         .with_rediscovery_file_name(PYPROJECT_TOML)
         .with_resolution_path(UV_LOCK)
@@ -2408,6 +2450,17 @@ fn uv_change_observation(package_directories: &[String]) -> ChangeObservation {
         .with_resolution_path("uv.toml")
         .with_ignore_prefix(".venv")
         .with_ignore_prefix("dist");
+    for name in ["VIRTUAL_ENV", "UV_PROJECT_ENVIRONMENT"] {
+        if let Some(path) = std::env::var_os(name)
+            .map(|path| {
+                AbsoluteSystemPathBuf::from_unknown(repo_root, path.to_string_lossy().as_ref())
+            })
+            .and_then(|path| repo_root.anchor(&path).ok())
+            .filter(|path| path.components().next().is_some())
+        {
+            observation = observation.with_ignore_prefix(path.to_unix().to_string());
+        }
+    }
     for directory in std::iter::once("").chain(package_directories.iter().map(String::as_str)) {
         for cache in [
             ".ruff_cache",
@@ -2497,7 +2550,7 @@ impl RepositoryContributor for UvContributor {
                 .collect();
             workspace_directories.sort();
             workspace_directories.dedup();
-            let change_observation = uv_change_observation(&workspace_directories);
+            let change_observation = uv_change_observation(&self.repo_root, &workspace_directories);
             let prune_domain = UvPruneKnowledge::discover(
                 &self.repo_root,
                 package_directories.clone(),
@@ -3488,7 +3541,7 @@ version = "0.1.0"
             .iter()
             .find(|task| task.name() == "test")
             .unwrap();
-        assert_eq!(root_test.display(), Some("uv run --frozen pytest"));
+        assert_eq!(root_test.display(), Some("uv run --active --frozen pytest"));
         assert_eq!(
             root_test.contract().entrypoint(),
             Some(crate::native_tasks::TaskEntrypoint::PreferredOnly)
@@ -3519,7 +3572,7 @@ version = "0.1.0"
         assert_eq!(
             member_test.display(),
             Some(
-                "uv run --frozen --package app --no-default-groups --group tests pytest \
+                "uv run --active --frozen --package app --no-default-groups --group tests pytest \
                  packages/app"
             )
         );
@@ -3532,6 +3585,7 @@ version = "0.1.0"
             resolved_args(member_test, &["-k", "smoke"]),
             [
                 "run",
+                "--active",
                 "--frozen",
                 "--package",
                 "app",
@@ -3573,12 +3627,12 @@ version = "0.1.0"
         let task = |name| tasks.iter().find(|task| task.name() == name).unwrap();
         assert_eq!(
             task("lint:ruff").display(),
-            Some("uv run --frozen ruff check packages/app")
+            Some("uv run --active --frozen ruff check packages/app")
         );
         assert_eq!(
             task("check:pyright").display(),
             Some(
-                "uv run --frozen --package app --no-default-groups --group types pyright \
+                "uv run --active --frozen --package app --no-default-groups --group types pyright \
                  packages/app"
             )
         );
@@ -3590,12 +3644,22 @@ version = "0.1.0"
         assert_eq!(arguments.suffix, ["packages/app"]);
         assert_eq!(
             resolved_args(task("lint:ruff"), &["--fix"]),
-            ["run", "--frozen", "ruff", "check", "--fix", "packages/app",].map(OsString::from)
+            [
+                "run",
+                "--active",
+                "--frozen",
+                "ruff",
+                "check",
+                "--fix",
+                "packages/app",
+            ]
+            .map(OsString::from)
         );
         assert_eq!(
             resolved_args(task("check:pyright"), &["--warnings"]),
             [
                 "run",
+                "--active",
                 "--frozen",
                 "--package",
                 "app",
@@ -3634,12 +3698,13 @@ version = "0.1.0"
             .unwrap();
         assert_eq!(
             lint.display(),
-            Some("uv run --frozen --all-packages ruff check packages/one packages/two")
+            Some("uv run --active --frozen --all-packages ruff check packages/one packages/two")
         );
         assert_eq!(
             resolved_args(lint, &["--fix", "--unsafe-fixes"]),
             [
                 "run",
+                "--active",
                 "--frozen",
                 "--all-packages",
                 "ruff",
@@ -3674,11 +3739,11 @@ version = "0.1.0"
         let task = |name| tasks.iter().find(|task| task.name() == name).unwrap();
         assert_eq!(
             task("format:ruff").display(),
-            Some("uv run --frozen --package app ruff format app")
+            Some("uv run --active --frozen --package app ruff format app")
         );
         assert_eq!(
             task("format:black").display(),
-            Some("uv run --frozen --package app black app")
+            Some("uv run --active --frozen --package app black app")
         );
         assert_eq!(
             task("format").display(),
@@ -3687,15 +3752,15 @@ version = "0.1.0"
         );
         assert_eq!(
             task("check:mypy").display(),
-            Some("uv run --frozen --package app mypy app")
+            Some("uv run --active --frozen --package app mypy app")
         );
         assert_eq!(
             task("check:ty").display(),
-            Some("uv run --frozen --package app ty check app")
+            Some("uv run --active --frozen --package app ty check app")
         );
         assert_eq!(
             task("check:pyright").display(),
-            Some("uv run --frozen --package app pyright app")
+            Some("uv run --active --frozen --package app pyright app")
         );
         assert!(matches!(
             task("lint").execution(),
@@ -3890,7 +3955,8 @@ version = "0.1.0"
 
     #[test]
     fn test_python_watch_ignores_root_and_member_caches() {
-        let observation = uv_change_observation(&["packages/app".to_string()]);
+        let root = AbsoluteSystemPathBuf::cwd().unwrap();
+        let observation = uv_change_observation(&root, &["packages/app".to_string()]);
         let expected = ChangeObservation::new()
             .with_rediscovery_file_name(PYPROJECT_TOML)
             .with_resolution_path(UV_LOCK)

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -697,7 +697,7 @@ the shared repository graph.
   unfiltered run, while a package filter can select only a directly declaring
   member. Member pytest tasks have no shared serial group and can run in
   parallel.
-- **Command shapes** are `uv build --package=<name>`, or `uv run --frozen`
+- **Command shapes** are `uv build --package=<name>`, or `uv run --active --frozen`
   followed by owner selection (`--package <name>` for a member,
   `--all-packages` for homogeneous member ownership, and no owner flag for a
   root declaration), non-default group activation (`--no-default-groups
@@ -716,8 +716,8 @@ the shared repository graph.
   Turborepo itself never creates or updates `uv.lock`. Pass-through arguments are
   inserted before path targets. Active aggregates reject them and name the
   package-qualified child tasks that can receive them.
-  Pytest commands are `uv run --frozen pytest` for the workspace or `uv run
-  --frozen --package <name> pytest <member-dir>` for members, with non-default
+  Pytest commands are `uv run --active --frozen pytest` for the workspace or `uv run
+  --active --frozen --package <name> pytest <member-dir>` for members, with non-default
   group activation inserted before pytest and pass-through arguments inserted
   before the member target.
 - **Hashing and affectedness** include member sources, relevant workspace
@@ -726,7 +726,11 @@ the shared repository graph.
   Quality workspace tasks include every member's sources; a bare workspace
   pytest task hashes the full repository because pytest controls collection.
   Quality caches, `.pytest_cache`, `.venv`, and `__pycache__` are excluded.
-  Path-valued uv settings, `UV_NO_SYNC`, `UV_NO_PROJECT`, active user/system uv
+  `VIRTUAL_ENV` is hashed and native `uv run` tasks opt into it with `--active`;
+  otherwise `UV_PROJECT_ENVIRONMENT` or the root `.venv` determines the effective
+  environment directory. An in-repository environment is excluded from task inputs,
+  and output globs that would archive it are rejected because virtual environments
+  are machine-specific. Path-valued uv settings, `UV_NO_SYNC`, `UV_NO_PROJECT`, active user/system uv
   configuration, and any pass-through arguments make automatic inputs
   untracked. Turborepo invokes `uv workspace metadata --frozen --offline` and
   hashes each scope's external dependency closure from uv's JSON resolution
@@ -740,7 +744,8 @@ the shared repository graph.
   all uv packages. Build output inference covers the bare command's matching
   `dist/` artifacts and becomes unavailable when arguments are present.
 - **Watch mode** rediscoveries follow any `pyproject.toml`, the root `uv.lock`,
-  `.python-version`, and `uv.toml`. Root `.venv/` and `dist/`, plus known quality-tool and Python cache
+  `.python-version`, and `uv.toml`. In-repository `VIRTUAL_ENV` and
+  `UV_PROJECT_ENVIRONMENT` directories, root `.venv/` and `dist/`, plus known quality-tool and Python cache
   directories at the root and member scopes, are ignored as task byproducts.
 - **Prune** uses the same uv metadata graph for reachability, including
   dependency groups and optional extras. It mechanically filters matching

--- a/crates/turborepo/tests/uv_workspace_test.rs
+++ b/crates/turborepo/tests/uv_workspace_test.rs
@@ -208,14 +208,14 @@ dev = ["Ruff", "black", "mypy", "ty", "pyright"]
     );
     assert_eq!(
         find_task(&check, "acme#check:mypy")["command"],
-        "uv run --frozen mypy packages/py-app packages/py-lib"
+        "uv run --active --frozen mypy packages/py-app packages/py-lib"
     );
 
     let format = dry_run_tasks(tempdir.path(), &["format"]);
     assert_eq!(task_ids(&format), vec!["acme#format".to_string()]);
     assert_eq!(
         find_task(&format, "acme#format")["command"],
-        "uv run --frozen ruff format packages/py-app packages/py-lib"
+        "uv run --active --frozen ruff format packages/py-app packages/py-lib"
     );
 
     let output = run_turbo(
@@ -233,7 +233,7 @@ dev = ["Ruff", "black", "mypy", "ty", "pyright"]
     assert_eq!(task_ids(&qualified), vec!["py-app#format:ruff".to_string()]);
     assert_eq!(
         find_task(&qualified, "py-app#format:ruff")["command"],
-        "uv run --frozen ruff format packages/py-app"
+        "uv run --active --frozen ruff format packages/py-app"
     );
 
     let warning_output = run_turbo(tempdir.path(), &["format", "--dry-run=json"]);
@@ -268,11 +268,11 @@ fn test_uv_heterogeneous_tools_use_member_entrypoints() {
     );
     assert_eq!(
         find_task(&format, "py-app#format")["command"],
-        "uv run --frozen --package py-app black packages/py-app"
+        "uv run --active --frozen --package py-app black packages/py-app"
     );
     assert_eq!(
         find_task(&format, "py-lib#format")["command"],
-        "uv run --frozen ruff format packages/py-lib"
+        "uv run --active --frozen ruff format packages/py-lib"
     );
 
     let check = dry_run_tasks(tempdir.path(), &["check"]);
@@ -304,7 +304,7 @@ fn test_uv_heterogeneous_tools_use_member_entrypoints() {
     assert!(task_ids(&lint).contains(&"acme#lint".to_string()));
     assert_eq!(
         find_task(&lint, "acme#lint:ruff")["command"],
-        "uv run --frozen ruff check packages/py-app packages/py-lib"
+        "uv run --active --frozen ruff check packages/py-app packages/py-lib"
     );
 }
 
@@ -324,14 +324,14 @@ fn test_uv_compatible_member_tools_use_all_packages_entrypoint() {
     assert!(task_ids(&lint).contains(&"acme#lint".to_string()));
     assert_eq!(
         find_task(&lint, "acme#lint:ruff")["command"],
-        "uv run --frozen --all-packages ruff check packages/py-app packages/py-lib"
+        "uv run --active --frozen --all-packages ruff check packages/py-app packages/py-lib"
     );
 
     let filtered = dry_run_tasks(tempdir.path(), &["lint:ruff", "--filter=py-app"]);
     assert_eq!(task_ids(&filtered), ["py-app#lint:ruff"]);
     assert_eq!(
         find_task(&filtered, "py-app#lint:ruff")["command"],
-        "uv run --frozen --package py-app ruff check packages/py-app"
+        "uv run --active --frozen --package py-app ruff check packages/py-app"
     );
 }
 
@@ -354,14 +354,14 @@ fn test_uv_root_pytest_is_workspace_only_and_member_filter_uses_direct_declarati
     assert_eq!(task_ids(&workspace), ["acme#test"]);
     assert_eq!(
         find_task(&workspace, "acme#test")["command"],
-        "uv run --frozen pytest"
+        "uv run --active --frozen pytest"
     );
 
     let app = dry_run_tasks(tempdir.path(), &["test", "--filter=py-app"]);
     assert_eq!(task_ids(&app), ["py-app#test"]);
     assert_eq!(
         find_task(&app, "py-app#test")["command"],
-        "uv run --frozen --package py-app pytest packages/py-app"
+        "uv run --active --frozen --package py-app pytest packages/py-app"
     );
 
     let lib = dry_run_tasks(tempdir.path(), &["test", "--filter=py-lib"]);
@@ -387,11 +387,12 @@ fn test_uv_member_pytest_tasks_run_per_declaring_package() {
     assert_eq!(task_ids(&test), ["py-app#test", "py-lib#test"]);
     assert_eq!(
         find_task(&test, "py-app#test")["command"],
-        "uv run --frozen --package py-app pytest packages/py-app"
+        "uv run --active --frozen --package py-app pytest packages/py-app"
     );
     assert_eq!(
         find_task(&test, "py-lib#test")["command"],
-        "uv run --frozen --package py-lib --no-default-groups --group tests pytest packages/py-lib"
+        "uv run --active --frozen --package py-lib --no-default-groups --group tests pytest \
+         packages/py-lib"
     );
 
     let output = run_turbo(
@@ -409,7 +410,7 @@ fn test_uv_member_pytest_tasks_run_per_declaring_package() {
     let filtered: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(
         find_task(&filtered, "py-app#test")["command"],
-        "uv run --frozen --package py-app pytest packages/py-app"
+        "uv run --active --frozen --package py-app pytest packages/py-app"
     );
 }
 
@@ -652,6 +653,127 @@ fn test_uv_quality_tasks_cache_with_toolchain_identity() {
     assert!(
         stdout.contains("FULL TURBO"),
         "expected cache hit: {stdout}"
+    );
+}
+
+#[test]
+fn test_uv_virtual_environment_is_hashed_and_excluded_from_inputs() {
+    if !uv_available() {
+        return;
+    }
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_uv_pure_workspace(tempdir.path());
+
+    let dry_run = |virtual_env: &Path| {
+        let config_dir = tempfile::tempdir().expect("failed to create config tempdir");
+        let mut command = common::turbo_command(tempdir.path());
+        let output = command
+            .env("TURBO_CONFIG_DIR_PATH", config_dir.path())
+            .env("UV_NO_CONFIG", "1")
+            .env("VIRTUAL_ENV", virtual_env)
+            .args(["build", "--filter=py-app", "--dry-run=json"])
+            .output()
+            .expect("failed to execute turbo");
+        assert_command_success(&output, "virtual environment dry-run");
+        serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap()
+    };
+
+    let first_env = tempdir.path().join("envs/first");
+    fs::create_dir_all(&first_env).unwrap();
+    let first = dry_run(&first_env);
+    let first_task = find_task(&first, "py-app#build");
+    assert!(
+        first_task["environmentVariables"]["specified"]["env"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|name| name == "VIRTUAL_ENV")
+    );
+    assert!(
+        first_task["resolvedTaskDefinition"]["inputs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|input| input.as_str().is_some_and(|input| {
+                input.starts_with('!') && input.ends_with("envs/first/**")
+            })),
+        "inputs: {}",
+        first_task["resolvedTaskDefinition"]["inputs"]
+    );
+
+    let second_env = tempdir.path().join("envs/second");
+    fs::create_dir_all(&second_env).unwrap();
+    let second = dry_run(&second_env);
+    assert_ne!(
+        first_task["hash"],
+        find_task(&second, "py-app#build")["hash"],
+        "changing VIRTUAL_ENV must invalidate the task hash"
+    );
+}
+
+#[test]
+fn test_uv_project_environment_is_excluded_from_inputs() {
+    if !uv_available() {
+        return;
+    }
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_uv_pure_workspace(tempdir.path());
+    let project_env = tempdir.path().join("envs/project");
+    fs::create_dir_all(&project_env).unwrap();
+
+    let config_dir = tempfile::tempdir().expect("failed to create config tempdir");
+    let mut command = common::turbo_command(tempdir.path());
+    let output = command
+        .env("TURBO_CONFIG_DIR_PATH", config_dir.path())
+        .env("UV_NO_CONFIG", "1")
+        .env_remove("VIRTUAL_ENV")
+        .env("UV_PROJECT_ENVIRONMENT", &project_env)
+        .args(["build", "--filter=py-app", "--dry-run=json"])
+        .output()
+        .expect("failed to execute turbo");
+    assert_command_success(&output, "project environment dry-run");
+    let dry_run: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let task = find_task(&dry_run, "py-app#build");
+    assert!(
+        task["resolvedTaskDefinition"]["inputs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|input| input.as_str().is_some_and(|input| {
+                input.starts_with('!') && input.ends_with("envs/project/**")
+            })),
+        "inputs: {}",
+        task["resolvedTaskDefinition"]["inputs"]
+    );
+}
+
+#[test]
+fn test_uv_virtual_environment_cannot_be_cached_as_output() {
+    if !uv_available() {
+        return;
+    }
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_uv_pure_workspace(tempdir.path());
+    fs::write(
+        tempdir.path().join("turbo.json"),
+        r#"{
+  "futureFlags": { "experimentalPythonWorkspaces": true },
+  "tasks": { "build": { "outputs": ["$TURBO_ROOT$/.venv/**"] } }
+}"#,
+    )
+    .unwrap();
+
+    let output = run_turbo(
+        tempdir.path(),
+        &["build", "--filter=py-app", "--dry-run=json"],
+    );
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("cannot cache Python virtual environment")
+            && stderr.contains(".venv")
+            && stderr.contains("dist/**"),
+        "expected actionable virtual environment output error: {stderr}"
     );
 }
 


### PR DESCRIPTION
## Summary

- honor activated Python environments for native `uv run` tasks with `--active`
- hash and pass through `VIRTUAL_ENV`, and exclude the effective in-repository environment from inputs and watch events
- reject task output globs that would cache a machine-specific virtual environment

Closes TURBO-5945
Closes TURBO-5946

## Testing

- `cargo test -p turborepo-repository uv::test -- --nocapture`
- `cargo test -p turborepo-engine derived_io_tests -- --nocapture`
- `cargo test -p turbo --test uv_workspace_test -- --skip test_uv_prune`
- `cargo test -p turbo --test uv_workspace_test test_uv_project_environment_is_excluded_from_inputs -- --nocapture`
- `cargo test -p turbo --test uv_workspace_test test_uv_virtual_environment -- --nocapture`
- `cargo check -p turborepo-repository -p turborepo-engine`
- `cargo fmt --all -- --check`
- `git diff --check`

The unfiltered `uv_workspace_test` suite still has the existing `test_uv_prune` fixture failure: the installed uv applies a newer global `exclude-newer` value and reports the fixture lockfile needs updating.
