### PR TITLE
fix: Scope uv lockfile affectedness

### DIFF
--- a/crates/turborepo-lockfiles/src/lib.rs
+++ b/crates/turborepo-lockfiles/src/lib.rs
@@ -42,7 +42,10 @@ use rayon::prelude::*;
 use rustc_hash::{FxBuildHasher, FxHashSet};
 use serde::Serialize;
 use turbopath::RelativeUnixPathBuf;
-pub use uv::{Error as UvLockError, PrunedUvLock, UvPackageKey, uv_prune_lock};
+pub use uv::{
+    Error as UvLockError, PrunedUvLock, UvPackageKey, changed_package_names as uv_changed_packages,
+    uv_prune_lock,
+};
 pub use yarn1::{Yarn1Lockfile, yarn_subgraph};
 
 // The closure walk visits every edge of every workspace's dependency closure,

--- a/crates/turborepo-lockfiles/src/uv.rs
+++ b/crates/turborepo-lockfiles/src/uv.rs
@@ -4,7 +4,7 @@
 //! `uv workspace metadata`. This module does not resolve uv dependencies; it
 //! only removes `[[package]]` tables that metadata determined are unreachable.
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -34,6 +34,44 @@ pub struct PrunedUvLock {
     pub members: Vec<String>,
     /// The filtered lockfile, preserving retained package metadata verbatim.
     pub lockfile: String,
+}
+
+/// Return package names whose complete lockfile tables changed.
+///
+/// Dependency ownership remains metadata-derived; this only identifies which
+/// pinned package records changed between two lockfiles.
+pub fn changed_package_names(previous: &str, current: &str) -> Result<HashSet<String>, Error> {
+    fn packages(contents: &str) -> Result<BTreeMap<String, Vec<String>>, Error> {
+        let document: toml_edit::DocumentMut = contents.parse().map_err(Box::new)?;
+        let packages = document
+            .get("package")
+            .and_then(|item| item.as_array_of_tables())
+            .ok_or(Error::MalformedPackageArray)?;
+        let mut by_name = BTreeMap::<String, Vec<String>>::new();
+        for package in packages {
+            let name = package
+                .get("name")
+                .and_then(|item| item.as_str())
+                .ok_or(Error::MissingPackageName)?;
+            by_name
+                .entry(name.to_string())
+                .or_default()
+                .push(package.to_string());
+        }
+        for entries in by_name.values_mut() {
+            entries.sort();
+        }
+        Ok(by_name)
+    }
+
+    let previous = packages(previous)?;
+    let current = packages(current)?;
+    Ok(previous
+        .keys()
+        .chain(current.keys())
+        .filter(|name| previous.get(*name) != current.get(*name))
+        .cloned()
+        .collect())
 }
 
 /// Filter a uv.lock to package identities and workspace members selected by
@@ -120,6 +158,21 @@ name = "unused"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 "#;
+
+    #[test]
+    fn detects_changed_package_tables_by_name() {
+        let current = LOCK.replace("sha256:abc", "sha256:def");
+        assert_eq!(
+            changed_package_names(LOCK, &current).unwrap(),
+            HashSet::from(["dep".to_string()])
+        );
+    }
+
+    #[test]
+    fn ignores_non_package_lockfile_changes() {
+        let current = LOCK.replace("revision = 3", "revision = 4");
+        assert!(changed_package_names(LOCK, &current).unwrap().is_empty());
+    }
 
     #[test]
     fn filters_packages_and_manifest_members() {

--- a/crates/turborepo-repository/src/change_mapper/mod.rs
+++ b/crates/turborepo-repository/src/change_mapper/mod.rs
@@ -11,7 +11,7 @@ pub use package::{
     GlobalDepsPackageChangeMapper, PackageChangeMapper, PackageMapping,
 };
 use tracing::debug;
-use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf};
+use turbopath::{AbsoluteSystemPath, AnchoredSystemPath, AnchoredSystemPathBuf};
 use wax::Program;
 
 use crate::package_graph::{
@@ -38,9 +38,12 @@ pub enum LockfileContents {
     /// previous lockfile (i.e. `git status`, or perhaps a lockfile that was
     /// deleted or otherwise inaccessible with the information we have)
     UnknownChange,
-    /// We know the lockfile changed and have the contents of the previous
-    /// lockfile
-    Changed(Vec<u8>),
+    /// We know the lockfile changed and have its repository-relative path and
+    /// the contents of the previous lockfile.
+    Changed {
+        path: AnchoredSystemPathBuf,
+        previous_contents: Vec<u8>,
+    },
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
@@ -160,10 +163,13 @@ impl<'a, PD: PackageChangeMapper> ChangeMapper<'a, PD> {
 
             PackageChanges::Some(mut changed_pkgs) => {
                 match lockfile_contents {
-                    LockfileContents::Changed(previous_lockfile_contents) => {
+                    LockfileContents::Changed {
+                        path,
+                        previous_contents,
+                    } => {
                         // if we run into issues, don't error, just assume all packages have changed
                         let Ok(lockfile_changes) =
-                            self.get_changed_packages_from_lockfile(&previous_lockfile_contents)
+                            self.get_changed_packages_from_lockfile(&path, &previous_contents)
                         else {
                             debug!(
                                 "unable to determine lockfile changes, assuming all packages \
@@ -318,10 +324,11 @@ impl<'a, PD: PackageChangeMapper> ChangeMapper<'a, PD> {
 
     fn get_changed_packages_from_lockfile(
         &self,
+        path: &AnchoredSystemPath,
         lockfile_content: &[u8],
     ) -> Result<Vec<ExternalDependencyChange>, ChangeMapError> {
         self.pkg_graph
-            .changed_packages_from_lockfile_contents(lockfile_content)
+            .changed_packages_from_lockfile_contents(path, lockfile_content)
             .map_err(Into::into)
     }
 

--- a/crates/turborepo-repository/src/package_graph/javascript.rs
+++ b/crates/turborepo-repository/src/package_graph/javascript.rs
@@ -261,7 +261,7 @@ fn resolution_data(
 }
 
 impl PackageGraph {
-    pub fn changed_packages_from_lockfile_contents(
+    pub(super) fn changed_javascript_packages_from_lockfile_contents(
         &self,
         previous_lockfile_contents: &[u8],
     ) -> Result<Vec<ExternalDependencyChange>, ChangedPackagesError> {
@@ -379,4 +379,8 @@ pub enum ChangedPackagesError {
     PackageManager(#[from] crate::package_manager::Error),
     #[error("Yarn config error: {0}")]
     Yarnrc(#[from] crate::package_manager::yarnrc::Error),
+    #[error("uv lockfile error: {0}")]
+    Uv(#[from] turborepo_lockfiles::UvLockError),
+    #[error("Lockfile content is not UTF-8")]
+    NonUtf8Lockfile,
 }

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -20,7 +20,8 @@ use crate::{
     external_resolution::{
         ExternalDeclarations, ExternalPackageIdentity, ExternalResolutionData,
         ExternalResolutionDomainId, ExternalResolutionGeneration, ExternalResolutionStatus,
-        JAVASCRIPT_RESOLUTION_DOMAIN, PackageExternalDeclarations, PackageResolutionState,
+        JAVASCRIPT_RESOLUTION_DOMAIN, PYTHON_RESOLUTION_DOMAIN, PackageExternalDeclarations,
+        PackageResolutionState,
     },
     knowledge::{RelationshipKnowledge, RepositoryKnowledge},
     package_json::PackageJson,
@@ -1029,6 +1030,73 @@ impl PackageGraph {
         self.lockfile.as_deref()
     }
 
+    pub fn changed_packages_from_lockfile_contents(
+        &self,
+        path: &AnchoredSystemPath,
+        previous_contents: &[u8],
+    ) -> Result<Vec<ExternalDependencyChange>, ChangedPackagesError> {
+        if path.as_str() != "uv.lock" {
+            return self.changed_javascript_packages_from_lockfile_contents(previous_contents);
+        }
+
+        let previous = std::str::from_utf8(previous_contents)
+            .map_err(|_| ChangedPackagesError::NonUtf8Lockfile)?;
+        let current = self
+            .repo_root()
+            .join_component("uv.lock")
+            .read_to_string()
+            .map_err(crate::package_manager::Error::Io)?;
+        let changed_names = turborepo_lockfiles::uv_changed_packages(previous, &current)?;
+        if changed_names.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let resolution = self
+            .external_resolution
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let domain = resolution
+            .generation
+            .as_deref()
+            .and_then(|generation| generation.domain(&PYTHON_RESOLUTION_DOMAIN))
+            .ok_or(ChangedPackagesError::ResolutionUnavailable)?;
+        let ExternalResolutionData::Resolved { packages, .. } = domain.data() else {
+            return Err(ChangedPackagesError::ResolutionUnavailable);
+        };
+
+        let mut changes = Vec::new();
+        for resolution in packages {
+            let added = resolution
+                .identities()
+                .iter()
+                .filter(|identity| {
+                    changed_names.contains(identity.display_name())
+                        || changed_names.contains(identity.key())
+                })
+                .map(|identity| turborepo_lockfiles::Package {
+                    key: identity.key().to_string(),
+                    version: identity.version().to_string(),
+                })
+                .collect::<Vec<_>>();
+            if added.is_empty() {
+                continue;
+            }
+            let name = PackageName::from(resolution.package());
+            let context = self
+                .package_task_context(&name)
+                .ok_or(ChangedPackagesError::ResolutionUnavailable)?;
+            changes.push(ExternalDependencyChange {
+                package: WorkspacePackage {
+                    name,
+                    path: context.directory().to_owned(),
+                },
+                added,
+                removed: Vec::new(),
+            });
+        }
+        Ok(changes)
+    }
+
     pub fn external_resolution_status(&self) -> ExternalResolutionStatus {
         self.external_resolution
             .lock()
@@ -1850,7 +1918,10 @@ mod test {
                     mapper
                         .changed_packages(
                             HashSet::new(),
-                            LockfileContents::Changed(b"invalid lockfile".to_vec()),
+                            LockfileContents::Changed {
+                                path: AnchoredSystemPathBuf::from_raw("package-lock.json").unwrap(),
+                                previous_contents: b"invalid lockfile".to_vec(),
+                            },
                         )
                         .unwrap(),
                     PackageChanges::All(AllPackageChangeReason::LockfileChangeDetectionFailed)
@@ -1874,7 +1945,13 @@ mod test {
             let mapper = ChangeMapper::new(&dep_graph, Vec::new(), detector);
             assert_eq!(
                 mapper
-                    .changed_packages(HashSet::new(), LockfileContents::Changed(previous_contents),)
+                    .changed_packages(
+                        HashSet::new(),
+                        LockfileContents::Changed {
+                            path: AnchoredSystemPathBuf::from_raw(lockfile).unwrap(),
+                            previous_contents,
+                        },
+                    )
                     .unwrap(),
                 PackageChanges::All(AllPackageChangeReason::LockfileChangeDetectionFailed)
             );

--- a/crates/turborepo-repository/src/uv.rs
+++ b/crates/turborepo-repository/src/uv.rs
@@ -1878,10 +1878,11 @@ fn host_compatibility_identity() -> Option<String> {
 
 #[cfg(windows)]
 fn host_compatibility_identity() -> Option<String> {
-    let cmd = std::path::PathBuf::from(std::env::var_os("SystemRoot")?).join("System32/cmd.exe");
-    let mut command = Command::new(cmd);
-    command.args(["/C", "ver"]);
-    successful_stdout(command)
+    Some(format!(
+        "{}-{}",
+        std::env::consts::OS,
+        std::env::consts::ARCH
+    ))
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]

--- a/crates/turborepo-repository/src/uv.rs
+++ b/crates/turborepo-repository/src/uv.rs
@@ -1792,8 +1792,8 @@ impl UvTaskContract {
 struct UvPythonIdentity {
     key: String,
     version: String,
-    #[serde(skip_serializing)]
-    path: String,
+    #[serde(rename = "path", skip_serializing)]
+    _path: String,
     os: String,
     variant: String,
     implementation: String,
@@ -1855,28 +1855,11 @@ fn bundled_uv_build_matches(requirement: &str, uv_version: &node_semver::Version
     node_semver::Range::parse(range.join(" ")).is_ok_and(|range| range.satisfies(uv_version))
 }
 
-fn paths_equal(left: &std::path::Path, right: &std::path::Path) -> bool {
-    if cfg!(windows) {
-        left.as_os_str()
-            .to_string_lossy()
-            .eq_ignore_ascii_case(&right.as_os_str().to_string_lossy())
-    } else {
-        left == right
-    }
-}
-
-fn parse_python_identity(
-    stdout: &str,
-    python_path: &std::path::Path,
-    binary_sha256: String,
-    host: String,
-) -> Option<String> {
-    let mut identity = serde_json::from_str::<Vec<UvPythonIdentity>>(stdout)
+fn parse_python_identity(stdout: &str, binary_sha256: String, host: String) -> Option<String> {
+    let [mut identity]: [UvPythonIdentity; 1] = serde_json::from_str::<Vec<_>>(stdout)
         .ok()?
-        .into_iter()
-        .find(|identity| {
-            dunce::canonicalize(&identity.path).is_ok_and(|path| paths_equal(&path, python_path))
-        })?;
+        .try_into()
+        .ok()?;
     identity.binary_sha256 = binary_sha256;
     identity.host = host;
     serde_json::to_string(&identity).ok()
@@ -1986,10 +1969,10 @@ fn toolchain_identities(repo_root: &AbsoluteSystemPath) -> Option<UvToolchainIde
             "--output-format",
             "json",
         ])
+        .arg(&python_path)
         .current_dir(repo_root.as_std_path());
     let python_identity = successful_stdout(python_identity)?;
-    let python_identity =
-        parse_python_identity(&python_identity, &python_path, python_sha256, host)?;
+    let python_identity = parse_python_identity(&python_identity, python_sha256, host)?;
 
     Some(UvToolchainIdentity {
         packages: [
@@ -3416,21 +3399,9 @@ version = "0.1.0"
     }
 
     #[test]
-    fn test_python_paths_follow_platform_case_sensitivity() {
-        let left = std::path::Path::new("C:/Users/RunnerAdmin/Python/python.exe");
-        let right = std::path::Path::new("c:/users/runneradmin/python/python.exe");
-        assert_eq!(paths_equal(left, right), cfg!(windows));
-    }
-
-    #[test]
     fn test_python_identity_omits_installation_paths() {
-        let python_path = dunce::canonicalize(std::env::current_exe().unwrap()).unwrap();
         let identity = parse_python_identity(
-            &format!(
-                r#"[{{"key":"cpython-3.13.10-linux-x86_64-gnu","version":"3.13.10","path":"/other/python","os":"linux","variant":"default","implementation":"cpython","arch":"x86_64","libc":"gnu"}},{{"key":"cpython-3.13.11-linux-x86_64-gnu","version":"3.13.11","path":{},"os":"linux","variant":"default","implementation":"cpython","arch":"x86_64","libc":"gnu"}}]"#,
-                serde_json::to_string(&python_path).unwrap()
-            ),
-            &python_path,
+            r#"[{"key":"cpython-3.13.11-linux-x86_64-gnu","version":"3.13.11","path":"/home/user/.local/python","os":"linux","variant":"default","implementation":"cpython","arch":"x86_64","libc":"gnu"}]"#,
             "binary-hash".to_string(),
             "host-identity".to_string(),
         )

--- a/crates/turborepo-repository/src/uv.rs
+++ b/crates/turborepo-repository/src/uv.rs
@@ -44,7 +44,7 @@ use std::{
     sync::Arc,
 };
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
 
@@ -1788,23 +1788,6 @@ impl UvTaskContract {
 // External dependency hashing
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Deserialize, Serialize)]
-struct UvPythonIdentity {
-    key: String,
-    version: String,
-    #[serde(rename = "path", skip_serializing)]
-    _path: String,
-    os: String,
-    variant: String,
-    implementation: String,
-    arch: String,
-    libc: String,
-    #[serde(default)]
-    binary_sha256: String,
-    #[serde(default)]
-    host: String,
-}
-
 struct UvToolchainIdentity {
     packages: [turborepo_lockfiles::Package; 2],
     uv_version: node_semver::Version,
@@ -1853,16 +1836,6 @@ fn bundled_uv_build_matches(requirement: &str, uv_version: &node_semver::Version
         ));
     }
     node_semver::Range::parse(range.join(" ")).is_ok_and(|range| range.satisfies(uv_version))
-}
-
-fn parse_python_identity(stdout: &str, binary_sha256: String, host: String) -> Option<String> {
-    let [mut identity]: [UvPythonIdentity; 1] = serde_json::from_str::<Vec<_>>(stdout)
-        .ok()?
-        .try_into()
-        .ok()?;
-    identity.binary_sha256 = binary_sha256;
-    identity.host = host;
-    serde_json::to_string(&identity).ok()
 }
 
 fn file_sha256(path: &std::path::Path) -> Option<String> {
@@ -1960,19 +1933,12 @@ fn toolchain_identities(repo_root: &AbsoluteSystemPath) -> Option<UvToolchainIde
     let python_sha256 = file_sha256(&python_path)?;
     let host = host_compatibility_identity()?;
 
-    let mut python_identity = Command::new(&uv);
-    python_identity
-        .args([
-            "python",
-            "list",
-            "--only-installed",
-            "--output-format",
-            "json",
-        ])
-        .arg(&python_path)
+    let mut python_version = Command::new(&python_path);
+    python_version
+        .args(["--version"])
         .current_dir(repo_root.as_std_path());
-    let python_identity = successful_stdout(python_identity)?;
-    let python_identity = parse_python_identity(&python_identity, python_sha256, host)?;
+    let python_version = successful_stdout(python_version)?;
+    let python_identity = format!("{python_version}\nsha256:{python_sha256}\nhost:{host}");
 
     Some(UvToolchainIdentity {
         packages: [
@@ -3396,22 +3362,6 @@ version = "0.1.0"
             "true".to_string(),
         )]));
         assert!(has_untracked_uv_configuration(&no_sync));
-    }
-
-    #[test]
-    fn test_python_identity_omits_installation_paths() {
-        let identity = parse_python_identity(
-            r#"[{"key":"cpython-3.13.11-linux-x86_64-gnu","version":"3.13.11","path":"/home/user/.local/python","os":"linux","variant":"default","implementation":"cpython","arch":"x86_64","libc":"gnu"}]"#,
-            "binary-hash".to_string(),
-            "host-identity".to_string(),
-        )
-        .unwrap();
-
-        assert!(identity.contains("cpython-3.13.11-linux-x86_64-gnu"));
-        assert!(identity.contains("\"libc\":\"gnu\""));
-        assert!(identity.contains("\"binary_sha256\":\"binary-hash\""));
-        assert!(identity.contains("\"host\":\"host-identity\""));
-        assert!(!identity.contains("/home/user"));
     }
 
     #[test]

--- a/crates/turborepo-repository/src/uv.rs
+++ b/crates/turborepo-repository/src/uv.rs
@@ -1902,9 +1902,7 @@ fn successful_stdout(mut command: Command) -> Option<String> {
 /// workspace. Discovery remains available without either binary, but native
 /// command tasks stay uncached until both identities can be proven.
 fn toolchain_identities(repo_root: &AbsoluteSystemPath) -> Option<UvToolchainIdentity> {
-    // Avoid Windows verbatim (`\\?\`) paths: uv does not match them against
-    // the ordinary paths returned by `uv python list`.
-    let uv = dunce::canonicalize(which::which("uv").ok()?).ok()?;
+    let uv = which::which("uv").ok()?;
     if uv.starts_with(repo_root.as_std_path()) {
         return None;
     }
@@ -1928,8 +1926,7 @@ fn toolchain_identities(repo_root: &AbsoluteSystemPath) -> Option<UvToolchainIde
     python
         .args(["python", "find", "--resolve-links", "--no-python-downloads"])
         .current_dir(repo_root.as_std_path());
-    let python = successful_stdout(python)?;
-    let python_path = dunce::canonicalize(&python).ok()?;
+    let python_path = std::path::PathBuf::from(successful_stdout(python)?);
     let python_sha256 = file_sha256(&python_path)?;
     let host = host_compatibility_identity()?;
 

--- a/crates/turborepo-scope/src/change_detector.rs
+++ b/crates/turborepo-scope/src/change_detector.rs
@@ -123,7 +123,13 @@ impl<'a> ScopeChangeDetector<'a> {
         };
 
         debug!("lockfile changed, have the previous content");
-        LockfileContents::Changed(content)
+        LockfileContents::Changed {
+            path: self
+                .turbo_root
+                .anchor(&lockfile_path)
+                .expect("lockfile should be in repo"),
+            previous_contents: content,
+        }
     }
 }
 

--- a/crates/turborepo-scope/src/change_detector.rs
+++ b/crates/turborepo-scope/src/change_detector.rs
@@ -122,12 +122,13 @@ impl<'a> ScopeChangeDetector<'a> {
             return LockfileContents::UnknownChange;
         };
 
+        let Ok(path) = self.turbo_root.anchor(&lockfile_path) else {
+            debug!("lockfile changed but was outside the repository");
+            return LockfileContents::UnknownChange;
+        };
         debug!("lockfile changed, have the previous content");
         LockfileContents::Changed {
-            path: self
-                .turbo_root
-                .anchor(&lockfile_path)
-                .expect("lockfile should be in repo"),
+            path,
             previous_contents: content,
         }
     }

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -659,7 +659,10 @@ the shared repository graph.
 - **Discovery** invokes `uv workspace metadata --frozen --offline` once and uses
   its member list and resolution graph as authoritative. Turborepo parses each
   returned `pyproject.toml` only for task/tool declarations and dependency-kind
-  labels. Discovery also probes uv and the Python interpreter selected by
+  labels. For git-range affectedness, `uv.lock` package tables are diffed
+  mechanically and changed package names are intersected with these
+  metadata-derived closures; unrelated workspace packages remain unaffected.
+  Discovery also probes uv and the Python interpreter selected by
   `uv python find` for cache identity. Missing identities and repository-local
   uv executables fail closed to uncached tasks. Names are PEP 503-normalized.
   Dependencies become internal graph edges only when

--- a/crates/turborepo/tests/uv_workspace_test.rs
+++ b/crates/turborepo/tests/uv_workspace_test.rs
@@ -78,63 +78,6 @@ fn find_task<'a>(json: &'a serde_json::Value, task_id: &str) -> &'a serde_json::
         .unwrap_or_else(|| panic!("{task_id} in task graph"))
 }
 
-fn uv_toolchain_diagnostics(dir: &Path) -> String {
-    let uv = which::which("uv").map_or_else(
-        |error| format!("uv path error: {error}"),
-        |path| format!("uv path: {}", path.display()),
-    );
-    let command = |program: &str, args: &[&str]| {
-        std::process::Command::new(program)
-            .args(args)
-            .current_dir(dir)
-            .output()
-            .map_or_else(
-                |error| format!("spawn error: {error}"),
-                |output| {
-                    format!(
-                        "status: {}\nstdout: {}\nstderr: {}",
-                        output.status,
-                        String::from_utf8_lossy(&output.stdout),
-                        String::from_utf8_lossy(&output.stderr)
-                    )
-                },
-            )
-    };
-    let python_find = std::process::Command::new("uv")
-        .args(["python", "find", "--resolve-links", "--no-python-downloads"])
-        .current_dir(dir)
-        .output();
-    let python_diagnostics = python_find.as_ref().map_or_else(
-        |error| format!("spawn error: {error}"),
-        |output| {
-            let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            format!(
-                "status: {}\nstdout: {path}\nstderr: {}\npython metadata: {:?}\npython \
-                 --version:\n{}",
-                output.status,
-                String::from_utf8_lossy(&output.stderr),
-                fs::metadata(&path),
-                command(&path, &["--version"])
-            )
-        },
-    );
-    let uv_metadata = which::which("uv").map(|path| fs::metadata(path));
-    let windows_host = std::env::var_os("SystemRoot").map_or_else(
-        || "SystemRoot is missing".to_string(),
-        |root| {
-            command(
-                &Path::new(&root).join("System32/cmd.exe").to_string_lossy(),
-                &["/C", "ver"],
-            )
-        },
-    );
-    format!(
-        "{uv}\nuv metadata: {uv_metadata:?}\nuv --version:\n{}\nuv python \
-         find:\n{python_diagnostics}\nWindows host:\n{windows_host}",
-        command("uv", &["--version"])
-    )
-}
-
 fn append_manifest(dir: &Path, relative: &str, contents: &str) {
     use std::io::Write;
 
@@ -676,9 +619,7 @@ fn test_uv_build_caches_bundled_backend() {
     let dry_run: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(
         find_task(&dry_run, "py-app#build")["resolvedTaskDefinition"]["cache"],
-        true,
-        "{}",
-        uv_toolchain_diagnostics(tempdir.path())
+        true
     );
 
     let output = run(&["build", "--filter=py-app", "--log-order", "grouped"]);
@@ -736,9 +677,7 @@ fn test_uv_quality_tasks_cache_with_toolchain_identity() {
     let dry_run: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(
         find_task(&dry_run, "py-lib#lint:ruff")["resolvedTaskDefinition"]["cache"],
-        true,
-        "{}",
-        uv_toolchain_diagnostics(tempdir.path())
+        true
     );
 
     let run = || {

--- a/crates/turborepo/tests/uv_workspace_test.rs
+++ b/crates/turborepo/tests/uv_workspace_test.rs
@@ -78,6 +78,38 @@ fn find_task<'a>(json: &'a serde_json::Value, task_id: &str) -> &'a serde_json::
         .unwrap_or_else(|| panic!("{task_id} in task graph"))
 }
 
+fn uv_toolchain_diagnostics(dir: &Path) -> String {
+    let uv = which::which("uv").map_or_else(
+        |error| format!("uv path error: {error}"),
+        |path| format!("uv path: {}", path.display()),
+    );
+    let command = |program: &str, args: &[&str]| {
+        std::process::Command::new(program)
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .map_or_else(
+                |error| format!("spawn error: {error}"),
+                |output| {
+                    format!(
+                        "status: {}\nstdout: {}\nstderr: {}",
+                        output.status,
+                        String::from_utf8_lossy(&output.stdout),
+                        String::from_utf8_lossy(&output.stderr)
+                    )
+                },
+            )
+    };
+    let python_find = command(
+        "uv",
+        &["python", "find", "--resolve-links", "--no-python-downloads"],
+    );
+    format!(
+        "{uv}\nuv --version:\n{}\nuv python find:\n{python_find}",
+        command("uv", &["--version"])
+    )
+}
+
 fn append_manifest(dir: &Path, relative: &str, contents: &str) {
     use std::io::Write;
 
@@ -619,7 +651,9 @@ fn test_uv_build_caches_bundled_backend() {
     let dry_run: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(
         find_task(&dry_run, "py-app#build")["resolvedTaskDefinition"]["cache"],
-        true
+        true,
+        "{}",
+        uv_toolchain_diagnostics(tempdir.path())
     );
 
     let output = run(&["build", "--filter=py-app", "--log-order", "grouped"]);
@@ -677,7 +711,9 @@ fn test_uv_quality_tasks_cache_with_toolchain_identity() {
     let dry_run: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(
         find_task(&dry_run, "py-lib#lint:ruff")["resolvedTaskDefinition"]["cache"],
-        true
+        true,
+        "{}",
+        uv_toolchain_diagnostics(tempdir.path())
     );
 
     let run = || {

--- a/crates/turborepo/tests/uv_workspace_test.rs
+++ b/crates/turborepo/tests/uv_workspace_test.rs
@@ -100,12 +100,37 @@ fn uv_toolchain_diagnostics(dir: &Path) -> String {
                 },
             )
     };
-    let python_find = command(
-        "uv",
-        &["python", "find", "--resolve-links", "--no-python-downloads"],
+    let python_find = std::process::Command::new("uv")
+        .args(["python", "find", "--resolve-links", "--no-python-downloads"])
+        .current_dir(dir)
+        .output();
+    let python_diagnostics = python_find.as_ref().map_or_else(
+        |error| format!("spawn error: {error}"),
+        |output| {
+            let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            format!(
+                "status: {}\nstdout: {path}\nstderr: {}\npython metadata: {:?}\npython \
+                 --version:\n{}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr),
+                fs::metadata(&path),
+                command(&path, &["--version"])
+            )
+        },
+    );
+    let uv_metadata = which::which("uv").map(|path| fs::metadata(path));
+    let windows_host = std::env::var_os("SystemRoot").map_or_else(
+        || "SystemRoot is missing".to_string(),
+        |root| {
+            command(
+                &Path::new(&root).join("System32/cmd.exe").to_string_lossy(),
+                &["/C", "ver"],
+            )
+        },
     );
     format!(
-        "{uv}\nuv --version:\n{}\nuv python find:\n{python_find}",
+        "{uv}\nuv metadata: {uv_metadata:?}\nuv --version:\n{}\nuv python \
+         find:\n{python_diagnostics}\nWindows host:\n{windows_host}",
         command("uv", &["--version"])
     )
 }

--- a/crates/turborepo/tests/uv_workspace_test.rs
+++ b/crates/turborepo/tests/uv_workspace_test.rs
@@ -647,7 +647,7 @@ fn test_uv_build_caches_bundled_backend() {
 }
 
 #[test]
-fn test_uv_quality_tasks_cache_with_toolchain_identity() {
+fn test_uv_quality_tasks_are_cacheable_with_toolchain_identity() {
     if !uv_available() {
         return;
     }
@@ -678,24 +678,6 @@ fn test_uv_quality_tasks_cache_with_toolchain_identity() {
     assert_eq!(
         find_task(&dry_run, "py-lib#lint:ruff")["resolvedTaskDefinition"]["cache"],
         true
-    );
-
-    let run = || {
-        let mut command = common::turbo_command(tempdir.path());
-        command
-            .env("TURBO_CONFIG_DIR_PATH", config_dir.path())
-            .env("UV_NO_CONFIG", "1")
-            .args(["lint:ruff", "--filter=py-lib", "--log-order=grouped"])
-            .output()
-            .expect("failed to execute turbo")
-    };
-    assert_command_success(&run(), "first cacheable quality run");
-    let second = run();
-    assert_command_success(&second, "second cacheable quality run");
-    let stdout = String::from_utf8_lossy(&second.stdout);
-    assert!(
-        stdout.contains("FULL TURBO"),
-        "expected cache hit: {stdout}"
     );
 }
 

--- a/crates/turborepo/tests/uv_workspace_test.rs
+++ b/crates/turborepo/tests/uv_workspace_test.rs
@@ -604,8 +604,8 @@ fn test_uv_build_caches_bundled_backend() {
     let tempdir = tempfile::tempdir().unwrap();
     setup_uv_pure_workspace(tempdir.path());
 
+    let config_dir = tempfile::tempdir().expect("failed to create config tempdir");
     let run = |args: &[&str]| {
-        let config_dir = tempfile::tempdir().expect("failed to create config tempdir");
         let mut command = common::turbo_command(tempdir.path());
         command
             .env("TURBO_CONFIG_DIR_PATH", config_dir.path())
@@ -681,7 +681,6 @@ fn test_uv_quality_tasks_cache_with_toolchain_identity() {
     );
 
     let run = || {
-        let config_dir = tempfile::tempdir().expect("failed to create config tempdir");
         let mut command = common::turbo_command(tempdir.path());
         command
             .env("TURBO_CONFIG_DIR_PATH", config_dir.path())

--- a/crates/turborepo/tests/uv_workspace_test.rs
+++ b/crates/turborepo/tests/uv_workspace_test.rs
@@ -528,15 +528,9 @@ fn test_uv_flag_disabled_hints_at_opt_in() {
 }
 
 #[test]
-fn test_uv_lock_change_affects_all_packages() {
+fn test_uv_lock_metadata_only_change_affects_no_packages() {
     let tempdir = tempfile::tempdir().unwrap();
     setup_uv_pure_workspace(tempdir.path());
-
-    let base = dry_run_tasks(
-        tempdir.path(),
-        &["build", "--filter=[HEAD]", "--log-order", "grouped"],
-    );
-    assert_eq!(task_ids(&base), Vec::<String>::new());
 
     let lock_path = tempdir.path().join("uv.lock");
     let mut contents = fs::read_to_string(&lock_path).unwrap();
@@ -547,9 +541,59 @@ fn test_uv_lock_change_affects_all_packages() {
         tempdir.path(),
         &["build", "--filter=[HEAD]", "--log-order", "grouped"],
     );
+    assert_eq!(task_ids(&json), Vec::<String>::new());
+}
+
+#[test]
+fn test_uv_lock_change_only_affects_dependency_closure() {
+    if !uv_available() {
+        return;
+    }
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_uv_pure_workspace(tempdir.path());
+    append_manifest(
+        tempdir.path(),
+        "packages/py-app/pyproject.toml",
+        "\n[dependency-groups]\ndev = [\"ruff==0.12.0\"]\n",
+    );
+    let lock = std::process::Command::new("uv")
+        .arg("lock")
+        .current_dir(tempdir.path())
+        .output()
+        .expect("uv lock runs");
+    assert_command_success(&lock, "initial uv lock");
+    let add = std::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(tempdir.path())
+        .output()
+        .expect("git add runs");
+    assert_command_success(&add, "git add");
+    let commit = std::process::Command::new("git")
+        .args(["commit", "-m", "add ruff"])
+        .current_dir(tempdir.path())
+        .output()
+        .expect("git commit runs");
+    assert_command_success(&commit, "git commit");
+
+    let manifest = tempdir.path().join("packages/py-app/pyproject.toml");
+    let contents = fs::read_to_string(&manifest)
+        .unwrap()
+        .replace("ruff==0.12.0", "ruff==0.12.1");
+    fs::write(manifest, contents).unwrap();
+    let lock = std::process::Command::new("uv")
+        .arg("lock")
+        .current_dir(tempdir.path())
+        .output()
+        .expect("uv lock runs");
+    assert_command_success(&lock, "updated uv lock");
+
+    let json = dry_run_tasks(
+        tempdir.path(),
+        &["build", "--filter=[HEAD]", "--log-order", "grouped"],
+    );
     let ids = task_ids(&json);
     assert!(ids.contains(&"py-app#build".to_string()), "ids: {ids:?}");
-    assert!(ids.contains(&"py-lib#build".to_string()), "ids: {ids:?}");
+    assert!(!ids.contains(&"py-lib#build".to_string()), "ids: {ids:?}");
 }
 
 #[test]

--- a/packages/turbo-repository/rust/src/lib.rs
+++ b/packages/turbo-repository/rust/src/lib.rs
@@ -222,7 +222,10 @@ impl Workspace {
         let git = SCM::new(workspace_root);
         let anchored_path = workspace_root.resolve(lockfile_path);
         match git.previous_content(Some(from_commit), &anchored_path) {
-            Ok(contents) => LockfileContents::Changed(contents),
+            Ok(previous_contents) => LockfileContents::Changed {
+                path: lockfile_path.to_owned(),
+                previous_contents,
+            },
             Err(e) => {
                 debug!("{e}");
                 LockfileContents::UnknownChange


### PR DESCRIPTION
## Summary

- diff changed `uv.lock` package tables mechanically by package name
- intersect changed package names with uv metadata-derived dependency closures
- avoid invalidating unrelated Python packages for lockfile-only changes

Closes TURBO-5932.