### PR TITLE
test: Isolate uv prune configuration

### DIFF
--- a/crates/turborepo/tests/uv_workspace_test.rs
+++ b/crates/turborepo/tests/uv_workspace_test.rs
@@ -807,7 +807,11 @@ fn test_uv_prune() {
     let tempdir = tempfile::tempdir().unwrap();
     setup_uv_pure_workspace(tempdir.path());
 
-    let output = run_turbo(tempdir.path(), &["prune", "py-app"]);
+    let output = common::run_turbo_with_env(
+        tempdir.path(),
+        &["prune", "py-app"],
+        &[("UV_NO_CONFIG", "1")],
+    );
     assert_command_success(&output, "turbo prune");
     let out = tempdir.path().join("out");
 
@@ -828,6 +832,7 @@ fn test_uv_prune() {
     if uv_available() {
         let check = std::process::Command::new("uv")
             .args(["lock", "--check"])
+            .env("UV_NO_CONFIG", "1")
             .current_dir(&out)
             .output()
             .expect("uv runs");
@@ -845,7 +850,11 @@ fn test_uv_prune_mixed_repo() {
     let tempdir = tempfile::tempdir().unwrap();
     setup_uv_monorepo(tempdir.path());
 
-    let output = run_turbo(tempdir.path(), &["prune", "py-lib"]);
+    let output = common::run_turbo_with_env(
+        tempdir.path(),
+        &["prune", "py-lib"],
+        &[("UV_NO_CONFIG", "1")],
+    );
     assert_command_success(&output, "turbo prune");
     let out = tempdir.path().join("out");
 


### PR DESCRIPTION
## Summary

- disable user-level uv configuration in Python prune integration tests
- validate pruned lockfiles with the same isolated uv configuration
- keep pure and mixed uv prune coverage deterministic across developer machines