### PR TITLE
fix: Explain disabled Cargo task caching

### DIFF
--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -857,9 +857,16 @@ impl CargoTaskContract {
         {
             io.input_safety = toolchain::DerivedInputSafety::Untracked;
             if workspace.repository_config_untracked {
+                io.cache_reason =
+                    Some("repository Cargo configuration cannot be hashed safely".to_string());
                 io.input_globs.retain(|glob| {
                     !glob.ends_with(".cargo/config.toml") && !glob.ends_with(".cargo/config")
                 });
+            } else {
+                io.cache_reason = Some(
+                    "Cargo configuration outside the repository is not included in the task hash"
+                        .to_string(),
+                );
             }
         }
 

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -500,7 +500,9 @@ whether anything changed; Cargo decides how and in what order to build.**
   crate directories instead of default-hashing the repo root.
   `$TURBO_DEFAULT$` in a Cargo task's `inputs` means "everything turbo
   derives automatically", so extra inputs (e.g. a file embedded via
-  `include_str!` from outside any crate directory) are additive.
+  `include_str!` from outside any crate directory) are additive. Unsafe
+  repository Cargo configuration and configuration inherited from outside the
+  repository disable implicit caching and emit the reason as a warning.
 - **External dependencies** (`turborepo-lockfiles/src/cargo.rs`): locked
   registry/git packages and the compiler itself flow through the same
   `ExternalResolutionGeneration` and resolution fingerprint used by JavaScript

--- a/crates/turborepo/tests/cargo_workspace_test.rs
+++ b/crates/turborepo/tests/cargo_workspace_test.rs
@@ -944,6 +944,12 @@ fn test_external_cargo_home_config_is_uncached_in_strict_mode() {
             String::from_utf8_lossy(&output.stdout).contains("cache bypass"),
             "external Cargo config must disable implicit caching"
         );
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains(
+                "Cargo configuration outside the repository is not included in the task hash"
+            ),
+            "external Cargo config must explain why caching is disabled: {output:?}"
+        );
     }
 }
 


### PR DESCRIPTION
## Description

- Explain when repository Cargo configuration cannot be hashed safely.
- Explain when Cargo configuration inherited from outside the repository disables implicit caching.
- Keep explicit `cache` configuration authoritative.

Closes TURBO-5928.
