### PR TITLE
fix: Explain uncached Cargo library builds

### DIFF
--- a/apps/docs/content/docs/guides/tools/rust.mdx
+++ b/apps/docs/content/docs/guides/tools/rust.mdx
@@ -188,7 +188,7 @@ Project-specific hashing inputs must be accounted for manually. This includes:
 
 ### Output caching
 
-Automatic output caching stores only the exact final `bin`, `cdylib`, and `staticlib` deliverables. It does not cache Cargo's incremental `target/` state or use profile or target wildcards. Library builds default to `cache: false` because their Cargo-internal artifacts are not stable Turborepo outputs. Enabling library build caching requires an explicit `cache: true`; configure `outputs` as needed to describe restorable artifacts. `outputs` alone does not override the uncached default.
+Automatic output caching stores only the exact final `bin`, `cdylib`, and `staticlib` deliverables. It does not cache Cargo's incremental `target/` state or use profile or target wildcards. Library builds default to `cache: false` because their Cargo-internal artifacts are not stable Turborepo outputs, and Turborepo emits a warning explaining this default. Enabling library build caching requires an explicit `cache: true`; configure `outputs` as needed to describe restorable artifacts. `outputs` alone does not override the uncached default.
 
 Turborepo resolves exact outputs for these layouts:
 

--- a/crates/turborepo-engine/src/builder/definitions.rs
+++ b/crates/turborepo-engine/src/builder/definitions.rs
@@ -501,8 +501,11 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
                     derived.outputs = turborepo_repository::toolchain::DerivedOutputs::Unavailable;
                 }
                 let cache_reason = (!had_explicit_cache
-                    && derived.input_safety
-                        == turborepo_repository::toolchain::DerivedInputSafety::Untracked)
+                    && (derived.input_safety
+                        == turborepo_repository::toolchain::DerivedInputSafety::Untracked
+                        || (!had_explicit_outputs
+                            && derived.outputs
+                                == turborepo_repository::toolchain::DerivedOutputs::Unavailable)))
                     .then(|| derived.cache_reason.clone())
                     .flatten();
                 apply_derived_task_io(

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -899,6 +899,11 @@ impl CargoTaskContract {
                 if subcommand == "build" {
                     if self.package.kind == CargoPackageKind::Library {
                         io.outputs = toolchain::DerivedOutputs::Unavailable;
+                        io.cache_reason = Some(
+                            "Cargo library artifacts have no stable outputs for Turborepo to \
+                             restore"
+                                .to_string(),
+                        );
                     } else {
                         io.outputs = self
                             .workspace

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -543,7 +543,8 @@ pub struct DerivedTaskIO {
     /// Directory prefixes that must not be cached as task outputs.
     pub forbidden_output_prefixes: Vec<String>,
     pub input_safety: DerivedInputSafety,
-    /// User-facing explanation when untracked inputs disable implicit caching.
+    /// User-facing explanation when derived inputs or outputs disable implicit
+    /// caching.
     pub cache_reason: Option<String>,
     pub outputs: DerivedOutputs,
 }

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -551,7 +551,8 @@ whether anything changed; Cargo decides how and in what order to build.**
   toggling it invalidates caches. Entrypoint `run`/`dev` tasks and library
   `build` tasks default to `cache: false`: a cache hit must not suppress a
   requested process, and library artifacts have no stable final path to restore.
-  An explicit turbo.json `cache` setting overrides the toolchain default.
+  Turborepo warns when unavailable library outputs disable implicit caching. An
+  explicit turbo.json `cache` setting overrides the toolchain default.
 
 - **Watch mode** (`ChangeKnowledge` and `PackageGraph::active_watch_spec`,
   consumed by `turborepo-lib/src/package_changes_watcher.rs`): discovery

--- a/crates/turborepo/tests/cargo_workspace_test.rs
+++ b/crates/turborepo/tests/cargo_workspace_test.rs
@@ -385,12 +385,18 @@ fn test_cargo_packages_in_task_graph() {
 fn test_cargo_library_build_can_be_filtered() {
     let tempdir = cargo_tempdir();
     setup_cargo_monorepo(tempdir.path());
+    configure_build_without_outputs(tempdir.path());
 
     let output = run_turbo(
         tempdir.path(),
         &["run", "build", "--filter=lib-a", "--dry-run=json"],
     );
     assert!(output.status.success(), "dry run failed: {output:?}");
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("Cargo library artifacts have no stable outputs for Turborepo to restore"),
+        "library build must explain why caching is disabled: {output:?}"
+    );
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     let task = json["tasks"]
         .as_array()


### PR DESCRIPTION
## Description

- Explain when Cargo library builds default to uncached because their internal artifacts have no stable restorable outputs.
- Reuse the shared derived-I/O warning path without changing library caching semantics.
- Keep explicit `outputs` and `cache` configuration authoritative.

Closes TURBO-5927.
