### PR TITLE
feat: Support Cargo root packages

### DIFF
--- a/apps/docs/content/docs/guides/tools/rust.mdx
+++ b/apps/docs/content/docs/guides/tools/rust.mdx
@@ -204,7 +204,7 @@ Untracked inputs are more strict. External, included, or symlinked Cargo configu
 
 ## Limitations
 
-- Only the root virtual Cargo workspace is discovered. Root crates are rejected, nested workspaces are not independently discovered, and resolved external or non-member local path dependencies fail closed.
+- Only the root Cargo workspace is discovered. A package defined in the root `Cargo.toml` participates in task execution, but cannot be a `turbo prune` target because its package directory is the entire repository. Nested workspaces are not independently discovered, and resolved external or non-member local path dependencies fail closed.
 - `cdylib`/`staticlib`-only entrypoints are build-only. Multi-bin crates require both `package.default-run` and an authored task definition for native `run` and `dev`; pass-through arguments cannot supply Cargo's `--bin` option.
 - Automatic artifact caching is deliberately disabled for unresolved output layouts and untracked inputs. Explicit outputs can authorize an unresolved output layout, but untracked inputs require an explicit `cache` setting. Cargo's full `target/` directory is never a task output.
 - The synthetic workspace package has no directory and cannot be passed to `turbo prune`; prune an entrypoint crate instead.

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -118,11 +118,6 @@ pub enum Error {
          `[workspace].exclude`."
     )]
     NonMemberLocalPackage { name: String, manifest_path: String },
-    #[error(
-        "Cargo package {name:?} is defined in the root Cargo.toml, which Turborepo cannot model \
-         as a package safely. Move it into a subdirectory and add it to `[workspace].members`."
-    )]
-    UnsupportedRootPackage { name: String },
     #[error("failed to resolve Cargo local package path {path}: {source}")]
     LocalPackagePath {
         path: String,
@@ -307,7 +302,6 @@ fn validate_resolved_local_packages(
             path: repo_root.to_string(),
             source,
         })?;
-    let root_manifest_path = real_repo_root.join_component(CARGO_TOML);
     for package in &metadata.packages {
         if package.source.is_some() {
             continue;
@@ -329,11 +323,6 @@ fn validate_resolved_local_packages(
             return Err(Error::OutsideRepositoryLocalPackage {
                 name: package.name.clone(),
                 manifest_path: package.manifest_path.clone(),
-            });
-        }
-        if real_manifest_path == root_manifest_path {
-            return Err(Error::UnsupportedRootPackage {
-                name: package.name.clone(),
             });
         }
         if !metadata.workspace_members.contains(&package.id) {
@@ -1479,7 +1468,7 @@ fn discover_contributor_workspace(
 
     match locked_metadata(repo_root) {
         Ok(metadata) => {
-            let workspace = workspace_from_metadata(repo_root, &root_manifest_path, &metadata)?;
+            let workspace = workspace_from_metadata(repo_root, &metadata)?;
             Ok((
                 workspace,
                 ContributorMetadata::Resolved { metadata, lockfile },
@@ -1988,8 +1977,8 @@ fn cargo_config_influence(
 /// is required.
 ///
 /// Crates whose manifests live outside the repository root, or whose names
-/// are invalid, are skipped with a warning. A `[package]` in the root
-/// manifest is skipped too: its directory would be the entire repository.
+/// are invalid, are skipped with a warning. A `[package]` in the root manifest
+/// is modeled as a normal Cargo package anchored at the repository root.
 pub fn discover_crates(repo_root: &AbsoluteSystemPath) -> Result<DiscoveredWorkspace, Error> {
     let root_manifest_path = repo_root.join_component(CARGO_TOML);
     if !root_manifest_path.exists() {
@@ -2020,12 +2009,11 @@ pub fn discover_crates(repo_root: &AbsoluteSystemPath) -> Result<DiscoveredWorks
     }
     let metadata: Metadata = serde_json::from_slice(&output.stdout)?;
 
-    workspace_from_metadata(repo_root, &root_manifest_path, &metadata)
+    workspace_from_metadata(repo_root, &metadata)
 }
 
 fn workspace_from_metadata(
     repo_root: &AbsoluteSystemPath,
-    root_manifest_path: &AbsoluteSystemPath,
     metadata: &Metadata,
 ) -> Result<DiscoveredWorkspace, Error> {
     let has_packages = !metadata.workspace_members.is_empty();
@@ -2037,7 +2025,7 @@ fn workspace_from_metadata(
         .filter(|package| metadata.workspace_members.contains(&package.id))
         .cloned()
         .collect();
-    let crates = connect_crates(parse_members(repo_root, root_manifest_path, packages));
+    let crates = connect_crates(parse_members(repo_root, packages));
 
     if let Some(name) = &name
         && let Some(collision) = crates.iter().find(|c| &c.name == name)
@@ -2149,7 +2137,6 @@ fn manifest_alters_output_layout(manifest_path: &AbsoluteSystemPath) -> bool {
 
 fn parse_members(
     repo_root: &AbsoluteSystemPath,
-    root_manifest_path: &AbsoluteSystemPath,
     packages: Vec<MetadataPackage>,
 ) -> Vec<ParsedCrate> {
     let mut parsed = Vec::new();
@@ -2162,13 +2149,6 @@ fn parse_members(
             );
             continue;
         };
-        if &*manifest_path == root_manifest_path {
-            tracing::warn!(
-                "ignoring [package] in the root Cargo.toml: a crate at the repository root is not \
-                 supported as a Turborepo package"
-            );
-            continue;
-        }
         if !repo_root.contains(&manifest_path) {
             tracing::warn!(
                 "skipping Cargo crate {}: manifest {manifest_path} is outside the repository",
@@ -2391,7 +2371,6 @@ mod test {
     #[test]
     fn full_metadata_discovers_only_workspace_members() {
         let (_temp, root) = tempdir_root();
-        let root_manifest = root.join_component(CARGO_TOML);
         let member_manifest = root.join_components(&["crates", "member", CARGO_TOML]);
         let metadata = Metadata {
             packages: vec![
@@ -2419,7 +2398,7 @@ mod test {
             metadata: serde_json::json!({ "name": "workspace" }),
         };
 
-        let workspace = workspace_from_metadata(&root, &root_manifest, &metadata).unwrap();
+        let workspace = workspace_from_metadata(&root, &metadata).unwrap();
         assert!(workspace.has_packages);
         assert_eq!(workspace.crates.len(), 1);
         assert_eq!(workspace.crates[0].name, "member");
@@ -3502,7 +3481,7 @@ release: 1.96.0-nightly\n",
     }
 
     #[test]
-    fn test_discover_crates_skips_root_crate() {
+    fn test_discover_crates_includes_root_crate() {
         let (_tmp, root) = tempdir_root();
         write(
             &root,
@@ -3521,8 +3500,7 @@ release: 1.96.0-nightly\n",
         let crates = discover_crates(&root).unwrap().crates;
         assert_eq!(
             crates.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
-            vec!["member"],
-            "the root crate's directory is the whole repository, so it is not a package"
+            vec!["member", "root-crate"]
         );
     }
 

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -2680,26 +2680,28 @@ dependencies = ["lib-a"]
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_cargo_toolchain_rejects_root_package() {
+    async fn test_cargo_toolchain_accepts_root_package() {
         let (_tmp, root) = tempdir_root();
         write(
             &root,
             &["Cargo.toml"],
             "[package]\nname = \"root-package\"\nversion = \"0.1.0\"\nedition = \
-             \"2021\"\n\n[workspace]\nmembers = []\nresolver = \"2\"\n",
+             \"2021\"\n\n[workspace]\nmembers = []\nresolver = \
+             \"2\"\n\n[workspace.metadata]\nname = \"root-workspace\"\n",
         );
         write(&root, &["src", "lib.rs"], "");
         generate_lockfile(&root);
 
-        let error = CargoContributor::new(root)
+        let discovered = CargoContributor::new(root)
             .discover_packages()
             .await
-            .unwrap_err();
-        assert!(
-            error.to_string().contains("root-package")
-                && error.to_string().contains("root Cargo.toml"),
-            "unexpected validation result: {error}"
-        );
+            .unwrap();
+        let names: Vec<_> = discovered
+            .packages()
+            .iter()
+            .filter_map(|package| package.clone().into_parts().name)
+            .collect();
+        assert_eq!(names, ["root-package", "root-workspace"]);
     }
 
     fn output_test_workspace(root: &AbsoluteSystemPath) -> CargoWorkspaceDetails {

--- a/crates/turborepo-repository/src/knowledge.rs
+++ b/crates/turborepo-repository/src/knowledge.rs
@@ -302,7 +302,8 @@ impl RepositoryKnowledge {
         let mut scopes = Vec::with_capacity(observations.len());
         let mut scope_lookup = HashMap::with_capacity(observations.len());
         let mut definitions = HashMap::<String, AnchoredSystemPathBuf>::new();
-        let mut definition_owners = HashMap::<std::path::PathBuf, String>::new();
+        let mut definition_owners =
+            HashMap::<std::path::PathBuf, (String, ToolchainId, ScopeKind)>::new();
         let workspace_roots =
             validate_workspace_roots(repository_root, workspace_root_observations)?;
 
@@ -357,8 +358,17 @@ impl RepositoryKnowledge {
                     existing_identity: "//".to_string(),
                 });
             }
-            if let Some(existing_identity) =
-                definition_owners.insert(physical_definition_path, identity.clone())
+            if let Some((existing_identity, existing_toolchain, existing_kind)) = definition_owners
+                .insert(
+                    physical_definition_path,
+                    (
+                        identity.clone(),
+                        observation.toolchain.clone(),
+                        observation.scope_kind,
+                    ),
+                )
+                && (existing_toolchain != observation.toolchain
+                    || existing_kind == observation.scope_kind)
             {
                 return Err(Error::DuplicateDefinitionPath {
                     path: definition_path,

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -428,10 +428,12 @@ whether anything changed; Cargo decides how and in what order to build.**
   or package-manager policy. The same snapshot validates resolution and every
   resolved local package. `--no-deps` is used only to preserve error precedence
   and classify memberless workspaces when locked metadata cannot be obtained.
-  Automatic in-repository workspace members are supported, while
-  excluded/non-member, outside-repository, and root-manifest local packages
-  hard-error because Turborepo cannot hash, watch, or prune their sources
-  safely. The Cargo contributor reports the current workspace root.
+  Automatic in-repository workspace members and a package defined by the root
+  manifest are supported, while excluded/non-member and outside-repository local
+  packages hard-error because Turborepo cannot hash, watch, or prune their
+  sources safely. A root package can execute but cannot be a prune target because
+  its package directory is the entire repository. The Cargo contributor reports
+  the current workspace root.
 - **Package shapes**: crates are classified via `CargoPackageKind`.
   *Entrypoints* (crates with `bin`/`cdylib`/`staticlib` targets) are the
   workspace's deliverables. *Libraries* exist in the package graph and expose

--- a/crates/turborepo/tests/cargo_workspace_test.rs
+++ b/crates/turborepo/tests/cargo_workspace_test.rs
@@ -183,6 +183,42 @@ fn setup_cargo_pure_workspace(dir: &Path) {
     );
 }
 
+fn setup_cargo_root_package(dir: &Path) {
+    fs::create_dir_all(dir.join("src")).unwrap();
+    fs::write(
+        dir.join("Cargo.toml"),
+        r#"[package]
+name = "root-app"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+resolver = "2"
+
+[workspace.metadata]
+name = "rust-workspace"
+"#,
+    )
+    .unwrap();
+    fs::write(dir.join("src/main.rs"), "fn main() {}\n").unwrap();
+    fs::write(
+        dir.join("turbo.json"),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "futureFlags": { "experimentalCargoWorkspaces": true },
+  "tasks": { "build": {} }
+}"#,
+    )
+    .unwrap();
+    let output = std::process::Command::new("cargo")
+        .arg("generate-lockfile")
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    assert_command_success(&output, "generate root package lockfile");
+    setup::setup_git(dir).unwrap();
+}
+
 fn cargo_binary(dir: &Path, segments: &[&str]) -> std::path::PathBuf {
     let mut path = dir.to_path_buf();
     path.extend(segments);
@@ -379,6 +415,51 @@ fn test_cargo_packages_in_task_graph() {
     let expected_output = format!("../../target/debug/{output_name}");
     assert_eq!(cargo_outputs, [expected_output.as_str()]);
     assert!(cargo_outputs.iter().all(|output| !output.contains('*')));
+}
+
+#[test]
+fn test_cargo_root_package_can_be_filtered_and_built() {
+    let tempdir = cargo_tempdir();
+    setup_cargo_root_package(tempdir.path());
+
+    let output = run_turbo(
+        tempdir.path(),
+        &["run", "build", "--filter=root-app", "--dry-run=json"],
+    );
+    assert_command_success(&output, "root package dry run");
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["packages"], serde_json::json!(["root-app"]));
+    let task = json["tasks"]
+        .as_array()
+        .and_then(|tasks| tasks.iter().find(|task| task["taskId"] == "root-app#build"))
+        .expect("root-app#build in graph");
+    assert_eq!(task["command"], "cargo build --package=root-app --locked");
+
+    let output = run_turbo(tempdir.path(), &["run", "build", "--filter=root-app"]);
+    assert_command_success(&output, "root package build");
+    let binary = tempdir
+        .path()
+        .join("target")
+        .join("debug")
+        .join(if cfg!(windows) {
+            "root-app.exe"
+        } else {
+            "root-app"
+        });
+    assert!(
+        binary.exists(),
+        "root package binary must exist at {binary:?}"
+    );
+
+    let output = run_turbo(tempdir.path(), &["prune", "root-app"]);
+    assert!(
+        !output.status.success(),
+        "root package prune must fail closed"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("has no directory of its own"),
+        "root package prune must explain the limitation: {output:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Description

- Discover a package defined alongside `[workspace]` in the root `Cargo.toml`.
- Allow the real root package and synthetic Cargo workspace aggregate to share one same-toolchain manifest definition.
- Support filtering and executing root-package tasks while keeping `turbo prune` fail-closed for repository-root package directories.

Closes TURBO-5926.
