### PR TITLE
fix: Restrict Factory to review comments

### DIFF
--- a/apps/factory/README.md
+++ b/apps/factory/README.md
@@ -104,13 +104,12 @@ Configure it with:
 
 - A private Vercel Blob store (the ledger lives beside the run
   registry).
-- A GitHub Vercel Connect connector subscribed to `push`, `issues`,
-  `issue_comment`, and `pull_request_review_comment`, with pull-request
-  read/write, issue read/write, contents write, and repository collaborator
-  metadata read permissions. Route
-  `push` to `/api/github/push`, and route `issues` plus both comment events to
-  `/eve/v1/github` (including the Deployment Protection bypass query parameter
-  on both destinations).
+- A GitHub Vercel Connect connector subscribed to `push` and
+  `pull_request_review_comment`, with pull-request read/write, contents write,
+  and repository collaborator metadata read permissions. Route `push` to
+  `/api/github/push`, and route `pull_request_review_comment` to `/eve/v1/github`
+  (including the Deployment Protection bypass query parameter on both
+  destinations).
 - `FACTORY_IMAGE_CONNECTOR_ID` set to that connector's stable `scl_...` ID.
 - A Production trigger destination for the `turborepo-factory` project at
   `/api/github/push`. Because Deployment Protection covers that path, append

--- a/apps/factory/agent/channels/github.ts
+++ b/apps/factory/agent/channels/github.ts
@@ -8,7 +8,6 @@ import {
   isTrustedFactoryPullRequestFeedback
 } from "../lib/github-feedback.js";
 import { githubCredentials } from "../lib/github.js";
-import { FACTORY_ISSUE_ATTRIBUTE } from "../lib/issue-handling.js";
 
 type PullRequestResponse = { head?: { ref?: string } };
 type PermissionResponse = { permission?: string };
@@ -19,30 +18,9 @@ export default githubChannel({
   botName,
   credentials: { ...githubCredentials, webhookVerifier: vercelOidc() },
   turnPolicy: "queue",
-  onIssue(ctx, issue) {
-    if (
-      issue.action !== "opened" ||
-      ctx.repository.fullName !== "vercel/turborepo" ||
-      ctx.sender.type === "Bot"
-    ) {
-      return null;
-    }
-    const auth = defaultGitHubAuth(ctx);
-    return {
-      auth: {
-        ...auth,
-        attributes: {
-          ...auth.attributes,
-          [FACTORY_ISSUE_ATTRIBUTE]: "true"
-        }
-      },
-      context: [
-        "This session was automatically opened for a new public issue. Follow the Automatic Issue Handling policy exactly."
-      ],
-      title: "Handle newly opened Turborepo issue"
-    };
-  },
   async onComment(ctx, comment) {
+    if (ctx.conversation.kind !== "review_thread") return null;
+
     const defaultMentionDispatch = () =>
       hasGitHubInvocation(comment.body, botName)
         ? { auth: defaultGitHubAuth(ctx) }

--- a/apps/factory/agent/lib/github-feedback.ts
+++ b/apps/factory/agent/lib/github-feedback.ts
@@ -31,8 +31,7 @@ export function isTrustedFactoryPullRequestFeedback(
 } {
   return (
     candidate.repository === "vercel/turborepo" &&
-    (candidate.conversationKind === "pull_request" ||
-      candidate.conversationKind === "review_thread") &&
+    candidate.conversationKind === "review_thread" &&
     candidate.pullRequestNumber !== null &&
     candidate.senderType !== "Bot" &&
     typeof candidate.branch === "string" &&

--- a/apps/factory/agent/lib/github.ts
+++ b/apps/factory/agent/lib/github.ts
@@ -73,7 +73,6 @@ export async function getGitHubToken(): Promise<string> {
       repo: "turborepo",
       permissions: {
         contents: "write",
-        issues: "write",
         pull_requests: "write"
       }
     })

--- a/apps/factory/tests/github-feedback.test.mjs
+++ b/apps/factory/tests/github-feedback.test.mjs
@@ -11,21 +11,17 @@ import {
 
 const trusted = {
   branch: "agents/examples-basic-2026-08-25",
-  conversationKind: "pull_request",
+  conversationKind: "review_thread",
   permission: "write",
   pullRequestNumber: 123,
   repository: "vercel/turborepo",
   senderType: "User"
 };
 
-test("accepts trusted feedback on Factory pull requests", () => {
+test("accepts trusted feedback on Factory pull request review threads", () => {
   assert.equal(isTrustedFactoryPullRequestFeedback(trusted), true);
   assert.equal(
-    isTrustedFactoryPullRequestFeedback({
-      ...trusted,
-      conversationKind: "review_thread",
-      permission: "admin"
-    }),
+    isTrustedFactoryPullRequestFeedback({ ...trusted, permission: "admin" }),
     true
   );
 });
@@ -34,6 +30,7 @@ test("rejects comments that cannot safely drive Factory changes", () => {
   for (const candidate of [
     { ...trusted, branch: "feature/not-factory" },
     { ...trusted, conversationKind: "issue" },
+    { ...trusted, conversationKind: "pull_request" },
     { ...trusted, permission: "read" },
     { ...trusted, pullRequestNumber: null },
     { ...trusted, repository: "someone/fork" },


### PR DESCRIPTION
## Summary

- Restrict automatic Factory feedback handling to inline pull request review threads.
- Remove automatic issue and pull request timeline-comment dispatch.
- Restore the credential exchange to contents and pull request permissions, avoiding the unsupported issues permission.
- Document the narrower Vercel Connect event and permission configuration.

## Validation

- `node --experimental-strip-types --test tests/github-feedback.test.mjs`
- `pnpm exec tsc --noEmit -p tsconfig.json --pretty false`
- `git diff --check`