### PR TITLE
fix: Detect package-level turbo.jsonc

### DIFF
--- a/crates/turborepo-config/src/lib.rs
+++ b/crates/turborepo-config/src/lib.rs
@@ -47,7 +47,10 @@ use tracing::debug;
 use turbo_json::TurboJsonReader;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 use turborepo_cache::CacheConfig;
-use turborepo_repository::package_graph::PackageName;
+use turborepo_repository::{
+    discovery::{MultipleTurboConfigsError, select_turbo_config_path},
+    package_graph::PackageName,
+};
 use turborepo_scm::WorktreeInfo;
 use turborepo_turbo_json::FutureFlags;
 use turborepo_types::{ConfigurationSource, EnvMode, LogOrder, UIMode};
@@ -739,20 +742,15 @@ pub fn resolve_turbo_config_path(
     let turbo_json_path = dir_path.join_component(CONFIG_FILE);
     let turbo_jsonc_path = dir_path.join_component(CONFIG_FILE_JSONC);
 
-    let turbo_json_exists = turbo_json_path.try_exists()?;
-    let turbo_jsonc_exists = turbo_jsonc_path.try_exists()?;
-
-    match (turbo_json_exists, turbo_jsonc_exists) {
-        (true, true) => Err(Error::TurboJsonError(
-            turborepo_turbo_json::Error::MultipleTurboConfigs {
-                directory: dir_path.to_string(),
-            },
-        )),
-        (true, false) => Ok(turbo_json_path),
-        (false, true) => Ok(turbo_jsonc_path),
-        // Default to turbo.json if neither exists
-        (false, false) => Ok(turbo_json_path),
-    }
+    select_turbo_config_path(
+        dir_path,
+        turbo_json_path.try_exists()?,
+        turbo_jsonc_path.try_exists()?,
+    )
+    .map(|path| path.unwrap_or(turbo_json_path))
+    .map_err(|MultipleTurboConfigsError { directory }| {
+        Error::TurboJsonError(turborepo_turbo_json::Error::MultipleTurboConfigs { directory })
+    })
 }
 
 #[cfg(test)]

--- a/crates/turborepo-filewatch/src/package_watcher.rs
+++ b/crates/turborepo-filewatch/src/package_watcher.rs
@@ -654,6 +654,52 @@ mod test {
 
     #[tokio::test]
     #[tracing_test::traced_test]
+    async fn initial_discovery_detects_package_turbo_jsonc() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(tmp.path())
+            .unwrap()
+            .to_realpath()
+            .unwrap();
+        let workspace_dir = repo_root.join_components(&["apps", "web"]);
+        let package_json = workspace_dir.join_component("package.json");
+        let turbo_jsonc = workspace_dir.join_component("turbo.jsonc");
+
+        package_json.ensure_dir().unwrap();
+        package_json
+            .create_with_contents(r#"{"name":"web"}"#)
+            .unwrap();
+        turbo_jsonc.create_with_contents("{}").unwrap();
+        repo_root
+            .join_component("package.json")
+            .create_with_contents(r#"{"workspaces":["apps/*"], "packageManager":"npm@10.0.0"}"#)
+            .unwrap();
+        repo_root
+            .join_component("package-lock.json")
+            .create_with_contents("")
+            .unwrap();
+
+        let watcher = FileSystemWatcher::new_with_default_cookie_dir(&repo_root).unwrap();
+        let recv = watcher.watch();
+        let cookie_writer = CookieWriter::new(
+            watcher.cookie_dir(),
+            Duration::from_millis(100),
+            recv.clone(),
+        );
+        let package_watcher = PackageWatcher::new(repo_root, recv, cookie_writer, false).unwrap();
+
+        let data = package_watcher.discover_packages_blocking().await.unwrap();
+
+        assert_eq!(
+            data.workspaces,
+            vec![WorkspaceData {
+                package_json,
+                turbo_json: Some(turbo_jsonc),
+            }]
+        );
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
     async fn subscriber_test() {
         let tmp = tempfile::tempdir().unwrap();
         let repo_root = AbsoluteSystemPathBuf::try_from(tmp.path())

--- a/crates/turborepo-filewatch/src/package_watcher.rs
+++ b/crates/turborepo-filewatch/src/package_watcher.rs
@@ -25,7 +25,7 @@ use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 use turborepo_repository::{
     discovery::{
         DiscoveryResponse, LocalPackageDiscoveryBuilder, PackageDiscovery, PackageDiscoveryBuilder,
-        WorkspaceData,
+        WorkspaceData, discover_turbo_config_path,
     },
     package_manager::{self, PackageManager},
     workspaces::WorkspaceGlobs,
@@ -477,6 +477,7 @@ impl Subscriber {
 
         // here, we can only update if we have a valid package state
         let mut changed = false;
+        let mut rediscover = false;
         // if a path is not a valid utf8 string, it is not a valid path, so ignore
         for path in file_event
             .paths
@@ -515,32 +516,28 @@ impl Subscriber {
 
             tracing::debug!("handling change to workspace {path_workspace}");
             let package_json = path_workspace.join_component("package.json");
-            let turbo_json = path_workspace.join_component("turbo.json");
-            let turbo_jsonc = path_workspace.join_component("turbo.jsonc");
-
-            let (package_exists, turbo_json_exists, turbo_jsonc_exists) = join!(
+            let (package_exists, turbo_json) = join!(
                 // It's possible that an IO error could occur other than the file not existing, but
                 // we will treat it like the file doesn't exist. It's possible we'll need to
                 // revisit this, depending on what kind of errors occur.
                 tokio::fs::try_exists(&package_json).map(|result| result.unwrap_or(false)),
-                tokio::fs::try_exists(&turbo_json),
-                tokio::fs::try_exists(&turbo_jsonc)
+                discover_turbo_config_path(path_workspace)
             );
 
             changed |= if package_exists {
+                let turbo_json = match turbo_json {
+                    Ok(path) => path,
+                    Err(_) => {
+                        rediscover = true;
+                        break;
+                    }
+                };
                 workspaces
                     .insert(
                         path_workspace.to_owned(),
                         WorkspaceData {
                             package_json,
-                            turbo_json: turbo_json_exists
-                                .unwrap_or_default()
-                                .then_some(turbo_json)
-                                .or_else(|| {
-                                    turbo_jsonc_exists
-                                        .unwrap_or_default()
-                                        .then_some(turbo_jsonc)
-                                }),
+                            turbo_json,
                         },
                     )
                     .is_none()
@@ -549,7 +546,9 @@ impl Subscriber {
             }
         }
 
-        if changed {
+        if rediscover {
+            self.bump_or_queue_rediscovery(state, package_state_tx);
+        } else if changed {
             self.write_state(package_state);
         }
     }

--- a/crates/turborepo-repository/src/discovery.rs
+++ b/crates/turborepo-repository/src/discovery.rs
@@ -41,6 +41,49 @@ pub enum Error {
     Failed(Box<dyn std::error::Error + Send + Sync>),
 }
 
+#[derive(thiserror::Error, Debug)]
+#[error(
+    "Found both turbo.json and turbo.jsonc in the same directory: {directory}\nRemove either \
+     turbo.json or turbo.jsonc so there is only one."
+)]
+pub struct MultipleTurboConfigsError {
+    pub directory: String,
+}
+
+pub fn select_turbo_config_path(
+    directory: &turbopath::AbsoluteSystemPath,
+    turbo_json_exists: bool,
+    turbo_jsonc_exists: bool,
+) -> Result<Option<AbsoluteSystemPathBuf>, MultipleTurboConfigsError> {
+    match (turbo_json_exists, turbo_jsonc_exists) {
+        (true, true) => Err(MultipleTurboConfigsError {
+            directory: directory.to_string(),
+        }),
+        (true, false) => Ok(Some(directory.join_component("turbo.json"))),
+        (false, true) => Ok(Some(directory.join_component("turbo.jsonc"))),
+        (false, false) => Ok(None),
+    }
+}
+
+pub async fn discover_turbo_config_path(
+    directory: &turbopath::AbsoluteSystemPath,
+) -> Result<Option<AbsoluteSystemPathBuf>, Error> {
+    let turbo_json = directory.join_component("turbo.json");
+    let turbo_jsonc = directory.join_component("turbo.jsonc");
+    let (turbo_json_exists, turbo_jsonc_exists) = tokio::join!(
+        tokio::fs::try_exists(turbo_json.as_path()),
+        tokio::fs::try_exists(turbo_jsonc.as_path())
+    );
+
+    // Discovery has historically treated stat errors as a missing optional config.
+    select_turbo_config_path(
+        directory,
+        turbo_json_exists.unwrap_or_default(),
+        turbo_jsonc_exists.unwrap_or_default(),
+    )
+    .map_err(|error| Error::Failed(Box::new(error)))
+}
+
 /// Defines a strategy for discovering packages on the filesystem.
 pub trait PackageDiscovery {
     // desugar to assert that the future is Send
@@ -185,27 +228,15 @@ impl PackageDiscovery for LocalPackageDiscovery {
         }
 
         // `buffered` keeps discovery order deterministic while letting the
-        // per-workspace turbo.json/turbo.jsonc stats run concurrently — sequentially
-        // these per-workspace syscalls cost ~20ms on large monorepos.
+        // per-workspace config discovery run concurrently — sequentially these
+        // per-workspace syscalls cost ~20ms on large monorepos.
         futures::stream::iter(package_paths.into_iter().map(|path| async move {
             let package_dir = path.parent().expect("non-root");
-            let potential_turbo = package_dir.join_component("turbo.json");
-            let potential_turbo_jsonc = package_dir.join_component("turbo.jsonc");
-            let (potential_turbo_exists, potential_turbo_jsonc_exists) = tokio::join!(
-                tokio::fs::try_exists(potential_turbo.as_path()),
-                tokio::fs::try_exists(potential_turbo_jsonc.as_path())
-            );
+            let turbo_json = discover_turbo_config_path(package_dir).await?;
 
             Ok(WorkspaceData {
                 package_json: path,
-                turbo_json: potential_turbo_exists
-                    .unwrap_or_default()
-                    .then_some(potential_turbo)
-                    .or_else(|| {
-                        potential_turbo_jsonc_exists
-                            .unwrap_or_default()
-                            .then_some(potential_turbo_jsonc)
-                    }),
+                turbo_json,
             })
         }))
         .buffered(64)
@@ -389,7 +420,7 @@ mod local_tests {
     }
 
     #[tokio::test]
-    async fn discovers_turbo_jsonc_and_prefers_turbo_json() {
+    async fn discovers_turbo_jsonc_and_rejects_duplicate_configs() {
         let (_dir, repo_root) = npm_workspace();
         let workspace_dir = repo_root.join_components(&["apps", "web"]);
         let turbo_json = workspace_dir.join_component("turbo.json");
@@ -406,11 +437,15 @@ mod local_tests {
 
         turbo_json.create_with_contents("{}").unwrap();
 
-        let discovery = LocalPackageDiscovery::new(repo_root, PackageManager::Npm)
+        let error = LocalPackageDiscovery::new(repo_root, PackageManager::Npm)
             .discover_packages()
             .await
-            .unwrap();
-        assert_eq!(discovery.workspaces[0].turbo_json, Some(turbo_json));
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("Found both turbo.json and turbo.jsonc")
+        );
     }
 }
 

--- a/crates/turborepo-repository/src/discovery.rs
+++ b/crates/turborepo-repository/src/discovery.rs
@@ -185,20 +185,27 @@ impl PackageDiscovery for LocalPackageDiscovery {
         }
 
         // `buffered` keeps discovery order deterministic while letting the
-        // per-workspace turbo.json stats run concurrently — sequentially
-        // these 1-per-workspace syscalls cost ~20ms on large monorepos.
+        // per-workspace turbo.json/turbo.jsonc stats run concurrently — sequentially
+        // these per-workspace syscalls cost ~20ms on large monorepos.
         futures::stream::iter(package_paths.into_iter().map(|path| async move {
-            let potential_turbo = path
-                .parent()
-                .expect("non-root")
-                .join_component("turbo.json");
-            let potential_turbo_exists = tokio::fs::try_exists(potential_turbo.as_path()).await;
+            let package_dir = path.parent().expect("non-root");
+            let potential_turbo = package_dir.join_component("turbo.json");
+            let potential_turbo_jsonc = package_dir.join_component("turbo.jsonc");
+            let (potential_turbo_exists, potential_turbo_jsonc_exists) = tokio::join!(
+                tokio::fs::try_exists(potential_turbo.as_path()),
+                tokio::fs::try_exists(potential_turbo_jsonc.as_path())
+            );
 
             Ok(WorkspaceData {
                 package_json: path,
                 turbo_json: potential_turbo_exists
                     .unwrap_or_default()
-                    .then_some(potential_turbo),
+                    .then_some(potential_turbo)
+                    .or_else(|| {
+                        potential_turbo_jsonc_exists
+                            .unwrap_or_default()
+                            .then_some(potential_turbo_jsonc)
+                    }),
             })
         }))
         .buffered(64)
@@ -379,6 +386,31 @@ mod local_tests {
         let without_turbo_json = builder.build().unwrap().discover_packages().await.unwrap();
         assert_eq!(without_turbo_json.workspaces.len(), 1);
         assert!(without_turbo_json.workspaces[0].turbo_json.is_none());
+    }
+
+    #[tokio::test]
+    async fn discovers_turbo_jsonc_and_prefers_turbo_json() {
+        let (_dir, repo_root) = npm_workspace();
+        let workspace_dir = repo_root.join_components(&["apps", "web"]);
+        let turbo_json = workspace_dir.join_component("turbo.json");
+        let turbo_jsonc = workspace_dir.join_component("turbo.jsonc");
+
+        turbo_json.remove_file().unwrap();
+        turbo_jsonc.create_with_contents("{}").unwrap();
+
+        let discovery = LocalPackageDiscovery::new(repo_root.clone(), PackageManager::Npm)
+            .discover_packages()
+            .await
+            .unwrap();
+        assert_eq!(discovery.workspaces[0].turbo_json, Some(turbo_jsonc));
+
+        turbo_json.create_with_contents("{}").unwrap();
+
+        let discovery = LocalPackageDiscovery::new(repo_root, PackageManager::Npm)
+            .discover_packages()
+            .await
+            .unwrap();
+        assert_eq!(discovery.workspaces[0].turbo_json, Some(turbo_json));
     }
 }
 


### PR DESCRIPTION
### Description

`LocalPackageDiscovery` only checked for `turbo.json` when discovering workspace configuration files. As a result, initial and full `PackageWatcher` discovery returned `None` for workspaces that only contained `turbo.jsonc`.

Check for both `turbo.json` and `turbo.jsonc` during local discovery while preserving the existing `turbo.json` precedence. This also makes initial discovery consistent with the watcher's incremental update path.

### Testing Instructions

Run:

cargo test -p turborepo-repository -p turborepo-filewatch --lib

The added tests verify that:

- Local package discovery detects a package-level `turbo.jsonc`.
- `turbo.json` remains preferred when both files exist.
- Initial `PackageWatcher` discovery returns the package-level `turbo.jsonc` path.