### PR TITLE
docs: Clarify turbo ls stability in Agent Skill

### DIFF
--- a/skills/turborepo/references/cli/commands.md
+++ b/skills/turborepo/references/cli/commands.md
@@ -332,13 +332,13 @@ turbo docs "prune" --docs-version=2.7.5  # override docs version (minimum: 2.7.5
 
 ## turbo ls
 
-List packages in the monorepo (experimental).
+List packages in the monorepo.
 
 ```bash
 turbo ls                 # all packages
 turbo ls web             # details for a specific package
 turbo ls --affected      # only packages changed vs main
-turbo ls --output=json   # machine-readable (default: pretty)
+turbo ls --output=json   # machine-readable (default: pretty; --output is experimental)
 ```
 
 ## turbo query
@@ -349,6 +349,10 @@ Query the monorepo using GraphQL.
 turbo query                                          # spins up GraphiQL server
 turbo query "query { packages { items { name } } }"  # run a query string
 turbo query ./query.gql                              # run a query from a file
+turbo query ls                                         # list packages (shorthand)
+turbo query ls web                                     # package details
+turbo query ls --affected                              # affected packages only
+turbo query affected                                   # affected tasks (replaces turbo-ignore)
 ```
 
 ## More


### PR DESCRIPTION
## Summary

- Remove the blanket "(experimental)" label from `turbo ls` in the Agent Skill; only `--output` is experimental in the CLI and official docs.
- Note that `--output` is experimental in the `turbo ls` examples.
- Document `turbo query ls` and `turbo query affected` shorthands that were missing from the skill.

## Motivation

Discussion #13605 flagged confusion between CLI help, docs, and agent-facing skill text about whether `turbo ls` is stable. The skill incorrectly marked the whole command experimental.

## Test plan

- [x] Verified against `turbo ls --help` (command stable; `--output` marked experimental)
- [x] Cross-checked with `/docs/reference/ls` and `/docs/reference/query`

Relates to #13605