### PR TITLE
docs: Document missing reference flags and fix query typo

### DIFF
--- a/apps/docs/content/docs/reference/logout.mdx
+++ b/apps/docs/content/docs/reference/logout.mdx
@@ -14,3 +14,15 @@ Log out of the account associated with your Remote Cache provider.
 ```bash title="Terminal"
 turbo logout
 ```
+
+## Flags
+
+### `--invalidate [<BOOL>]`
+
+Invalidate the token on the server. Defaults to `true`.
+
+Pass `--invalidate=false` to remove the local token without revoking it on the server.
+
+```bash title="Terminal"
+turbo logout --invalidate=false
+```

--- a/apps/docs/content/docs/reference/ls.mdx
+++ b/apps/docs/content/docs/reference/ls.mdx
@@ -30,6 +30,15 @@ turbo ls web @repo/ui [package(s)]
 
 ## Flags
 
+### `--filter` (`-F`)
+
+Use pnpm-style package selectors to narrow the package list. Same syntax as [`turbo run --filter`](/docs/reference/run#--filter-string).
+
+```bash title="Terminal"
+turbo ls --filter=web...
+turbo ls -F my-app...
+```
+
 ### `--affected`
 
 Automatically filter to only packages that are affected by changes on the current branch.

--- a/apps/docs/content/docs/reference/query.mdx
+++ b/apps/docs/content/docs/reference/query.mdx
@@ -9,13 +9,15 @@ related:
   - /docs/reference/system-environment-variables
 ---
 
+import { ExperimentalBadge } from "@/components/geistdocs/experimental-badge";
+
 Run GraphQL queries against your monorepo.
 
 ```bash title="Terminal"
 turbo query [query] [flags]
 ```
 
-To quickly get the GraphQL schema, use the `--schema`flag.
+To quickly get the GraphQL schema, use the `--schema` flag.
 
 ```bash title="Terminal"
 turbo query --schema
@@ -97,7 +99,7 @@ turbo query ls --affected
 turbo query ls --affected --filter=web
 ```
 
-#### `--output`
+#### `--output` <ExperimentalBadge />
 
 Control the output format. Defaults to `pretty` (human-readable).
 

--- a/apps/docs/content/docs/support-policy.mdx
+++ b/apps/docs/content/docs/support-policy.mdx
@@ -108,7 +108,7 @@ We encourage you to help us test experimental APIs in side projects, proof-of-co
 
 - [`turbo boundaries`](/docs/reference/boundaries) and [Tags](/docs/reference/boundaries#tags)
 - [`--experimental-write-cache` for `turbo watch`](/docs/reference/watch#caching)
-- [`--output=json` for `turbo ls --affected` flag](/docs/reference/ls)
+- [`--output` for `turbo ls`](/docs/reference/ls#--output-format)
 
 ### Deprecated
 


### PR DESCRIPTION
### Description

- Document `--filter` / `-F` on the `turbo ls` reference page (already supported by the CLI; mirrored from `query.mdx`).
- Document `--invalidate` on the `turbo logout` reference page (defaults to `true`; `--invalidate=false` skips remote revoke).
- Fix typo in `query.mdx` (`--schema`flag → `--schema` flag).
- Mark `turbo query ls --output` as experimental to match `ls.mdx` and CLI help.
- Correct support-policy wording: experimental applies to `turbo ls --output`, not only with `--affected`.

### Testing Instructions

- [x] Verified content against `turbo ls --help`, `turbo logout --help`, and existing `ls.mdx` / `query.mdx` patterns.
- [x] `pnpm exec oxfmt --check` on edited MDX files (via repo pre-push `format` task).
- [x] No overlap with open PR #13811 (`run.mdx` / env vars) or #13684 (orphaned cross-links).