### PR TITLE
test: Cover watch startup timeout and document missing CLI flags

### DIFF
--- a/apps/docs/content/docs/reference/boundaries.mdx
+++ b/apps/docs/content/docs/reference/boundaries.mdx
@@ -104,3 +104,34 @@ Package names can also be used in place of a tag in allow and deny lists.
 Tags allow you to ensure that the wrong package isn't getting imported somewhere in your graph. These rules are
 applied even for dependencies of dependencies, so if you import a package that in turn imports another package
 with a denied tag, you will still get a rule violation.
+
+## Flags
+
+### `--filter` (`-F`)
+
+Use pnpm-style package selectors to limit which packages Boundaries checks. Same syntax as [`turbo run --filter`](/docs/reference/run#--filter-string).
+
+```bash title="Terminal"
+turbo boundaries --filter=web
+turbo boundaries -F ./apps/*
+```
+
+### `--ignore`
+
+Automatically add `@boundaries-ignore` comments for reported violations.
+
+- `--ignore` or `--ignore=prompt` (default when the flag is present): prompt before adding each comment
+- `--ignore=all`: add comments everywhere possible without prompting
+
+```bash title="Terminal"
+turbo boundaries --ignore
+turbo boundaries --ignore=all
+```
+
+### `--reason <string>`
+
+When using `--ignore`, set the reason recorded in the generated `@boundaries-ignore` comments. Requires `--ignore`.
+
+```bash title="Terminal"
+turbo boundaries --ignore=all --reason="legacy package"
+```

--- a/apps/docs/content/docs/reference/link.mdx
+++ b/apps/docs/content/docs/reference/link.mdx
@@ -43,3 +43,11 @@ The scope to which you are linking. For example, when using Vercel, this is your
 ```bash title="Terminal"
 turbo link --scope=your-team
 ```
+
+### `--no-gitignore`
+
+Do not create or modify `.gitignore`. By default, `turbo link` may update `.gitignore` for Remote Cache artifacts.
+
+```bash title="Terminal"
+turbo link --no-gitignore
+```

--- a/apps/docs/content/docs/reference/watch.mdx
+++ b/apps/docs/content/docs/reference/watch.mdx
@@ -58,3 +58,13 @@ If you have tasks that write to files checked into source control, there is a po
 files for changes and will re-run tasks in packages that have changed. If a task creates a change, then that will trigger the task again.
 
 Watch Mode has some logic to prevent this from happening using file hashes, but it isn't foolproof. To avoid this issue, we recommend removing any task outputs from git.
+
+### Startup timeout
+
+`turbo watch` waits for the file watcher and initial package hash to become ready before running tasks. The default timeout is **120 seconds**.
+
+If startup times out (for example because a large file is slowing the initial hash), raise the limit with `TURBO_WATCH_STARTUP_TIMEOUT` (seconds), or remove / `.gitignore` the large file:
+
+```bash title="Terminal"
+TURBO_WATCH_STARTUP_TIMEOUT=300 turbo watch build
+```

--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -852,7 +852,13 @@ impl Subscriber {
 
 #[cfg(test)]
 mod test {
-    use std::{collections::HashSet, path::PathBuf, sync::Arc, time::Duration};
+    use std::{
+        collections::HashSet,
+        env,
+        path::PathBuf,
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
 
     use ignore::gitignore::GitignoreBuilder;
     use notify::event::{CreateKind, EventKind};
@@ -872,8 +878,9 @@ mod test {
 
     use super::{
         ancestors_is_ignored, baseline_matches, classify_changed_files, hash_scopes,
-        is_in_git_folder, ChangedFiles, FileChangeAction, PackageChangeEvent,
+        is_in_git_folder, startup_timeout_secs, ChangedFiles, FileChangeAction, PackageChangeEvent,
         PackageChangesWatcher, PackageHashBaseline, RepositoryIgnore, Subscriber, CONFIG_FILE,
+        DEFAULT_STARTUP_TIMEOUT_SECS,
     };
     use crate::repository_graph::RepositoryGraphFeatures;
 
@@ -2337,5 +2344,66 @@ mod test {
             matches!(event, Some(PackageChangeEvent::Package { .. })),
             "ignored burst should not cause rediscovery before source change, got {event:?}"
         );
+    }
+
+    static STARTUP_TIMEOUT_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn startup_timeout_defaults_when_unset() {
+        let _lock = STARTUP_TIMEOUT_ENV_LOCK
+            .lock()
+            .expect("startup timeout env lock poisoned");
+        unsafe {
+            env::remove_var("TURBO_WATCH_STARTUP_TIMEOUT");
+        }
+        assert_eq!(startup_timeout_secs(), DEFAULT_STARTUP_TIMEOUT_SECS);
+    }
+
+    #[test]
+    fn startup_timeout_parses_valid_override() {
+        let _lock = STARTUP_TIMEOUT_ENV_LOCK
+            .lock()
+            .expect("startup timeout env lock poisoned");
+        unsafe {
+            env::set_var("TURBO_WATCH_STARTUP_TIMEOUT", "30");
+        }
+        assert_eq!(startup_timeout_secs(), 30);
+        unsafe {
+            env::remove_var("TURBO_WATCH_STARTUP_TIMEOUT");
+        }
+    }
+
+    #[test]
+    fn startup_timeout_allows_zero() {
+        let _lock = STARTUP_TIMEOUT_ENV_LOCK
+            .lock()
+            .expect("startup timeout env lock poisoned");
+        unsafe {
+            env::set_var("TURBO_WATCH_STARTUP_TIMEOUT", "0");
+        }
+        assert_eq!(startup_timeout_secs(), 0);
+        unsafe {
+            env::remove_var("TURBO_WATCH_STARTUP_TIMEOUT");
+        }
+    }
+
+    #[test]
+    fn startup_timeout_falls_back_on_invalid_values() {
+        let _lock = STARTUP_TIMEOUT_ENV_LOCK
+            .lock()
+            .expect("startup timeout env lock poisoned");
+        for invalid in ["", "abc", "-1", "12.5", " 30 "] {
+            unsafe {
+                env::set_var("TURBO_WATCH_STARTUP_TIMEOUT", invalid);
+            }
+            assert_eq!(
+                startup_timeout_secs(),
+                DEFAULT_STARTUP_TIMEOUT_SECS,
+                "expected default for invalid value {invalid:?}"
+            );
+        }
+        unsafe {
+            env::remove_var("TURBO_WATCH_STARTUP_TIMEOUT");
+        }
     }
 }

--- a/skills/turborepo/references/boundaries/RULE.md
+++ b/skills/turborepo/references/boundaries/RULE.md
@@ -13,9 +13,15 @@ Boundaries enforce package isolation by detecting:
 
 ```bash
 turbo boundaries
+turbo boundaries --filter=web
+turbo boundaries --ignore=all --reason="legacy package"
 ```
 
 Run this to check for workspace violations across your monorepo.
+
+- `--filter` / `-F`: limit checks to matching packages (same syntax as `turbo run --filter`)
+- `--ignore` / `--ignore=prompt` / `--ignore=all`: add `@boundaries-ignore` comments for violations
+- `--reason`: reason text for generated ignore comments (requires `--ignore`)
 
 ## Tags
 

--- a/skills/turborepo/references/watch/RULE.md
+++ b/skills/turborepo/references/watch/RULE.md
@@ -78,6 +78,14 @@ If tasks write files tracked by git, watch mode may loop infinitely. Watch mode 
 
 **Recommendation**: Remove task outputs from git.
 
+### Startup Timeout
+
+`turbo watch` waits up to **120 seconds** for the file watcher / initial hash to become ready. Override with `TURBO_WATCH_STARTUP_TIMEOUT` (seconds) if a large file slows startup:
+
+```bash
+TURBO_WATCH_STARTUP_TIMEOUT=300 turbo watch build
+```
+
 ## vs turbo run
 
 | Feature           | `turbo run` | `turbo watch` |


### PR DESCRIPTION
### Description

- Add unit tests for `startup_timeout_secs()` / `TURBO_WATCH_STARTUP_TIMEOUT` (default 120s, valid override, zero, invalid fallback), with an env mutex so parallel lib tests stay safe.
- Document the watch startup timeout on the `turbo watch` reference page and Agent Skill.
- Document missing CLI flags that already exist in the binary:
  - `turbo link --no-gitignore`
  - `turbo boundaries --filter` / `--ignore` / `--reason`

No behavior changes — tests + docs for shipped surfaces. Does not touch `system-environment-variables.mdx` (open PR #13811).

### Testing Instructions

- [x] `cargo test -p turborepo-lib --lib startup_timeout` → 4 passed
- [x] `cargo fmt --check` (via pre-push)
- [x] Cross-checked against CLI help / existing `args.rs` definitions