### PR TITLE
fix: Correct devtools --port default in CLI help

### DIFF
--- a/crates/turborepo-lib/src/cli/args.rs
+++ b/crates/turborepo-lib/src/cli/args.rs
@@ -1008,7 +1008,7 @@ pub enum Command {
     /// Visualize your monorepo's package graph in the browser
     Devtools {
         /// Port for the WebSocket server
-        #[usage(long, default_value_t = turborepo_devtools::DEFAULT_PORT, default = "9789")]
+        #[usage(long, default_value_t = turborepo_devtools::DEFAULT_PORT, default = "9876")]
         port: u16,
         /// Don't automatically open the browser
         #[usage(long)]

--- a/crates/turborepo-lib/src/cli/snapshots/turborepo_lib__cli__test__devtools_short_help.snap
+++ b/crates/turborepo-lib/src/cli/snapshots/turborepo_lib__cli__test__devtools_short_help.snap
@@ -1,0 +1,60 @@
+---
+source: crates/turborepo-lib/src/cli/test.rs
+expression: "Args::render_help(cmd, false).unwrap()"
+---
+Visualize your monorepo's package graph in the browser
+
+Usage: turbo devtools [--port <PORT>] [--no-open]
+
+Flags:
+      --port <PORT>               Port for the WebSocket server (default: 9876)
+      --no-open                   Don't automatically open the browser
+  -h, --help                      Print help
+
+Global flags:
+      --version
+      --skip-infer                Skip any attempts to infer which version of
+                                  Turbo the project is configured to use
+      --no-update-notifier        Disable the turbo update notification
+      --api <API>                 Override the endpoint for API calls
+      --color                     Force color usage in the terminal
+      --cwd <CWD>                 The directory in which to run turbo
+      --heap <HEAP>               Specify a file to save a pprof heap profile
+      --ui <UI>                   Specify whether to use the streaming UI or TUI
+      --login <LOGIN>             Override the login endpoint
+      --no-color                  Suppress color usage in the terminal
+      --preflight                 When enabled, turbo will precede HTTP requests
+                                  with an OPTIONS request for authorization
+      --remote-cache-timeout <TIMEOUT>  Set a timeout for all HTTP requests.
+      --team <TEAM>               Set the team slug for API calls
+      --token <TOKEN>             Set the auth token for API calls
+      --trace <TRACE>             Specify a file to save a pprof trace
+      --verbosity <COUNT>         Verbosity level. Useful when debugging
+                                  Turborepo or creating logs for issue reports
+      --experimental-otel-enabled [EXPERIMENTAL_OTEL_ENABLED]
+                                  Enable OpenTelemetry metrics export
+      --experimental-otel-protocol <PROTOCOL>  OTLP transport protocol (grpc or
+                                  http-protobuf)
+      --experimental-otel-endpoint <URL>  OTLP collector endpoint URL
+      --experimental-otel-timeout-ms <MILLISECONDS>
+                                  OTLP export timeout in milliseconds (default:
+                                  10000)
+      --experimental-otel-interval-ms <MILLISECONDS>
+                                  OTLP export interval in milliseconds (default:
+                                  15000)
+      --experimental-otel-header <KEY=VALUE>  Add header to OTLP requests (can
+                                  be repeated)
+      --experimental-otel-resource <KEY=VALUE>  Add resource attribute to
+                                  metrics (can be repeated)
+      --experimental-otel-metrics-run-summary [EXPERIMENTAL_OTEL_METRICS_RUN_SUMMARY]
+                                  Emit run-level summary metrics (default: true)
+      --experimental-otel-metrics-task-details [EXPERIMENTAL_OTEL_METRICS_TASK_DETAILS]
+                                  Emit per-task detail metrics (default: false)
+      --experimental-otel-use-remote-cache-token [EXPERIMENTAL_OTEL_USE_REMOTE_CACHE_TOKEN]
+                                  Use remote cache token for OTLP authentication
+      --dangerously-disable-package-manager-check
+                                  Allow for missing `packageManager` in
+                                  `package.json`.
+      --root-turbo-json <ROOT_TURBO_JSON>  Use the `turbo.json` located at the
+                                  provided path instead of one at the
+                                  root of the repository.

--- a/crates/turborepo-lib/src/cli/test.rs
+++ b/crates/turborepo-lib/src/cli/test.rs
@@ -145,6 +145,12 @@ fn logout_short_help() {
     assert_snapshot!(Args::render_help(cmd, false).unwrap());
 }
 
+#[test]
+fn devtools_short_help() {
+    let cmd = get_subcommand("devtools");
+    assert_snapshot!(Args::render_help(cmd, false).unwrap());
+}
+
 struct CommandTestCase {
     command: &'static str,
     command_args: Vec<Vec<&'static str>>,


### PR DESCRIPTION
### Description

- Fix `turbo devtools --help` advertising port **9789** as the default for `--port`.
- The real default is **9876** (`turborepo_devtools::DEFAULT_PORT`), which already matches `/docs/reference/devtools`.
- Add an insta snapshot test for `turbo devtools --help` so the default stays aligned.

### Testing Instructions

- [x] `INSTA_UPDATE=1 cargo test -p turborepo-lib --lib devtools_short_help`
- [x] Verified snapshot shows `(default: 9876)`
- [x] `cargo fmt --check` (via pre-push hook)