### PR TITLE
docs: Add turbo daemon command reference

### DIFF
--- a/apps/docs/content/docs/reference/daemon.mdx
+++ b/apps/docs/content/docs/reference/daemon.mdx
@@ -1,0 +1,93 @@
+---
+title: daemon
+description: API reference for the `turbo daemon` command
+product: turborepo
+type: reference
+summary: Reference for the `turbo daemon` command that manages the Turborepo background daemon.
+related:
+  - /docs/reference/watch
+  - /docs/reference/run
+  - /docs/reference/configuration
+---
+
+Manage the Turborepo background daemon (`turbod`).
+
+```bash title="Terminal"
+turbo daemon [subcommand] [flags]
+```
+
+The daemon is no longer used for [`turbo run`](/docs/reference/run#--daemon-and---no-daemon). It is still used by [`turbo watch`](/docs/reference/watch) and the Turborepo LSP.
+
+When invoked without a subcommand, `turbo daemon` starts the daemon server.
+
+## Subcommands
+
+### `start`
+
+Ensure the daemon is running.
+
+```bash title="Terminal"
+turbo daemon start
+```
+
+### `stop`
+
+Stop the daemon.
+
+```bash title="Terminal"
+turbo daemon stop
+```
+
+### `restart`
+
+Restart the daemon.
+
+```bash title="Terminal"
+turbo daemon restart
+```
+
+### `status`
+
+Report whether the daemon is running.
+
+```bash title="Terminal"
+turbo daemon status
+turbo daemon status --json
+```
+
+Pass `--json` to print machine-readable status.
+
+### `clean`
+
+Stop the daemon if it is running and remove stale daemon state.
+
+```bash title="Terminal"
+turbo daemon clean
+turbo daemon clean --clean-logs=false
+```
+
+### `logs`
+
+Show daemon logs.
+
+```bash title="Terminal"
+turbo daemon logs
+```
+
+## Flags
+
+### `--idle-time <duration>`
+
+Set how long the daemon waits before shutting down when idle. Defaults to `4h0m0s`.
+
+```bash title="Terminal"
+turbo daemon --idle-time=30m0s start
+```
+
+### `--turbo-json-path <path>`
+
+Path to a custom `turbo.json` file for the daemon to watch.
+
+```bash title="Terminal"
+turbo daemon --turbo-json-path=./config/turbo.json start
+```

--- a/apps/docs/content/docs/reference/index.mdx
+++ b/apps/docs/content/docs/reference/index.mdx
@@ -55,6 +55,13 @@ Turborepo's API reference is broken up into the following sections:
         href="/docs/reference/watch"
         description="Dependency-aware, single-process task watcher."
     />
+
+    <Card
+        title="daemon"
+        href="/docs/reference/daemon"
+        description="Manage the Turborepo background daemon."
+    />
+
     <Card
         title="prune"
         href="/docs/reference/prune"

--- a/apps/docs/content/docs/reference/meta.json
+++ b/apps/docs/content/docs/reference/meta.json
@@ -10,6 +10,7 @@
     "---Commands---",
     "run",
     "watch",
+    "daemon",
     "prune",
     "boundaries",
     "ls",

--- a/skills/turborepo/references/cli/commands.md
+++ b/skills/turborepo/references/cli/commands.md
@@ -355,10 +355,25 @@ turbo query ls --affected                              # affected packages only
 turbo query affected                                   # affected tasks (replaces turbo-ignore)
 ```
 
+## turbo daemon
+
+Manage the Turborepo background daemon. No longer used for `turbo run`; still used by `turbo watch` and the Turborepo LSP.
+
+```bash
+turbo daemon start
+turbo daemon status
+turbo daemon status --json
+turbo daemon stop
+turbo daemon restart
+turbo daemon clean
+turbo daemon logs
+```
+
+See `references/daemon/` for details.
+
 ## More
 
 - `turbo devtools` - visualize the package graph in the browser
 - `turbo info` - print debugging information
 - `turbo bin` - print the path to the turbo binary
-- `turbo daemon` - run/manage the background daemon
 - `turbo telemetry` - enable or disable anonymous telemetry

--- a/skills/turborepo/references/daemon/RULE.md
+++ b/skills/turborepo/references/daemon/RULE.md
@@ -1,0 +1,36 @@
+# turbo daemon
+
+Full docs: https://turborepo.dev/docs/reference/daemon
+
+Manage the Turborepo background daemon (`turbod`).
+
+```bash
+turbo daemon [subcommand] [flags]
+```
+
+The daemon is **not** used for `turbo run` (deprecated). It is still used by `turbo watch` and the Turborepo LSP.
+
+## Subcommands
+
+| Subcommand | Description                                                                |
+| ---------- | -------------------------------------------------------------------------- |
+| `start`    | Ensure the daemon is running                                               |
+| `stop`     | Stop the daemon                                                            |
+| `restart`  | Restart the daemon                                                         |
+| `status`   | Report daemon status (`--json` for machine-readable output)                |
+| `clean`    | Stop the daemon and remove stale state (`--clean-logs=false` to keep logs) |
+| `logs`     | Show daemon logs                                                           |
+
+## Flags
+
+- `--idle-time <duration>` — idle shutdown timeout (default: `4h0m0s`)
+- `--turbo-json-path <path>` — custom `turbo.json` path to watch
+
+## Examples
+
+```bash
+turbo daemon start
+turbo daemon status --json
+turbo daemon --idle-time=30m0s start
+turbo daemon clean
+```


### PR DESCRIPTION
### Description

- Add `/docs/reference/daemon` documenting `turbo daemon` subcommands (`start`, `stop`, `restart`, `status`, `clean`, `logs`) and flags (`--idle-time`, `--turbo-json-path`).
- Register the page in the reference sidebar (`meta.json`) and index cards.
- Add Agent Skill coverage in `skills/turborepo/references/daemon/RULE.md` and expand the CLI commands cheat sheet.

Notes that the daemon is deprecated for `turbo run` but still used by `turbo watch` and the Turborepo LSP.

### Testing Instructions

- [x] Verified content against `turbo daemon --help` and `args.rs` definitions
- [x] `pnpm exec oxfmt --check` on edited MDX files (via pre-push `format` task)
- [x] No overlap with open PR #13811 (env vars) or #13904 (watch/link/boundaries)