### PR TITLE
fix: Bound memory usage for streamed task output

### DIFF
--- a/crates/turborepo-log/src/grouping.rs
+++ b/crates/turborepo-log/src/grouping.rs
@@ -73,7 +73,6 @@ impl GroupingLayer {
             task_id: id,
             layer: Arc::clone(self),
             buffer,
-            accumulated_bytes: Vec::new(),
         }
     }
 
@@ -92,7 +91,6 @@ impl GroupingLayer {
             display_label: display_label.into(),
             layer: Arc::clone(self),
             buffer,
-            accumulated_bytes: Vec::new(),
         }
     }
 }
@@ -111,10 +109,6 @@ enum TaskEvent {
 /// In passthrough mode, all calls forward to the logger immediately.
 /// In grouped mode, calls are buffered and flushed atomically when
 /// [`finish`](Self::finish) is called.
-///
-/// `accumulated_bytes` always collects all output bytes regardless of
-/// mode — these are returned by `finish()` for cache log writing and
-/// run summary use.
 pub struct TaskHandle {
     task_id: String,
     /// Human-facing label for CI group markers. Defaults to `task_id`.
@@ -122,7 +116,6 @@ pub struct TaskHandle {
     layer: Arc<GroupingLayer>,
     /// `None` in passthrough mode; `Some` in grouped mode.
     buffer: Option<Vec<TaskEvent>>,
-    accumulated_bytes: Vec<u8>,
 }
 
 impl TaskHandle {
@@ -141,7 +134,6 @@ impl TaskHandle {
 
     /// Write raw child process output bytes for this task.
     pub fn task_output(&mut self, channel: OutputChannel, bytes: &[u8]) {
-        self.accumulated_bytes.extend_from_slice(bytes);
         match &mut self.buffer {
             None => {
                 self.layer.logger.task_output(&self.task_id, channel, bytes);
@@ -160,10 +152,7 @@ impl TaskHandle {
     /// In grouped mode, acquires the flush lock to prevent interleaving
     /// with other tasks, then replays all buffered events and output
     /// through the logger bracketed by `begin/end_task_group` calls.
-    ///
-    /// Returns all accumulated output bytes (useful for cache log
-    /// writing and run summary).
-    pub fn finish(self, is_error: bool) -> Vec<u8> {
+    pub fn finish(self, is_error: bool) {
         if let Some(buffer) = self.buffer
             && !buffer.is_empty()
         {
@@ -192,7 +181,6 @@ impl TaskHandle {
                 .logger
                 .end_task_group(&self.display_label, is_error);
         }
-        self.accumulated_bytes
     }
 
     /// Create a writer that forwards to [`task_output`](Self::task_output).
@@ -304,8 +292,7 @@ mod tests {
         handle.task_output(OutputChannel::Stdout, b"hello\n");
         assert_eq!(sink.output_chunks.lock().unwrap().len(), 1);
 
-        let bytes = handle.finish(false);
-        assert_eq!(bytes, b"hello\n");
+        handle.finish(false);
 
         // No group markers in passthrough
         assert!(sink.group_begins.lock().unwrap().is_empty());
@@ -325,7 +312,7 @@ mod tests {
         assert!(sink.events.lock().unwrap().is_empty());
         assert!(sink.output_chunks.lock().unwrap().is_empty());
 
-        let bytes = handle.finish(false);
+        handle.finish(false);
 
         // Now everything flushed
         assert_eq!(sink.events.lock().unwrap().len(), 1);
@@ -339,9 +326,6 @@ mod tests {
         let ends = sink.group_ends.lock().unwrap();
         assert_eq!(ends.len(), 1);
         assert_eq!(ends[0], ("web#build".to_string(), false));
-
-        // Accumulated bytes contain both chunks
-        assert_eq!(bytes, b"building...\nwarning: unused var\n");
     }
 
     #[test]
@@ -369,18 +353,6 @@ mod tests {
 
         assert!(sink.group_begins.lock().unwrap().is_empty());
         assert!(sink.group_ends.lock().unwrap().is_empty());
-    }
-
-    #[test]
-    fn passthrough_accumulates_bytes() {
-        let (_sink, layer) = setup(GroupingMode::Passthrough);
-        let mut handle = layer.task("web#build");
-
-        handle.task_output(OutputChannel::Stdout, b"line 1\n");
-        handle.task_output(OutputChannel::Stderr, b"line 2\n");
-
-        let bytes = handle.finish(false);
-        assert_eq!(bytes, b"line 1\nline 2\n");
     }
 
     #[test]

--- a/crates/turborepo-ui/src/log_sinks.rs
+++ b/crates/turborepo-ui/src/log_sinks.rs
@@ -72,6 +72,7 @@ impl LogSinks {
     /// Re-enable all terminal output when the TUI didn't start
     /// (stream mode, web mode, terminal too small).
     pub fn enable_for_stream(&self) {
+        self.tui.disable();
         self.terminal.enable();
     }
 }

--- a/crates/turborepo-ui/src/tui_sink.rs
+++ b/crates/turborepo-ui/src/tui_sink.rs
@@ -36,6 +36,7 @@ enum SinkState {
         task_output: Vec<(String, Vec<u8>)>,
     },
     Connected(TuiSender),
+    Disabled,
 }
 
 impl Default for TuiSink {
@@ -76,6 +77,14 @@ impl TuiSink {
         }
         *state = SinkState::Connected(sender);
     }
+
+    /// Discard startup output and stop buffering when the TUI will not start.
+    pub fn disable(&self) {
+        *self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = SinkState::Disabled;
+    }
 }
 
 impl LogSink for TuiSink {
@@ -97,6 +106,7 @@ impl LogSink for TuiSink {
                     sender.log_event(event.clone());
                 }
             }
+            SinkState::Disabled => {}
         }
     }
 
@@ -113,6 +123,7 @@ impl LogSink for TuiSink {
             SinkState::Connected(sender) => {
                 let _ = sender.output(task.to_string(), normalized);
             }
+            SinkState::Disabled => {}
         }
     }
 }
@@ -153,8 +164,21 @@ mod tests {
                 assert_eq!(events[0].message(), "first");
                 assert_eq!(events[1].message(), "second");
             }
-            SinkState::Connected(_) => panic!("expected Buffering state"),
+            SinkState::Connected(_) | SinkState::Disabled => panic!("expected Buffering state"),
         }
+    }
+
+    #[test]
+    fn disable_discards_buffer_and_future_output() {
+        let sink = TuiSink::new();
+        sink.emit(&make_event("buffered"));
+        sink.task_output("web#build", OutputChannel::Stdout, b"output\n");
+
+        sink.disable();
+        sink.emit(&make_event("ignored"));
+        sink.task_output("web#build", OutputChannel::Stdout, b"ignored\n");
+
+        assert!(matches!(*sink.state.lock().unwrap(), SinkState::Disabled));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Stop retaining a redundant copy of task output in `TaskHandle`
- Disable the inactive TUI sink when falling back to streamed output
- Preserve grouped output buffering and existing stream rendering behavior

Fixes #13907

## Verification

Using the issue reproduction with 256 MiB of output, native Turbo RSS remained approximately 67 MiB instead of growing with the output stream.