### PR TITLE
fix: Clarify generator action reporting

### DIFF
--- a/packages/turbo-gen/__tests__/cli.test.ts
+++ b/packages/turbo-gen/__tests__/cli.test.ts
@@ -75,6 +75,20 @@ export default function generator(plop: any): void {
 }
 `;
 
+const TS_CONFIG_WITH_NO_OP_APPEND = `
+export default function generator(plop: any): void {
+  plop.setGenerator("no-op-append", {
+    prompts: [],
+    actions: [{
+      type: "append",
+      path: "target.txt",
+      pattern: /missing anchor/,
+      template: "appended content"
+    }]
+  });
+}
+`;
+
 // CJS config (works for .js without "type":"module" and .cjs)
 const JS_CJS_CONFIG = (name: string) => `
 module.exports = function generator(plop) {
@@ -214,6 +228,36 @@ describeIfBuilt("@turbo/gen CLI", () => {
       expect(out).toContain("run");
       expect(out).toContain("workspace");
     });
+  });
+
+  // Regression test for https://github.com/vercel/turborepo/issues/13909
+  it("does not report a no-op append as a change", () => {
+    const projectDir = path.join(tmpDir, "no-op-append");
+    fs.mkdirSync(projectDir, { recursive: true });
+    createProject(projectDir, {
+      configFile: "config.ts",
+      configContent: TS_CONFIG_WITH_NO_OP_APPEND
+    });
+    fs.writeFileSync(path.join(projectDir, "target.txt"), "unchanged\n");
+
+    const output = run(
+      [
+        "raw",
+        "run",
+        "--json",
+        JSON.stringify({
+          root: projectDir,
+          generator_name: "no-op-append"
+        })
+      ],
+      projectDir
+    );
+
+    expect(output).toContain("Actions completed:");
+    expect(output).not.toContain("Changes made:");
+    expect(fs.readFileSync(path.join(projectDir, "target.txt"), "utf8")).toBe(
+      "unchanged\n"
+    );
   });
 
   // Regression test for https://github.com/vercel/turborepo/issues/13735

--- a/packages/turbo-gen/__tests__/cli.test.ts
+++ b/packages/turbo-gen/__tests__/cli.test.ts
@@ -89,6 +89,15 @@ export default function generator(plop: any): void {
 }
 `;
 
+const TS_CONFIG_WITH_NO_ACTIONS = `
+export default function generator(plop: any): void {
+  plop.setGenerator("no-actions", {
+    prompts: [],
+    actions: []
+  });
+}
+`;
+
 // CJS config (works for .js without "type":"module" and .cjs)
 const JS_CJS_CONFIG = (name: string) => `
 module.exports = function generator(plop) {
@@ -228,6 +237,31 @@ describeIfBuilt("@turbo/gen CLI", () => {
       expect(out).toContain("run");
       expect(out).toContain("workspace");
     });
+  });
+
+  it("reports when no actions were taken", () => {
+    const projectDir = path.join(tmpDir, "no-actions");
+    fs.mkdirSync(projectDir, { recursive: true });
+    createProject(projectDir, {
+      configFile: "config.ts",
+      configContent: TS_CONFIG_WITH_NO_ACTIONS
+    });
+
+    const output = run(
+      [
+        "raw",
+        "run",
+        "--json",
+        JSON.stringify({
+          root: projectDir,
+          generator_name: "no-actions"
+        })
+      ],
+      projectDir
+    );
+
+    expect(output).toContain("No actions were taken.");
+    expect(output).not.toContain("Actions completed:");
   });
 
   // Regression test for https://github.com/vercel/turborepo/issues/13909

--- a/packages/turbo-gen/src/utils/plop.ts
+++ b/packages/turbo-gen/src/utils/plop.ts
@@ -404,5 +404,7 @@ export async function runCustomGenerator({
         logger.item(`${c.path} (${c.type})`);
       }
     }
+  } else {
+    logger.info("No actions were taken.");
   }
 }

--- a/packages/turbo-gen/src/utils/plop.ts
+++ b/packages/turbo-gen/src/utils/plop.ts
@@ -398,7 +398,7 @@ export async function runCustomGenerator({
   }
 
   if (results.changes.length > 0) {
-    logger.info("Changes made:");
+    logger.info("Actions completed:");
     for (const c of results.changes) {
       if (c.path) {
         logger.item(`${c.path} (${c.type})`);


### PR DESCRIPTION
## Summary

- Rename the custom generator result heading from `Changes made` to `Actions completed`
- Preserve successful no-op behavior when an append pattern does not match
- Add regression coverage for a no-op append

Closes #13909