### PR TITLE
fix: Bump tar to 7.5.22 in @turbo/releaser (CVE-2026-73566)

### DIFF
--- a/packages/turbo-releaser/package.json
+++ b/packages/turbo-releaser/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "commander": "11.0.0",
     "semver": "7.5.2",
-    "tar": "7.5.18"
+    "tar": "7.5.22"
   },
   "devDependencies": {
     "@turbo/tsconfig": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -829,8 +829,8 @@ importers:
         specifier: 7.5.2
         version: 7.5.2
       tar:
-        specifier: 7.5.18
-        version: 7.5.18
+        specifier: 7.5.22
+        version: 7.5.22
     devDependencies:
       '@turbo/tsconfig':
         specifier: workspace:*
@@ -10768,6 +10768,10 @@ packages:
 
   tar@7.5.18:
     resolution: {integrity: sha512-PwA+nJl+AzsS9hRqtNRRq8/kTdNPoOLEPXpz9WBaErNm4+TFedJyQFJLITWdsmIBnwNS/TwXf1NV5Ak1KITc8g==}
+    engines: {node: '>=18'}
+
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
     engines: {node: '>=18'}
 
   terminal-link@4.0.0:
@@ -22701,6 +22705,14 @@ snapshots:
       - react-native-b4a
 
   tar@7.5.18:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
+  tar@7.5.22:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0


### PR DESCRIPTION
### Description

Resolves [VULN-14042](https://linear.app/vercel/issue/VULN-14042/dependency-vulnerability-cve-2026-73566-affects-tar7518-in).

`tar@7.5.18` is affected by **CVE-2026-73566** ([GHSA-r292-9mhp-454m](https://github.com/advisories/GHSA-r292-9mhp-454m), High). A crafted ~188-byte gzip tar can trigger an uncatchable `RangeError` stack overflow via `mapHas` recursion when member selection is used with `tar.t()` / `tar.x()`, terminating the Node.js process. Because the failure happens on async/streaming paths, a `try`/`catch` around the call does not prevent process exit.

This bumps the pinned dependency in `packages/turbo-releaser/package.json` from `7.5.18` to `7.5.22` and updates `pnpm-lock.yaml`.

**Version choice:** the advisory's minimum fixed version is `7.5.21`; `7.5.22` is the current latest patch. Both have an identical dependency set (`@isaacs/fs-minipass`, `chownr`, `minipass`, `minizlib`, `yallist`) and the same `engines: {node: '>=18'}` as `7.5.18`, so this is a drop-in patch upgrade with no transitive-dependency churn.

**Exposure note:** `@turbo/releaser` only calls `tar.create()` (`src/operations.ts`) to produce release artifacts — it never lists or extracts an archive, so it does not exercise the vulnerable code path. The upgrade is applied to clear the advisory rather than to fix an exploitable path in this package.

### Testing Instructions

```
pnpm install
pnpm --filter @turbo/releaser build
cd packages/turbo-releaser && node --import tsx --test src/*.test.ts
```

Locally on this branch:

- `pnpm --filter @turbo/releaser build` — succeeds
- `node --import tsx --test` over the package's 10 test files — **29/29 passing, 0 failures** (includes `e2e.test.ts`, which builds a real artifact through `tar.create()` and verifies the tarball is byte-for-byte reproducible)
- `node -e "require('tar/package.json').version"` in `packages/turbo-releaser` — reports `7.5.22`

### Follow-up (out of scope for this PR)

`packages/turbo-utils` also pins `tar@7.5.18`, and unlike the releaser it *does* use the affected API — `src/examples.ts` imports `Parser` / `extract` and runs them over a tarball downloaded from `codeload.github.com`. That is the API surface the advisory describes. It's left untouched here to keep this PR scoped to VULN-14042, but it should get its own bump.
