### PR TITLE
fix: Resolve lint errors

### DIFF
--- a/apps/factory/agent/lib/harness-agent.ts
+++ b/apps/factory/agent/lib/harness-agent.ts
@@ -106,9 +106,10 @@ export function createFactoryHarness(
         webSearch: true
       });
     }
-    case "cursor":
+    case "cursor": {
       // Cursor controls provider routing itself. Keep its native default model.
       return createCursor({ auth: "auto", port: FACTORY_HARNESS_PORT });
+    }
     case "opencode": {
       const selected = splitGatewayModel(model);
       return createOpenCode({
@@ -119,17 +120,19 @@ export function createFactoryHarness(
         port: FACTORY_HARNESS_PORT
       });
     }
-    case "pi":
+    case "pi": {
       return createPi({
         auth: "ai-gateway",
         ...(model === undefined ? {} : { model })
       });
-    case "fx":
+    }
+    case "fx": {
       return createFx({
         auth: "ai-gateway",
         ...(model === undefined ? {} : { model }),
         port: FACTORY_HARNESS_PORT
       });
+    }
   }
 }
 

--- a/apps/factory/app/workspace-client.tsx
+++ b/apps/factory/app/workspace-client.tsx
@@ -201,12 +201,13 @@ function WorkspaceChat({
       if (restarting) return;
 
       restarting = true;
-      while (reconnectRequested && !disposed) {
+      while (reconnectRequested) {
         await streamTask;
         if (disposed) break;
 
         reconnectRequested = false;
-        controller = new AbortController();
+        const streamController = new AbortController();
+        controller = streamController;
         const session = new Client({
           headers: CONSOLE_HEADERS,
           host: ""
@@ -216,13 +217,13 @@ function WorkspaceChat({
         streamTask = (async () => {
           try {
             for await (const event of session.stream({
-              signal: controller?.signal
+              signal: streamController.signal
             })) {
               streamIndex.current = session.state.streamIndex;
               setExternalEvents((current) => appendUniqueEvent(current, event));
             }
           } catch (cause) {
-            if (!controller?.signal.aborted) console.error(cause);
+            if (!streamController.signal.aborted) console.error(cause);
           }
         })();
       }

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -1630,6 +1630,7 @@ fn route_materialized_interests(
     route_event(registry, Ok(&event));
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_watcher(
     #[cfg(target_os = "macos")] backend: MacOsBackend,
     root: &AbsoluteSystemPath,


### PR DESCRIPTION
## Summary

- Add braces to Factory harness switch cases required by the updated lint rule.
- Keep each workspace event stream tied to its own abort controller.
- Preserve disposal behavior while satisfying loop and closure lint checks.
- Allow the existing watcher orchestration signature on macOS, where the selected backend adds an eighth argument.