### PR TITLE
fix: Preserve task metadata for command overrides

### DIFF
--- a/crates/turborepo-engine/src/builder/definitions.rs
+++ b/crates/turborepo-engine/src/builder/definitions.rs
@@ -357,9 +357,7 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
                 .map(|(definition, _)| definition),
         );
         let had_explicit_cache = processed_task_definition.cache.is_some();
-        if should_apply_toolchain_defaults(command_override.as_ref())
-            && let Some(context) = package_context.as_ref()
-        {
+        if let Some(context) = package_context.as_ref() {
             let defaults = native_contract
                 .as_ref()
                 .map(|contract| contract.defaults().clone())
@@ -439,19 +437,18 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         // `$TURBO_DEFAULT$` on a derived task means "everything the toolchain
         // derives automatically", so explicit `inputs` can append without
         // forfeiting automatic invalidation; explicit inputs without
-        // `$TURBO_DEFAULT$` take full control.
-        if inherits_toolchain_task_io(task_def.command.as_ref())
-            && let Some(package_context) = package_context.as_ref().filter(|context| {
-                native_contract.as_ref().map_or_else(
-                    || {
-                        context
-                            .task_contract()
-                            .derives_task_io(task_id.as_inner().task())
-                    },
-                    NativeTaskContract::derives_io,
-                )
-            })
-        {
+        // `$TURBO_DEFAULT$` take full control. Command overrides replace only
+        // task execution and keep the native task's complete contract.
+        if let Some(package_context) = package_context.as_ref().filter(|context| {
+            native_contract.as_ref().map_or_else(
+                || {
+                    context
+                        .task_contract()
+                        .derives_task_io(task_id.as_inner().task())
+                },
+                NativeTaskContract::derives_io,
+            )
+        }) {
             let wants_automatic_inputs = !had_explicit_inputs || task_def.inputs.default;
             // Only assembled when the toolchain will actually use it:
             // `dependencies` walks the package's full transitive closure,
@@ -974,24 +971,13 @@ fn resolve_command_override(
     }
 }
 
-fn should_apply_toolchain_defaults(command: Option<&TaskCommandOverride>) -> bool {
-    command.is_none()
-}
-
-/// Native hash wiring describes a toolchain-synthesized command. An argv
-/// override executes arbitrary user-selected work, so only turbo.json can
-/// soundly describe its inputs, outputs, and environment.
-fn inherits_toolchain_task_io(command: Option<&TaskCommandOverride>) -> bool {
-    !matches!(command, Some(TaskCommandOverride::Argv(_)))
-}
-
 #[cfg(test)]
 mod command_override_tests {
     use turborepo_errors::Spanned;
     use turborepo_repository::task_contracts::{CommandMapTarget, ScopeTaskContract};
     use turborepo_types::TaskCommandOverride;
 
-    use super::{ProcessedCommand, inherits_toolchain_task_io, resolve_command_override};
+    use super::{ProcessedCommand, resolve_command_override};
 
     fn argv(items: &[&str]) -> ProcessedCommand {
         ProcessedCommand::Argv(Spanned::new(items.iter().map(|s| s.to_string()).collect()))
@@ -1072,36 +1058,6 @@ mod command_override_tests {
 
         // Level 5: nothing configured → the toolchain resolves as usual.
         assert_eq!(resolve_command_override(None, None, Some(rust)), None,);
-    }
-
-    #[test]
-    fn only_native_commands_inherit_toolchain_defaults() {
-        assert!(super::should_apply_toolchain_defaults(None));
-        assert!(!super::should_apply_toolchain_defaults(Some(
-            &TaskCommandOverride::Argv(vec!["node".to_string()])
-        )));
-        assert!(!super::should_apply_toolchain_defaults(Some(
-            &TaskCommandOverride::OptOut
-        )));
-    }
-
-    #[test]
-    fn synthesized_commands_inherit_toolchain_task_io() {
-        assert!(inherits_toolchain_task_io(None));
-    }
-
-    #[test]
-    fn command_opt_out_preserves_toolchain_task_io() {
-        assert!(inherits_toolchain_task_io(Some(
-            &TaskCommandOverride::OptOut
-        )));
-    }
-
-    #[test]
-    fn argv_override_does_not_inherit_toolchain_task_io() {
-        assert!(!inherits_toolchain_task_io(Some(
-            &TaskCommandOverride::Argv(vec!["node".to_string(), "build.js".to_string(),])
-        )));
     }
 }
 

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -372,10 +372,13 @@ entrypoint classification, and whether that task derives I/O. Broader behavior
 such as environment projection, dependency-source participation, dynamic I/O,
 pruning, and command-map capability remains on `ScopeTaskContract`. Engine
 composition uses the task-local contract when present and the scope contract
-only as a fallback. Definition memoization keys include native execution and
-task-local contract facts, and it is disabled for package-scoped definitions or
-per-package derived I/O. This prevents scopes with the same turbo.json chain but
-different aggregates or contracts from sharing an invalid definition.
+only as a fallback. An explicit argv override replaces only native execution;
+defaults, inputs, outputs, environment, and cache policy continue to come from
+the same native task contract and authored configuration.
+Definition memoization keys include native execution and task-local contract
+facts, and it is disabled for package-scoped definitions or per-package derived
+I/O. This prevents scopes with the same turbo.json chain but different
+aggregates or contracts from sharing an invalid definition.
 
 JavaScript is the first production producer. Machinery that predates the
 abstraction (package-manager resolution for dependency splitting and the JS

--- a/crates/turborepo/tests/cargo_workspace_test.rs
+++ b/crates/turborepo/tests/cargo_workspace_test.rs
@@ -1372,7 +1372,7 @@ fn test_unavailable_outputs_preserve_explicit_intent() {
 }
 
 #[test]
-fn test_cargo_command_override_uses_only_configured_io() {
+fn test_cargo_command_override_preserves_native_task_contract() {
     let tempdir = cargo_tempdir();
     setup_cargo_monorepo(tempdir.path());
     fs::write(
@@ -1390,7 +1390,7 @@ fn test_cargo_command_override_uses_only_configured_io() {
         "-e",
         "require('fs').writeFileSync('custom-output.txt', process.env.OVERRIDE_ENV)"
       ],
-      "inputs": ["Cargo.toml"],
+      "inputs": ["$TURBO_DEFAULT$", "custom-input.txt"],
       "outputs": ["custom-output.txt"],
       "env": ["OVERRIDE_ENV"]
     }
@@ -1398,6 +1398,7 @@ fn test_cargo_command_override_uses_only_configured_io() {
 }"#,
     )
     .unwrap();
+    fs::write(tempdir.path().join("crates/app/custom-input.txt"), "input").unwrap();
 
     let output = run_turbo(
         tempdir.path(),
@@ -1411,15 +1412,40 @@ fn test_cargo_command_override_uses_only_configured_io() {
         .and_then(|tasks| tasks.iter().find(|task| task["taskId"] == "app#build"))
         .expect("app#build in graph");
     let definition = &build["resolvedTaskDefinition"];
-    assert_eq!(definition["inputs"], serde_json::json!(["Cargo.toml"]));
-    assert_eq!(
-        definition["outputs"],
-        serde_json::json!(["custom-output.txt"])
+    let inputs = definition["inputs"].as_array().expect("resolved inputs");
+    assert!(
+        inputs.iter().any(|input| input == "../../Cargo.toml"),
+        "override should preserve the native Cargo workspace inputs: {inputs:?}"
     );
-    assert_eq!(definition["env"], serde_json::json!(["OVERRIDE_ENV"]));
+    assert!(
+        inputs.iter().any(|input| input == "../../crates/lib-a/**"),
+        "override should preserve native dependency inputs: {inputs:?}"
+    );
+    assert!(
+        inputs.iter().any(|input| input == "custom-input.txt"),
+        "override should append explicitly configured inputs: {inputs:?}"
+    );
+    let outputs = definition["outputs"].as_array().expect("resolved outputs");
+    assert!(
+        outputs.iter().any(|output| output == "custom-output.txt"),
+        "override should preserve explicitly configured outputs: {outputs:?}"
+    );
+    let output_name = if cfg!(windows) { "app.exe" } else { "app" };
+    let cargo_output = format!("../../target/debug/{output_name}");
+    assert!(
+        outputs.iter().any(|output| output == &cargo_output),
+        "override should preserve native Cargo outputs: {outputs:?}"
+    );
+    let env = definition["env"].as_array().expect("resolved environment");
+    assert!(env.iter().any(|value| value == "OVERRIDE_ENV"));
+    assert!(
+        env.iter().any(|value| value == "RUSTFLAGS"),
+        "override should preserve native Cargo hash environment: {env:?}"
+    );
+    assert_eq!(definition["cache"], true);
 
-    // A stale Cargo deliverable present on the override's cache miss must not
-    // become one of that arbitrary command's cached outputs.
+    // A stale Cargo deliverable present on the override's cache miss becomes
+    // part of the task's native output contract.
     let bin = tempdir
         .path()
         .join("target")
@@ -1450,7 +1476,7 @@ fn test_cargo_command_override_uses_only_configured_io() {
         "expected cache hit: {stdout}"
     );
     assert!(custom_output.exists(), "configured output must be restored");
-    assert!(!bin.exists(), "Cargo deliverable must not be restored");
+    assert!(bin.exists(), "native Cargo output must be restored");
 }
 
 #[test]
@@ -1531,7 +1557,7 @@ fn test_explicit_cache_overrides_cargo_run_default() {
 }
 
 #[test]
-fn test_command_override_uses_generic_cache_default_across_toolchains() {
+fn test_command_override_preserves_native_cache_defaults() {
     let tempdir = cargo_tempdir();
     setup_cargo_monorepo(tempdir.path());
     fs::write(
@@ -1568,16 +1594,22 @@ fn test_command_override_uses_generic_cache_default_across_toolchains() {
     let json: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("dry-run emits JSON");
     let tasks = json["tasks"].as_array().expect("tasks array");
-    for task_id in ["app#run", "js-pkg#run"] {
-        let task = tasks
-            .iter()
-            .find(|task| task["taskId"] == task_id)
-            .unwrap_or_else(|| panic!("{task_id} in graph"));
-        assert_eq!(
-            task["resolvedTaskDefinition"]["cache"], true,
-            "{task_id} should use the generic cache default"
-        );
-    }
+    let cargo_run = tasks
+        .iter()
+        .find(|task| task["taskId"] == "app#run")
+        .expect("app#run in graph");
+    assert_eq!(
+        cargo_run["resolvedTaskDefinition"]["cache"], false,
+        "the command override should preserve Cargo's uncached run default"
+    );
+    let js_run = tasks
+        .iter()
+        .find(|task| task["taskId"] == "js-pkg#run")
+        .expect("js-pkg#run in graph");
+    assert_eq!(
+        js_run["resolvedTaskDefinition"]["cache"], true,
+        "the command override should preserve JavaScript's cache default"
+    );
 
     let output = run_turbo(
         tempdir.path(),

--- a/turbo.json
+++ b/turbo.json
@@ -38,19 +38,20 @@
       // actually need to build before running tests.
       "dependsOn": ["^build"]
     },
-    // The Rust workspace tests run through nextest with per-test process
-    // isolation. Some tests read root-level config and integration fixtures
-    // outside the Cargo workspace, so declare them explicitly.
-    // Excludes mirror the CI invocations: turborepo-lsp, schema-gen, and
-    // napi need extra build environments.
     "turborepo-crates#test": {
       "dependsOn": [],
       "inputs": [
-        "$TURBO_DEFAULT$",
-        "$TURBO_ROOT$/version.txt",
+        "$TURBO_ROOT$/Cargo.toml",
+        "$TURBO_ROOT$/Cargo.lock",
+        "$TURBO_ROOT$/rust-toolchain.toml",
+        "$TURBO_ROOT$/.cargo/**",
         "$TURBO_ROOT$/.config/nextest.toml",
         "$TURBO_ROOT$/.config/insta.yaml",
-        "$TURBO_ROOT$/turborepo-tests/integration/**"
+        "$TURBO_ROOT$/crates/**",
+        "$TURBO_ROOT$/packages/turbo-repository/rust/**",
+        "$TURBO_ROOT$/packages/turbo-types/src/json/frameworks.json",
+        "$TURBO_ROOT$/turborepo-tests/integration/**",
+        "$TURBO_ROOT$/version.txt"
       ],
       "command": [
         "cargo",

--- a/turbo.json
+++ b/turbo.json
@@ -38,20 +38,19 @@
       // actually need to build before running tests.
       "dependsOn": ["^build"]
     },
+    // The Rust workspace tests run through nextest with per-test process
+    // isolation. Some tests read root-level config and integration fixtures
+    // outside the Cargo workspace, so declare them explicitly.
+    // Excludes mirror the CI invocations: turborepo-lsp, schema-gen, and
+    // napi need extra build environments.
     "turborepo-crates#test": {
       "dependsOn": [],
       "inputs": [
-        "$TURBO_ROOT$/Cargo.toml",
-        "$TURBO_ROOT$/Cargo.lock",
-        "$TURBO_ROOT$/rust-toolchain.toml",
-        "$TURBO_ROOT$/.cargo/**",
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/version.txt",
         "$TURBO_ROOT$/.config/nextest.toml",
         "$TURBO_ROOT$/.config/insta.yaml",
-        "$TURBO_ROOT$/crates/**",
-        "$TURBO_ROOT$/packages/turbo-repository/rust/**",
-        "$TURBO_ROOT$/packages/turbo-types/src/json/frameworks.json",
-        "$TURBO_ROOT$/turborepo-tests/integration/**",
-        "$TURBO_ROOT$/version.txt"
+        "$TURBO_ROOT$/turborepo-tests/integration/**"
       ],
       "command": [
         "cargo",


### PR DESCRIPTION
## Summary

- Make experimental `command` overrides replace only task execution
- Preserve native task defaults, inputs, outputs, environment, and cache policy
- Keep `$TURBO_DEFAULT$` using Cargo-derived workspace inputs when the command is overridden
- Add regression coverage for the complete native task contract

## Verification

- Confirmed a docs-only edit leaves the overridden Rust workspace test hash unchanged
- Confirmed a Rust source edit changes the overridden Rust workspace test hash
- Confirmed command overrides preserve Cargo inputs, outputs, environment, and cache defaults