### PR TITLE
fix: Only treat files literally named .gitignore as ignore files in the untracked walk

### DIFF
--- a/crates/turborepo-scm/src/repo_index.rs
+++ b/crates/turborepo-scm/src/repo_index.rs
@@ -995,7 +995,7 @@ fn find_untracked_files(
                     .filter(|e| !e.is_delete)
                     .map(|e| e.path.as_str()),
             )
-            .filter(|s| *s == ".gitignore" || s.ends_with("/.gitignore"))
+            .filter(|s| is_gitignore_file(s))
             .collect();
         gitignore_paths.sort_unstable();
         gitignore_paths.dedup();
@@ -1225,7 +1225,7 @@ fn find_untracked_files(
     let untracked_gitignores: Vec<&RelativeUnixPathBuf> = untracked
         .paths
         .iter()
-        .filter(|p| p.as_str().ends_with(".gitignore"))
+        .filter(|p| is_gitignore_file(p.as_str()))
         .collect();
 
     if !untracked_gitignores.is_empty() {
@@ -1244,7 +1244,7 @@ fn find_untracked_files(
         }
         if !extra_matchers.is_empty() {
             let not_ignored = |p: &RelativeUnixPathBuf| {
-                if p.as_str().ends_with(".gitignore") {
+                if is_gitignore_file(p.as_str()) {
                     return true;
                 }
                 let abs = root.join(p.as_str());
@@ -1355,6 +1355,10 @@ impl UntrackedScope {
             rel_path == prefix || is_nested_path_bytes(rel_path, prefix)
         })
     }
+}
+
+fn is_gitignore_file(path: &str) -> bool {
+    path == ".gitignore" || path.ends_with("/.gitignore")
 }
 
 fn is_nested_path(path: &str, prefix: &str) -> bool {
@@ -2089,6 +2093,29 @@ mod tests {
         untracked.sort();
 
         assert_eq!(untracked, vec![path("pkg/debug.log")]);
+    }
+
+    #[test]
+    fn test_find_untracked_files_ignores_untracked_suffix_named_gitignore_files() {
+        let tempdir = TempDir::new().unwrap();
+        let root = tempdir.path();
+        let git = test_git_repo(root);
+
+        write_file(root, "pkg/Node.gitignore", "*.log\n");
+        write_file(root, "pkg/debug.log", "untracked");
+
+        let index = make_index(vec![], vec![]);
+
+        let mut untracked =
+            find_untracked_files(&git, &index.ls_tree_hashes, &index.status_entries, None)
+                .unwrap()
+                .paths;
+        untracked.sort();
+
+        assert_eq!(
+            untracked,
+            vec![path("pkg/Node.gitignore"), path("pkg/debug.log")]
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Description

#13221 established that only files literally named `.gitignore` carry ignore rules, and fixed the tracked and dirty case. its commit message put it plainly:

> Additionally, tracked files merely *ending* in `.gitignore` (e.g. `template.gitignore`) were wrongly applied as ignore files.
> Only files literally named `.gitignore` contribute rules.

the untracked walk was left on the old loose test, so the rule is only half applied. `find_untracked_files` still does

```rust
.filter(|p| p.as_str().ends_with(".gitignore"))
```

which treats a vendored `Node.gitignore`, a `template.gitignore`, or any stray `old.gitignore` as a real ignore file. patterns are read out of it and the files it appears to ignore are dropped from `untracked.paths` before they ever reach `to_hash`.

that lands in the cache key. those files are genuinely untracked as far as git is concerned, `git check-ignore` does not ignore them, but turbo never hashes them. editing one does not change the task hash, so `turbo run` serves a cache entry that does not match the inputs on disk. it is the default path, `populate_repo_index_untracked` is reached from `run/builder.rs` on every run.

the same file already had the correct predicate 230 lines above, so this fixes the drift by giving both sites one helper rather than a second copy of the string test. the self-exemption inside `not_ignored` had the same loose test and is covered too.

### Testing Instructions

added `test_find_untracked_files_ignores_untracked_suffix_named_gitignore_files`, the untracked twin of the existing `test_find_untracked_files_ignores_suffix_named_gitignore_files`. same fixture shape, except the template is untracked rather than tracked.

`cargo test -p turborepo-scm gitignore` passes, 14 tests.

i also checked the test actually catches this rather than just passing. reverting the predicate and rerunning gives

```
assertion `left == right` failed
  left: [RelativeUnixPathBuf("pkg/Node.gitignore")]
 right: [RelativeUnixPathBuf("pkg/Node.gitignore"), RelativeUnixPathBuf("pkg/debug.log")]
```

`pkg/debug.log` disappearing there is the bug: it is untracked, it should be hashed, and on main it silently is not.
