### PR TITLE
fix: Pass merge_base and allow_unknown_objects in signature order for task-level filter ranges

### DIFF
--- a/crates/turborepo-lib/src/run/task_filter.rs
+++ b/crates/turborepo-lib/src/run/task_filter.rs
@@ -442,8 +442,8 @@ fn get_changed_files(
         git_range.from_ref.as_deref(),
         git_range.to_ref.as_deref(),
         git_range.include_uncommitted,
-        git_range.merge_base,
         git_range.allow_unknown_objects,
+        git_range.merge_base,
     )?;
     Ok(result)
 }

--- a/crates/turborepo/tests/affected_test.rs
+++ b/crates/turborepo/tests/affected_test.rs
@@ -500,7 +500,10 @@ fn test_filter_merge_base_range_with_filter_using_tasks() {
     );
     fs::write(&turbo_json_path, turbo_json).unwrap();
     git(tempdir.path(), &["add", "turbo.json"]);
-    git(tempdir.path(), &["commit", "-m", "configure future flags", "--quiet"]);
+    git(
+        tempdir.path(),
+        &["commit", "-m", "configure future flags", "--quiet"],
+    );
     git(tempdir.path(), &["checkout", "-b", "my-branch", "--quiet"]);
 
     let pkg_path = tempdir.path().join("apps/my-app/package.json");
@@ -509,7 +512,10 @@ fn test_filter_merge_base_range_with_filter_using_tasks() {
     pkg["description"] = serde_json::Value::String("foo".to_string());
     fs::write(&pkg_path, serde_json::to_string_pretty(&pkg).unwrap()).unwrap();
     git(tempdir.path(), &["add", "."]);
-    git(tempdir.path(), &["commit", "-m", "change my-app", "--quiet"]);
+    git(
+        tempdir.path(),
+        &["commit", "-m", "change my-app", "--quiet"],
+    );
 
     git(tempdir.path(), &["checkout", "main", "--quiet"]);
     let index_path = tempdir.path().join("packages/util/index.js");
@@ -517,7 +523,10 @@ fn test_filter_merge_base_range_with_filter_using_tasks() {
     idx.push_str("\nfoo");
     fs::write(&index_path, idx).unwrap();
     git(tempdir.path(), &["add", "."]);
-    git(tempdir.path(), &["commit", "-m", "change util on main", "--quiet"]);
+    git(
+        tempdir.path(),
+        &["commit", "-m", "change util on main", "--quiet"],
+    );
     git(tempdir.path(), &["checkout", "my-branch", "--quiet"]);
 
     let output = run_turbo(
@@ -540,7 +549,8 @@ fn test_filter_merge_base_range_with_filter_using_tasks() {
     assert!(tasks.contains("my-app#build"), "{tasks:?}");
     assert!(
         !tasks.contains("util#build"),
-        "util changed on main after the branch point, a merge-base range must not select it: {tasks:?}"
+        "util changed on main after the branch point, a merge-base range must not select it: \
+         {tasks:?}"
     );
 }
 

--- a/crates/turborepo/tests/affected_test.rs
+++ b/crates/turborepo/tests/affected_test.rs
@@ -486,6 +486,64 @@ fn test_affected_merge_base_diverged() {
     );
 }
 
+#[test]
+fn test_filter_merge_base_range_with_filter_using_tasks() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
+
+    let turbo_json_path = tempdir.path().join("turbo.json");
+    let turbo_json = fs::read_to_string(&turbo_json_path).unwrap();
+    let turbo_json = turbo_json.replacen(
+        "{\n",
+        "{\n  \"futureFlags\": { \"filterUsingTasks\": true },\n",
+        1,
+    );
+    fs::write(&turbo_json_path, turbo_json).unwrap();
+    git(tempdir.path(), &["add", "turbo.json"]);
+    git(tempdir.path(), &["commit", "-m", "configure future flags", "--quiet"]);
+    git(tempdir.path(), &["checkout", "-b", "my-branch", "--quiet"]);
+
+    let pkg_path = tempdir.path().join("apps/my-app/package.json");
+    let contents = fs::read_to_string(&pkg_path).unwrap();
+    let mut pkg: serde_json::Value = serde_json::from_str(&contents).unwrap();
+    pkg["description"] = serde_json::Value::String("foo".to_string());
+    fs::write(&pkg_path, serde_json::to_string_pretty(&pkg).unwrap()).unwrap();
+    git(tempdir.path(), &["add", "."]);
+    git(tempdir.path(), &["commit", "-m", "change my-app", "--quiet"]);
+
+    git(tempdir.path(), &["checkout", "main", "--quiet"]);
+    let index_path = tempdir.path().join("packages/util/index.js");
+    let mut idx = fs::read_to_string(&index_path).unwrap_or_default();
+    idx.push_str("\nfoo");
+    fs::write(&index_path, idx).unwrap();
+    git(tempdir.path(), &["add", "."]);
+    git(tempdir.path(), &["commit", "-m", "change util on main", "--quiet"]);
+    git(tempdir.path(), &["checkout", "my-branch", "--quiet"]);
+
+    let output = run_turbo(
+        tempdir.path(),
+        &["run", "build", "--filter=[main...HEAD]", "--dry=json"],
+    );
+    assert!(
+        output.status.success(),
+        "run failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let tasks: std::collections::HashSet<String> = json["tasks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|task| task["taskId"].as_str().unwrap().to_string())
+        .collect();
+
+    assert!(tasks.contains("my-app#build"), "{tasks:?}");
+    assert!(
+        !tasks.contains("util#build"),
+        "util changed on main after the branch point, a merge-base range must not select it: {tasks:?}"
+    );
+}
+
 // ── affectedTasks tests ──
 
 #[test]


### PR DESCRIPTION
### Description

with `filterUsingTasks` on, `--filter='[main...HEAD]'` diffs the two tips instead of merge base to head.

`get_changed_files` in `task_filter.rs` passes the last two bools to `scm.changed_files` in the wrong order. the signature is `(…, include_uncommitted, allow_unknown_objects, merge_base)`, the call passes `include_uncommitted, merge_base, allow_unknown_objects`. both are `bool`, so nothing catches it.

the selector parser sets `merge_base: true, allow_unknown_objects: false` for a three dot range. after the swap `changed_files` gets `merge_base: false, allow_unknown_objects: true`, the opposite of both. so `...` behaves like `..`, and an unknown ref is quietly tolerated instead of erroring.

the package level path in `change_detector.rs` passes them the right way round, so the two disagree inside one run. this came in with #12363 and has been that way since, it just needs `filterUsingTasks` and a branch that has diverged from main to show.

what it looks like: `main` moves ahead after you branch, you run `turbo run build --filter='[main...HEAD]'`, and tasks in packages you never touched get selected because they changed on `main`. the other direction is worse: if a file is byte identical on both tips because you cherry picked it, the two dot diff does not list it and the task is silently skipped.

### Testing Instructions

added `test_filter_merge_base_range_with_filter_using_tasks` to `affected_test.rs`. it is the task level twin of `test_affected_merge_base_diverged`: branch, change `my-app` on the branch, change `util` on `main`, then run `turbo run build --filter='[main...HEAD]' --dry=json` with the flag on. `build` has no `dependsOn` in that fixture so `util#build` only shows up if the range is wrong.

on main it fails with

```
util changed on main after the branch point, a merge-base range must not select it: {"my-app#build", "util#build"}
```

with the fix it selects only `my-app#build`. `cargo test -p turbo --test affected_test` passes, 36 tests.
