### PR TITLE
fix: Allow release versioning with pending changes

### DIFF
--- a/packages/turbo-releaser/src/stage.test.ts
+++ b/packages/turbo-releaser/src/stage.test.ts
@@ -45,6 +45,7 @@ describe("prepareStage", () => {
       "version",
       "1.2.3",
       "--allow-same-version",
+      "--no-git-checks",
       "--no-git-tag-version"
     ]);
     assert.match(

--- a/packages/turbo-releaser/src/stage.ts
+++ b/packages/turbo-releaser/src/stage.ts
@@ -74,7 +74,13 @@ export async function prepareStage({
   for (const releasePackage of releasePackages) {
     dependencies.run(
       "pnpm",
-      ["version", version, "--allow-same-version", "--no-git-tag-version"],
+      [
+        "version",
+        version,
+        "--allow-same-version",
+        "--no-git-checks",
+        "--no-git-tag-version"
+      ],
       { cwd: path.join(root, releasePackage.directory), stdio: "inherit" }
     );
   }


### PR DESCRIPTION
## Summary

- Allow pnpm 12 to update release package versions after `version.txt` is intentionally modified.
- Keep Git commit and tag creation disabled while bypassing only pnpm’s clean-working-tree check.
- Update the stage preparation test to cover the required flag.