### PR TITLE
fix: Give the package changes watcher the future flags so root inputs reach the task filter

### DIFF
--- a/crates/turborepo-lib/src/commands/daemon.rs
+++ b/crates/turborepo-lib/src/commands/daemon.rs
@@ -196,6 +196,7 @@ pub async fn daemon_server(
         {
             let graph_features =
                 crate::repository_graph::RepositoryGraphFeatures::new(&base.opts().future_flags);
+            let future_flags = base.opts().future_flags;
             move |args| {
                 PackageChangesWatcher::new(
                     args.repo_root,
@@ -205,6 +206,7 @@ pub async fn daemon_server(
                     false,
                     args.allow_no_package_manager,
                     graph_features,
+                    future_flags,
                 )
             }
         },

--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -29,7 +29,7 @@ use turborepo_scm::GitHashes;
 use crate::{
     config::{resolve_turbo_config_path, CONFIG_FILE, CONFIG_FILE_JSONC},
     repository_graph::RepositoryGraphFeatures,
-    turbo_json::{TurboJson, TurboJsonReader, UnifiedTurboJsonLoader},
+    turbo_json::{FutureFlags, TurboJson, TurboJsonReader, UnifiedTurboJsonLoader},
 };
 
 /// Watches for changes to a package's files and directories.
@@ -70,6 +70,7 @@ impl PackageChangesWatcher {
         single_package: bool,
         allow_no_package_manager: bool,
         graph_features: RepositoryGraphFeatures,
+        future_flags: FutureFlags,
     ) -> Self {
         let (exit_tx, exit_rx) = oneshot::channel();
         let (package_change_events_tx, package_change_events_rx) =
@@ -83,6 +84,7 @@ impl PackageChangesWatcher {
             single_package,
             allow_no_package_manager,
             graph_features,
+            future_flags,
         );
 
         let _handle = tokio::spawn(subscriber.watch(exit_rx));
@@ -134,6 +136,7 @@ struct Subscriber {
     single_package: bool,
     allow_no_package_manager: bool,
     graph_features: RepositoryGraphFeatures,
+    future_flags: FutureFlags,
 }
 
 fn is_in_git_folder(path: &AnchoredSystemPath) -> bool {
@@ -354,6 +357,7 @@ impl Subscriber {
         single_package: bool,
         allow_no_package_manager: bool,
         graph_features: RepositoryGraphFeatures,
+        future_flags: FutureFlags,
     ) -> Self {
         // Try to canonicalize the custom path to match what the file watcher reports
         let normalized_custom_path = custom_turbo_json_path.map(|path| {
@@ -406,6 +410,7 @@ impl Subscriber {
             single_package,
             allow_no_package_manager,
             graph_features,
+            future_flags,
         }
     }
 
@@ -458,7 +463,8 @@ impl Subscriber {
             }
         };
 
-        let reader = TurboJsonReader::new(self.repo_root.clone());
+        let reader =
+            TurboJsonReader::new(self.repo_root.clone()).with_future_flags(self.future_flags);
         let root_turbo_json = if self.single_package {
             let root_scripts = pkg_dep_graph
                 .package_task_context(&PackageName::Root)
@@ -803,11 +809,12 @@ impl Subscriber {
                         // In single-package mode the root IS the only package, so
                         // all changes must propagate regardless.
                         if !self.single_package && filtered_pkgs.contains(&root_pkg) {
-                            let has_root_tasks = repo_state
-                                .root_turbo_json
-                                .as_ref()
-                                .is_some_and(|turbo| turbo.has_root_tasks());
-                            if !has_root_tasks {
+                            let keep_root =
+                                repo_state.root_turbo_json.as_ref().is_some_and(|turbo| {
+                                    turbo.has_root_tasks()
+                                        || turbo.future_flags.watch_using_task_inputs
+                                });
+                            if !keep_root {
                                 filtered_pkgs.remove(&root_pkg);
                             }
                         }
@@ -875,7 +882,7 @@ mod test {
         is_in_git_folder, ChangedFiles, FileChangeAction, PackageChangeEvent,
         PackageChangesWatcher, PackageHashBaseline, RepositoryIgnore, Subscriber, CONFIG_FILE,
     };
-    use crate::repository_graph::RepositoryGraphFeatures;
+    use crate::{repository_graph::RepositoryGraphFeatures, turbo_json::FutureFlags};
 
     fn anchored(s: &str) -> AnchoredSystemPathBuf {
         AnchoredSystemPathBuf::try_from(s).unwrap()
@@ -980,6 +987,7 @@ mod test {
                 cargo: cargo_enabled,
                 python: false,
             },
+            FutureFlags::default(),
         )
     }
 
@@ -1810,6 +1818,7 @@ mod test {
                 cargo: false,
                 python: false,
             },
+            FutureFlags::default(),
         );
 
         TestWatcherHandle {

--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -314,6 +314,7 @@ impl WatchClient {
             base.opts().run_opts.single_package,
             base.opts().repo_opts.allow_no_package_manager,
             graph_features,
+            base.opts().future_flags,
         );
 
         // Subscribe before building the Run so we don't miss the initial

--- a/crates/turborepo/tests/watch_test.rs
+++ b/crates/turborepo/tests/watch_test.rs
@@ -417,6 +417,75 @@ fn watch_task_inputs_reruns_deferred_dependency_output_consumers() {
     );
 }
 
+fn setup_watch_turbo_root_input_test() -> (tempfile::TempDir, PathBuf) {
+    let (tempdir, test_dir) = setup_watch_test();
+
+    fs::write(test_dir.join("schema.json"), "{\"v\":1}\n").unwrap();
+    fs::write(
+        test_dir.join("turbo.json"),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "futureFlags": {
+    "watchUsingTaskInputs": true
+  },
+  "tasks": {
+    "build": {
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/schema.json"],
+      "outputs": []
+    }
+  }
+}
+"#,
+    )
+    .unwrap();
+
+    common::git(&test_dir, &["add", "."]);
+    common::git(
+        &test_dir,
+        &[
+            "commit",
+            "-m",
+            "configure turbo root input watch test",
+            "--quiet",
+        ],
+    );
+
+    (tempdir, test_dir)
+}
+
+#[test]
+fn watch_task_inputs_reruns_on_turbo_root_input_without_root_tasks() {
+    let (_tempdir, test_dir) = setup_watch_turbo_root_input_test();
+    let guard = WatchGuard::new(spawn_turbo_watch(&test_dir));
+
+    wait_for_markers(&test_dir, "a", 1, Duration::from_secs(30));
+    std::thread::sleep(Duration::from_secs(2));
+
+    let before = marker_count(&test_dir, "a");
+    let mut after = before;
+    for attempt in 0..3 {
+        fs::write(
+            test_dir.join("schema.json"),
+            format!("{{\"v\":{}}}\n", 2 + attempt),
+        )
+        .unwrap();
+        common::git(&test_dir, &["add", "."]);
+        common::git(&test_dir, &["commit", "-m", "change schema", "--quiet"]);
+        after = wait_for_markers(&test_dir, "a", before + 1, Duration::from_secs(15));
+        if after > before {
+            break;
+        }
+    }
+
+    drop(guard);
+
+    assert!(
+        after > before,
+        "package a declares $TURBO_ROOT$/schema.json as an input and turbo.json has no root \
+         tasks, so a root file change must still rerun it. before: {before}, after: {after}"
+    );
+}
+
 #[test]
 fn watch_file_change_reruns_affected_package() {
     let (_tempdir, test_dir) = setup_watch_test();


### PR DESCRIPTION
### Description

fixes #13925

with `watchUsingTaskInputs` on, `turbo watch` never re-runs a task whose `$TURBO_ROOT$/<file>` input changes, if `turbo.json` has no `//#` task. the event is classified to the root package and then dropped by a gate in `package_changes_watcher.rs` that predates `$TURBO_ROOT$`, before the task level filter built for this case ever runs.

two changes.

the watcher now gets the future flags. it built `TurboJsonReader::new(repo_root)` without `.with_future_flags`, and `TurboJson::read` overwrites the flags parsed from the file with the reader's, so every future flag was false inside the watcher regardless of `turbo.json`. `run/builder.rs` and `devtools.rs` already pass them in, the watcher now does too, threaded from `base.opts().future_flags` at both construction sites.

the root gate keeps the root package when `watch_using_task_inputs` is on, not only when root tasks exist. the noise the gate was guarding against is handled downstream already, `run/watch.rs` skips the run when the task filter matches nothing, and the repro confirms that: editing a root file that is not anyone's input logs `no executable tasks after filtering, skipping run` and does not rebuild.

the second change is dead without the first, which is how i found the first. checking the flag at the gate did nothing until the reader had it.

### Testing Instructions

added `watch_task_inputs_reruns_on_turbo_root_input_without_root_tasks` to `watch_test.rs`. one package with `inputs: ["$TURBO_DEFAULT$", "$TURBO_ROOT$/schema.json"]`, no root task, edit and commit `schema.json`, expect a rebuild. on main it fails with `before: 1, after: 1`. with this branch it passes, and the rest of `watch_test.rs` is green, 18 tests. `package_changes_watcher` unit tests pass, 45.

reproduction repo: https://github.com/Nixxx19/turborepo-watch-root-input-repro. on 2.10.12 and 2.10.13-canary.1 the schema.json edit leaves the marker count at 2, expected 3. against a build of this branch it is 3. it also checks that `turbo run --dry=json` already treats the file as an input, so this is watch disagreeing with the hasher, not a config problem.
