### PR TITLE
fix: Support pnpm 6 single-package lockfiles

### DIFF
--- a/crates/turborepo-lockfiles/src/pnpm/data.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data.rs
@@ -45,6 +45,20 @@ pub struct PnpmLockfile {
     package_extensions_checksum: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     patched_dependencies: Option<Map<String, PatchFile>>,
+    // pnpm 6 single-project lockfiles store the project snapshot at the root
+    // instead of under `importers["."]`. These fields are normalized into an
+    // importer immediately after parsing.
+    #[serde(default, skip_serializing)]
+    specifiers: Option<Map<String, String>>,
+    #[serde(default, skip_serializing)]
+    dependencies: Option<Map<String, String>>,
+    #[serde(default, rename = "optionalDependencies", skip_serializing)]
+    optional_dependencies: Option<Map<String, String>>,
+    #[serde(default, rename = "devDependencies", skip_serializing)]
+    dev_dependencies: Option<Map<String, String>>,
+    #[serde(default, rename = "dependenciesMeta", skip_serializing)]
+    root_dependencies_meta: Option<Map<String, DependenciesMeta>>,
+    #[serde(default)]
     importers: BTreeMap<String, ProjectSnapshot>,
     #[serde(skip_serializing_if = "Option::is_none")]
     packages: Option<Packages>,
@@ -291,15 +305,46 @@ impl PnpmLockfile {
 
             let mut this: Self = Self::deserialize(document)?;
             this.leading_documents = leading_documents;
+            this.normalize_single_project_lockfile();
             this.cached_version = this.compute_version();
             this.build_dependency_index();
             return Ok(this);
         }
 
         let mut this: Self = serde_yaml_ng::from_slice(bytes)?;
+        this.normalize_single_project_lockfile();
         this.cached_version = this.compute_version();
         this.build_dependency_index();
         Ok(this)
+    }
+
+    fn normalize_single_project_lockfile(&mut self) {
+        if !self.importers.is_empty() {
+            return;
+        }
+
+        let has_root_project = self.specifiers.is_some()
+            || self.dependencies.is_some()
+            || self.optional_dependencies.is_some()
+            || self.dev_dependencies.is_some()
+            || self.root_dependencies_meta.is_some();
+        if !has_root_project {
+            return;
+        }
+
+        self.importers.insert(
+            ".".to_string(),
+            ProjectSnapshot {
+                dependencies: DependencyInfo::PreV6 {
+                    specifiers: self.specifiers.take(),
+                    dependencies: self.dependencies.take(),
+                    optional_dependencies: self.optional_dependencies.take(),
+                    dev_dependencies: self.dev_dependencies.take(),
+                },
+                dependencies_meta: self.root_dependencies_meta.take(),
+                publish_directory: None,
+            },
+        );
     }
 
     /// Merge per-workspace lockfiles into this lockfile.
@@ -318,7 +363,7 @@ impl PnpmLockfile {
         workspace_lockfiles: &[(&str, &[u8])],
     ) -> Result<(), crate::Error> {
         for &(workspace_path, bytes) in workspace_lockfiles {
-            let ws_lockfile: PnpmLockfile = serde_yaml_ng::from_slice(bytes)?;
+            let ws_lockfile = PnpmLockfile::from_bytes(bytes)?;
 
             // Re-key the "." importer to the workspace's relative path
             for (key, snapshot) in ws_lockfile.importers {
@@ -938,6 +983,11 @@ impl crate::Lockfile for PnpmLockfile {
             overrides: self.overrides.clone(),
             package_extensions_checksum: self.package_extensions_checksum.clone(),
             patched_dependencies: patches,
+            specifiers: None,
+            dependencies: None,
+            optional_dependencies: None,
+            dev_dependencies: None,
+            root_dependencies_meta: None,
             snapshots: pruned_snapshots,
             dependency_index: FxHashMap::default(),
             time: None,
@@ -1220,6 +1270,34 @@ mod tests {
 
     use super::*;
     use crate::Lockfile;
+
+    #[test]
+    fn test_parses_pnpm_v6_single_project_lockfile() {
+        let yaml = r#"lockfileVersion: 5.3
+
+specifiers:
+  is-odd: ^3.0.1
+
+dependencies:
+  is-odd: 3.0.1
+
+packages:
+  /is-odd/3.0.1:
+    resolution: {integrity: sha512-test}
+"#;
+
+        let lockfile = PnpmLockfile::from_bytes(yaml.as_bytes()).unwrap();
+        let root = lockfile.importers.get(".").unwrap();
+        assert_eq!(
+            root.dependencies.find_resolution("is-odd"),
+            Some(("^3.0.1", "3.0.1"))
+        );
+
+        let encoded = lockfile.encode().unwrap();
+        let encoded = std::str::from_utf8(&encoded).unwrap();
+        assert!(encoded.contains("importers:"));
+        assert!(!encoded.starts_with("specifiers:"));
+    }
 
     #[test]
     fn test_injected_package_round_trip() {

--- a/crates/turborepo-lockfiles/src/pnpm/data_fast_parse.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data_fast_parse.rs
@@ -1235,8 +1235,11 @@ impl TopLevelFields {
             overrides: self.overrides,
             package_extensions_checksum: self.package_extensions_checksum,
             patched_dependencies: self.patched_dependencies,
-            // `importers` has no `#[serde(default)]`; a missing field is a
-            // serde error, so let the fallback path report it.
+            specifiers: None,
+            dependencies: None,
+            optional_dependencies: None,
+            dev_dependencies: None,
+            root_dependencies_meta: None,
             importers: self.importers.ok_or_else(Unsupported::here)?,
             packages: self.packages,
             snapshots: self.snapshots,

--- a/lockfile-tests/fixtures/pnpm6-single-project-lockfiles/.npmrc
+++ b/lockfile-tests/fixtures/pnpm6-single-project-lockfiles/.npmrc
@@ -1,0 +1,1 @@
+shared-workspace-lockfile=false

--- a/lockfile-tests/fixtures/pnpm6-single-project-lockfiles/apps/web/package.json
+++ b/lockfile-tests/fixtures/pnpm6-single-project-lockfiles/apps/web/package.json
@@ -1,0 +1,1 @@
+{"name":"web","version":"1.0.0","private":true,"dependencies":{"@repo/ui":"workspace:*","is-odd":"^3.0.1"}}

--- a/lockfile-tests/fixtures/pnpm6-single-project-lockfiles/apps/web/pnpm-lock.yaml
+++ b/lockfile-tests/fixtures/pnpm6-single-project-lockfiles/apps/web/pnpm-lock.yaml
@@ -1,0 +1,23 @@
+lockfileVersion: 5.3
+
+specifiers:
+  '@repo/ui': workspace:*
+  is-odd: ^3.0.1
+
+dependencies:
+  '@repo/ui': link:../../packages/ui
+  is-odd: 3.0.1
+
+packages:
+
+  /is-number/6.0.0:
+    resolution: {integrity: sha512-Wu1VHeILBK8KAWJUAiSZQX94GmOE45Rg6/538fKwiloUu21KncEkYGPqob2oSZ5mUT73vLGrHQjKw3KMPwfDzg==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /is-odd/3.0.1:
+    resolution: {integrity: sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==}
+    engines: {node: '>=4'}
+    dependencies:
+      is-number: 6.0.0
+    dev: false

--- a/lockfile-tests/fixtures/pnpm6-single-project-lockfiles/meta.json
+++ b/lockfile-tests/fixtures/pnpm6-single-project-lockfiles/meta.json
@@ -1,0 +1,5 @@
+{
+  "packageManager": "pnpm",
+  "packageManagerVersion": "pnpm@6.35.1",
+  "lockfileName": "pnpm-lock.yaml"
+}

--- a/lockfile-tests/fixtures/pnpm6-single-project-lockfiles/package.json
+++ b/lockfile-tests/fixtures/pnpm6-single-project-lockfiles/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "pnpm6-single-project-lockfiles",
+  "private": true,
+  "packageManager": "pnpm@6.35.1",
+  "devDependencies": {
+    "is-number": "^7.0.0"
+  }
+}

--- a/lockfile-tests/fixtures/pnpm6-single-project-lockfiles/packages/ui/package.json
+++ b/lockfile-tests/fixtures/pnpm6-single-project-lockfiles/packages/ui/package.json
@@ -1,0 +1,1 @@
+{"name":"@repo/ui","version":"1.0.0","private":true,"dependencies":{"lodash":"^4.17.21"}}

--- a/lockfile-tests/fixtures/pnpm6-single-project-lockfiles/packages/ui/pnpm-lock.yaml
+++ b/lockfile-tests/fixtures/pnpm6-single-project-lockfiles/packages/ui/pnpm-lock.yaml
@@ -1,0 +1,13 @@
+lockfileVersion: 5.3
+
+specifiers:
+  lodash: ^4.17.21
+
+dependencies:
+  lodash: 4.18.1
+
+packages:
+
+  /lodash/4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+    dev: false

--- a/lockfile-tests/fixtures/pnpm6-single-project-lockfiles/pnpm-lock.yaml
+++ b/lockfile-tests/fixtures/pnpm6-single-project-lockfiles/pnpm-lock.yaml
@@ -1,0 +1,14 @@
+lockfileVersion: 5.3
+
+specifiers:
+  is-number: ^7.0.0
+
+devDependencies:
+  is-number: 7.0.0
+
+packages:
+
+  /is-number/7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+    dev: true

--- a/lockfile-tests/fixtures/pnpm6-single-project-lockfiles/pnpm-workspace.yaml
+++ b/lockfile-tests/fixtures/pnpm6-single-project-lockfiles/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - "apps/*"
+  - "packages/*"

--- a/lockfile-tests/fixtures/pnpm6-single-project-lockfiles/turbo.json
+++ b/lockfile-tests/fixtures/pnpm6-single-project-lockfiles/turbo.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {}
+  }
+}

--- a/lockfile-tests/runners/local.ts
+++ b/lockfile-tests/runners/local.ts
@@ -97,6 +97,7 @@ function lockfileValidationCommand(
           const output = combinedOutput(result);
           return (
             (output.includes("Lockfile is up to date") ||
+              output.includes("Lockfile is up-to-date") ||
               output.includes("Already up to date")) &&
             output.includes("ERR_PNPM_NO_OFFLINE_TARBALL")
           );


### PR DESCRIPTION
## Summary

- normalize root-level pnpm 6 dependency fields into the canonical root importer
- parse and merge pnpm 6 per-workspace single-package lockfiles
- add a pnpm 6.35.1 lockfile fixture covering frozen installs after pruning
- recognize pnpm 6 lockfile validation output in the check-lockfiles runner