### PR TITLE
feat: Add skipPackageGraph option to @turbo/repository Workspace.find

### DIFF
--- a/crates/turborepo-repository/src/package_graph/dep_splitter.rs
+++ b/crates/turborepo-repository/src/package_graph/dep_splitter.rs
@@ -22,12 +22,19 @@ impl<'a> WorkspacePathIndex<'a> {
     /// Builds the production index from authoritative package definitions
     /// rather than transient descriptors or contributor identity.
     pub(crate) fn from_knowledge(knowledge: &'a RepositoryKnowledge) -> Self {
-        Self(
+        Self::from_directories(
             knowledge
                 .package_json_packages()
-                .map(|(identity, directory)| (directory, PackageName::from(identity)))
-                .collect(),
+                .map(|(identity, directory)| (directory, PackageName::from(identity))),
         )
+    }
+
+    /// Builds the index from explicit package directories, for callers that
+    /// resolve manifests without constructing repository knowledge.
+    pub(crate) fn from_directories(
+        directories: impl IntoIterator<Item = (&'a AnchoredSystemPath, PackageName)>,
+    ) -> Self {
+        Self(directories.into_iter().collect())
     }
 }
 

--- a/crates/turborepo-repository/src/package_graph/lockfile_closure.rs
+++ b/crates/turborepo-repository/src/package_graph/lockfile_closure.rs
@@ -1,0 +1,136 @@
+//! Lockfile closure resolution without a [`super::PackageGraph`].
+//!
+//! Consumers that only need the set of external packages a workspace's
+//! lockfile pins (for example dependency auditing) don't need the internal
+//! package graph, task knowledge, or change knowledge that
+//! [`super::PackageGraphBuilder`] constructs. This walks the workspace
+//! `package.json` files just far enough to split internal from external
+//! declarations, then computes the transitive closure over the lockfile.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use rayon::prelude::*;
+use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf};
+use turborepo_lockfiles::{Lockfile, Package};
+
+use super::{
+    PackageName,
+    dep_splitter::{DependencySplitter, WorkspacePathIndex},
+};
+use crate::{
+    package_json::{DependencyKind, PackageJson},
+    package_manager::{self, PackageManager},
+};
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    PackageManager(#[from] package_manager::Error),
+    #[error(transparent)]
+    PackageJson(#[from] crate::package_json::Error),
+    #[error(transparent)]
+    Path(#[from] turbopath::PathError),
+    #[error(transparent)]
+    Lockfile(#[from] turborepo_lockfiles::Error),
+}
+
+/// Every external package reachable from any workspace package's
+/// declarations, deduplicated by lockfile key and sorted.
+///
+/// Workspace packages are discovered through the package manager's workspace
+/// globs; declarations that resolve to another workspace package are excluded
+/// so the result mirrors the lockfile domain of
+/// [`super::PackageGraph::javascript_external_resolution`].
+pub fn external_packages(
+    repo_root: &AbsoluteSystemPath,
+    package_manager: &PackageManager,
+    root_package_json: &PackageJson,
+    lockfile: &dyn Lockfile,
+) -> Result<Vec<Package>, Error> {
+    let workspace_paths = match package_manager.get_package_jsons(repo_root) {
+        Ok(paths) => paths.collect::<Vec<_>>(),
+        // No configured workspaces is not an error: only the root manifest
+        // contributes declarations.
+        Err(package_manager::Error::Workspace(_)) => Vec::new(),
+        Err(error) => return Err(error.into()),
+    };
+    let mut manifests = workspace_paths
+        .into_par_iter()
+        .map(|path| {
+            let package_json = PackageJson::load(&path)?;
+            let directory = repo_root.anchor(path.parent().unwrap_or(repo_root))?;
+            Ok((directory, package_json))
+        })
+        .collect::<Result<Vec<_>, Error>>()?;
+    manifests.push((AnchoredSystemPathBuf::default(), root_package_json.clone()));
+
+    // Name-keyed manifests for `workspace:` alias resolution. Nameless
+    // manifests can't be depended on by name but still declare externals.
+    let workspaces: HashMap<PackageName, PackageJson> = manifests
+        .iter()
+        .filter_map(|(directory, package_json)| {
+            let name = if directory.as_str().is_empty() {
+                PackageName::Root
+            } else {
+                PackageName::Other(package_json.name.as_ref()?.as_inner().clone())
+            };
+            Some((name, package_json.clone()))
+        })
+        .collect();
+    let path_index = WorkspacePathIndex::from_directories(manifests.iter().filter_map(
+        |(directory, package_json)| {
+            let name = if directory.as_str().is_empty() {
+                PackageName::Root
+            } else {
+                PackageName::Other(package_json.name.as_ref()?.as_inner().clone())
+            };
+            Some((directory.as_ref(), name))
+        },
+    ));
+    let link_workspace_packages = package_manager.link_workspace_packages(repo_root);
+    let catalogs = package_manager.read_catalogs(repo_root);
+
+    let external_dependencies: HashMap<String, BTreeMap<String, String>> = manifests
+        .iter()
+        .map(|(directory, package_json)| {
+            let workspace_dir = repo_root.resolve(directory);
+            let splitter = DependencySplitter::new(
+                repo_root,
+                &workspace_dir,
+                &workspaces,
+                link_workspace_packages,
+                &path_index,
+                catalogs.as_ref(),
+            );
+            // First declaration of a name wins, before the internal/external
+            // split, matching `javascript::external_dependencies`.
+            let mut seen = HashSet::new();
+            let mut dependencies = BTreeMap::new();
+            for (name, specifier, kind) in package_json.dependencies_with_kind() {
+                if !seen.insert(name.as_str())
+                    || matches!(kind, DependencyKind::Peer { .. })
+                    || splitter.is_internal(name, specifier).is_some()
+                {
+                    continue;
+                }
+                dependencies.insert(name.clone(), specifier.clone());
+            }
+            (directory.to_unix().to_string(), dependencies)
+        })
+        .collect();
+
+    let closures = turborepo_lockfiles::all_transitive_closures_sorted(
+        lockfile,
+        external_dependencies,
+        false,
+    )?;
+    let mut seen = HashSet::new();
+    let mut packages: Vec<Package> = closures
+        .into_values()
+        .flatten()
+        .filter(|package| seen.insert(package.key.clone()))
+        .map(|package| (*package).clone())
+        .collect();
+    packages.sort_unstable();
+    Ok(packages)
+}

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -32,6 +32,7 @@ use crate::{
 pub mod builder;
 mod dep_splitter;
 mod javascript;
+pub mod lockfile_closure;
 mod projections;
 
 pub use builder::{Error, PackageGraphBuilder};

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -197,7 +197,11 @@ Represents the workspace structure and package dependencies:
   the same resolution generation (including a lazy compact reverse index)
   rather than retained manifest payloads or live lockfile human-name callbacks.
   N-API JavaScript lockfile package listing uses the JavaScript domain of that
-  generation. The JavaScript
+  generation; when the N-API caller opts out of graph construction
+  (`skipPackageGraph`), `package_graph/lockfile_closure.rs` computes the same
+  external closure directly from workspace manifests and the lockfile, reusing
+  the internal/external `DependencySplitter` without building repository or
+  relationship knowledge. The JavaScript
   adapter owns package-manager configuration, previous-lockfile parsing, and
   resolution through the same producer used at graph construction. Core
   compares the resulting normalized package identities without parser or

--- a/packages/turbo-repository/__tests__/lockfile-packages.test.ts
+++ b/packages/turbo-repository/__tests__/lockfile-packages.test.ts
@@ -245,6 +245,62 @@ describe("lockfilePackages", () => {
   });
 });
 
+describe("lockfilePackages with skipPackageGraph", () => {
+  it("matches the package-graph result for a pnpm monorepo", async () => {
+    const withGraph = await (
+      await Workspace.find(PNPM_MONOREPO_PATH)
+    ).lockfilePackages();
+    const withoutGraph = await (
+      await Workspace.find(PNPM_MONOREPO_PATH, { skipPackageGraph: true })
+    ).lockfilePackages();
+
+    assert.ok(
+      withoutGraph.packages.length > 0,
+      "Expected at least one package"
+    );
+    assert.deepEqual(withoutGraph, withGraph);
+  });
+
+  it("matches the package-graph result for a Yarn 1 fixture", async () => {
+    const dir = path.join(LOCKFILE_FIXTURES_PATH, "yarn1-file-dep");
+    const withGraph = await (await Workspace.find(dir)).lockfilePackages();
+    const withoutGraph = await (
+      await Workspace.find(dir, { skipPackageGraph: true })
+    ).lockfilePackages();
+
+    assert.deepEqual(withoutGraph, withGraph);
+  });
+
+  it("still works for single-package repos", async () => {
+    const withGraph = await (
+      await Workspace.find(NPM_SINGLE_PACKAGE_PATH)
+    ).lockfilePackages();
+    const withoutGraph = await (
+      await Workspace.find(NPM_SINGLE_PACKAGE_PATH, { skipPackageGraph: true })
+    ).lockfilePackages();
+
+    assert.deepEqual(withoutGraph, withGraph);
+  });
+
+  it("rejects graph-backed methods with a clear error", async () => {
+    const workspace = await Workspace.find(PNPM_MONOREPO_PATH, {
+      skipPackageGraph: true
+    });
+    assert.equal(workspace.isMultiPackage, true);
+    assert.equal(workspace.packageManager.version, "9.15.9");
+
+    for (const call of [
+      () => workspace.findPackages(),
+      () => workspace.findPackagesWithGraph(),
+      () => workspace.packagesFromLockfile(),
+      () => workspace.affectedPackages([]),
+      () => workspace.findPackageByPath("apps/app/index.js")
+    ]) {
+      await assert.rejects(call, /skipPackageGraph/);
+    }
+  });
+});
+
 describe("packageManager version", () => {
   it("exposes the version from the packageManager field", async () => {
     const workspace = await Workspace.find(PNPM_MONOREPO_PATH);

--- a/packages/turbo-repository/js/index.d.ts
+++ b/packages/turbo-repository/js/index.d.ts
@@ -84,6 +84,17 @@ export interface LockfilePackages {
   /** Declared package-manager version, when available. */
   packageManagerVersion?: string;
 }
+/** Options for [`Workspace::find`]. */
+export interface WorkspaceFindOptions {
+  /**
+   * Skip constructing the package graph. Only
+   * [`Workspace::lockfile_packages`] is available on the resulting
+   * workspace; every graph-backed method rejects. Use this when you only
+   * need the lockfile closure (for example dependency auditing) and want to
+   * avoid the cost of building the full monorepo graph.
+   */
+  skipPackageGraph?: boolean;
+}
 export class Package {
   name: string;
   /** The absolute path to the package root. */
@@ -121,7 +132,10 @@ export class Workspace {
    * Finds the workspace root from the given path, and returns a new
    * Workspace.
    */
-  static find(path?: string | undefined | null): Promise<Workspace>;
+  static find(
+    path?: string | undefined | null,
+    options?: WorkspaceFindOptions | undefined | null
+  ): Promise<Workspace>;
   /** Finds and returns packages within the workspace. */
   findPackages(): Promise<Array<Package>>;
   /**
@@ -151,6 +165,10 @@ export class Workspace {
    * `errors` list rather than an exception, so callers can emit metrics on
    * both success and failure. Package manager identity is exposed separately
    * on [`Workspace::package_manager`].
+   *
+   * This is the only method available on a workspace opened with
+   * `skipPackageGraph`; in that mode the closure is computed directly from
+   * the workspace manifests and lockfile.
    */
   lockfilePackages(): Promise<LockfilePackages>;
   /**

--- a/packages/turbo-repository/rust/src/internal.rs
+++ b/packages/turbo-repository/rust/src/internal.rs
@@ -6,7 +6,7 @@ use turbopath::{AbsoluteSystemPathBuf, PathError};
 use turborepo_lockfiles::Lockfile;
 use turborepo_repository::{
     inference::{self, RepoMode as WorkspaceType, RepoState as WorkspaceState},
-    package_graph::{PackageGraph, PackageGraphBuilder},
+    package_graph::{PackageGraph, PackageGraphBuilder, lockfile_closure},
     package_json::{DependencyKind, PackageJson},
     package_manager,
 };
@@ -19,7 +19,7 @@ use crate::{
     Package, PackageManager, Workspace, package_source_name, split_identity,
 };
 
-enum SinglePackageLockfileRead {
+enum DirectLockfileRead {
     Loaded(Box<dyn Lockfile>),
     Missing(String),
     Unreadable {
@@ -28,71 +28,100 @@ enum SinglePackageLockfileRead {
     },
 }
 
-pub(crate) struct SinglePackageLockfile {
-    lockfile: SinglePackageLockfileRead,
-    dependencies: BTreeMap<String, String>,
+/// Resolves the workspace lockfile directly from the root `package.json`,
+/// bypassing the package graph. Used for single-package repositories (whose
+/// core graph intentionally skips lockfile resolution) and for multi-package
+/// repositories opened with `skipPackageGraph`.
+pub(crate) struct DirectLockfile {
+    workspace_root: AbsoluteSystemPathBuf,
+    package_manager: package_manager::PackageManager,
+    root_package_json: PackageJson,
+    lockfile: DirectLockfileRead,
 }
 
-impl SinglePackageLockfile {
+impl DirectLockfile {
     fn new(
         workspace_root: &turbopath::AbsoluteSystemPath,
         package_manager: &package_manager::PackageManager,
         package_json: &PackageJson,
     ) -> Self {
-        let mut dependencies = BTreeMap::new();
-        for (name, specifier, kind) in package_json.dependencies_with_kind() {
-            if !matches!(kind, DependencyKind::Peer { .. }) {
-                dependencies
-                    .entry(name.clone())
-                    .or_insert_with(|| specifier.clone());
-            }
-        }
         let lockfile = match package_manager.read_lockfile(workspace_root, package_json) {
-            Ok(lockfile) => SinglePackageLockfileRead::Loaded(lockfile),
+            Ok(lockfile) => DirectLockfileRead::Loaded(lockfile),
             Err(package_manager::Error::LockfileMissing(_))
                 if matches!(
                     package_manager.lockfile_manager(),
                     package_manager::PackageManager::Bun
                 ) && workspace_root.join_component("bun.lockb").exists() =>
             {
-                SinglePackageLockfileRead::Unreadable {
+                DirectLockfileRead::Unreadable {
                     kind: LockfileErrorKind::UnsupportedBunLockfile,
                     message: "Only found bun.lockb, please run `bun install --save-text-lockfile`"
                         .to_string(),
                 }
             }
             Err(package_manager::Error::LockfileMissing(path)) => {
-                SinglePackageLockfileRead::Missing(format!("Lockfile not found at {path}"))
+                DirectLockfileRead::Missing(format!("Lockfile not found at {path}"))
             }
-            Err(error) => SinglePackageLockfileRead::Unreadable {
+            Err(error) => DirectLockfileRead::Unreadable {
                 kind: classify_package_manager_error(&error),
                 message: error.to_string(),
             },
         };
         Self {
+            workspace_root: workspace_root.to_owned(),
+            package_manager: package_manager.clone(),
+            root_package_json: package_json.clone(),
             lockfile,
-            dependencies,
         }
     }
 
     pub(crate) fn error_kind(&self) -> Option<LockfileErrorKind> {
         match &self.lockfile {
-            SinglePackageLockfileRead::Loaded(_) => None,
-            SinglePackageLockfileRead::Missing(_) => Some(LockfileErrorKind::NoLockfile),
-            SinglePackageLockfileRead::Unreadable { kind, .. } => Some(*kind),
+            DirectLockfileRead::Loaded(_) => None,
+            DirectLockfileRead::Missing(_) => Some(LockfileErrorKind::NoLockfile),
+            DirectLockfileRead::Unreadable { kind, .. } => Some(*kind),
         }
     }
 
     pub(crate) fn error_message(&self) -> Option<String> {
         match &self.lockfile {
-            SinglePackageLockfileRead::Loaded(_) => None,
-            SinglePackageLockfileRead::Missing(message)
-            | SinglePackageLockfileRead::Unreadable { message, .. } => Some(message.clone()),
+            DirectLockfileRead::Loaded(_) => None,
+            DirectLockfileRead::Missing(message)
+            | DirectLockfileRead::Unreadable { message, .. } => Some(message.clone()),
         }
+    }
+
+    /// The transitive closure of the root `package.json` declarations only.
+    /// Single-package repositories have no other manifests.
+    fn root_closure(
+        &self,
+        lockfile: &dyn Lockfile,
+    ) -> Result<Vec<turborepo_lockfiles::Package>, String> {
+        let mut dependencies = BTreeMap::new();
+        for (name, specifier, kind) in self.root_package_json.dependencies_with_kind() {
+            if !matches!(kind, DependencyKind::Peer { .. }) {
+                dependencies
+                    .entry(name.clone())
+                    .or_insert_with(|| specifier.clone());
+            }
+        }
+        let mut closures = turborepo_lockfiles::all_transitive_closures_sorted(
+            lockfile,
+            HashMap::from([(String::new(), dependencies)]),
+            false,
+        )
+        .map_err(|error| error.to_string())?;
+        Ok(closures
+            .remove("")
+            .unwrap_or_default()
+            .into_iter()
+            .map(|package| (*package).clone())
+            .collect())
     }
 
     pub(crate) fn packages(
         &self,
+        is_multi_package: bool,
         lockfile_path: &str,
         lockfile_format: &str,
         package_manager: &PackageManager,
@@ -105,8 +134,8 @@ impl SinglePackageLockfile {
             package_manager_version: package_manager.version.clone(),
         };
         let lockfile = match &self.lockfile {
-            SinglePackageLockfileRead::Loaded(lockfile) => lockfile,
-            SinglePackageLockfileRead::Missing(message) => {
+            DirectLockfileRead::Loaded(lockfile) => lockfile.as_ref(),
+            DirectLockfileRead::Missing(message) => {
                 return LockfilePackages::new(
                     Vec::new(),
                     vec![LockfileError {
@@ -116,7 +145,7 @@ impl SinglePackageLockfile {
                     metadata(None),
                 );
             }
-            SinglePackageLockfileRead::Unreadable { kind, message } => {
+            DirectLockfileRead::Unreadable { kind, message } => {
                 return LockfilePackages::new(
                     Vec::new(),
                     vec![LockfileError {
@@ -128,18 +157,25 @@ impl SinglePackageLockfile {
             }
         };
 
-        let closures = match turborepo_lockfiles::all_transitive_closures_sorted(
-            lockfile.as_ref(),
-            HashMap::from([(String::new(), self.dependencies.clone())]),
-            false,
-        ) {
-            Ok(closures) => closures,
-            Err(error) => {
+        let closure = if is_multi_package {
+            lockfile_closure::external_packages(
+                &self.workspace_root,
+                &self.package_manager,
+                &self.root_package_json,
+                lockfile,
+            )
+            .map_err(|error| error.to_string())
+        } else {
+            self.root_closure(lockfile)
+        };
+        let closure = match closure {
+            Ok(closure) => closure,
+            Err(message) => {
                 return LockfilePackages::new(
                     Vec::new(),
                     vec![LockfileError {
                         kind: LockfileErrorKind::ResolutionFailed,
-                        message: error.to_string(),
+                        message,
                     }],
                     metadata(lockfile.format_version()),
                 );
@@ -148,7 +184,7 @@ impl SinglePackageLockfile {
 
         let mut packages = Vec::new();
         let mut errors = Vec::new();
-        for package in closures.get("").into_iter().flatten() {
+        for package in &closure {
             let display_name = lockfile
                 .human_name(package)
                 .unwrap_or_else(|| package.key.clone());
@@ -208,6 +244,11 @@ pub(crate) enum Error {
     PackageJson(#[from] turborepo_repository::package_json::Error),
     #[error("turbo.json error: {0}")]
     TurboJson(#[from] turborepo_turbo_json::Error),
+    #[error(
+        "package graph is unavailable because the workspace was opened with skipPackageGraph; \
+         only lockfilePackages() is supported"
+    )]
+    PackageGraphSkipped,
 }
 
 impl From<Error> for napi::Error<Status> {
@@ -217,7 +258,10 @@ impl From<Error> for napi::Error<Status> {
 }
 
 impl Workspace {
-    pub(crate) async fn find_internal(path: Option<String>) -> Result<Self, Error> {
+    pub(crate) async fn find_internal(
+        path: Option<String>,
+        skip_package_graph: bool,
+    ) -> Result<Self, Error> {
         let reference_dir = match path {
             Some(path) => {
                 AbsoluteSystemPathBuf::from_cwd(&path).map_err(|path_error| Error::StartingPath {
@@ -317,18 +361,22 @@ impl Workspace {
         };
         let root_package_json = PackageJson::load(&workspace_root.join_component("package.json"))?;
         let package_manager_version = detect_package_manager_version(&root_package_json);
-        let lockfile =
-            SinglePackageLockfile::new(workspace_root, package_manager, &root_package_json);
-        let mut package_graph_builder = PackageGraphBuilder::new(workspace_root, root_package_json)
-            .with_single_package_mode(!is_multi_package)
-            .with_package_manager(package_manager.clone());
-        if turbo_json.future_flags.experimental_cargo_workspaces {
-            package_graph_builder = package_graph_builder.with_cargo();
-        }
-        if turbo_json.future_flags.experimental_python_workspaces {
-            package_graph_builder = package_graph_builder.with_uv();
-        }
-        let package_graph = package_graph_builder.build().await?;
+        let lockfile = DirectLockfile::new(workspace_root, package_manager, &root_package_json);
+        let package_graph = if skip_package_graph {
+            None
+        } else {
+            let mut package_graph_builder =
+                PackageGraphBuilder::new(workspace_root, root_package_json)
+                    .with_single_package_mode(!is_multi_package)
+                    .with_package_manager(package_manager.clone());
+            if turbo_json.future_flags.experimental_cargo_workspaces {
+                package_graph_builder = package_graph_builder.with_cargo();
+            }
+            if turbo_json.future_flags.experimental_python_workspaces {
+                package_graph_builder = package_graph_builder.with_uv();
+            }
+            Some(package_graph_builder.build().await?)
+        };
 
         Ok(Self {
             absolute_path: workspace_state.root.to_string(),
@@ -344,8 +392,14 @@ impl Workspace {
         })
     }
 
+    /// The package graph, or an error when the workspace was opened with
+    /// `skipPackageGraph`.
+    pub(crate) fn graph(&self) -> Result<&PackageGraph, Error> {
+        self.graph.as_ref().ok_or(Error::PackageGraphSkipped)
+    }
+
     pub(crate) async fn packages_internal(&self) -> Result<Vec<Package>, Error> {
-        packages_from_graph(&self.graph)
+        packages_from_graph(self.graph()?)
     }
 }
 

--- a/packages/turbo-repository/rust/src/lib.rs
+++ b/packages/turbo-repository/rust/src/lib.rs
@@ -167,6 +167,18 @@ impl LockfilePackages {
     }
 }
 
+/// Options for [`Workspace::find`].
+#[napi(object)]
+#[derive(Default)]
+pub struct WorkspaceFindOptions {
+    /// Skip constructing the package graph. Only
+    /// [`Workspace::lockfile_packages`] is available on the resulting
+    /// workspace; every graph-backed method rejects. Use this when you only
+    /// need the lockfile closure (for example dependency auditing) and want to
+    /// avoid the cost of building the full monorepo graph.
+    pub skip_package_graph: Option<bool>,
+}
+
 #[napi]
 pub struct Workspace {
     /// The absolute path to the workspace root.
@@ -178,12 +190,13 @@ pub struct Workspace {
     /// The package manager used by the workspace.
     #[napi(readonly)]
     pub package_manager: PackageManager,
-    /// The package graph for the workspace.
-    graph: PackageGraph,
-    /// Inputs for resolving a single-package repository's root lockfile on
-    /// demand. Core single-package graphs intentionally skip lockfile
-    /// resolution, so the JS API retains this repository-local fallback.
-    lockfile: internal::SinglePackageLockfile,
+    /// The package graph for the workspace. `None` when opened with
+    /// `skipPackageGraph`.
+    graph: Option<PackageGraph>,
+    /// Inputs for resolving the root lockfile without the package graph.
+    /// Used for single-package repositories (whose core graph intentionally
+    /// skips lockfile resolution) and for `skipPackageGraph` workspaces.
+    lockfile: internal::DirectLockfile,
     lockfile_path: String,
     lockfile_format: String,
 }
@@ -252,8 +265,16 @@ impl Workspace {
     /// Finds the workspace root from the given path, and returns a new
     /// Workspace.
     #[napi(factory)]
-    pub async fn find(path: Option<String>) -> Result<Workspace, napi::Error> {
-        Self::find_internal(path).await.map_err(|e| e.into())
+    pub async fn find(
+        path: Option<String>,
+        options: Option<WorkspaceFindOptions>,
+    ) -> Result<Workspace, napi::Error> {
+        let skip_package_graph = options
+            .and_then(|options| options.skip_package_graph)
+            .unwrap_or(false);
+        Self::find_internal(path, skip_package_graph)
+            .await
+            .map_err(|e| e.into())
     }
 
     /// Finds and returns packages within the workspace.
@@ -272,6 +293,7 @@ impl Workspace {
     ///  }
     #[napi]
     pub async fn find_packages_with_graph(&self) -> Result<HashMap<String, PackageDetails>, Error> {
+        let graph = self.graph()?;
         let packages = self.find_packages().await?;
 
         let workspace_path = match AbsoluteSystemPath::new(self.absolute_path.as_str()) {
@@ -284,12 +306,12 @@ impl Workspace {
             .map(|package| {
                 let details = PackageDetails {
                     dependencies: package
-                        .dependencies(&self.graph, workspace_path)
+                        .dependencies(graph, workspace_path)
                         .into_iter()
                         .map(|p| p.relative_path)
                         .collect(),
                     dependents: package
-                        .dependents(&self.graph, workspace_path)
+                        .dependents(graph, workspace_path)
                         .into_iter()
                         .map(|p| p.relative_path)
                         .collect(),
@@ -307,8 +329,9 @@ impl Workspace {
     /// preserve the historical lockfile-only listing.
     #[napi]
     pub async fn packages_from_lockfile(&self) -> Result<Vec<String>, napi::Error> {
-        let identities = self.graph.javascript_external_package_identities();
-        if identities.is_empty() && self.graph.lockfile().is_none() {
+        let graph = self.graph()?;
+        let identities = graph.javascript_external_package_identities();
+        if identities.is_empty() && graph.lockfile().is_none() {
             return Err(napi::Error::from_reason("No lockfile found"));
         }
 
@@ -332,18 +355,22 @@ impl Workspace {
     /// `errors` list rather than an exception, so callers can emit metrics on
     /// both success and failure. Package manager identity is exposed separately
     /// on [`Workspace::package_manager`].
+    ///
+    /// This is the only method available on a workspace opened with
+    /// `skipPackageGraph`; in that mode the closure is computed directly from
+    /// the workspace manifests and lockfile.
     #[napi]
     pub async fn lockfile_packages(&self) -> LockfilePackages {
-        if !self.is_multi_package {
+        let Some(graph) = self.graph.as_ref().filter(|_| self.is_multi_package) else {
             return self.lockfile.packages(
+                self.is_multi_package,
                 &self.lockfile_path,
                 &self.lockfile_format,
                 &self.package_manager,
             );
-        }
+        };
 
-        let lockfile_version = self
-            .graph
+        let lockfile_version = graph
             .lockfile()
             .and_then(|lockfile| lockfile.format_version());
         let metadata = || LockfilePackagesMetadata {
@@ -354,15 +381,14 @@ impl Workspace {
             package_manager_version: self.package_manager.version.clone(),
         };
 
-        match self.graph.javascript_external_resolution() {
+        match graph.javascript_external_resolution() {
             JavascriptExternalResolution::Resolved(identities) => {
                 let mut packages = Vec::with_capacity(identities.len());
                 let mut errors = Vec::new();
                 for identity in identities {
                     match split_identity(identity.display_name()) {
                         Some((name, version)) => {
-                            let source = self
-                                .graph
+                            let source = graph
                                 .lockfile()
                                 .map(|lockfile| {
                                     lockfile.package_source(&ResolvedPackage {
@@ -425,21 +451,21 @@ impl Workspace {
         }
     }
 
-    pub fn get_lockfile_contents(
-        &self,
+    fn get_lockfile_contents(
+        graph: &PackageGraph,
         changed_files: &HashSet<AnchoredSystemPathBuf>,
         workspace_root: &AbsoluteSystemPath,
         from_commit: &str,
     ) -> LockfileContents {
-        let Some(lockfile_path) = self
-            .graph
-            .change_knowledge()
-            .resolution_paths()
-            .iter()
-            .find_map(|path| {
-                let path = AnchoredSystemPath::new(path).ok()?;
-                changed_files.contains(path).then_some(path)
-            })
+        let Some(lockfile_path) =
+            graph
+                .change_knowledge()
+                .resolution_paths()
+                .iter()
+                .find_map(|path| {
+                    let path = AnchoredSystemPath::new(path).ok()?;
+                    changed_files.contains(path).then_some(path)
+                })
         else {
             return LockfileContents::Unchanged;
         };
@@ -469,6 +495,7 @@ impl Workspace {
         base: Option<&str>, // this is required when optimize_global_invalidations is true
         optimize_global_invalidations: Option<bool>,
     ) -> Result<Vec<Package>, Error> {
+        let graph = self.graph()?;
         let base = matches!(optimize_global_invalidations, Some(true))
             .then(|| {
                 base.ok_or_else(|| {
@@ -491,16 +518,15 @@ impl Workspace {
 
         // Create a ChangeMapper with no ignore patterns
         let change_detector = if base.is_some() {
-            Either::Left(DefaultPackageChangeMapperWithLockfile::new(&self.graph))
+            Either::Left(DefaultPackageChangeMapperWithLockfile::new(graph))
         } else {
-            Either::Right(DefaultPackageChangeMapper::new(&self.graph))
+            Either::Right(DefaultPackageChangeMapper::new(graph))
         };
-        let mapper = ChangeMapper::new(&self.graph, vec![], change_detector);
+        let mapper = ChangeMapper::new(graph, vec![], change_detector);
 
         let lockfile_contents = if let Some(base) = base {
-            self.get_lockfile_contents(&changed_files, workspace_root, base)
-        } else if self
-            .graph
+            Self::get_lockfile_contents(graph, &changed_files, workspace_root, base)
+        } else if graph
             .change_knowledge()
             .resolution_paths()
             .iter()
@@ -518,8 +544,7 @@ impl Workspace {
         };
 
         let packages = match package_changes {
-            PackageChanges::All(_) => self
-                .graph
+            PackageChanges::All(_) => graph
                 .package_task_contexts()
                 .map(|context| WorkspacePackage {
                     name: context.package().clone(),
@@ -529,7 +554,7 @@ impl Workspace {
             PackageChanges::Some(packages) => packages.into_keys().collect(),
         };
 
-        self.serialize_packages(packages)
+        self.serialize_packages(graph, packages)
     }
 
     /// Given a path (relative to the workspace root), returns the
@@ -541,7 +566,7 @@ impl Workspace {
     /// containing-package of every ancestor.
     #[napi]
     pub async fn find_package_by_path(&self, path: String) -> Result<Package, Error> {
-        let package_mapper = DefaultPackageChangeMapper::new(&self.graph);
+        let package_mapper = DefaultPackageChangeMapper::new(self.graph()?);
         let anchored_path = AnchoredSystemPath::new(&path)
             .map_err(|e| Error::from_reason(e.to_string()))?
             .clean();
@@ -566,13 +591,14 @@ impl Workspace {
 
     fn serialize_packages(
         &self,
+        graph: &PackageGraph,
         packages: impl IntoIterator<Item = WorkspacePackage>,
     ) -> Result<Vec<Package>, Error> {
         let workspace_root = AbsoluteSystemPath::new(&self.absolute_path)
             .map_err(|error| Error::from_reason(error.to_string()))?;
         let mut packages = packages
             .into_iter()
-            .filter(|package| self.graph.is_real_package(&package.name))
+            .filter(|package| graph.is_real_package(&package.name))
             .map(|package| {
                 let package_path = workspace_root.resolve(&package.path);
                 Package::new(package.name.to_string(), workspace_root, &package_path)


### PR DESCRIPTION
### Description

Adds an opt-in `skipPackageGraph` option to `@turbo/repository`'s `Workspace.find` so callers that only need the lockfile closure (for example scanning for malicious packages) can avoid constructing the full monorepo package graph.

```ts
const workspace = await Workspace.find(root, { skipPackageGraph: true });
const { packages, errors } = await workspace.lockfilePackages();
```

- `Workspace.find(path, options?)` accepts `WorkspaceFindOptions { skipPackageGraph?: boolean }`. When set, `PackageGraphBuilder` is not run at all: no repository knowledge, relationship knowledge, task/change/prune knowledge, or petgraph construction.
- `lockfilePackages()` on such a workspace computes the closure through a new `package_graph::lockfile_closure::external_packages` helper. It globs workspace `package.json` files via the package manager, splits internal from external declarations with the existing `DependencySplitter` (honoring `link_workspace_packages`, pnpm catalogs, `workspace:` aliases and paths, first-declaration-wins, and peer exclusion), then runs `all_transitive_closures_sorted`. The output is identical to the graph-backed path.
- Every graph-backed method (`findPackages`, `findPackagesWithGraph`, `packagesFromLockfile`, `affectedPackages`, `findPackageByPath`) rejects with a clear error naming `skipPackageGraph` when the graph was skipped.
- `SinglePackageLockfile` is generalized to `DirectLockfile`, which now serves both single-package repositories and skip-graph multi-package repositories.
- `WorkspacePathIndex::from_directories` lets the splitter be built without `RepositoryKnowledge`.
- ARCHITECTURE.md notes the new direct closure path.

Default behavior (no options) is unchanged.

### Testing Instructions

New tests in `packages/turbo-repository/__tests__/lockfile-packages.test.ts` assert `deepEqual` between the graph and skip-graph `lockfilePackages()` results for the pnpm monorepo fixture (which has a `workspace:` internal dependency and a nameless package), the Yarn 1 fixture, and the npm single-package fixture, plus the rejection behavior for every graph-backed method.

`cargo test -p turborepo-napi` has one pre-existing failure (`package_listing_uses_manifest_capability_not_provenance`) that also fails on `main`; it is unrelated to this change.
