### PR TITLE
fix: Use pnpm 12 in library release containers

### DIFF
--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -63,7 +63,7 @@ jobs:
               chmod +x rustup-init
               ./rustup-init -y
               rm rustup-init
-              npm i -g --force pnpm@10.28.0
+              npm i -g --force pnpm@12.0.0
               mkdir ../zig
               curl --fail --show-error --silent --location --output zig.tar.xz https://ziglang.org/download/0.14.0/zig-linux-x86_64-0.14.0.tar.xz
               echo "473ec26806133cf4d1918caf1a410f8403a13d979726a9045b421b685031a982  zig.tar.xz" | sha256sum --check --strict
@@ -80,7 +80,7 @@ jobs:
             install: |
               apk update && apk upgrade
               apk add libc6-compat curl
-              npm i -g --force pnpm@10.28.0
+              npm i -g --force pnpm@12.0.0
               echo /root/.cargo/bin >> ${GITHUB_PATH}
               echo /usr/local/cargo/bin/rustup >> ${GITHUB_PATH}
             setup: |
@@ -95,7 +95,7 @@ jobs:
             install: |
               apk update && apk upgrade
               apk add libc6-compat curl
-              npm i -g --force pnpm@10.28.0
+              npm i -g --force pnpm@12.0.0
               echo /root/.cargo/bin >> ${GITHUB_PATH}
               echo /usr/local/cargo/bin/rustup >> ${GITHUB_PATH}
               echo /aarch64-linux-musl-cross/bin >> ${GITHUB_PATH}


### PR DESCRIPTION
## Summary

- install pnpm 12 directly in Linux library release containers
- prevent pnpm 10 from bootstrapping pnpm 12 with blocked lifecycle scripts
- keep the release toolchain aligned with the root `packageManager` version

Fixes the failure in https://github.com/vercel/turborepo/actions/runs/33761933731/job/100670172964.