### PR TITLE
fix: Use Node 20 for musl library builds

### DIFF
--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -78,34 +78,29 @@ jobs:
 
           - host: ubuntu-24.04
             target: x86_64-unknown-linux-musl
-            container: ghcr.io/napi-rs/napi-rs/nodejs-rust:stable-2023-09-17-alpine@sha256:11bf6f488b38a7d22592c92bfacfbb1479ef61943e42c911f84135c3aae67112
+            container: node:20-alpine@sha256:afdf98210b07b586eb71fa22ba2e432e058e4cd1304d31ed60888755b8c865fb
             install: |
-              apk update && apk upgrade
-              apk add libc6-compat curl
+              apk add --no-cache bash build-base curl git libc6-compat python3 rustup tar xz
+              rustup-init -y --default-toolchain none
               npm i -g --force pnpm@12.0.0
               echo /root/.cargo/bin >> ${GITHUB_PATH}
-              echo /usr/local/cargo/bin/rustup >> ${GITHUB_PATH}
             setup: |
-              export PATH=/usr/local/cargo/bin/rustup:/root/.cargo/bin:${PATH}
-              rustup show active-toolchain
-              dirname $(rustup which cargo) >> ${GITHUB_PATH}
               pnpm install --filter @turbo/repository --frozen-lockfile
 
           - host: ubuntu-24.04
             target: aarch64-unknown-linux-musl
-            container: ghcr.io/napi-rs/napi-rs/nodejs-rust:stable-2023-09-17-alpine@sha256:11bf6f488b38a7d22592c92bfacfbb1479ef61943e42c911f84135c3aae67112
+            container: node:20-alpine@sha256:afdf98210b07b586eb71fa22ba2e432e058e4cd1304d31ed60888755b8c865fb
             install: |
-              apk update && apk upgrade
-              apk add libc6-compat curl
+              apk add --no-cache bash build-base curl git libc6-compat python3 rustup tar xz
+              rustup-init -y --default-toolchain none
               npm i -g --force pnpm@12.0.0
+              curl --proto '=https' --tlsv1.2 --fail --show-error --silent --location --output aarch64-linux-musl-cross.tgz https://github.com/napi-rs/napi-rs/releases/download/linux-musl-cross%4010/aarch64-linux-musl-cross.tgz
+              echo "0f18a885b161815520bbb5757a4b4ab40d0898c29bebee58d0cddd6112e59cc6  aarch64-linux-musl-cross.tgz" | sha256sum -c
+              tar -xzf aarch64-linux-musl-cross.tgz -C /
+              rm aarch64-linux-musl-cross.tgz
               echo /root/.cargo/bin >> ${GITHUB_PATH}
-              echo /usr/local/cargo/bin/rustup >> ${GITHUB_PATH}
               echo /aarch64-linux-musl-cross/bin >> ${GITHUB_PATH}
             setup: |
-              export PATH=/aarch64-linux-musl-cross/bin:/usr/local/cargo/bin/rustup:/root/.cargo/bin:${PATH}
-              rustup show active-toolchain
-              rustup target add aarch64-unknown-linux-musl
-              dirname $(rustup which cargo) >> ${GITHUB_PATH}
               pnpm install --filter @turbo/repository --frozen-lockfile
             rust_env: CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc RUSTFLAGS="-Ctarget-feature=-crt-static"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ When making changes to the codebase, check if the following docs need updates:
 - Linux Rust shards include `terminal-control` black-box TUI integration tests; known regressions remain explicitly ignored.
 - Rust test shards pin Node.js 18.20.2, so any `packageManager` version an integration fixture declares has to run on that Node.
 - The `@turbo/repository` native-package matrix tests Node.js 20, 22, and 24; N-API v3's CLI does not support Node.js 18.
+- The `@turbo/repository` musl release builds use a pinned Node.js 20 Alpine container and install their Rust and ARM cross toolchains explicitly.
 - Rust test shards and the `@turbo/repository` native-package matrix install the pinned uv version because Python workspace discovery invokes `uv workspace metadata`.
 - Rust integration tests read fixtures from `turborepo-tests/integration/fixtures/`, never from `examples/`. Examples are version-bumped on their own cadence and are not declared inputs of the Rust test task.
 - Example validation remains push-only because it requires Vercel credentials and project state.


### PR DESCRIPTION
## Description

- Replace the stale Node.js 18 N-API Alpine image in the two musl library-release jobs with a pinned Node.js 20 Alpine image.
- Install the pinned Rust toolchain prerequisites explicitly.
- Download and verify the existing ARM musl cross-toolchain for the aarch64 build.

The N-API v3 CLI requires Node.js 20 or newer. The previous container used Node.js 18.17.1, causing both musl builds to fail while loading `@inquirer/core`.

## Testing

- Built the x86_64 musl addon in the exact pinned Node.js 20 Alpine container.
- Built the aarch64 musl addon in the exact pinned Node.js 20 Alpine container with the verified cross-toolchain archive.
