### PR TITLE
fix: Allow unclean tree in bump-version

### DIFF
--- a/packages/turbo-repository/scripts/bump-version.sh
+++ b/packages/turbo-repository/scripts/bump-version.sh
@@ -23,7 +23,7 @@ echo "Version: ${TARGET}"
 for dir in "${PKG_ROOT}"/npm/*; do
   dep="@turbo/repository-$(basename "${dir}")"
   # bump the native dependency version
-  cd "${dir}" && pnpm version "${TARGET}" --allow-same-version
+  cd "${dir}" && pnpm version "${TARGET}" --allow-same-version --no-git-checks
 
   # bump the optional dependency listed in the metapackage
   update_dep=$(jq ".optionalDependencies.\"${dep}\" = \$newVal" --arg newVal "${TARGET}" "${JS_PACKAGE_JSON}")
@@ -31,4 +31,4 @@ for dir in "${PKG_ROOT}"/npm/*; do
 done
 
 #finally, bump the top-level version of the metapackage
-cd "${PKG_ROOT}/js" && pnpm version "${TARGET}" --allow-same-version
+cd "${PKG_ROOT}/js" && pnpm version "${TARGET}" --allow-same-version --no-git-checks


### PR DESCRIPTION
## Description

- Add `--no-git-checks` to the two `pnpm version` calls in `packages/turbo-repository/scripts/bump-version.sh`.

The Library Release workflow intentionally dirties the working tree with `npm version` on the metapackage before invoking this script, and pnpm 12 rejects `pnpm version` in an unclean tree with `ERR_PNPM_UNCLEAN_WORKING_TREE`. The script is designed to accumulate several version edits before the workflow commits them together, so disabling pnpm's git checks here matches its intent.

## Verification

- Reproduced the failure mode and validated the fix in a temporary fixture workspace with pnpm 12.0.0: with the tree dirtied exactly like the workflow, the script bumped both platform packages, the metapackage, and the `optionalDependencies` pins to `0.0.1-canary.27`.
