### PR TITLE
fix: Skip git commit in bump-version

### DIFF
--- a/packages/turbo-repository/scripts/bump-version.sh
+++ b/packages/turbo-repository/scripts/bump-version.sh
@@ -23,7 +23,7 @@ echo "Version: ${TARGET}"
 for dir in "${PKG_ROOT}"/npm/*; do
   dep="@turbo/repository-$(basename "${dir}")"
   # bump the native dependency version
-  cd "${dir}" && pnpm version "${TARGET}" --allow-same-version --no-git-checks
+  cd "${dir}" && pnpm version "${TARGET}" --allow-same-version --no-git-checks --no-git-tag-version
 
   # bump the optional dependency listed in the metapackage
   update_dep=$(jq ".optionalDependencies.\"${dep}\" = \$newVal" --arg newVal "${TARGET}" "${JS_PACKAGE_JSON}")
@@ -31,4 +31,4 @@ for dir in "${PKG_ROOT}"/npm/*; do
 done
 
 #finally, bump the top-level version of the metapackage
-cd "${PKG_ROOT}/js" && pnpm version "${TARGET}" --allow-same-version --no-git-checks
+cd "${PKG_ROOT}/js" && pnpm version "${TARGET}" --allow-same-version --no-git-checks --no-git-tag-version


### PR DESCRIPTION
## Description

- Add `--no-git-tag-version` to the two `pnpm version` calls in `packages/turbo-repository/scripts/bump-version.sh`.

The Library Release workflow commits the version bump itself with `create-github-api-commit.mjs`, and its `npm version` call already passes `--no-git-tag-version`. The script's `pnpm version` calls did not, so on the identity-less release runner pnpm attempted `git commit -m <version>` and failed with `Author identity unknown`.

## Verification

- Validated in a temporary fixture workspace with pnpm 12.0.0: after running the script with the tree dirtied like the workflow, all package versions and `optionalDependencies` pins reached `0.0.1-canary.27`, `git rev-list --count HEAD` remained at the single init commit, and `git tag -l` listed zero tags.
