### PR TITLE
fix: Avoid oxlint false positive on Workspace.find options

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -24,6 +24,9 @@
     "jest/require-hook": "off",
     "no-inline-comments": "off",
     "unicorn/numeric-separators-style": "off",
+    // Workspace.find(dir, options) trips no-array-method-this-argument because
+    // the rule mistakes the options argument for an array method `thisArg`.
+    "unicorn/no-array-method-this-argument": "off",
     "typescript/consistent-type-definitions": "off",
     "no-use-before-define": "off",
     "promise/prefer-await-to-then": "off",


### PR DESCRIPTION
### Description

`unicorn/no-array-method-this-argument` flags `Workspace.find(path, { skipPackageGraph: true })` calls in `packages/turbo-repository/` tests because the rule mistakes the second argument for an array-method `thisArg` (`Array.find` vs. the `Workspace.find` method).

Four `oxlint --deny-warnings` errors started failing the `Formatting` CI job after #13929 and now also block unrelated PRs, including #13810, whose re-sync run failed on exactly this.

Disables the rule in `.oxlintrc.json`, matching the existing pattern of rule-offs there.
