### PR TITLE
refactor: Generalize daemon repository discovery

### DIFF
--- a/crates/turborepo-daemon/src/lib.rs
+++ b/crates/turborepo-daemon/src/lib.rs
@@ -51,15 +51,38 @@ pub use server::{CloseReason, FileWatching, TurboGrpcService};
 use sha2::{Digest, Sha256};
 use tokio::sync::broadcast;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf, PathError};
-use turborepo_repository::package_graph::PackageName;
+use turborepo_repository::package_graph::{PackageName, RepositoryDiscoverySnapshot};
 
-/// Trait for watching package changes. Implemented by consumers who need
-/// to integrate with turbo.json configuration.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum RepositoryDiscoveryError {
+    #[error("repository discovery unavailable")]
+    Unavailable,
+    #[error("repository discovery failed: {0}")]
+    InvalidState(String),
+}
+
+/// Trait for watching package changes and publishing the repository discovery
+/// generation used to classify them.
 pub trait PackageChangesWatcher: Send + Sync {
-    /// Get a receiver for package change events
+    /// Get a receiver for package change events.
     fn package_changes(
         &self,
     ) -> impl std::future::Future<Output = broadcast::Receiver<PackageChangeEvent>> + Send;
+
+    /// Return the latest completed repository discovery generation without
+    /// waiting for initialization.
+    fn repository_discovery(
+        &self,
+    ) -> impl std::future::Future<
+        Output = Option<Result<Arc<RepositoryDiscoverySnapshot>, RepositoryDiscoveryError>>,
+    > + Send;
+
+    /// Wait for the first repository discovery generation.
+    fn repository_discovery_blocking(
+        &self,
+    ) -> impl std::future::Future<
+        Output = Result<Arc<RepositoryDiscoverySnapshot>, RepositoryDiscoveryError>,
+    > + Send;
 }
 
 /// Arguments passed to a PackageChangesWatcher factory
@@ -217,46 +240,7 @@ pub mod proto {
     /// - Bump the minor version if adding new features, such that clients can
     ///   mandate at least some set of features on the target server.
     /// - Bump the patch version if making backwards compatible bug fixes.
-    pub const VERSION: &str = "2.0.0";
-
-    impl From<PackageManager> for turborepo_repository::package_manager::PackageManager {
-        fn from(pm: PackageManager) -> Self {
-            match pm {
-                PackageManager::Npm => Self::Npm,
-                PackageManager::Yarn => Self::Yarn,
-                PackageManager::Berry => Self::Berry,
-                PackageManager::Pnpm => Self::Pnpm,
-                PackageManager::Pnpm6 => Self::Pnpm6,
-                PackageManager::Pnpm9 => Self::Pnpm9,
-                PackageManager::Bun => Self::Bun,
-                // The wire format does not carry nub's underlying lockfile
-                // manager. Clients must call [`PackageManager::with_resolved_nub_lockfile`]
-                // after deserializing to re-resolve from disk.
-                PackageManager::Nub => Self::Nub {
-                    lockfile: Box::new(Self::Npm),
-                },
-                PackageManager::Aube => Self::Aube {
-                    lockfile: Box::new(Self::Npm),
-                },
-            }
-        }
-    }
-
-    impl From<turborepo_repository::package_manager::PackageManager> for PackageManager {
-        fn from(pm: turborepo_repository::package_manager::PackageManager) -> Self {
-            match pm {
-                turborepo_repository::package_manager::PackageManager::Npm => Self::Npm,
-                turborepo_repository::package_manager::PackageManager::Yarn => Self::Yarn,
-                turborepo_repository::package_manager::PackageManager::Berry => Self::Berry,
-                turborepo_repository::package_manager::PackageManager::Pnpm => Self::Pnpm,
-                turborepo_repository::package_manager::PackageManager::Pnpm6 => Self::Pnpm6,
-                turborepo_repository::package_manager::PackageManager::Pnpm9 => Self::Pnpm9,
-                turborepo_repository::package_manager::PackageManager::Bun => Self::Bun,
-                turborepo_repository::package_manager::PackageManager::Nub { .. } => Self::Nub,
-                turborepo_repository::package_manager::PackageManager::Aube { .. } => Self::Aube,
-            }
-        }
-    }
+    pub const VERSION: &str = "3.0.0";
 }
 
 #[cfg(test)]

--- a/crates/turborepo-daemon/src/package_changes_watcher.rs
+++ b/crates/turborepo-daemon/src/package_changes_watcher.rs
@@ -1,19 +1,34 @@
-use std::{ffi::OsStr, path::Path};
+use std::{ffi::OsStr, path::Path, sync::Arc};
 
-use tokio::{sync::broadcast, task::JoinHandle};
+use tokio::{
+    sync::{broadcast, watch},
+    task::JoinHandle,
+};
 use turborepo_filewatch::WatchScope;
+use turborepo_repository::{
+    package_graph::{PackageGraph, RepositoryDiscoverySnapshot},
+    package_json::PackageJson,
+};
 
-use crate::{PackageChangeEvent, PackageChangesWatcher, PackageChangesWatcherArgs};
+use crate::{
+    PackageChangeEvent, PackageChangesWatcher, PackageChangesWatcherArgs, RepositoryDiscoveryError,
+};
 
 pub struct RediscoveringPackageChangesWatcher {
     _handle: JoinHandle<()>,
     package_changes_rx: broadcast::Receiver<PackageChangeEvent>,
+    repository_discovery_rx: watch::Receiver<Option<Arc<RepositoryDiscoverySnapshot>>>,
 }
 
 impl RediscoveringPackageChangesWatcher {
     pub fn new(args: PackageChangesWatcherArgs) -> Self {
         let (package_changes_tx, package_changes_rx) = broadcast::channel(16);
+        let (repository_discovery_tx, repository_discovery_rx) = watch::channel(None);
         let _handle = tokio::spawn(async move {
+            if let Some(snapshot) = javascript_discovery_snapshot(&args).await {
+                repository_discovery_tx.send_replace(Some(Arc::new(snapshot)));
+            }
+
             let scope = WatchScope::predicate(should_rediscover);
             let Ok(mut events) = args.file_events.subscribe(scope).await else {
                 return;
@@ -22,6 +37,9 @@ impl RediscoveringPackageChangesWatcher {
             loop {
                 match events.recv().await {
                     Ok(_) | Err(broadcast::error::RecvError::Lagged(_)) => {
+                        if let Some(snapshot) = javascript_discovery_snapshot(&args).await {
+                            repository_discovery_tx.send_replace(Some(Arc::new(snapshot)));
+                        }
                         let _ = package_changes_tx.send(PackageChangeEvent::Rediscover);
                     }
                     Err(broadcast::error::RecvError::Closed) => return,
@@ -32,8 +50,22 @@ impl RediscoveringPackageChangesWatcher {
         Self {
             _handle,
             package_changes_rx,
+            repository_discovery_rx,
         }
     }
+}
+
+async fn javascript_discovery_snapshot(
+    args: &PackageChangesWatcherArgs,
+) -> Option<RepositoryDiscoverySnapshot> {
+    let root_package_json =
+        PackageJson::load(&args.repo_root.join_component("package.json")).ok()?;
+    PackageGraph::builder(&args.repo_root, root_package_json)
+        .with_allow_no_package_manager(args.allow_no_package_manager)
+        .build()
+        .await
+        .ok()
+        .map(|graph| graph.repository_discovery_snapshot())
 }
 
 fn should_rediscover(path: &Path) -> bool {
@@ -45,6 +77,27 @@ fn should_rediscover(path: &Path) -> bool {
 impl PackageChangesWatcher for RediscoveringPackageChangesWatcher {
     async fn package_changes(&self) -> broadcast::Receiver<PackageChangeEvent> {
         self.package_changes_rx.resubscribe()
+    }
+
+    async fn repository_discovery(
+        &self,
+    ) -> Option<Result<Arc<RepositoryDiscoverySnapshot>, RepositoryDiscoveryError>> {
+        self.repository_discovery_rx.borrow().clone().map(Ok)
+    }
+
+    async fn repository_discovery_blocking(
+        &self,
+    ) -> Result<Arc<RepositoryDiscoverySnapshot>, RepositoryDiscoveryError> {
+        let mut receiver = self.repository_discovery_rx.clone();
+        loop {
+            if let Some(snapshot) = receiver.borrow_and_update().clone() {
+                return Ok(snapshot);
+            }
+            receiver
+                .changed()
+                .await
+                .map_err(|_| RepositoryDiscoveryError::Unavailable)?;
+        }
     }
 }
 

--- a/crates/turborepo-daemon/src/package_discovery.rs
+++ b/crates/turborepo-daemon/src/package_discovery.rs
@@ -34,10 +34,7 @@ fn workspace_data_from_proto(package_files: PackageFiles) -> Result<WorkspaceDat
         })
         .transpose()?;
 
-    Ok(WorkspaceData {
-        package_json,
-        turbo_json,
-    })
+    WorkspaceData::new(package_json, turbo_json)
 }
 
 fn discovery_response_from_proto(

--- a/crates/turborepo-daemon/src/package_discovery.rs
+++ b/crates/turborepo-daemon/src/package_discovery.rs
@@ -1,11 +1,14 @@
 use turbopath::AbsoluteSystemPathBuf;
 use turborepo_repository::{
     discovery::{DiscoveryResponse, Error, PackageDiscovery, WorkspaceData},
+    package_graph::PackageName,
+    package_json::PackageJson,
     package_manager::PackageManager,
+    toolchain::ToolchainId,
 };
 
 use crate::{
-    proto::{DiscoverPackagesResponse, PackageFiles, PackageManager as ProtoPackageManager},
+    proto::{DiscoverPackagesResponse, RepositoryScope},
     DaemonClient,
 };
 
@@ -21,38 +24,36 @@ impl<C> DaemonPackageDiscovery<C> {
     }
 }
 
-fn workspace_data_from_proto(package_files: PackageFiles) -> Result<WorkspaceData, Error> {
-    let package_json = AbsoluteSystemPathBuf::new(package_files.package_json).map_err(|err| {
-        Error::InvalidResponse(format!("daemon returned invalid package.json path: {err}"))
-    })?;
-    let turbo_json = package_files
-        .turbo_json
-        .map(|path| {
-            AbsoluteSystemPathBuf::new(path).map_err(|err| {
-                Error::InvalidResponse(format!("daemon returned invalid turbo.json path: {err}"))
-            })
-        })
-        .transpose()?;
+fn javascript_workspace_from_proto(scope: RepositoryScope) -> Result<Option<WorkspaceData>, Error> {
+    if scope.toolchain != ToolchainId::JAVASCRIPT.as_str()
+        || scope.name == PackageName::Root.as_str()
+    {
+        return Ok(None);
+    }
 
-    WorkspaceData::new(package_json, turbo_json)
+    let package_json = AbsoluteSystemPathBuf::new(scope.manifest_path).map_err(|err| {
+        Error::InvalidResponse(format!(
+            "daemon returned invalid JavaScript manifest path: {err}"
+        ))
+    })?;
+
+    WorkspaceData::new(package_json, None).map(Some)
 }
 
 fn discovery_response_from_proto(
     response: DiscoverPackagesResponse,
     repo_root: &turbopath::AbsoluteSystemPath,
 ) -> Result<DiscoveryResponse, Error> {
-    let package_manager: PackageManager = ProtoPackageManager::try_from(response.package_manager)
-        .map_err(|_| {
-            Error::InvalidResponse(format!(
-                "daemon returned invalid package manager: {}",
-                response.package_manager
-            ))
-        })?
-        .into();
+    let root_package_json = PackageJson::load(&repo_root.join_component("package.json"))
+        .map_err(|error| Error::Failed(Box::new(error)))?;
+    let package_manager =
+        PackageManager::read_or_detect_package_manager(&root_package_json, repo_root)
+            .map_err(|error| Error::Failed(Box::new(error)))?;
     let workspaces = response
-        .package_files
+        .scopes
         .into_iter()
-        .map(workspace_data_from_proto)
+        .map(javascript_workspace_from_proto)
+        .filter_map(Result::transpose)
         .collect::<Result<_, _>>()?;
 
     Ok(DiscoveryResponse {
@@ -61,13 +62,43 @@ fn discovery_response_from_proto(
     })
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn javascript_adapter_filters_generic_repository_scopes() {
+        let javascript = RepositoryScope {
+            name: "web".to_string(),
+            toolchain: ToolchainId::JAVASCRIPT.as_str().to_string(),
+            manifest_path: if cfg!(windows) {
+                r"C:\repo\apps\web\package.json".to_string()
+            } else {
+                "/repo/apps/web/package.json".to_string()
+            },
+        };
+        let rust = RepositoryScope {
+            name: "api".to_string(),
+            toolchain: ToolchainId::RUST.as_str().to_string(),
+            manifest_path: if cfg!(windows) {
+                r"C:\repo\crates\api\Cargo.toml".to_string()
+            } else {
+                "/repo/crates/api/Cargo.toml".to_string()
+            },
+        };
+
+        assert!(javascript_workspace_from_proto(javascript)
+            .unwrap()
+            .is_some());
+        assert!(javascript_workspace_from_proto(rust).unwrap().is_none());
+    }
+}
+
 impl<C: Clone + Send + Sync> PackageDiscovery for DaemonPackageDiscovery<C> {
     async fn discover_packages(&self) -> Result<DiscoveryResponse, Error> {
         tracing::debug!("discovering packages using daemon");
 
-        // clone here so we can make concurrent requests
         let mut daemon = self.daemon.clone();
-
         let response = daemon
             .discover_packages()
             .await
@@ -79,9 +110,7 @@ impl<C: Clone + Send + Sync> PackageDiscovery for DaemonPackageDiscovery<C> {
     async fn discover_packages_blocking(&self) -> Result<DiscoveryResponse, Error> {
         tracing::debug!("discovering packages using daemon");
 
-        // clone here so we can make concurrent requests
         let mut daemon = self.daemon.clone();
-
         let response = daemon
             .discover_packages_blocking()
             .await

--- a/crates/turborepo-daemon/src/proto/turbod.proto
+++ b/crates/turborepo-daemon/src/proto/turbod.proto
@@ -118,25 +118,21 @@ message PackageChanged {
 message RediscoverPackages {}
 
 message DiscoverPackagesResponse {
-  repeated PackageFiles package_files = 1;
-  PackageManager package_manager = 2;
+  repeated RepositoryScope scopes = 1;
+  reserved 2;
+  repeated RepositoryWorkspaceRoot workspace_roots = 3;
 }
 
-message PackageFiles {
-  string package_json = 1;
-  optional string turbo_json = 2;
+message RepositoryScope {
+  string name = 1;
+  string toolchain = 2;
+  string manifest_path = 3;
 }
 
-enum PackageManager {
-  Berry = 0;
-  Npm = 1;
-  Pnpm = 2;
-  Pnpm6 = 3;
-  Yarn = 4;
-  Bun = 5;
-  Pnpm9 = 6;
-  Nub = 7;
-  Aube = 8;
+message RepositoryWorkspaceRoot {
+  string toolchain = 1;
+  string kind = 2;
+  string path = 3;
 }
 
 message GetFileHashesRequest {

--- a/crates/turborepo-daemon/src/server.rs
+++ b/crates/turborepo-daemon/src/server.rs
@@ -662,9 +662,12 @@ impl<W: PackageChangesWatcher + 'static> proto::turbod_server::Turbod for TurboG
                 package_files: packages
                     .workspaces
                     .into_iter()
-                    .map(|d| proto::PackageFiles {
-                        package_json: d.package_json.to_string(),
-                        turbo_json: d.turbo_json.map(|t| t.to_string()),
+                    .map(|d| {
+                        let (package_json, turbo_json) = d.into_paths();
+                        proto::PackageFiles {
+                            package_json: package_json.to_string(),
+                            turbo_json: turbo_json.map(|t| t.to_string()),
+                        }
                     })
                     .collect(),
                 package_manager: proto::PackageManager::from(packages.package_manager).into(),
@@ -687,9 +690,12 @@ impl<W: PackageChangesWatcher + 'static> proto::turbod_server::Turbod for TurboG
                 package_files: packages
                     .workspaces
                     .into_iter()
-                    .map(|d| proto::PackageFiles {
-                        package_json: d.package_json.to_string(),
-                        turbo_json: d.turbo_json.map(|t| t.to_string()),
+                    .map(|d| {
+                        let (package_json, turbo_json) = d.into_paths();
+                        proto::PackageFiles {
+                            package_json: package_json.to_string(),
+                            turbo_json: turbo_json.map(|t| t.to_string()),
+                        }
                     })
                     .collect(),
                 package_manager: proto::PackageManager::from(packages.package_manager).into(),

--- a/crates/turborepo-daemon/src/server.rs
+++ b/crates/turborepo-daemon/src/server.rs
@@ -32,7 +32,7 @@ use turborepo_filewatch::{
     cookies::CookieWriter,
     globwatcher::{Error as GlobWatcherError, GlobError, GlobSet, GlobWatcher},
     hash_watcher::{Error as HashWatcherError, HashSpec, HashWatcher, InputGlobs},
-    package_watcher::{PackageWatchError, PackageWatcher},
+    package_watcher::PackageWatcher,
     FileSystemWatcher, WatchError, WatchScope,
 };
 use turborepo_repository::package_manager;
@@ -358,7 +358,6 @@ struct TurboGrpcServiceInner<W: PackageChangesWatcher + 'static> {
     times_saved: Arc<Mutex<HashMap<String, u64>>>,
     start_time: Instant,
     log_file: AbsoluteSystemPathBuf,
-    package_watcher: Arc<PackageWatcher>,
 }
 
 type TurboGrpcServiceInnerInit<W> = Result<
@@ -393,8 +392,6 @@ impl<W: PackageChangesWatcher + 'static> TurboGrpcServiceInner<W> {
         )?;
 
         tracing::debug!("initing package discovery");
-        // Note that we're cloning the Arc, not the package watcher itself
-        let package_watcher = Arc::clone(&file_watching.package_watcher);
 
         // exit_root_watch delivers a signal to the root watch loop to exit.
         // In the event that the server shuts down via some other mechanism, this
@@ -409,7 +406,6 @@ impl<W: PackageChangesWatcher + 'static> TurboGrpcServiceInner<W> {
 
         Ok((
             TurboGrpcServiceInner {
-                package_watcher,
                 shutdown: trigger_shutdown,
                 file_watching,
                 times_saved: Arc::new(Mutex::new(HashMap::new())),
@@ -492,6 +488,31 @@ impl<W: PackageChangesWatcher + 'static> TurboGrpcServiceInner<W> {
                     .map(|(path, hash)| (path.to_string(), String::from(*hash)))
                     .collect()
             })
+    }
+}
+
+fn discovery_response(
+    snapshot: &turborepo_repository::package_graph::RepositoryDiscoverySnapshot,
+) -> proto::DiscoverPackagesResponse {
+    proto::DiscoverPackagesResponse {
+        scopes: snapshot
+            .scopes
+            .iter()
+            .map(|scope| proto::RepositoryScope {
+                name: scope.name.as_str().to_string(),
+                toolchain: scope.toolchain.as_str().to_string(),
+                manifest_path: scope.manifest_path.to_string(),
+            })
+            .collect(),
+        workspace_roots: snapshot
+            .workspace_roots
+            .iter()
+            .map(|root| proto::RepositoryWorkspaceRoot {
+                toolchain: root.toolchain.as_str().to_string(),
+                kind: root.kind.clone(),
+                path: root.path.to_string(),
+            })
+            .collect(),
     }
 }
 
@@ -657,25 +678,17 @@ impl<W: PackageChangesWatcher + 'static> proto::turbod_server::Turbod for TurboG
         &self,
         _request: tonic::Request<proto::DiscoverPackagesRequest>,
     ) -> Result<tonic::Response<proto::DiscoverPackagesResponse>, tonic::Status> {
-        match self.package_watcher.discover_packages().await {
-            Some(Ok(packages)) => Ok(tonic::Response::new(proto::DiscoverPackagesResponse {
-                package_files: packages
-                    .workspaces
-                    .into_iter()
-                    .map(|d| {
-                        let (package_json, turbo_json) = d.into_paths();
-                        proto::PackageFiles {
-                            package_json: package_json.to_string(),
-                            turbo_json: turbo_json.map(|t| t.to_string()),
-                        }
-                    })
-                    .collect(),
-                package_manager: proto::PackageManager::from(packages.package_manager).into(),
-            })),
-            None | Some(Err(PackageWatchError::Unavailable)) => {
-                Err(tonic::Status::unavailable("package discovery unavailable"))
-            }
-            Some(Err(PackageWatchError::InvalidState(reason))) => {
+        match self
+            .file_watching
+            .get_or_init_package_changes_watcher()
+            .repository_discovery()
+            .await
+        {
+            Some(Ok(snapshot)) => Ok(tonic::Response::new(discovery_response(&snapshot))),
+            None | Some(Err(crate::RepositoryDiscoveryError::Unavailable)) => Err(
+                tonic::Status::unavailable("repository discovery unavailable"),
+            ),
+            Some(Err(crate::RepositoryDiscoveryError::InvalidState(reason))) => {
                 Err(tonic::Status::failed_precondition(reason))
             }
         }
@@ -685,25 +698,17 @@ impl<W: PackageChangesWatcher + 'static> proto::turbod_server::Turbod for TurboG
         &self,
         _request: tonic::Request<proto::DiscoverPackagesRequest>,
     ) -> Result<tonic::Response<proto::DiscoverPackagesResponse>, tonic::Status> {
-        match self.package_watcher.discover_packages_blocking().await {
-            Ok(packages) => Ok(tonic::Response::new(proto::DiscoverPackagesResponse {
-                package_files: packages
-                    .workspaces
-                    .into_iter()
-                    .map(|d| {
-                        let (package_json, turbo_json) = d.into_paths();
-                        proto::PackageFiles {
-                            package_json: package_json.to_string(),
-                            turbo_json: turbo_json.map(|t| t.to_string()),
-                        }
-                    })
-                    .collect(),
-                package_manager: proto::PackageManager::from(packages.package_manager).into(),
-            })),
-            Err(PackageWatchError::Unavailable) => {
-                Err(tonic::Status::unavailable("package discovery unavailable"))
-            }
-            Err(PackageWatchError::InvalidState(reason)) => {
+        match self
+            .file_watching
+            .get_or_init_package_changes_watcher()
+            .repository_discovery_blocking()
+            .await
+        {
+            Ok(snapshot) => Ok(tonic::Response::new(discovery_response(&snapshot))),
+            Err(crate::RepositoryDiscoveryError::Unavailable) => Err(tonic::Status::unavailable(
+                "repository discovery unavailable",
+            )),
+            Err(crate::RepositoryDiscoveryError::InvalidState(reason)) => {
                 Err(tonic::Status::failed_precondition(reason))
             }
         }
@@ -858,6 +863,26 @@ mod test {
     impl PackageChangesWatcher for MockPackageChangesWatcher {
         async fn package_changes(&self) -> broadcast::Receiver<PackageChangeEvent> {
             self.tx.subscribe()
+        }
+
+        async fn repository_discovery(
+            &self,
+        ) -> Option<
+            Result<
+                std::sync::Arc<turborepo_repository::package_graph::RepositoryDiscoverySnapshot>,
+                crate::RepositoryDiscoveryError,
+            >,
+        > {
+            None
+        }
+
+        async fn repository_discovery_blocking(
+            &self,
+        ) -> Result<
+            std::sync::Arc<turborepo_repository::package_graph::RepositoryDiscoverySnapshot>,
+            crate::RepositoryDiscoveryError,
+        > {
+            Err(crate::RepositoryDiscoveryError::Unavailable)
         }
     }
 

--- a/crates/turborepo-filewatch/src/hash_watcher.rs
+++ b/crates/turborepo-filewatch/src/hash_watcher.rs
@@ -949,10 +949,11 @@ impl Subscriber {
         debug!("handling package data {:?}", package_data);
         let mut package_paths = graph_package_paths.clone();
         if let Some(Ok(data)) = package_data {
-            package_paths.extend(data.workspaces.iter().filter_map(|ws| {
-                let package_dir = ws.package_json.parent()?;
-                self.repo_root.anchor(package_dir).ok()
-            }));
+            package_paths.extend(
+                data.workspaces
+                    .iter()
+                    .filter_map(|ws| self.repo_root.anchor(ws.workspace_root()).ok()),
+            );
         } else if package_paths.is_empty() {
             hashes.drain("package discovery is unavailable");
             return;

--- a/crates/turborepo-filewatch/src/package_watcher.rs
+++ b/crates/turborepo-filewatch/src/package_watcher.rs
@@ -200,18 +200,51 @@ const INVALIDATION_PATHS: &[&str] = &[
     package_manager::bun::LOCKFILE,
 ];
 
+fn matches_workspace_glob(
+    repo_root: &AbsoluteSystemPath,
+    workspace_globs: &WorkspaceGlobs,
+    path: &AbsoluteSystemPath,
+) -> bool {
+    workspace_globs
+        .target_is_workspace(repo_root, path)
+        .unwrap_or(false)
+}
+
+fn workspace_event_is_relevant(
+    repo_root: &AbsoluteSystemPath,
+    workspace_globs: &WorkspaceGlobs,
+    path: &AbsoluteSystemPath,
+) -> bool {
+    std::iter::once(path)
+        .chain(path.parent())
+        .any(|candidate| matches_workspace_glob(repo_root, workspace_globs, candidate))
+}
+
 fn workspace_path_for_event<'a>(
     repo_root: &AbsoluteSystemPath,
     workspace_globs: &WorkspaceGlobs,
+    workspaces: &HashMap<AbsoluteSystemPathBuf, WorkspaceData>,
     path: &'a AbsoluteSystemPath,
 ) -> Option<&'a AbsoluteSystemPath> {
-    std::iter::once(path)
-        .chain(path.parent())
-        .find(|candidate| {
-            workspace_globs
-                .target_is_workspace(repo_root, candidate)
-                .unwrap_or(false)
-        })
+    if workspaces.contains_key(path) {
+        return Some(path);
+    }
+
+    let parent = path.parent();
+    if parent.is_some_and(|parent| workspaces.contains_key(parent)) {
+        return parent;
+    }
+
+    // A directory that still exists is unambiguous. For file events (including
+    // removed files), prefer the parent before testing the path itself: recursive
+    // globs such as `**` can also match the file path.
+    if path.as_std_path().is_dir() && matches_workspace_glob(repo_root, workspace_globs, path) {
+        return Some(path);
+    }
+    if parent.is_some_and(|parent| matches_workspace_glob(repo_root, workspace_globs, parent)) {
+        return parent;
+    }
+    matches_workspace_glob(repo_root, workspace_globs, path).then_some(path)
 }
 
 impl Subscriber {
@@ -256,7 +289,7 @@ impl Subscriber {
                     return path.file_name() == Some("package.json")
                         && repository_ignore.is_relevant(path.as_std_path(), false);
                 };
-                workspace_path_for_event(&repo_root, globs, path).is_some()
+                workspace_event_is_relevant(&repo_root, globs, path)
             })
         };
         Ok(Self {
@@ -492,7 +525,7 @@ impl Subscriber {
                 continue;
             };
             let Some(path_workspace) =
-                workspace_path_for_event(&self.repo_root, filter, &path_file)
+                workspace_path_for_event(&self.repo_root, filter, workspaces, &path_file)
             else {
                 // Ignore paths that do not identify a workspace or a direct child of one.
                 continue;
@@ -628,7 +661,7 @@ async fn discover_packages(
 
 #[cfg(test)]
 mod test {
-    use std::time::Duration;
+    use std::{collections::HashMap, time::Duration};
 
     use turbopath::AbsoluteSystemPathBuf;
     use turborepo_repository::{
@@ -647,15 +680,17 @@ mod test {
         let repo_root = AbsoluteSystemPathBuf::try_from(tmp.path()).unwrap();
         let workspace = repo_root.join_components(&["apps", "web"]);
         let globs = WorkspaceGlobs::new(vec!["apps/*"], Vec::<&str>::new()).unwrap();
+        let workspaces = HashMap::new();
 
         assert_eq!(
-            workspace_path_for_event(&repo_root, &globs, &workspace),
+            workspace_path_for_event(&repo_root, &globs, &workspaces, &workspace),
             Some(&*workspace)
         );
         assert_eq!(
             workspace_path_for_event(
                 &repo_root,
                 &globs,
+                &workspaces,
                 &workspace.join_component("future-workspace-metadata.toml")
             ),
             Some(&*workspace)
@@ -664,9 +699,20 @@ mod test {
             workspace_path_for_event(
                 &repo_root,
                 &globs,
+                &workspaces,
                 &workspace.join_components(&["src", "index.ts"])
             ),
             None
+        );
+
+        let recursive_globs = WorkspaceGlobs::new(vec!["**"], Vec::<&str>::new()).unwrap();
+        let package_json = workspace.join_component("package.json");
+        package_json.ensure_dir().unwrap();
+        package_json.create_with_contents("{}").unwrap();
+        assert_eq!(
+            workspace_path_for_event(&repo_root, &recursive_globs, &workspaces, &package_json),
+            Some(&*workspace),
+            "recursive globs must not resolve a manifest event to the manifest itself"
         );
     }
 

--- a/crates/turborepo-filewatch/src/package_watcher.rs
+++ b/crates/turborepo-filewatch/src/package_watcher.rs
@@ -200,6 +200,13 @@ const INVALIDATION_PATHS: &[&str] = &[
     package_manager::bun::LOCKFILE,
 ];
 
+fn workspace_path_for_event(path: &AbsoluteSystemPath) -> Option<&AbsoluteSystemPath> {
+    match path.file_name() {
+        Some("package.json" | "turbo.json" | "turbo.jsonc") => path.parent(),
+        _ => Some(path),
+    }
+}
+
 impl Subscriber {
     /// Creates a new instance of PackageDiscovery. This will start a task that
     /// performs the initial discovery using the `backup_discovery` of your
@@ -235,20 +242,15 @@ impl Subscriber {
                 let Ok(path) = AbsoluteSystemPath::from_std_path(path) else {
                     return false;
                 };
-                let workspace_path = if path.file_name() == Some("package.json") {
-                    let Some(parent) = path.parent() else {
-                        return false;
-                    };
-                    parent
-                } else {
-                    path
-                };
                 let workspace_globs = workspace_globs
                     .read()
                     .unwrap_or_else(|poisoned| poisoned.into_inner());
                 let Some(globs) = workspace_globs.as_ref() else {
                     return path.file_name() == Some("package.json")
                         && repository_ignore.is_relevant(path.as_std_path(), false);
+                };
+                let Some(workspace_path) = workspace_path_for_event(path) else {
+                    return false;
                 };
                 globs
                     .target_is_workspace(&repo_root, workspace_path)
@@ -487,32 +489,16 @@ impl Subscriber {
             let Ok(path_file) = AbsoluteSystemPathBuf::new(path) else {
                 continue;
             };
-            let path_workspace: &AbsoluteSystemPath =
-                if path_file.file_name() == Some("package.json") {
-                    // The file event is for a package.json file. Check if the parent is a workspace
-                    let Some(path_parent) = path_file.parent() else {
-                        continue;
-                    };
-                    if filter
-                        .target_is_workspace(&self.repo_root, path_parent)
-                        .unwrap_or(false)
-                    {
-                        path_parent
-                    } else {
-                        // irrelevant package.json file update, it's not in a directory
-                        // matching workspace globs
-                        continue;
-                    }
-                } else if filter
-                    .target_is_workspace(&self.repo_root, &path_file)
-                    .unwrap_or(false)
-                {
-                    // The file event is for a workspace directory itself
-                    &path_file
-                } else {
-                    // irrelevant file update, it's not a package.json file or a workspace directory
-                    continue;
-                };
+            let Some(path_workspace) = workspace_path_for_event(&path_file) else {
+                continue;
+            };
+            if !filter
+                .target_is_workspace(&self.repo_root, path_workspace)
+                .unwrap_or(false)
+            {
+                // Ignore files that are not in a directory matching workspace globs.
+                continue;
+            }
 
             tracing::debug!("handling change to workspace {path_workspace}");
             let package_json = path_workspace.join_component("package.json");
@@ -532,15 +518,15 @@ impl Subscriber {
                         break;
                     }
                 };
-                workspaces
-                    .insert(
-                        path_workspace.to_owned(),
-                        WorkspaceData {
-                            package_json,
-                            turbo_json,
-                        },
-                    )
-                    .is_none()
+                let workspace_data = WorkspaceData {
+                    package_json,
+                    turbo_json,
+                };
+                let changed = workspaces
+                    .get(path_workspace)
+                    .map_or(true, |existing| existing != &workspace_data);
+                workspaces.insert(path_workspace.to_owned(), workspace_data);
+                changed
             } else {
                 workspaces.remove(path_workspace).is_some()
             }
@@ -695,6 +681,58 @@ mod test {
                 turbo_json: Some(turbo_jsonc),
             }]
         );
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn incremental_discovery_updates_package_turbo_config() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(tmp.path())
+            .unwrap()
+            .to_realpath()
+            .unwrap();
+        let workspace_dir = repo_root.join_components(&["apps", "web"]);
+        let package_json = workspace_dir.join_component("package.json");
+        let turbo_json = workspace_dir.join_component("turbo.json");
+        let turbo_jsonc = workspace_dir.join_component("turbo.jsonc");
+
+        package_json.ensure_dir().unwrap();
+        package_json
+            .create_with_contents(r#"{"name":"web"}"#)
+            .unwrap();
+        repo_root
+            .join_component("package.json")
+            .create_with_contents(r#"{"workspaces":["apps/*"], "packageManager":"npm@10.0.0"}"#)
+            .unwrap();
+        repo_root
+            .join_component("package-lock.json")
+            .create_with_contents("")
+            .unwrap();
+
+        let watcher = FileSystemWatcher::new_with_default_cookie_dir(&repo_root).unwrap();
+        let recv = watcher.watch();
+        let cookie_writer = CookieWriter::new(
+            watcher.cookie_dir(),
+            Duration::from_millis(100),
+            recv.clone(),
+        );
+        let package_watcher = PackageWatcher::new(repo_root, recv, cookie_writer, false).unwrap();
+
+        let data = package_watcher.discover_packages_blocking().await.unwrap();
+        assert_eq!(data.workspaces[0].turbo_json, None);
+
+        turbo_json.create_with_contents("{}").unwrap();
+        let data = package_watcher.discover_packages_blocking().await.unwrap();
+        assert_eq!(data.workspaces[0].turbo_json, Some(turbo_json.clone()));
+
+        turbo_json.remove_file().unwrap();
+        turbo_jsonc.create_with_contents("{}").unwrap();
+        let data = package_watcher.discover_packages_blocking().await.unwrap();
+        assert_eq!(data.workspaces[0].turbo_json, Some(turbo_jsonc.clone()));
+
+        turbo_jsonc.remove_file().unwrap();
+        let data = package_watcher.discover_packages_blocking().await.unwrap();
+        assert_eq!(data.workspaces[0].turbo_json, None);
     }
 
     #[tokio::test]

--- a/crates/turborepo-filewatch/src/package_watcher.rs
+++ b/crates/turborepo-filewatch/src/package_watcher.rs
@@ -200,11 +200,18 @@ const INVALIDATION_PATHS: &[&str] = &[
     package_manager::bun::LOCKFILE,
 ];
 
-fn workspace_path_for_event(path: &AbsoluteSystemPath) -> Option<&AbsoluteSystemPath> {
-    match path.file_name() {
-        Some("package.json" | "turbo.json" | "turbo.jsonc") => path.parent(),
-        _ => Some(path),
-    }
+fn workspace_path_for_event<'a>(
+    repo_root: &AbsoluteSystemPath,
+    workspace_globs: &WorkspaceGlobs,
+    path: &'a AbsoluteSystemPath,
+) -> Option<&'a AbsoluteSystemPath> {
+    std::iter::once(path)
+        .chain(path.parent())
+        .find(|candidate| {
+            workspace_globs
+                .target_is_workspace(repo_root, candidate)
+                .unwrap_or(false)
+        })
 }
 
 impl Subscriber {
@@ -249,12 +256,7 @@ impl Subscriber {
                     return path.file_name() == Some("package.json")
                         && repository_ignore.is_relevant(path.as_std_path(), false);
                 };
-                let Some(workspace_path) = workspace_path_for_event(path) else {
-                    return false;
-                };
-                globs
-                    .target_is_workspace(&repo_root, workspace_path)
-                    .unwrap_or(false)
+                workspace_path_for_event(&repo_root, globs, path).is_some()
             })
         };
         Ok(Self {
@@ -447,8 +449,8 @@ impl Subscriber {
         *state = State::Pending { debouncer, version }
     }
 
-    // checks if the file event contains any changes to package.json files, or
-    // directories that would map to a workspace.
+    // Checks whether any event path identifies a workspace or a file directly in
+    // one.
     async fn handle_workspace_changes(
         &mut self,
         state: &mut State,
@@ -489,16 +491,12 @@ impl Subscriber {
             let Ok(path_file) = AbsoluteSystemPathBuf::new(path) else {
                 continue;
             };
-            let Some(path_workspace) = workspace_path_for_event(&path_file) else {
+            let Some(path_workspace) =
+                workspace_path_for_event(&self.repo_root, filter, &path_file)
+            else {
+                // Ignore paths that do not identify a workspace or a direct child of one.
                 continue;
             };
-            if !filter
-                .target_is_workspace(&self.repo_root, path_workspace)
-                .unwrap_or(false)
-            {
-                // Ignore files that are not in a directory matching workspace globs.
-                continue;
-            }
 
             tracing::debug!("handling change to workspace {path_workspace}");
             let package_json = path_workspace.join_component("package.json");
@@ -518,9 +516,12 @@ impl Subscriber {
                         break;
                     }
                 };
-                let workspace_data = WorkspaceData {
-                    package_json,
-                    turbo_json,
+                let workspace_data = match WorkspaceData::new(package_json, turbo_json) {
+                    Ok(workspace_data) => workspace_data,
+                    Err(_) => {
+                        rediscover = true;
+                        break;
+                    }
                 };
                 let changed = workspaces
                     .get(path_workspace)
@@ -616,10 +617,7 @@ async fn discover_packages(
     let workspaces = initial_discovery
         .workspaces
         .into_iter()
-        .filter_map(|p| {
-            let parent = p.package_json.parent()?.to_owned();
-            Some((parent, p))
-        })
+        .map(|workspace| (workspace.workspace_root().to_owned(), workspace))
         .collect::<HashMap<_, _>>();
     PackageState::ValidWorkspaces {
         package_manager: initial_discovery.package_manager,
@@ -633,9 +631,44 @@ mod test {
     use std::time::Duration;
 
     use turbopath::AbsoluteSystemPathBuf;
-    use turborepo_repository::{discovery::WorkspaceData, package_manager::PackageManager};
+    use turborepo_repository::{
+        discovery::WorkspaceData, package_manager::PackageManager, workspaces::WorkspaceGlobs,
+    };
 
-    use crate::{FileSystemWatcher, cookies::CookieWriter, package_watcher::PackageWatcher};
+    use crate::{
+        FileSystemWatcher,
+        cookies::CookieWriter,
+        package_watcher::{PackageWatcher, workspace_path_for_event},
+    };
+
+    #[test]
+    fn workspace_event_paths_resolve_without_filename_knowledge() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(tmp.path()).unwrap();
+        let workspace = repo_root.join_components(&["apps", "web"]);
+        let globs = WorkspaceGlobs::new(vec!["apps/*"], Vec::<&str>::new()).unwrap();
+
+        assert_eq!(
+            workspace_path_for_event(&repo_root, &globs, &workspace),
+            Some(&*workspace)
+        );
+        assert_eq!(
+            workspace_path_for_event(
+                &repo_root,
+                &globs,
+                &workspace.join_component("future-workspace-metadata.toml")
+            ),
+            Some(&*workspace)
+        );
+        assert_eq!(
+            workspace_path_for_event(
+                &repo_root,
+                &globs,
+                &workspace.join_components(&["src", "index.ts"])
+            ),
+            None
+        );
+    }
 
     #[tokio::test]
     #[tracing_test::traced_test]
@@ -676,10 +709,7 @@ mod test {
 
         assert_eq!(
             data.workspaces,
-            vec![WorkspaceData {
-                package_json,
-                turbo_json: Some(turbo_jsonc),
-            }]
+            vec![WorkspaceData::new(package_json, Some(turbo_jsonc)).unwrap()]
         );
     }
 
@@ -719,20 +749,20 @@ mod test {
         let package_watcher = PackageWatcher::new(repo_root, recv, cookie_writer, false).unwrap();
 
         let data = package_watcher.discover_packages_blocking().await.unwrap();
-        assert_eq!(data.workspaces[0].turbo_json, None);
+        assert_eq!(data.workspaces[0].turbo_json(), None);
 
         turbo_json.create_with_contents("{}").unwrap();
         let data = package_watcher.discover_packages_blocking().await.unwrap();
-        assert_eq!(data.workspaces[0].turbo_json, Some(turbo_json.clone()));
+        assert_eq!(data.workspaces[0].turbo_json(), Some(&*turbo_json));
 
         turbo_json.remove_file().unwrap();
         turbo_jsonc.create_with_contents("{}").unwrap();
         let data = package_watcher.discover_packages_blocking().await.unwrap();
-        assert_eq!(data.workspaces[0].turbo_json, Some(turbo_jsonc.clone()));
+        assert_eq!(data.workspaces[0].turbo_json(), Some(&*turbo_jsonc));
 
         turbo_jsonc.remove_file().unwrap();
         let data = package_watcher.discover_packages_blocking().await.unwrap();
-        assert_eq!(data.workspaces[0].turbo_json, None);
+        assert_eq!(data.workspaces[0].turbo_json(), None);
     }
 
     #[tokio::test]
@@ -745,21 +775,23 @@ mod test {
             .unwrap();
 
         let package_data = vec![
-            WorkspaceData {
-                package_json: repo_root.join_components(&["packages", "foo", "package.json"]),
-                turbo_json: None,
-            },
-            WorkspaceData {
-                package_json: repo_root.join_components(&["packages", "bar", "package.json"]),
-                turbo_json: None,
-            },
+            WorkspaceData::new(
+                repo_root.join_components(&["packages", "foo", "package.json"]),
+                None,
+            )
+            .unwrap(),
+            WorkspaceData::new(
+                repo_root.join_components(&["packages", "bar", "package.json"]),
+                None,
+            )
+            .unwrap(),
         ];
 
         // create folders and files
         for data in &package_data {
-            data.package_json.ensure_dir().unwrap();
-            let name = data.package_json.parent().unwrap().file_name().unwrap();
-            data.package_json
+            data.package_json().ensure_dir().unwrap();
+            let name = data.workspace_root().file_name().unwrap();
+            data.package_json()
                 .create_with_contents(format!("{{\"name\": \"{name}\"}}"))
                 .unwrap();
         }
@@ -789,18 +821,20 @@ mod test {
 
         let mut data = package_watcher.discover_packages_blocking().await.unwrap();
         data.workspaces
-            .sort_by_key(|workspace| workspace.package_json.clone());
+            .sort_by_key(|workspace| workspace.package_json().to_owned());
         assert_eq!(
             data.workspaces,
             vec![
-                WorkspaceData {
-                    package_json: repo_root.join_components(&["packages", "bar", "package.json",]),
-                    turbo_json: None,
-                },
-                WorkspaceData {
-                    package_json: repo_root.join_components(&["packages", "foo", "package.json",]),
-                    turbo_json: None,
-                },
+                WorkspaceData::new(
+                    repo_root.join_components(&["packages", "bar", "package.json",]),
+                    None
+                )
+                .unwrap(),
+                WorkspaceData::new(
+                    repo_root.join_components(&["packages", "foo", "package.json",]),
+                    None
+                )
+                .unwrap(),
             ]
         );
 
@@ -814,13 +848,16 @@ mod test {
 
         let mut data = package_watcher.discover_packages_blocking().await.unwrap();
         data.workspaces
-            .sort_by_key(|workspace| workspace.package_json.clone());
+            .sort_by_key(|workspace| workspace.package_json().to_owned());
         assert_eq!(
             data.workspaces,
-            vec![WorkspaceData {
-                package_json: repo_root.join_components(&["packages", "bar", "package.json"]),
-                turbo_json: None,
-            }]
+            vec![
+                WorkspaceData::new(
+                    repo_root.join_components(&["packages", "bar", "package.json"]),
+                    None
+                )
+                .unwrap()
+            ]
         );
 
         // move package bar
@@ -831,7 +868,7 @@ mod test {
 
         let mut data = package_watcher.discover_packages_blocking().await.unwrap();
         data.workspaces
-            .sort_by_key(|workspace| workspace.package_json.clone());
+            .sort_by_key(|workspace| workspace.package_json().to_owned());
         assert_eq!(data.workspaces, vec![]);
     }
 
@@ -845,27 +882,29 @@ mod test {
             .unwrap();
 
         let package_data = vec![
-            WorkspaceData {
-                package_json: repo_root
+            WorkspaceData::new(
+                repo_root
                     .join_component("packages")
                     .join_component("foo")
                     .join_component("package.json"),
-                turbo_json: None,
-            },
-            WorkspaceData {
-                package_json: repo_root
+                None,
+            )
+            .unwrap(),
+            WorkspaceData::new(
+                repo_root
                     .join_component("packages2")
                     .join_component("bar")
                     .join_component("package.json"),
-                turbo_json: None,
-            },
+                None,
+            )
+            .unwrap(),
         ];
 
         // create folders and files
         for data in &package_data {
-            data.package_json.ensure_dir().unwrap();
-            let name = data.package_json.parent().unwrap().file_name().unwrap();
-            data.package_json
+            data.package_json().ensure_dir().unwrap();
+            let name = data.workspace_root().file_name().unwrap();
+            data.package_json()
                 .create_with_contents(format!("{{\"name\": \"{name}\"}}"))
                 .unwrap();
         }
@@ -895,25 +934,27 @@ mod test {
 
         let mut data = package_watcher.discover_packages_blocking().await.unwrap();
         data.workspaces
-            .sort_by_key(|workspace| workspace.package_json.clone());
+            .sort_by_key(|workspace| workspace.package_json().to_owned());
 
         assert_eq!(
             data.workspaces,
             vec![
-                WorkspaceData {
-                    package_json: repo_root
+                WorkspaceData::new(
+                    repo_root
                         .join_component("packages")
                         .join_component("foo")
                         .join_component("package.json"),
-                    turbo_json: None,
-                },
-                WorkspaceData {
-                    package_json: repo_root
+                    None
+                )
+                .unwrap(),
+                WorkspaceData::new(
+                    repo_root
                         .join_component("packages2")
                         .join_component("bar")
                         .join_component("package.json"),
-                    turbo_json: None,
-                },
+                    None
+                )
+                .unwrap(),
             ]
         );
 
@@ -927,17 +968,20 @@ mod test {
 
         let mut data = package_watcher.discover_packages_blocking().await.unwrap();
         data.workspaces
-            .sort_by_key(|workspace| workspace.package_json.clone());
+            .sort_by_key(|workspace| workspace.package_json().to_owned());
 
         assert_eq!(
             data.workspaces,
-            vec![WorkspaceData {
-                package_json: repo_root
-                    .join_component("packages")
-                    .join_component("foo")
-                    .join_component("package.json"),
-                turbo_json: None,
-            }]
+            vec![
+                WorkspaceData::new(
+                    repo_root
+                        .join_component("packages")
+                        .join_component("foo")
+                        .join_component("package.json"),
+                    None
+                )
+                .unwrap()
+            ]
         );
 
         // move the packages2 workspace into package
@@ -947,24 +991,26 @@ mod test {
             .unwrap();
         let mut data = package_watcher.discover_packages_blocking().await.unwrap();
         data.workspaces
-            .sort_by_key(|workspace| workspace.package_json.clone());
+            .sort_by_key(|workspace| workspace.package_json().to_owned());
         assert_eq!(
             data.workspaces,
             vec![
-                WorkspaceData {
-                    package_json: repo_root
+                WorkspaceData::new(
+                    repo_root
                         .join_component("packages")
                         .join_component("bar")
                         .join_component("package.json"),
-                    turbo_json: None,
-                },
-                WorkspaceData {
-                    package_json: repo_root
+                    None
+                )
+                .unwrap(),
+                WorkspaceData::new(
+                    repo_root
                         .join_component("packages")
                         .join_component("foo")
                         .join_component("package.json"),
-                    turbo_json: None,
-                },
+                    None
+                )
+                .unwrap(),
             ]
         );
     }

--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -319,10 +319,7 @@ mod test {
                     let file = std::fs::File::create(package_json.as_std_path()).unwrap();
                     serde_json::to_writer(file, &package).unwrap();
 
-                    WorkspaceData {
-                        package_json,
-                        turbo_json: None,
-                    }
+                    WorkspaceData::new(package_json, None).unwrap()
                 })
                 .collect();
 

--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -10,9 +10,12 @@ use std::{
 
 use notify::Event;
 use radix_trie::{Trie, TrieCommon};
-use tokio::sync::{broadcast, oneshot, Mutex};
+use tokio::sync::{broadcast, oneshot, watch, Mutex};
 use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPath, AnchoredSystemPathBuf};
-use turborepo_daemon::{PackageChangeEvent, PackageChangesWatcher as PackageChangesWatcherTrait};
+use turborepo_daemon::{
+    PackageChangeEvent, PackageChangesWatcher as PackageChangesWatcherTrait,
+    RepositoryDiscoveryError,
+};
 use turborepo_filewatch::{
     hash_watcher::{HashSpec, HashWatcher, InputGlobs},
     RepositoryIgnore, WatchScope, WatchSource,
@@ -21,7 +24,7 @@ use turborepo_repository::{
     change_mapper::{
         ChangeMapper, GlobalDepsPackageChangeMapper, LockfileContents, PackageChanges,
     },
-    package_graph::{PackageGraph, PackageName, WorkspacePackage},
+    package_graph::{PackageGraph, PackageName, RepositoryDiscoverySnapshot, WorkspacePackage},
     toolchain::WatchSpec,
 };
 use turborepo_scm::GitHashes;
@@ -37,6 +40,7 @@ pub struct PackageChangesWatcher {
     _exit_tx: oneshot::Sender<()>,
     _handle: tokio::task::JoinHandle<()>,
     package_change_events_rx: broadcast::Receiver<PackageChangeEvent>,
+    repository_discovery_rx: watch::Receiver<Option<Arc<RepositoryDiscoverySnapshot>>>,
 }
 
 /// The number of events that can be buffered in the channel.
@@ -75,10 +79,12 @@ impl PackageChangesWatcher {
         let (exit_tx, exit_rx) = oneshot::channel();
         let (package_change_events_tx, package_change_events_rx) =
             broadcast::channel(CHANGE_EVENT_CHANNEL_CAPACITY);
+        let (repository_discovery_tx, repository_discovery_rx) = watch::channel(None);
         let subscriber = Subscriber::new(
             repo_root,
             file_events,
             package_change_events_tx,
+            repository_discovery_tx,
             hash_watcher,
             custom_turbo_json_path,
             single_package,
@@ -92,6 +98,7 @@ impl PackageChangesWatcher {
             _exit_tx: exit_tx,
             _handle,
             package_change_events_rx,
+            repository_discovery_rx,
         }
     }
 }
@@ -99,6 +106,27 @@ impl PackageChangesWatcher {
 impl PackageChangesWatcherTrait for PackageChangesWatcher {
     async fn package_changes(&self) -> broadcast::Receiver<PackageChangeEvent> {
         self.package_change_events_rx.resubscribe()
+    }
+
+    async fn repository_discovery(
+        &self,
+    ) -> Option<Result<Arc<RepositoryDiscoverySnapshot>, RepositoryDiscoveryError>> {
+        self.repository_discovery_rx.borrow().clone().map(Ok)
+    }
+
+    async fn repository_discovery_blocking(
+        &self,
+    ) -> Result<Arc<RepositoryDiscoverySnapshot>, RepositoryDiscoveryError> {
+        let mut receiver = self.repository_discovery_rx.clone();
+        loop {
+            if let Some(snapshot) = receiver.borrow_and_update().clone() {
+                return Ok(snapshot);
+            }
+            receiver
+                .changed()
+                .await
+                .map_err(|_| RepositoryDiscoveryError::Unavailable)?;
+        }
     }
 }
 
@@ -131,6 +159,7 @@ struct Subscriber {
     watch_spec: Arc<RwLock<WatchSpec>>,
     watch_spec_ready: Arc<AtomicBool>,
     package_change_events_tx: broadcast::Sender<PackageChangeEvent>,
+    repository_discovery_tx: watch::Sender<Option<Arc<RepositoryDiscoverySnapshot>>>,
     hash_watcher: Arc<HashWatcher>,
     custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
     single_package: bool,
@@ -352,6 +381,7 @@ impl Subscriber {
         repo_root: AbsoluteSystemPathBuf,
         file_events: WatchSource,
         package_change_events_tx: broadcast::Sender<PackageChangeEvent>,
+        repository_discovery_tx: watch::Sender<Option<Arc<RepositoryDiscoverySnapshot>>>,
         hash_watcher: Arc<HashWatcher>,
         custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
         single_package: bool,
@@ -405,6 +435,7 @@ impl Subscriber {
             // without consulting live toolchains for bootstrap facts.
             watch_spec_ready: Arc::new(AtomicBool::new(false)),
             package_change_events_tx,
+            repository_discovery_tx,
             hash_watcher,
             custom_turbo_json_path: normalized_custom_path,
             single_package,
@@ -498,6 +529,10 @@ impl Subscriber {
             .write()
             .unwrap_or_else(|poisoned| poisoned.into_inner()) = pkg_dep_graph.active_watch_spec();
         self.watch_spec_ready.store(true, Ordering::Release);
+
+        self.repository_discovery_tx.send_replace(Some(Arc::new(
+            pkg_dep_graph.repository_discovery_snapshot(),
+        )));
 
         Some(RepoState {
             root_turbo_json,
@@ -974,6 +1009,7 @@ mod test {
             repo_root.clone(),
             file_events,
             broadcast::channel(8).0,
+            watch::channel(None).0,
             Arc::new(HashWatcher::new(
                 repo_root.clone(),
                 discovery_rx,

--- a/crates/turborepo-lsp/src/lib.rs
+++ b/crates/turborepo-lsp/src/lib.rs
@@ -924,16 +924,16 @@ impl Backend {
         let mut package_jsons = HashMap::with_capacity(response.workspaces.len());
         let mut sources = HashMap::with_capacity(response.workspaces.len() + 1);
         for workspace in response.workspaces {
-            let Ok(text) = std::fs::read_to_string(&workspace.package_json) else {
+            let (package_json_path, _) = workspace.into_paths();
+            let Ok(text) = std::fs::read_to_string(&package_json_path) else {
                 continue;
             };
-            let Ok(package_json) =
-                PackageJson::load_from_str(&text, workspace.package_json.as_str())
+            let Ok(package_json) = PackageJson::load_from_str(&text, package_json_path.as_str())
             else {
                 continue;
             };
-            package_jsons.insert(workspace.package_json.clone(), package_json.clone());
-            sources.insert(workspace.package_json, PackageSource { text, package_json });
+            package_jsons.insert(package_json_path.clone(), package_json.clone());
+            sources.insert(package_json_path, PackageSource { text, package_json });
         }
         retain_unique_named(&mut package_jsons);
 

--- a/crates/turborepo-repository/src/change_mapper/package.rs
+++ b/crates/turborepo-repository/src/change_mapper/package.rs
@@ -263,14 +263,8 @@ mod tests {
                     // Parent first reproduces the observation order that used
                     // to make it incorrectly claim the child's files.
                     workspaces: vec![
-                        discovery::WorkspaceData {
-                            package_json: self.parent_manifest.clone(),
-                            turbo_json: None,
-                        },
-                        discovery::WorkspaceData {
-                            package_json: self.child_manifest.clone(),
-                            turbo_json: None,
-                        },
+                        discovery::WorkspaceData::new(self.parent_manifest.clone(), None)?,
+                        discovery::WorkspaceData::new(self.child_manifest.clone(), None)?,
                     ],
                 })
             }
@@ -337,18 +331,15 @@ mod tests {
                 Ok(discovery::DiscoveryResponse {
                     package_manager: PackageManager::Npm,
                     workspaces: vec![
-                        discovery::WorkspaceData {
-                            package_json: self.root.join_component("package.json"),
-                            turbo_json: None,
-                        },
-                        discovery::WorkspaceData {
-                            package_json: self.root.join_components(&[
-                                "packages",
-                                "lib-a",
-                                "package.json",
-                            ]),
-                            turbo_json: None,
-                        },
+                        discovery::WorkspaceData::new(
+                            self.root.join_component("package.json"),
+                            None,
+                        )?,
+                        discovery::WorkspaceData::new(
+                            self.root
+                                .join_components(&["packages", "lib-a", "package.json"]),
+                            None,
+                        )?,
                     ],
                 })
             }

--- a/crates/turborepo-repository/src/discovery.rs
+++ b/crates/turborepo-repository/src/discovery.rs
@@ -12,7 +12,7 @@
 use futures::StreamExt;
 use tokio::time::error::Elapsed;
 use tracing::Instrument;
-use turbopath::AbsoluteSystemPathBuf;
+use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 
 use crate::{
     package_json::PackageJson,
@@ -21,8 +21,50 @@ use crate::{
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct WorkspaceData {
-    pub package_json: AbsoluteSystemPathBuf,
-    pub turbo_json: Option<AbsoluteSystemPathBuf>,
+    workspace_root: AbsoluteSystemPathBuf,
+    package_json: AbsoluteSystemPathBuf,
+    turbo_json: Option<AbsoluteSystemPathBuf>,
+}
+
+impl WorkspaceData {
+    pub fn new(
+        package_json: AbsoluteSystemPathBuf,
+        turbo_json: Option<AbsoluteSystemPathBuf>,
+    ) -> Result<Self, Error> {
+        let workspace_root = package_json.parent().ok_or_else(|| {
+            Error::InvalidResponse("workspace package.json has no parent directory".into())
+        })?;
+        if turbo_json
+            .as_deref()
+            .is_some_and(|turbo_json| turbo_json.parent() != Some(workspace_root))
+        {
+            return Err(Error::InvalidResponse(
+                "workspace turbo.json must be in the same directory as package.json".into(),
+            ));
+        }
+
+        Ok(Self {
+            workspace_root: workspace_root.to_owned(),
+            package_json,
+            turbo_json,
+        })
+    }
+
+    pub fn workspace_root(&self) -> &AbsoluteSystemPath {
+        &self.workspace_root
+    }
+
+    pub fn package_json(&self) -> &AbsoluteSystemPath {
+        &self.package_json
+    }
+
+    pub fn turbo_json(&self) -> Option<&AbsoluteSystemPath> {
+        self.turbo_json.as_deref()
+    }
+
+    pub fn into_paths(self) -> (AbsoluteSystemPathBuf, Option<AbsoluteSystemPathBuf>) {
+        (self.package_json, self.turbo_json)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -218,11 +260,8 @@ impl PackageDiscovery for LocalPackageDiscovery {
             return Ok(DiscoveryResponse {
                 workspaces: package_paths
                     .into_iter()
-                    .map(|package_json| WorkspaceData {
-                        package_json,
-                        turbo_json: None,
-                    })
-                    .collect(),
+                    .map(|package_json| WorkspaceData::new(package_json, None))
+                    .collect::<Result<_, _>>()?,
                 package_manager: self.package_manager.clone(),
             });
         }
@@ -234,10 +273,7 @@ impl PackageDiscovery for LocalPackageDiscovery {
             let package_dir = path.parent().expect("non-root");
             let turbo_json = discover_turbo_config_path(package_dir).await?;
 
-            Ok(WorkspaceData {
-                package_json: path,
-                turbo_json,
-            })
+            WorkspaceData::new(path, turbo_json)
         }))
         .buffered(64)
         .collect::<Vec<Result<WorkspaceData, Error>>>()
@@ -379,6 +415,25 @@ mod local_tests {
     use turbopath::AbsoluteSystemPath;
 
     use super::*;
+
+    #[test]
+    fn workspace_data_owns_valid_workspace_paths() {
+        let (_dir, repo_root) = npm_workspace();
+        let workspace_root = repo_root.join_components(&["apps", "web"]);
+        let package_json = workspace_root.join_component("package.json");
+        let turbo_json = workspace_root.join_component("turbo.json");
+
+        let workspace = WorkspaceData::new(package_json.clone(), Some(turbo_json.clone())).unwrap();
+        assert_eq!(workspace.workspace_root(), &*workspace_root);
+        assert_eq!(workspace.package_json(), &*package_json);
+        assert_eq!(workspace.turbo_json(), Some(&*turbo_json));
+
+        let other_turbo_json = repo_root.join_components(&["apps", "other", "turbo.json"]);
+        assert!(WorkspaceData::new(package_json, Some(other_turbo_json)).is_err());
+
+        let other_manifest = workspace_root.join_component("pyproject.toml");
+        assert!(WorkspaceData::new(other_manifest, None).is_ok());
+    }
 
     fn npm_workspace() -> (TempDir, AbsoluteSystemPathBuf) {
         let dir = TempDir::new().unwrap();

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -150,6 +150,26 @@ pub struct PackageGraph {
 /// There are other structs in this module that have "Workspace" in the name,
 /// but they do NOT follow the glossary, and instead mean "package" when they
 /// say Workspace. Some of these are labeled as such.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepositoryDiscoveryScope {
+    pub name: PackageName,
+    pub toolchain: crate::toolchain::ToolchainId,
+    pub manifest_path: AbsoluteSystemPathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepositoryDiscoveryWorkspaceRoot {
+    pub toolchain: crate::toolchain::ToolchainId,
+    pub kind: String,
+    pub path: AbsoluteSystemPathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepositoryDiscoverySnapshot {
+    pub scopes: Vec<RepositoryDiscoveryScope>,
+    pub workspace_roots: Vec<RepositoryDiscoveryWorkspaceRoot>,
+}
+
 #[derive(Debug, Eq, PartialEq, Hash, Clone)]
 pub struct WorkspacePackage {
     pub name: PackageName,
@@ -700,6 +720,37 @@ impl PackageGraph {
 
     pub fn package_manager(&self) -> Option<&PackageManager> {
         self.package_manager.as_ref()
+    }
+
+    /// Immutable, parser-neutral discovery facts suitable for sharing with
+    /// repository consumers such as the daemon.
+    pub fn repository_discovery_snapshot(&self) -> RepositoryDiscoverySnapshot {
+        let scopes = self
+            .package_scope_directories()
+            .filter_map(|(name, _)| {
+                Some(RepositoryDiscoveryScope {
+                    toolchain: self.package_toolchain(&name)?.clone(),
+                    manifest_path: self
+                        .repo_root()
+                        .resolve(self.package_definition_path(&name)?),
+                    name,
+                })
+            })
+            .collect();
+        let workspace_roots = self
+            .knowledge
+            .workspace_roots()
+            .map(|root| RepositoryDiscoveryWorkspaceRoot {
+                toolchain: root.toolchain().clone(),
+                kind: root.kind().to_string(),
+                path: self.repo_root().resolve(root.path()),
+            })
+            .collect();
+
+        RepositoryDiscoverySnapshot {
+            scopes,
+            workspace_roots,
+        }
     }
 
     /// Root `engines` captured into task-contract knowledge at construction.
@@ -3031,6 +3082,28 @@ version = "0.1.0"
                 pkg_graph.package_toolchain(&PackageName::from("acme")),
                 Some(&crate::toolchain::ToolchainId::RUST)
             );
+
+            let discovery = pkg_graph.repository_discovery_snapshot();
+            assert!(discovery.scopes.iter().any(|scope| {
+                scope.name == PackageName::from("js-pkg")
+                    && scope.toolchain == crate::toolchain::ToolchainId::JAVASCRIPT
+                    && scope.manifest_path.ends_with("js-pkg/package.json")
+            }));
+            assert!(discovery.scopes.iter().any(|scope| {
+                scope.name == PackageName::from("app")
+                    && scope.toolchain == crate::toolchain::ToolchainId::RUST
+                    && scope.manifest_path.ends_with("rust/app/Cargo.toml")
+            }));
+            assert!(discovery.workspace_roots.iter().any(|workspace_root| {
+                workspace_root.toolchain == crate::toolchain::ToolchainId::JAVASCRIPT
+                    && workspace_root.kind == "npm"
+                    && workspace_root.path == root
+            }));
+            assert!(discovery.workspace_roots.iter().any(|workspace_root| {
+                workspace_root.toolchain == crate::toolchain::ToolchainId::RUST
+                    && workspace_root.kind == "cargo"
+                    && workspace_root.path == root
+            }));
 
             let knowledge = pkg_graph.repository_knowledge();
             let cargo_app = knowledge.scope("app").expect("Cargo crate is a package");

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -731,8 +731,9 @@ impl<P: PackageDiscovery + Send + Sync> RepositoryContributor for JavaScriptCont
                     .workspaces
                     .into_par_iter()
                     .map(|workspace| {
-                        let descriptor = PackageJson::load(&workspace.package_json)?;
-                        Ok(Self::package_from_json(workspace.package_json, descriptor))
+                        let (package_json, _) = workspace.into_paths();
+                        let descriptor = PackageJson::load(&package_json)?;
+                        Ok(Self::package_from_json(package_json, descriptor))
                     })
                     .collect::<Result<Vec<_>, Error>>()
             })?;
@@ -878,10 +879,7 @@ mod tests {
             .unwrap();
         let toolchain = JavaScriptContributor::new(
             StubDiscovery(discovery::DiscoveryResponse {
-                workspaces: vec![discovery::WorkspaceData {
-                    package_json,
-                    turbo_json: None,
-                }],
+                workspaces: vec![discovery::WorkspaceData::new(package_json, None).unwrap()],
                 package_manager: PackageManager::Pnpm6,
             }),
             repo_root.clone(),

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -99,10 +99,20 @@ application and the standalone `turborepo-lsp` binary use this shared API, so a
 without requiring the LSP to depend on `turborepo-lib`.
 
 The `turbo` application supplies its package-graph-aware change watcher and
-keeps CLI-specific rendering in `turborepo-lib`. The standalone LSP supplies a
-conservative daemon-owned watcher that emits full rediscovery for filesystem
-changes. This preserves correctness when the packaged LSP hosts the daemon,
-while the richer watcher avoids unnecessary rediscovery when `turbo` hosts it.
+keeps CLI-specific rendering in `turborepo-lib`. Each completed graph generation
+also publishes one immutable repository-discovery snapshot to the daemon. The
+snapshot contains toolchain-tagged scope identities and manifest paths plus
+workspace-root observations, so the daemon protocol does not encode
+`package.json`, JavaScript package managers, or any other ecosystem-specific
+metadata. Consumers that only support one ecosystem filter by toolchain
+explicitly; the JavaScript package-discovery adapter is one such compatibility
+boundary.
+
+The standalone LSP supplies a conservative daemon-owned watcher that emits full
+rediscovery for filesystem changes and rebuilds a JavaScript-only graph snapshot.
+This preserves correctness when the packaged LSP hosts the daemon, while the
+richer watcher uses the feature-enabled multi-toolchain graph and avoids
+unnecessary rediscovery when `turbo` hosts it.
 
 ### 1. Run Builder (`crates/turborepo-lib/src/run/builder.rs`)
 


### PR DESCRIPTION
### Description

Fix stale repository discovery after package-level metadata changes and make the daemon discovery boundary generic across toolchains.

- Publish an immutable discovery snapshot from each completed, feature-configured `PackageGraph` generation.
- Represent discovered scopes with their identity, open `ToolchainId`, and native manifest path, plus toolchain-tagged workspace-root observations.
- Replace the daemon's JavaScript-specific `PackageFiles` and `PackageManager` wire fields with the generic repository snapshot and bump the daemon protocol major version.
- Keep JavaScript compatibility explicit: `DaemonPackageDiscovery` filters JavaScript scopes and resolves the JavaScript package manager locally rather than treating JavaScript metadata as repository-wide state.
- Rebuild the standalone LSP daemon's JavaScript-only fallback snapshot whenever it emits rediscovery.
- Resolve filewatcher events structurally as a workspace or direct child, so new workspace-level metadata does not require another filename allowlist.
- Document the discovery generation and compatibility boundary in the run architecture.

### Testing Instructions

```shell
cargo test -p turborepo-repository --lib package_graph::test::test_cargo_toolchain_packages_in_graph
cargo test -p turborepo-daemon --lib
cargo test -p turborepo-lib --lib package_changes_watcher::test
cargo check -p turborepo-daemon -p turborepo-lib -p turborepo-lsp -p turborepo-repository --tests
```
