### PR TITLE
fix: Hash native workspace task inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9077,7 +9077,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
- "sha2",
  "tempfile",
  "test-case",
  "thiserror 2.0.18",

--- a/apps/docs/content/docs/guides/tools/python.mdx
+++ b/apps/docs/content/docs/guides/tools/python.mdx
@@ -90,7 +90,11 @@ Turborepo also detects common Python tools declared in `[project].dependencies`,
 | Pyright       | `turbo check`, `turbo check:pyright` | `uv run --active --frozen --package <name> pyright <dir>`     |
 | pytest        | `turbo test`                         | `uv run --active --frozen --package <name> pytest <dir>`      |
 
-Tools declared in the root `pyproject.toml` apply to every member unless a member declares its own tool for that role, and root-declared tools run once without `--package`. `lint` and `check` run every detected tool for that role. `format` runs one formatter, preferring Ruff over Black. A root pytest declaration creates one repository-wide `test` task on the workspace package; a member declaration creates `test` for that member only.
+Tools declared in the root `pyproject.toml` apply to every member unless a member declares its own tool for that role, and root-declared tools run once without `--package`. `lint` and `check` run every detected tool for that role.
+
+- `format` runs one formatter, preferring Ruff over Black.
+- A root pytest declaration creates one repository-wide `test` task running `uv run --active --frozen --all-packages pytest`, installing src-layout workspace members before collection. A member declaration creates `test` for that member only. When both declare pytest, both scopes run.
+- Without a declared type checker, the built-in `check` task runs uv's bundled ty type checker. Declared mypy, ty, or Pyright tools take precedence when present.
 
 You can use [`--filter`](/docs/reference/run#--filter-string) to target a specific member in the workspace.
 
@@ -149,7 +153,7 @@ With zero configuration, Turborepo creates task hashes using:
 - The resolved external dependency closure from `uv.lock`, scoped to each member
 - The uv and Python interpreter identities. If Turborepo cannot resolve them, uv tasks remain runnable but implicit caching is disabled with a warning.
 
-Automatic inputs exclude `.venv`, `__pycache__`, and tool cache directories such as `.ruff_cache`, `.mypy_cache`, and `.pytest_cache`. Because formatting mutates source files, `format` tasks default to uncached. The fallback `uv check` task is also uncached because uv resolves its bundled checker independently of `uv.lock`.
+Automatic inputs exclude `.venv`, `__pycache__`, and tool cache directories such as `.ruff_cache`, `.mypy_cache`, and `.pytest_cache` at any depth. Because formatting mutates source files, `format` tasks default to uncached. The built-in `uv check` task is cacheable when Turborepo can identify uv and Python.
 
 Project-specific hashing inputs must be accounted for manually. This includes:
 

--- a/crates/turborepo-repository/Cargo.toml
+++ b/crates/turborepo-repository/Cargo.toml
@@ -26,7 +26,6 @@ rust-ini = "0.20.0"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }
-sha2 = { workspace = true }
 thiserror = { workspace = true }
 tokio.workspace = true
 toml = { workspace = true }

--- a/crates/turborepo-repository/src/uv.rs
+++ b/crates/turborepo-repository/src/uv.rs
@@ -39,13 +39,12 @@
 
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
-    io::{self, Read},
+    io,
     process::Command,
     sync::Arc,
 };
 
 use serde::Deserialize;
-use sha2::{Digest, Sha256};
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
 
 use crate::{
@@ -1179,17 +1178,18 @@ fn uv_command_task(
         toolchain::TaskDefaults {
             cache: Some(cacheable),
         },
-        Some(uv_task_entrypoint(kind)),
+        Some(uv_task_entrypoint(kind, name)),
         true,
     ))
 }
 
-fn uv_task_entrypoint(kind: UvPackageKind) -> crate::native_tasks::TaskEntrypoint {
+fn uv_task_entrypoint(kind: UvPackageKind, task: &str) -> crate::native_tasks::TaskEntrypoint {
     use crate::native_tasks::TaskEntrypoint;
 
-    match kind {
-        UvPackageKind::Workspace => TaskEntrypoint::PreferredOnly,
-        UvPackageKind::Package | UvPackageKind::VirtualPackage => TaskEntrypoint::Candidate,
+    match (kind, task) {
+        (UvPackageKind::Workspace, "test") => TaskEntrypoint::Candidate,
+        (UvPackageKind::Workspace, _) => TaskEntrypoint::PreferredOnly,
+        (UvPackageKind::Package | UvPackageKind::VirtualPackage, _) => TaskEntrypoint::Candidate,
     }
 }
 
@@ -1270,20 +1270,16 @@ pub fn native_tasks_for_package(
     ));
 
     let check_arguments = match kind {
-        UvPackageKind::Package | UvPackageKind::VirtualPackage => {
-            vec![
-                "check".to_string(),
-                "--frozen".to_string(),
-                format!("--package={package}"),
-            ]
-        }
-        UvPackageKind::Workspace => {
-            vec![
-                "check".to_string(),
-                "--frozen".to_string(),
-                "--all-packages".to_string(),
-            ]
-        }
+        UvPackageKind::Package | UvPackageKind::VirtualPackage => vec![
+            "check".to_string(),
+            "--frozen".to_string(),
+            format!("--package={package}"),
+        ],
+        UvPackageKind::Workspace => vec![
+            "check".to_string(),
+            "--frozen".to_string(),
+            "--all-packages".to_string(),
+        ],
     };
     tasks.push(uv_command_task(
         kind,
@@ -1309,7 +1305,7 @@ fn aggregate_task(
 
     NativeTask::aggregate(name, children).with_contract(NativeTaskContract::new(
         toolchain::TaskDefaults::default(),
-        Some(uv_task_entrypoint(kind)),
+        Some(uv_task_entrypoint(kind, name)),
         false,
     ))
 }
@@ -1330,6 +1326,9 @@ fn declared_tool_task(
         "--frozen".to_string(),
     ];
     match execution.owner {
+        ExecutionOwner::Root if kind == UvPackageKind::Workspace && tool == PythonTool::Pytest => {
+            prefix.push("--all-packages".to_string());
+        }
         ExecutionOwner::Root => {}
         ExecutionOwner::Member => {
             prefix.extend(["--package".to_string(), package.to_string()]);
@@ -1563,26 +1562,19 @@ fn python_tasks_for_package(
 // Task contract
 // ---------------------------------------------------------------------------
 
-/// Standard uv and pip environment variables that can change what a uv
-/// invocation resolves, installs, or builds. Credentials and purely
-/// cosmetic settings are deliberately excluded.
+/// Standard uv environment variables that can change what an invocation
+/// executes or builds. Download locations are deliberately excluded because
+/// frozen tasks are identified by their lockfile closure and URLs can contain
+/// credentials, which must never enter a task hash.
 pub const HASHED_ENV_VARS: &[&str] = &[
     "UV_BUILD_CONSTRAINT",
     "UV_COMPILE_BYTECODE",
     "UV_CONFIG_FILE",
     "UV_CONSTRAINT",
-    "UV_DEFAULT_INDEX",
     "UV_EXCLUDE",
-    "UV_EXCLUDE_NEWER",
     "UV_ENV_FILE",
-    "UV_INDEX",
-    "UV_INDEX_STRATEGY",
-    "UV_INDEX_URL",
-    "UV_EXTRA_INDEX_URL",
-    "UV_FIND_LINKS",
     "UV_FORK_STRATEGY",
     "UV_GIT_LFS",
-    "UV_INSECURE_HOST",
     "UV_LINK_MODE",
     "UV_NO_BUILD_ISOLATION",
     "UV_NO_BUILD_ISOLATION_PACKAGE",
@@ -1605,13 +1597,8 @@ pub const HASHED_ENV_VARS: &[&str] = &[
     "UV_NO_SYNC",
     "UV_OFFLINE",
     "UV_OVERRIDE",
-    "UV_RESOLUTION",
-    "UV_PRERELEASE",
-    "UV_SYSTEM_CERTS",
     "UV_ISOLATED",
     "UV_WORKING_DIR",
-    "PIP_INDEX_URL",
-    "PIP_EXTRA_INDEX_URL",
     "PYTHONHOME",
     "PYTHONPATH",
     "VIRTUAL_ENV",
@@ -1620,8 +1607,8 @@ pub const HASHED_ENV_VARS: &[&str] = &[
 /// Variables needed for task-I/O derivation or strict-mode execution whose raw
 /// values are represented semantically elsewhere rather than in the task hash.
 pub(crate) const PROJECTED_ONLY_ENV_VARS: &[&str] = &[
-    // Config roots affect uv only when a config exists there; that condition
-    // disables implicit caching in `untracked_uv_configuration_reason`.
+    // Config roots locate uv configuration. Frozen verification tasks classify
+    // its fields, while builds conservatively disable implicit caching.
     "APPDATA",
     "HOME",
     "XDG_CONFIG_HOME",
@@ -1632,6 +1619,37 @@ pub(crate) const PROJECTED_ONLY_ENV_VARS: &[&str] = &[
     "UV_PYTHON",
     "UV_PYTHON_DOWNLOADS",
     "UV_PYTHON_PREFERENCE",
+    // Frozen resolution is represented by the lockfile closure. Keep download
+    // policy available to uv without hashing URLs that may embed credentials.
+    "UV_DEFAULT_INDEX",
+    "UV_EXCLUDE_NEWER",
+    "UV_INDEX",
+    "UV_INDEX_STRATEGY",
+    "UV_INDEX_URL",
+    "UV_EXTRA_INDEX_URL",
+    "UV_FIND_LINKS",
+    "UV_INSECURE_HOST",
+    "UV_RESOLUTION",
+    "UV_PRERELEASE",
+    "UV_SYSTEM_CERTS",
+    "PIP_INDEX_URL",
+    "PIP_EXTRA_INDEX_URL",
+];
+
+const UV_DOWNLOAD_POLICY_ENV_VARS: &[&str] = &[
+    "UV_DEFAULT_INDEX",
+    "UV_EXCLUDE_NEWER",
+    "UV_INDEX",
+    "UV_INDEX_STRATEGY",
+    "UV_INDEX_URL",
+    "UV_EXTRA_INDEX_URL",
+    "UV_FIND_LINKS",
+    "UV_INSECURE_HOST",
+    "UV_RESOLUTION",
+    "UV_PRERELEASE",
+    "UV_SYSTEM_CERTS",
+    "PIP_INDEX_URL",
+    "PIP_EXTRA_INDEX_URL",
 ];
 
 const UV_PATH_ENV_VARS: &[&str] = &[
@@ -1687,22 +1705,35 @@ fn environment_flag(environment: &toolchain::TaskIOEnvironment, name: &str) -> b
     })
 }
 
-fn untracked_uv_configuration_reason(environment: &toolchain::TaskIOEnvironment) -> Option<String> {
-    if let Some(name) = UV_PATH_ENV_VARS
-        .iter()
-        .find(|name| environment.get(name).is_some())
-    {
-        return Some(format!("{name} points to inputs Turborepo cannot hash"));
-    }
-    if environment_flag(environment, "UV_NO_SYNC") {
-        return Some("UV_NO_SYNC can use an environment Turborepo cannot hash".to_string());
-    }
-    if environment_flag(environment, "UV_NO_PROJECT") {
-        return Some("UV_NO_PROJECT can select inputs Turborepo cannot hash".to_string());
-    }
-    if environment_flag(environment, "UV_NO_CONFIG") {
-        return None;
-    }
+const FROZEN_VERIFICATION_CONFIG_KEYS: &[&str] = &[
+    // Resolution and download policy cannot change an already-locked frozen
+    // invocation. Credentials are deliberately neither inspected nor hashed.
+    "allow-insecure-host",
+    "default-index",
+    "exclude-newer",
+    "exclude-newer-package",
+    "extra-index-url",
+    "find-links",
+    "fork-strategy",
+    "index",
+    "index-strategy",
+    "index-url",
+    "keyring-provider",
+    "native-tls",
+    "offline",
+    "prerelease",
+    "resolution",
+    "system-certs",
+    // These only control local storage or environment materialization.
+    "cache-dir",
+    "compile-bytecode",
+    "link-mode",
+    "no-cache",
+    "refresh",
+    "refresh-package",
+];
+
+fn external_uv_config_paths(environment: &toolchain::TaskIOEnvironment) -> Vec<std::path::PathBuf> {
     let mut paths = Vec::new();
     if let Some(config_home) = environment.get("XDG_CONFIG_HOME") {
         paths.push(std::path::PathBuf::from(config_home).join("uv/uv.toml"));
@@ -1717,11 +1748,59 @@ fn untracked_uv_configuration_reason(environment: &toolchain::TaskIOEnvironment)
     }
     #[cfg(unix)]
     paths.push(std::path::PathBuf::from("/etc/uv/uv.toml"));
-
     paths
+}
+
+fn external_uv_config_is_safe_for_frozen_verification(path: &std::path::Path) -> bool {
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    let Ok(toml::Value::Table(settings)) = toml::from_str(&contents) else {
+        return false;
+    };
+    settings
+        .keys()
+        .all(|key| FROZEN_VERIFICATION_CONFIG_KEYS.contains(&key.as_str()))
+}
+
+fn untracked_uv_configuration_reason(
+    task_class: UvTaskClass,
+    environment: &toolchain::TaskIOEnvironment,
+) -> Option<String> {
+    if let Some(name) = UV_PATH_ENV_VARS
+        .iter()
+        .find(|name| environment.get(name).is_some())
+    {
+        return Some(format!("{name} points to inputs Turborepo cannot hash"));
+    }
+    if task_class == UvTaskClass::Build
+        && let Some(name) = UV_DOWNLOAD_POLICY_ENV_VARS
+            .iter()
+            .find(|name| environment.get(name).is_some())
+    {
+        return Some(format!(
+            "{name} can change build inputs without exposing credentials to the task hash"
+        ));
+    }
+    if environment_flag(environment, "UV_NO_SYNC") {
+        return Some("UV_NO_SYNC can use an environment Turborepo cannot hash".to_string());
+    }
+    if environment_flag(environment, "UV_NO_PROJECT") {
+        return Some("UV_NO_PROJECT can select inputs Turborepo cannot hash".to_string());
+    }
+    if environment_flag(environment, "UV_NO_CONFIG") {
+        return None;
+    }
+
+    let external_config = external_uv_config_paths(environment)
         .into_iter()
-        .any(|path| path.is_file())
-        .then(|| "user or system uv configuration is outside the task hash".to_string())
+        .filter(|path| path.is_file())
+        .any(|path| {
+            task_class == UvTaskClass::Build
+                || !external_uv_config_is_safe_for_frozen_verification(&path)
+        });
+    external_config
+        .then(|| "user or system uv configuration contains untracked semantic inputs".to_string())
 }
 
 /// Input globs whose changes should invalidate a Python task's cache: the
@@ -1762,12 +1841,12 @@ pub fn hash_input_globs(prefix: &str) -> Vec<String> {
 }
 
 const PYTHON_CACHE_GLOBS: [&str; 7] = [
-    ".venv/**",
-    ".pytest_cache/**",
-    ".ruff_cache/**",
-    ".mypy_cache/**",
-    ".pyright/**",
-    ".ty/**",
+    "**/.venv/**",
+    "**/.pytest_cache/**",
+    "**/.ruff_cache/**",
+    "**/.mypy_cache/**",
+    "**/.pyright/**",
+    "**/.ty/**",
     "**/__pycache__/**",
 ];
 
@@ -1847,7 +1926,7 @@ impl UvTaskContract {
         // These variables point at files whose contents affect uv. Until the
         // paths can be resolved against the repository safely, fail closed
         // instead of restoring an artifact hashed only by the path string.
-        if let Some(reason) = untracked_uv_configuration_reason(context.environment) {
+        if let Some(reason) = untracked_uv_configuration_reason(task_class, context.environment) {
             io.input_safety = toolchain::DerivedInputSafety::Untracked;
             io.cache_reason = Some(reason);
         }
@@ -1991,20 +2070,6 @@ fn bundled_uv_build_matches(requirement: &str, uv_version: &node_semver::Version
     node_semver::Range::parse(range.join(" ")).is_ok_and(|range| range.satisfies(uv_version))
 }
 
-fn file_sha256(path: &std::path::Path) -> Result<String, std::io::Error> {
-    let mut file = std::fs::File::open(path)?;
-    let mut hasher = Sha256::new();
-    let mut buffer = [0; 64 * 1024];
-    loop {
-        let read = file.read(&mut buffer)?;
-        if read == 0 {
-            break;
-        }
-        hasher.update(&buffer[..read]);
-    }
-    Ok(format!("{:x}", hasher.finalize()))
-}
-
 #[cfg(target_os = "linux")]
 fn host_compatibility_identity() -> Option<String> {
     let kernel = std::fs::read_to_string("/proc/sys/kernel/osrelease").ok()?;
@@ -2082,9 +2147,6 @@ fn toolchain_identities(repo_root: &AbsoluteSystemPath) -> Result<UvToolchainIde
     if uv.starts_with(repo_root.as_std_path()) {
         return Err("the uv executable is inside the repository".to_string());
     }
-    let uv_sha256 = file_sha256(&uv)
-        .map_err(|error| format!("unable to hash uv at {}: {error}", uv.display()))?;
-
     let mut uv_version = Command::new(&uv);
     uv_version
         .arg("--version")
@@ -2096,19 +2158,13 @@ fn toolchain_identities(repo_root: &AbsoluteSystemPath) -> Result<UvToolchainIde
         .ok_or_else(|| format!("unexpected uv version output: {uv_version_output}"))?;
     let uv_version = node_semver::Version::parse(version)
         .map_err(|error| format!("unable to parse uv version {version:?}: {error}"))?;
-    let uv_identity = format!("{uv_version_output}\nsha256:{uv_sha256}");
+    let uv_identity = uv_version_output;
 
     let mut python = Command::new(&uv);
     python
         .args(["python", "find", "--resolve-links", "--no-python-downloads"])
         .current_dir(repo_root.as_std_path());
     let python_path = std::path::PathBuf::from(identity_stdout(python, "uv python find")?);
-    let python_sha256 = file_sha256(&python_path).map_err(|error| {
-        format!(
-            "unable to hash Python interpreter at {}: {error}",
-            python_path.display()
-        )
-    })?;
     let host = host_compatibility_identity()
         .ok_or_else(|| "unable to identify host compatibility".to_string())?;
 
@@ -2117,7 +2173,7 @@ fn toolchain_identities(repo_root: &AbsoluteSystemPath) -> Result<UvToolchainIde
         .args(["--version"])
         .current_dir(repo_root.as_std_path());
     let python_version = identity_stdout(python_version, "Python --version")?;
-    let python_identity = format!("{python_version}\nsha256:{python_sha256}\nhost:{host}");
+    let python_identity = format!("{python_version}\nhost:{host}");
 
     Ok(UvToolchainIdentity {
         packages: [
@@ -3640,6 +3696,10 @@ version = "0.1.0"
         ] {
             assert!(PROJECTED_ONLY_ENV_VARS.contains(&variable));
         }
+        for variable in UV_DOWNLOAD_POLICY_ENV_VARS {
+            assert!(!HASHED_ENV_VARS.contains(variable));
+            assert!(PROJECTED_ONLY_ENV_VARS.contains(variable));
+        }
     }
 
     #[test]
@@ -3649,11 +3709,14 @@ version = "0.1.0"
             "/outside/uv.toml".to_string(),
         )]));
         assert_eq!(
-            untracked_uv_configuration_reason(&environment).as_deref(),
+            untracked_uv_configuration_reason(UvTaskClass::Quality, &environment).as_deref(),
             Some("UV_CONFIG_FILE points to inputs Turborepo cannot hash")
         );
         assert_eq!(
-            untracked_uv_configuration_reason(&toolchain::TaskIOEnvironment::default()),
+            untracked_uv_configuration_reason(
+                UvTaskClass::Quality,
+                &toolchain::TaskIOEnvironment::default()
+            ),
             None
         );
 
@@ -3662,7 +3725,7 @@ version = "0.1.0"
             "true".to_string(),
         )]));
         assert_eq!(
-            untracked_uv_configuration_reason(&no_sync).as_deref(),
+            untracked_uv_configuration_reason(UvTaskClass::Quality, &no_sync).as_deref(),
             Some("UV_NO_SYNC can use an environment Turborepo cannot hash")
         );
     }
@@ -3676,23 +3739,48 @@ version = "0.1.0"
                 "/outside/constraints.txt".to_string(),
             ),
         ]));
-        assert!(untracked_uv_configuration_reason(&environment).is_some());
+        assert!(untracked_uv_configuration_reason(UvTaskClass::Quality, &environment).is_some());
     }
 
     #[test]
-    fn test_user_uv_config_disables_automatic_inputs() {
+    fn test_user_uv_config_is_classified_by_task_effect() {
         let tempdir = tempfile::tempdir().unwrap();
         let config_dir = tempdir.path().join("uv");
         std::fs::create_dir_all(&config_dir).unwrap();
-        std::fs::write(config_dir.join("uv.toml"), "offline = true\n").unwrap();
+        let config_path = config_dir.join("uv.toml");
+        std::fs::write(
+            &config_path,
+            "exclude-newer = \"2026-01-01T00:00:00Z\"\noffline = true\nlink-mode = \"copy\"\n",
+        )
+        .unwrap();
         let environment = toolchain::TaskIOEnvironment::new(HashMap::from([(
             "XDG_CONFIG_HOME".to_string(),
             tempdir.path().to_string_lossy().to_string(),
         )]));
         assert_eq!(
-            untracked_uv_configuration_reason(&environment).as_deref(),
-            Some("user or system uv configuration is outside the task hash")
+            untracked_uv_configuration_reason(UvTaskClass::Quality, &environment),
+            None
         );
+        assert_eq!(
+            untracked_uv_configuration_reason(UvTaskClass::Test, &environment),
+            None
+        );
+        assert!(untracked_uv_configuration_reason(UvTaskClass::Build, &environment).is_some());
+
+        let index_environment = toolchain::TaskIOEnvironment::new(HashMap::from([(
+            "UV_INDEX_URL".to_string(),
+            "https://user:secret@example.com/simple".to_string(),
+        )]));
+        assert_eq!(
+            untracked_uv_configuration_reason(UvTaskClass::Quality, &index_environment),
+            None
+        );
+        assert!(
+            untracked_uv_configuration_reason(UvTaskClass::Build, &index_environment).is_some()
+        );
+
+        std::fs::write(&config_path, "constraint-dependencies = [\"foo==1\"]\n").unwrap();
+        assert!(untracked_uv_configuration_reason(UvTaskClass::Quality, &environment).is_some());
     }
 
     #[test]
@@ -3741,12 +3829,25 @@ version = "0.1.0"
         assert_eq!(display("build"), Some("uv build --package=py-app"));
         assert_eq!(display("format"), Some("uv format -- packages/py-app"));
         assert_eq!(display("check"), Some("uv check --frozen --package=py-app"));
+        let workspace_tasks = native_tasks_for_package(
+            UvPackageKind::Workspace,
+            "acme",
+            ".",
+            &["packages/py-app".to_string()],
+            true,
+            false,
+        );
+        assert_eq!(
+            workspace_tasks
+                .iter()
+                .find(|task| task.name() == "check")
+                .and_then(|task| task.display()),
+            Some("uv check --frozen --all-packages")
+        );
         let build = tasks.iter().find(|task| task.name() == "build").unwrap();
         assert_eq!(build.contract().defaults().cache, Some(false));
         let format = tasks.iter().find(|task| task.name() == "format").unwrap();
         assert_eq!(format.contract().defaults().cache, Some(false));
-        let check = tasks.iter().find(|task| task.name() == "check").unwrap();
-        assert_eq!(check.contract().defaults().cache, Some(true));
         assert_eq!(
             build.contract().entrypoint(),
             Some(crate::native_tasks::TaskEntrypoint::Candidate)
@@ -3785,10 +3886,13 @@ version = "0.1.0"
             .iter()
             .find(|task| task.name() == "test")
             .unwrap();
-        assert_eq!(root_test.display(), Some("uv run --active --frozen pytest"));
+        assert_eq!(
+            root_test.display(),
+            Some("uv run --active --frozen --all-packages pytest")
+        );
         assert_eq!(
             root_test.contract().entrypoint(),
-            Some(crate::native_tasks::TaskEntrypoint::PreferredOnly)
+            Some(crate::native_tasks::TaskEntrypoint::Candidate)
         );
 
         let member: PyProjectManifest =
@@ -4067,6 +4171,7 @@ version = "0.1.0"
             false,
         );
         let check = tasks.iter().find(|task| task.name() == "check").unwrap();
+        assert_eq!(check.display(), Some("uv check --frozen --package=py-app"));
         assert_eq!(check.contract().defaults().cache, Some(true));
     }
 
@@ -4145,10 +4250,11 @@ version = "0.1.0"
         );
         assert!(
             io.input_globs
-                .contains(&"!../../packages/lib/.mypy_cache/**".to_string())
+                .contains(&"!../../packages/lib/**/.mypy_cache/**".to_string())
         );
         assert!(io.input_globs.contains(&"!**/__pycache__/**".to_string()));
-        assert!(io.input_globs.contains(&"!.pytest_cache/**".to_string()));
+        assert!(io.input_globs.contains(&"!**/.pytest_cache/**".to_string()));
+        assert!(io.input_globs.contains(&"!**/.ruff_cache/**".to_string()));
 
         let args = vec!["--fix".to_string()];
         let context = toolchain::TaskIOContext {
@@ -4209,6 +4315,24 @@ version = "0.1.0"
             !workspace_io
                 .input_globs
                 .contains(&"packages/app/**".to_string())
+        );
+
+        let workspace_lint = UvTaskContract::workspace(
+            "acme",
+            vec!["packages/app".to_string(), "packages/lib".to_string()],
+        )
+        .derived_task_io(&package, "lint:ruff", "", &[], true, &context)
+        .unwrap();
+        assert_eq!(workspace_lint.package_default_inputs, Some(false));
+        assert!(
+            workspace_lint
+                .input_globs
+                .contains(&"packages/app/**".to_string())
+        );
+        assert!(
+            workspace_lint
+                .input_globs
+                .contains(&"packages/lib/**".to_string())
         );
     }
 

--- a/crates/turborepo-scm/src/manual.rs
+++ b/crates/turborepo-scm/src/manual.rs
@@ -31,7 +31,9 @@ fn expand_dir_pattern<'a>(base: &AbsoluteSystemPath, pattern: &'a str) -> Cow<'a
 
 fn to_glob(input: &str) -> Result<Glob<'static>, Error> {
     let glob = fix_glob_pattern(input).into_unix();
-    let g = Glob::new(glob.as_str()).map(|g| g.into_owned())?;
+    // Walked paths are package-relative and never start with `./`. Native
+    // workspace contracts and authored inputs may include that prefix.
+    let g = Glob::new(glob.as_str().trim_start_matches("./")).map(|g| g.into_owned())?;
 
     Ok(g)
 }
@@ -426,6 +428,40 @@ mod tests {
             Err(e) => assert!(want_err, "unexpected error {e}"),
             Ok(hashes) => assert_eq!(hashes, expected),
         }
+    }
+
+    #[test_case("./src/**"; "glob")]
+    #[test_case("./src/"; "directory")]
+    #[test_case("././src/**"; "repeated current directory")]
+    fn test_current_directory_inputs_without_git(source_input: &str) {
+        let (_tmp, root) = tmp_dir();
+        root.join_component("src").create_dir_all().unwrap();
+        root.join_components(&["src", "main.py"])
+            .create_with_contents("VALUE = 1\n")
+            .unwrap();
+        root.join_components(&["src", "ignored.py"])
+            .create_with_contents("ignored\n")
+            .unwrap();
+        root.join_component("pyproject.toml")
+            .create_with_contents("[project]\n")
+            .unwrap();
+        let hash = |inputs: &[&str]| {
+            get_package_file_hashes_without_git(
+                &root,
+                AnchoredSystemPath::new("").unwrap(),
+                inputs,
+                false,
+                None,
+                None,
+            )
+            .unwrap()
+        };
+        let expected = hash(&["src/**", "pyproject.toml", "!src/ignored.py"]);
+        assert_eq!(expected.len(), 2);
+        assert_eq!(
+            hash(&[source_input, "./pyproject.toml", "!./src/ignored.py"]),
+            expected
+        );
     }
 
     #[test]

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -710,57 +710,62 @@ the shared repository graph.
   activation group for a role, unfiltered runs use the workspace scope;
   member-owned tools add `--all-packages`. Otherwise, member scopes are the
   entrypoints for that role. Filtered runs use member commands. A root pytest
-  declaration registers a preferred-only workspace `test`; direct member
-  declarations register candidate member `test` tasks. The root task wins an
-  unfiltered run, while a package filter can select only a directly declaring
-  member. Member pytest tasks have no shared serial group and can run in
-  parallel.
+  declaration registers a workspace `test`; direct member declarations register
+  member `test` tasks. An unfiltered run retains both root and member tasks when
+  both declare pytest, accepting possible duplicate collection rather than
+  silently skipping either scope. A package filter can select only a directly
+  declaring member. Member pytest tasks have no shared serial group and can run
+  in parallel.
 - **Command shapes** are `uv build --package=<name>`, or `uv run --active --frozen`
-  followed by owner selection (`--package <name>` for a member,
-  `--all-packages` for homogeneous member ownership, and no owner flag for a
-  root declaration), non-default group activation (`--no-default-groups
+  followed by owner selection (`--package <name>` for a member and
+  `--all-packages` for homogeneous member ownership or root pytest so src-layout
+  workspace members are installed), non-default group activation (`--no-default-groups
   --group <group>`), the tool and subcommand, pass-through arguments, and the
   member-directory targets. Ruff uses `check`/`format`; ty uses `check`.
   Fallbacks remain `uv format -- <dirs...>` and either
-  `uv check --frozen --package=<name>` or `uv check --frozen --all-packages`.
-  Detected-tool and
-  fallback `check` commands use the `uv` serial group. Detected lint, check, and
-  test commands default to cacheable when uv and Python identities resolve;
-  otherwise they fail closed to uncached. The fallback `uv check` stays uncached
-  because its bundled checker is not represented in `uv.lock`. Builds using
+  `uv check --frozen --package=<name>` or `uv check --frozen --all-packages`;
+  `uv check` runs uv's bundled ty type checker. Detected-tool and fallback check
+  commands use the `uv` serial group. Detected lint, check, test, and fallback
+  `uv check` commands default to cacheable when uv and Python identities resolve;
+  otherwise they fail closed to uncached. Builds using
   `uv_build` cache when their sole build requirement accepts the identified uv
   executable's bundled backend version. Other PEP 517 builds remain uncached,
   and format commands remain uncached because they mutate source. Detected-tool commands use `--frozen`;
   Turborepo itself never creates or updates `uv.lock`. Pass-through arguments are
   inserted before path targets. Active aggregates reject them and name the
   package-qualified child tasks that can receive them.
-  Pytest commands are `uv run --active --frozen pytest` for the workspace or `uv run
+  Pytest commands are `uv run --active --frozen --all-packages pytest` for the workspace or `uv run
   --active --frozen --package <name> pytest <member-dir>` for members, with non-default
   group activation inserted before pytest and pass-through arguments inserted
   before the member target.
 - **Hashing and affectedness** include member sources, relevant workspace
-  files, supported tool configuration, and uv/pip environment variables;
+  files, supported tool configuration, and semantic uv environment variables;
   `check`, `check:*`, and member `test` also include internal source closures.
   Quality workspace tasks include every member's sources; a bare workspace
   pytest task hashes the full repository because pytest controls collection.
+  The manual (Git-free) hasher normalizes leading `./` in local input and
+  exclusion patterns so native workspace inputs match package-relative paths.
   Quality caches, `.pytest_cache`, `.venv`, and `__pycache__` are excluded.
   `VIRTUAL_ENV` is hashed and native `uv run` tasks opt into it with `--active`;
   otherwise `UV_PROJECT_ENVIRONMENT` or the root `.venv` determines the effective
   environment directory. An in-repository environment is excluded from task inputs,
   and output globs that would archive it are rejected because virtual environments
-  are machine-specific. Path-valued uv settings, `UV_NO_SYNC`, `UV_NO_PROJECT`, active user/system uv
-  configuration, and any pass-through arguments make automatic inputs
-  untracked. Unless `cache` is explicitly configured, Turborepo disables caching
-  and emits the reason as a warning. Turborepo invokes
+  are machine-specific. Path-valued uv settings, `UV_NO_SYNC`, `UV_NO_PROJECT`,
+  user/system uv configuration with unknown or semantic fields, and any
+  pass-through arguments make automatic inputs untracked. Frozen lint, check,
+  and test tasks allow external configuration limited to resolution/download
+  policy and local materialization fields; builds conservatively reject any
+  external uv configuration. Unless `cache` is explicitly configured,
+  Turborepo disables caching and emits the reason as a warning. Turborepo invokes
   `uv workspace metadata --frozen --offline` and
   hashes each scope's external dependency closure from uv's JSON resolution
   graph; root-owned tools conservatively add the workspace closure. Package
   identities include version, source, and artifact hashes. Turborepo therefore
   does not interpret `uv.lock` for task hashing; pruning also uses metadata for
   reachability and only parses TOML to filter selected package tables. Every scope also
-  includes path-independent uv and Python identities
-  containing executable content hashes, Python implementation and version,
-  operating system, architecture, libc, variant, and host compatibility. If either
+  includes path-independent uv and Python identities containing uv and Python
+  versions, operating system, architecture, libc, variant, and host compatibility.
+  If either
   identity probe fails, native uv command tasks fail closed to uncached and emit one
   warning for the workspace with the concrete probe failure. A `uv.lock` change across git refs conservatively affects
   all uv packages. Build output inference covers the bare command's matching

--- a/crates/turborepo/tests/uv_workspace_test.rs
+++ b/crates/turborepo/tests/uv_workspace_test.rs
@@ -336,7 +336,59 @@ fn test_uv_compatible_member_tools_use_all_packages_entrypoint() {
 }
 
 #[test]
-fn test_uv_root_pytest_is_workspace_only_and_member_filter_uses_direct_declaration() {
+fn test_uv_workspace_quality_hashes_member_sources_and_ignores_nested_caches() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_uv_native_tools(tempdir.path());
+    let source = tempdir
+        .path()
+        .join("packages/py-app/src/py_app/__init__.py");
+    fs::create_dir_all(source.parent().unwrap()).unwrap();
+    fs::write(&source, "VALUE = 1\n").unwrap();
+
+    let task_hash = || {
+        let json = dry_run_tasks(tempdir.path(), &["lint:ruff", "--filter=acme"]);
+        let task = find_task(&json, "acme#lint:ruff");
+        let inputs = task["inputs"].as_object().unwrap();
+        for expected in [
+            "packages/py-app/pyproject.toml",
+            "packages/py-app/src/py_app/__init__.py",
+            "packages/py-lib/pyproject.toml",
+            "pyproject.toml",
+        ] {
+            assert!(
+                inputs.contains_key(expected),
+                "workspace Ruff inputs must contain {expected:?}: {inputs:?}"
+            );
+        }
+        task["hash"].as_str().unwrap().to_string()
+    };
+
+    let baseline = task_hash();
+    fs::write(&source, "VALUE = 2\n").unwrap();
+    let source_changed = task_hash();
+    assert_ne!(
+        baseline, source_changed,
+        "workspace Ruff tasks must hash member sources"
+    );
+
+    for cache in [".pytest_cache", ".ruff_cache"] {
+        let cache_file = tempdir
+            .path()
+            .join("packages/py-app/src/py_app")
+            .join(cache)
+            .join("nested/cache-file");
+        fs::create_dir_all(cache_file.parent().unwrap()).unwrap();
+        fs::write(cache_file, "cache contents").unwrap();
+        assert_eq!(
+            source_changed,
+            task_hash(),
+            "nested {cache} contents must not affect Python task hashes"
+        );
+    }
+}
+
+#[test]
+fn test_uv_root_and_member_pytest_both_run_and_member_filter_uses_direct_declaration() {
     let tempdir = tempfile::tempdir().unwrap();
     setup_uv_pure_workspace(tempdir.path());
     append_manifest(
@@ -351,10 +403,14 @@ fn test_uv_root_pytest_is_workspace_only_and_member_filter_uses_direct_declarati
     );
 
     let workspace = dry_run_tasks(tempdir.path(), &["test"]);
-    assert_eq!(task_ids(&workspace), ["acme#test"]);
+    assert_eq!(task_ids(&workspace), ["acme#test", "py-app#test"]);
     assert_eq!(
         find_task(&workspace, "acme#test")["command"],
-        "uv run --active --frozen pytest"
+        "uv run --active --frozen --all-packages pytest"
+    );
+    assert_eq!(
+        find_task(&workspace, "py-app#test")["command"],
+        "uv run --active --frozen --package py-app pytest packages/py-app"
     );
 
     let app = dry_run_tasks(tempdir.path(), &["test", "--filter=py-app"]);


### PR DESCRIPTION
## Summary

- Hash Python workspace member sources and recursively exclude Python tool caches.
- Run root pytest with all workspace members installed, and retain the native `uv check` type-checking fallback.
- Normalize leading `./` input patterns in the Git-free hasher so native Rust and Python workspace task inputs are not silently omitted.
- Update Python support documentation and add regressions for workspace task hashing.

## Verification

- Validated cache invalidation in a Git-free copy of the combined Rust/Python workspace: Python source edits produced a Ruff cache miss and F401; Rust test edits produced a cache miss and failed test.
