### PR TITLE
feat: Make daemon discovery toolchain generic

### DIFF
--- a/crates/turborepo-daemon/src/client.rs
+++ b/crates/turborepo-daemon/src/client.rs
@@ -6,6 +6,13 @@ use thiserror::Error;
 use tonic::{Code, IntoRequest, Status};
 use tracing::info;
 use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPath, PathError};
+use turborepo_repository::{
+    package_graph::{
+        PackageName, RepositoryDiscoveryScope, RepositoryDiscoverySnapshot,
+        RepositoryDiscoveryWorkspaceRoot,
+    },
+    toolchain::ToolchainId,
+};
 use turborepo_types::TaskInputs;
 
 use super::{
@@ -15,6 +22,41 @@ use super::{
     Paths,
 };
 use crate::proto::{self, PackageChangeEvent};
+
+fn repository_discovery_from_proto(
+    response: DiscoverPackagesResponse,
+) -> Result<RepositoryDiscoverySnapshot, DaemonError> {
+    let scopes = response
+        .scopes
+        .into_iter()
+        .map(|scope| {
+            Ok::<_, DaemonError>(RepositoryDiscoveryScope {
+                name: PackageName::from(scope.name),
+                toolchain: ToolchainId::new(scope.toolchain),
+                manifest_path: AbsoluteSystemPathBuf::new(scope.manifest_path)
+                    .map_err(|_| DaemonError::MalformedResponse)?,
+                tasks: scope.tasks,
+            })
+        })
+        .collect::<Result<_, _>>()?;
+    let workspace_roots = response
+        .workspace_roots
+        .into_iter()
+        .map(|root| {
+            Ok::<_, DaemonError>(RepositoryDiscoveryWorkspaceRoot {
+                toolchain: ToolchainId::new(root.toolchain),
+                kind: root.kind,
+                path: AbsoluteSystemPathBuf::new(root.path)
+                    .map_err(|_| DaemonError::MalformedResponse)?,
+            })
+        })
+        .collect::<Result<_, _>>()?;
+
+    Ok(RepositoryDiscoverySnapshot {
+        scopes,
+        workspace_roots,
+    })
+}
 
 #[derive(Debug, Clone)]
 pub struct DaemonClient<T> {
@@ -148,6 +190,12 @@ impl<T> DaemonClient<T> {
         Ok(response)
     }
 
+    pub async fn discover_repository_blocking(
+        &mut self,
+    ) -> Result<RepositoryDiscoverySnapshot, DaemonError> {
+        repository_discovery_from_proto(self.discover_packages_blocking().await?)
+    }
+
     pub async fn package_changes(
         &mut self,
     ) -> Result<tonic::codec::Streaming<PackageChangeEvent>, DaemonError> {
@@ -276,7 +324,10 @@ impl From<Status> for DaemonError {
 mod test {
     use std::path::MAIN_SEPARATOR_STR;
 
-    use crate::client::format_repo_relative_glob;
+    use crate::{
+        client::{format_repo_relative_glob, repository_discovery_from_proto},
+        proto::{DiscoverPackagesResponse, RepositoryScope, RepositoryWorkspaceRoot},
+    };
 
     #[test]
     fn test_format_repo_relative_glob() {
@@ -288,5 +339,37 @@ mod test {
 
         let result = format_repo_relative_glob(&raw_glob);
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn decodes_generic_repository_discovery() {
+        let manifest_path = if cfg!(windows) {
+            r"C:\repo\Cargo.toml"
+        } else {
+            "/repo/Cargo.toml"
+        };
+        let response = DiscoverPackagesResponse {
+            scopes: vec![RepositoryScope {
+                name: "api".to_string(),
+                toolchain: "rust".to_string(),
+                manifest_path: manifest_path.to_string(),
+                tasks: vec!["build".to_string(), "test".to_string()],
+            }],
+            workspace_roots: vec![RepositoryWorkspaceRoot {
+                toolchain: "rust".to_string(),
+                kind: "cargo".to_string(),
+                path: if cfg!(windows) {
+                    r"C:\repo".to_string()
+                } else {
+                    "/repo".to_string()
+                },
+            }],
+        };
+
+        let snapshot = repository_discovery_from_proto(response).unwrap();
+        assert_eq!(snapshot.scopes[0].name.as_str(), "api");
+        assert_eq!(snapshot.scopes[0].toolchain.as_str(), "rust");
+        assert_eq!(snapshot.scopes[0].tasks, ["build", "test"]);
+        assert_eq!(snapshot.workspace_roots[0].kind, "cargo");
     }
 }

--- a/crates/turborepo-daemon/src/lib.rs
+++ b/crates/turborepo-daemon/src/lib.rs
@@ -240,7 +240,7 @@ pub mod proto {
     /// - Bump the minor version if adding new features, such that clients can
     ///   mandate at least some set of features on the target server.
     /// - Bump the patch version if making backwards compatible bug fixes.
-    pub const VERSION: &str = "3.0.0";
+    pub const VERSION: &str = "3.1.0";
 }
 
 #[cfg(test)]

--- a/crates/turborepo-daemon/src/package_changes_watcher.rs
+++ b/crates/turborepo-daemon/src/package_changes_watcher.rs
@@ -25,7 +25,7 @@ impl RediscoveringPackageChangesWatcher {
         let (package_changes_tx, package_changes_rx) = broadcast::channel(16);
         let (repository_discovery_tx, repository_discovery_rx) = watch::channel(None);
         let _handle = tokio::spawn(async move {
-            if let Some(snapshot) = javascript_discovery_snapshot(&args).await {
+            if let Some(snapshot) = repository_discovery_snapshot(&args).await {
                 repository_discovery_tx.send_replace(Some(Arc::new(snapshot)));
             }
 
@@ -37,7 +37,7 @@ impl RediscoveringPackageChangesWatcher {
             loop {
                 match events.recv().await {
                     Ok(_) | Err(broadcast::error::RecvError::Lagged(_)) => {
-                        if let Some(snapshot) = javascript_discovery_snapshot(&args).await {
+                        if let Some(snapshot) = repository_discovery_snapshot(&args).await {
                             repository_discovery_tx.send_replace(Some(Arc::new(snapshot)));
                         }
                         let _ = package_changes_tx.send(PackageChangeEvent::Rediscover);
@@ -55,13 +55,32 @@ impl RediscoveringPackageChangesWatcher {
     }
 }
 
-async fn javascript_discovery_snapshot(
+async fn repository_discovery_snapshot(
     args: &PackageChangesWatcherArgs,
 ) -> Option<RepositoryDiscoverySnapshot> {
-    let root_package_json =
-        PackageJson::load(&args.repo_root.join_component("package.json")).ok()?;
-    PackageGraph::builder(&args.repo_root, root_package_json)
-        .with_allow_no_package_manager(args.allow_no_package_manager)
+    let package_json_path = args.repo_root.join_component("package.json");
+    let cargo_enabled = args
+        .repo_root
+        .join_component(turborepo_repository::cargo::CARGO_TOML)
+        .exists();
+    let python_enabled = args
+        .repo_root
+        .join_component(turborepo_repository::uv::PYPROJECT_TOML)
+        .exists();
+    let root_package_json = PackageJson::load(&package_json_path).ok();
+    if root_package_json.is_none() && !cargo_enabled && !python_enabled {
+        return None;
+    }
+
+    let mut builder = PackageGraph::builder_optional(&args.repo_root, root_package_json)
+        .with_allow_no_package_manager(args.allow_no_package_manager);
+    if cargo_enabled {
+        builder = builder.with_cargo();
+    }
+    if python_enabled {
+        builder = builder.with_uv();
+    }
+    builder
         .build()
         .await
         .ok()

--- a/crates/turborepo-daemon/src/package_discovery.rs
+++ b/crates/turborepo-daemon/src/package_discovery.rs
@@ -76,6 +76,7 @@ mod tests {
             } else {
                 "/repo/apps/web/package.json".to_string()
             },
+            tasks: vec!["build".to_string()],
         };
         let rust = RepositoryScope {
             name: "api".to_string(),
@@ -85,6 +86,7 @@ mod tests {
             } else {
                 "/repo/crates/api/Cargo.toml".to_string()
             },
+            tasks: vec!["build".to_string()],
         };
 
         assert!(javascript_workspace_from_proto(javascript)

--- a/crates/turborepo-daemon/src/proto/turbod.proto
+++ b/crates/turborepo-daemon/src/proto/turbod.proto
@@ -127,6 +127,7 @@ message RepositoryScope {
   string name = 1;
   string toolchain = 2;
   string manifest_path = 3;
+  repeated string tasks = 4;
 }
 
 message RepositoryWorkspaceRoot {

--- a/crates/turborepo-daemon/src/server.rs
+++ b/crates/turborepo-daemon/src/server.rs
@@ -502,6 +502,7 @@ fn discovery_response(
                 name: scope.name.as_str().to_string(),
                 toolchain: scope.toolchain.as_str().to_string(),
                 manifest_path: scope.manifest_path.to_string(),
+                tasks: scope.tasks.clone(),
             })
             .collect(),
         workspace_roots: snapshot

--- a/crates/turborepo-lsp/src/lib.rs
+++ b/crates/turborepo-lsp/src/lib.rs
@@ -32,14 +32,16 @@ use tower_lsp::{
 };
 use turbopath::AbsoluteSystemPathBuf;
 use turborepo_daemon::{
-    DaemonClient, DaemonConnector, DaemonConnectorError, DaemonError, DaemonPackageDiscovery,
-    Paths as DaemonPaths,
+    DaemonClient, DaemonConnector, DaemonConnectorError, DaemonError, Paths as DaemonPaths,
 };
 use turborepo_repository::{
-    discovery::{self, PackageDiscovery},
+    discovery,
     inference::RepoState,
-    native_tasks::observation_from_package_json,
-    package_graph::{self, PackageGraph, PackageName},
+    package_graph::{self, PackageName, RepositoryDiscoverySnapshot},
+};
+#[cfg(test)]
+use turborepo_repository::{
+    native_tasks::observation_from_package_json, package_graph::PackageGraph,
     package_json::PackageJson,
 };
 
@@ -56,10 +58,11 @@ struct LspPackage {
     /// not represent (notably an unnamed workspace).
     identity: Option<PackageName>,
     source_path: AbsoluteSystemPathBuf,
-    source: String,
-    package_json: PackageJson,
+    source: Option<String>,
+    tasks: Vec<String>,
 }
 
+#[cfg(test)]
 #[derive(Debug)]
 struct PackageSource {
     text: String,
@@ -71,28 +74,18 @@ struct LspPackages {
     packages: Vec<LspPackage>,
 }
 
-impl LspPackages {
-    fn from_graph_or_unscoped(
-        graph: Result<PackageGraph, package_graph::Error>,
-        mut sources: HashMap<AbsoluteSystemPathBuf, PackageSource>,
-        root_path: &AbsoluteSystemPathBuf,
-    ) -> Self {
-        match graph {
-            Ok(graph) => Self::from_graph(&graph, sources),
-            Err(_) => {
-                let root = sources.remove(root_path).map(|source| LspPackage {
-                    identity: Some(PackageName::Root),
-                    source_path: root_path.clone(),
-                    source: source.text,
-                    package_json: source.package_json,
-                });
-                let mut packages = Self::unscoped(sources).packages;
-                packages.extend(root);
-                Self::new(packages)
-            }
-        }
-    }
+#[cfg(test)]
+fn task_names_from_package_json(identity: &PackageName, package_json: &PackageJson) -> Vec<String> {
+    observation_from_package_json(identity.as_str(), package_json)
+        .tasks
+        .into_iter()
+        .filter(|task| task.script().is_some())
+        .map(|task| task.name().to_string())
+        .collect()
+}
 
+impl LspPackages {
+    #[cfg(test)]
     fn from_graph(
         graph: &PackageGraph,
         mut sources: HashMap<AbsoluteSystemPathBuf, PackageSource>,
@@ -116,22 +109,23 @@ impl LspPackages {
                 continue;
             }
             packages.push(LspPackage {
+                tasks: task_names_from_package_json(&identity, &source.package_json),
                 identity: Some(identity),
                 source_path: definition_path,
-                source: source.text,
-                package_json: source.package_json,
+                source: Some(source.text),
             });
         }
 
         packages.extend(sources.into_iter().map(|(source_path, source)| LspPackage {
             identity: None,
             source_path,
-            source: source.text,
-            package_json: source.package_json,
+            tasks: task_names_from_package_json(&PackageName::Root, &source.package_json),
+            source: Some(source.text),
         }));
         Self::new(packages)
     }
 
+    #[cfg(test)]
     fn unscoped(sources: HashMap<AbsoluteSystemPathBuf, PackageSource>) -> Self {
         Self::new(
             sources
@@ -139,8 +133,8 @@ impl LspPackages {
                 .map(|(source_path, source)| LspPackage {
                     identity: None,
                     source_path,
-                    source: source.text,
-                    package_json: source.package_json,
+                    tasks: task_names_from_package_json(&PackageName::Root, &source.package_json),
+                    source: Some(source.text),
                 })
                 .collect(),
         )
@@ -155,20 +149,28 @@ impl LspPackages {
         Self { packages }
     }
 
-    /// Map an unsaved/in-memory package.json payload to the same native-task
-    /// observation vocabulary used by the repository catalog.
-    fn observed_task_names(package: &LspPackage) -> Vec<String> {
-        let scope = package
-            .identity
-            .as_ref()
-            .map(|identity| identity.as_str())
-            .unwrap_or("//");
-        observation_from_package_json(scope, &package.package_json)
-            .tasks
-            .into_iter()
-            .filter(|task| task.script().is_some())
-            .map(|task| task.name().to_string())
-            .collect()
+    fn from_repository_discovery(response: RepositoryDiscoverySnapshot) -> Self {
+        Self::new(
+            response
+                .scopes
+                .into_iter()
+                .filter_map(|scope| {
+                    let source_path = scope.manifest_path;
+                    let identity = scope.name;
+                    let source = std::fs::read_to_string(&source_path).ok();
+                    Some(LspPackage {
+                        identity: Some(identity),
+                        source_path,
+                        source,
+                        tasks: scope.tasks,
+                    })
+                })
+                .collect(),
+        )
+    }
+
+    fn observed_task_names(package: &LspPackage) -> &[String] {
+        &package.tasks
     }
 
     fn task_index(&self) -> HashMap<String, Vec<Option<String>>> {
@@ -179,7 +181,7 @@ impl LspPackages {
                 .as_ref()
                 .map(|identity| identity.as_str().to_string());
             for script in Self::observed_task_names(package) {
-                let identities = tasks.entry(script).or_default();
+                let identities = tasks.entry(script.clone()).or_default();
                 if !identities.contains(&identity) {
                     identities.push(identity.clone());
                 }
@@ -192,11 +194,15 @@ impl LspPackages {
         let qualified = self.packages.iter().flat_map(|package| {
             package.identity.iter().flat_map(|identity| {
                 Self::observed_task_names(package)
-                    .into_iter()
+                    .iter()
                     .map(move |script| format!("{}#{script}", identity.as_str()))
             })
         });
-        let tasks = self.packages.iter().flat_map(Self::observed_task_names);
+        let tasks = self
+            .packages
+            .iter()
+            .flat_map(Self::observed_task_names)
+            .cloned();
 
         qualified.chain(tasks).unique().collect()
     }
@@ -220,10 +226,13 @@ impl LspPackages {
                     .any(|name| name == task)
             })
             .filter_map(|package| {
+                // Native task locations are not yet normalized into repository
+                // knowledge. JavaScript source remains optional enrichment.
+                let source = package.source.as_deref()?;
                 // TODO: use jsonc_ast instead of text search.
-                let start = package.source.find(&format!("\"{task}\""))?;
+                let start = source.find(&format!("\"{task}\""))?;
                 let end = start + task.len() + 2;
-                let rope = crop::Rope::from(package.source.as_str());
+                let rope = crop::Rope::from(source);
                 let start_line = rope.line_of_byte(start);
                 let end_line = rope.line_of_byte(end);
                 let range = Range {
@@ -260,6 +269,7 @@ impl LspPackageCache {
     }
 }
 
+#[cfg(test)]
 fn retain_unique_named(package_jsons: &mut HashMap<AbsoluteSystemPathBuf, PackageJson>) {
     let counts = package_jsons
         .values()
@@ -813,9 +823,7 @@ impl LanguageServer for Backend {
     }
 
     async fn did_save(&self, document: DidSaveTextDocumentParams) {
-        if document.text_document.uri.path().ends_with("/package.json") {
-            self.packages.invalidate();
-        }
+        self.packages.invalidate();
         self.client
             .log_message(
                 MessageType::INFO,
@@ -881,26 +889,11 @@ impl Backend {
         if let Some(packages) = self.packages.get() {
             return Ok(packages);
         }
-        let repo_root =
-            lock_or_recover(&self.repo_root)
-                .clone()
-                .ok_or(package_graph::Error::Discovery(
-                    discovery::Error::Unavailable,
-                ))?;
-        let root_manifest_path = repo_root.join_component("package.json");
-
-        // LSP has no Cargo package features today. Still construct the same
-        // repository view so a pure Cargo repository cannot gain a synthetic
-        // JavaScript manifest or root script scope.
-        if !root_manifest_path.exists() {
-            let graph = PackageGraph::builder_optional(&repo_root, None)
-                .build()
-                .await?;
-            let packages = Arc::new(LspPackages::from_graph(&graph, HashMap::new()));
-            self.packages.set(packages.clone());
-            return Ok(packages);
+        if lock_or_recover(&self.repo_root).is_none() {
+            return Err(package_graph::Error::Discovery(
+                discovery::Error::Unavailable,
+            ));
         }
-
         let daemon = {
             let mut daemon = self.daemon.clone();
             let daemon = daemon
@@ -915,54 +908,14 @@ impl Backend {
             daemon.clone()
         };
 
-        let response = DaemonPackageDiscovery::new(daemon, repo_root.clone())
-            .discover_packages_blocking()
-            .await?;
-
-        // Parse each manifest once. The parsed map seeds graph construction;
-        // the parallel source map is retained only for scripts and ranges.
-        let mut package_jsons = HashMap::with_capacity(response.workspaces.len());
-        let mut sources = HashMap::with_capacity(response.workspaces.len() + 1);
-        for workspace in response.workspaces {
-            let (package_json_path, _) = workspace.into_paths();
-            let Ok(text) = std::fs::read_to_string(&package_json_path) else {
-                continue;
-            };
-            let Ok(package_json) = PackageJson::load_from_str(&text, package_json_path.as_str())
-            else {
-                continue;
-            };
-            package_jsons.insert(package_json_path.clone(), package_json.clone());
-            sources.insert(package_json_path, PackageSource { text, package_json });
-        }
-        retain_unique_named(&mut package_jsons);
-
-        let root_text = std::fs::read_to_string(&root_manifest_path).ok();
-        let parsed_root = root_text
-            .as_deref()
-            .and_then(|text| PackageJson::load_from_str(text, root_manifest_path.as_str()).ok());
-        let root_package_json = parsed_root.clone().unwrap_or_default();
-        if let (Some(text), Some(package_json)) = (root_text, parsed_root) {
-            sources.insert(
-                root_manifest_path.clone(),
-                PackageSource { text, package_json },
-            );
-        }
-
-        let graph = PackageGraph::builder(&repo_root, root_package_json)
-            .with_package_manager(response.package_manager)
-            .with_package_jsons(Some(package_jsons))
-            .build()
-            .await;
-
-        // Discovery succeeded, so repository validation errors should not
-        // disable every LSP script feature. Sources that cannot be joined to
-        // authoritative knowledge remain deliberately unscoped.
-        let packages = Arc::new(LspPackages::from_graph_or_unscoped(
-            graph,
-            sources,
-            &root_manifest_path,
-        ));
+        let mut daemon = daemon;
+        let response = daemon
+            .discover_repository_blocking()
+            .await
+            .map_err(|error| {
+                package_graph::Error::Discovery(discovery::Error::Failed(Box::new(error)))
+            })?;
+        let packages = Arc::new(LspPackages::from_repository_discovery(response));
         self.packages.set(packages.clone());
         Ok(packages)
     }
@@ -1731,6 +1684,48 @@ mod tests {
             Some(&vec![Some("//".to_string()), Some("@repo/ui".to_string())])
         );
         assert_eq!(tasks.get("test"), Some(&vec![Some("@repo/ui".to_string())]));
+    }
+
+    #[test]
+    fn repository_discovery_indexes_tasks_from_every_toolchain() {
+        let repository = TestRepository::new();
+        let js_manifest = repository.root.join_component("package.json");
+        js_manifest
+            .create_with_contents(r#"{"scripts":{"lint":"eslint"}}"#)
+            .expect("JavaScript manifest");
+        let rust_manifest = repository.root.join_component("Cargo.toml");
+        rust_manifest
+            .create_with_contents("[package]\nname = \"api\"\nversion = \"0.1.0\"\n")
+            .expect("Rust manifest");
+        let packages = LspPackages::from_repository_discovery(
+            turborepo_repository::package_graph::RepositoryDiscoverySnapshot {
+                scopes: vec![
+                    turborepo_repository::package_graph::RepositoryDiscoveryScope {
+                        name: PackageName::Root,
+                        toolchain: turborepo_repository::toolchain::ToolchainId::JAVASCRIPT,
+                        manifest_path: js_manifest,
+                        tasks: vec!["lint".to_string()],
+                    },
+                    turborepo_repository::package_graph::RepositoryDiscoveryScope {
+                        name: PackageName::from("api"),
+                        toolchain: turborepo_repository::toolchain::ToolchainId::RUST,
+                        manifest_path: rust_manifest,
+                        tasks: vec!["build".to_string(), "test".to_string()],
+                    },
+                ],
+                workspace_roots: Vec::new(),
+            },
+        );
+
+        let labels = packages.completion_labels();
+        assert!(labels.contains(&"//#lint".to_string()));
+        assert!(labels.contains(&"api#build".to_string()));
+        assert!(labels.contains(&"api#test".to_string()));
+        assert_eq!(
+            packages.task_index().get("build"),
+            Some(&vec![Some("api".to_string())])
+        );
+        assert_eq!(packages.references("api#build").len(), 0);
     }
 
     #[tokio::test]

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -155,6 +155,7 @@ pub struct RepositoryDiscoveryScope {
     pub name: PackageName,
     pub toolchain: crate::toolchain::ToolchainId,
     pub manifest_path: AbsoluteSystemPathBuf,
+    pub tasks: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -726,14 +727,19 @@ impl PackageGraph {
     /// repository consumers such as the daemon.
     pub fn repository_discovery_snapshot(&self) -> RepositoryDiscoverySnapshot {
         let scopes = self
-            .package_scope_directories()
-            .filter_map(|(name, _)| {
+            .package_task_contexts()
+            .filter_map(|context| {
                 Some(RepositoryDiscoveryScope {
-                    toolchain: self.package_toolchain(&name)?.clone(),
-                    manifest_path: self
-                        .repo_root()
-                        .resolve(self.package_definition_path(&name)?),
-                    name,
+                    name: context.package().clone(),
+                    toolchain: context.toolchain()?.clone(),
+                    manifest_path: self.repo_root().resolve(context.definition_path?),
+                    tasks: context
+                        .native_tasks()
+                        .tasks()
+                        .iter()
+                        .filter(|task| task.authored() || task.registered())
+                        .map(|task| task.name().to_string())
+                        .collect(),
                 })
             })
             .collect();
@@ -3088,11 +3094,13 @@ version = "0.1.0"
                 scope.name == PackageName::from("js-pkg")
                     && scope.toolchain == crate::toolchain::ToolchainId::JAVASCRIPT
                     && scope.manifest_path.ends_with("js-pkg/package.json")
+                    && scope.tasks.is_empty()
             }));
             assert!(discovery.scopes.iter().any(|scope| {
                 scope.name == PackageName::from("app")
                     && scope.toolchain == crate::toolchain::ToolchainId::RUST
                     && scope.manifest_path.ends_with("rust/app/Cargo.toml")
+                    && scope.tasks.contains(&"build".to_string())
             }));
             assert!(discovery.workspace_roots.iter().any(|workspace_root| {
                 workspace_root.toolchain == crate::toolchain::ToolchainId::JAVASCRIPT

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -101,18 +101,22 @@ without requiring the LSP to depend on `turborepo-lib`.
 The `turbo` application supplies its package-graph-aware change watcher and
 keeps CLI-specific rendering in `turborepo-lib`. Each completed graph generation
 also publishes one immutable repository-discovery snapshot to the daemon. The
-snapshot contains toolchain-tagged scope identities and manifest paths plus
-workspace-root observations, so the daemon protocol does not encode
-`package.json`, JavaScript package managers, or any other ecosystem-specific
-metadata. Consumers that only support one ecosystem filter by toolchain
-explicitly; the JavaScript package-discovery adapter is one such compatibility
-boundary.
+snapshot contains toolchain-tagged scope identities, manifest paths, and
+normalized task names plus workspace-root observations, so the daemon protocol
+does not encode `package.json`, JavaScript package managers, or any other
+ecosystem-specific metadata. The daemon client decodes this wire representation
+back into repository-owned snapshot types. Consumers that only support one
+ecosystem filter by toolchain explicitly; the JavaScript package-discovery
+adapter is one such compatibility boundary.
 
-The standalone LSP supplies a conservative daemon-owned watcher that emits full
-rediscovery for filesystem changes and rebuilds a JavaScript-only graph snapshot.
-This preserves correctness when the packaged LSP hosts the daemon, while the
-richer watcher uses the feature-enabled multi-toolchain graph and avoids
-unnecessary rediscovery when `turbo` hosts it.
+The LSP consumes the generic snapshot directly for package identity, task
+completion, and task validation rather than rebuilding a JavaScript-only graph.
+Manifest text is optional enrichment for reference locations; it is not the
+authority for scope identity or task membership. The standalone LSP daemon
+supplies a conservative watcher that emits full rediscovery and enables built-in
+Cargo and uv contributors when their root manifests are present. The richer
+`turbo` watcher continues to use command feature flags and avoids unnecessary
+rediscovery.
 
 ### 1. Run Builder (`crates/turborepo-lib/src/run/builder.rs`)
 


### PR DESCRIPTION
### Description

Make daemon-backed repository discovery and LSP task indexing generic across language toolchains.

- Add normalized native task names to each toolchain-tagged repository scope published by `PackageGraph`.
- Decode the daemon wire response into repository-owned discovery snapshot types instead of exposing protobuf types to consumers.
- Have the LSP consume the generic snapshot directly for package identity, completion, and task validation rather than rebuilding a JavaScript-only graph.
- Keep manifest text as optional reference-location enrichment instead of task or identity authority.
- Enable Cargo and uv contributors in the standalone LSP daemon when their root manifests are present.
- Invalidate the LSP package cache when any document is saved, not only `package.json`.
- Bump the daemon protocol minor version for the new task-catalog capability.
- Document the generic daemon/LSP discovery flow.

### Testing Instructions

```shell
cargo test -p turborepo-lsp --lib
cargo test -p turborepo-daemon --lib
cargo test -p turborepo-repository --lib package_graph::test::test_cargo_toolchain_packages_in_graph
cargo check -p turborepo-repository -p turborepo-daemon -p turborepo-lsp --tests
```
