### PR TITLE
feat: Add native Go task tables

### DIFF
--- a/crates/turborepo-repository/src/go.rs
+++ b/crates/turborepo-repository/src/go.rs
@@ -529,7 +529,7 @@ pub fn native_tasks_for_module(module: &GoModule) -> Vec<crate::native_tasks::Na
             WorkingDirectoryPolicy::PackageDirectory,
         ),
         go_command_task(
-            "vet",
+            "lint",
             "vet",
             vec!["./...".to_string()],
             PassThroughPlacement::BeforeSuffix,
@@ -575,12 +575,12 @@ pub fn native_tasks_for_workspace(
     let mut module_patterns = module_patterns.to_vec();
     module_patterns.sort();
     module_patterns.dedup();
-    let mut tasks = ["test", "vet", "format"]
+    let mut tasks = [("test", "test"), ("lint", "vet"), ("format", "fmt")]
         .into_iter()
-        .map(|name| {
+        .map(|(name, subcommand)| {
             go_command_task(
                 name,
-                if name == "format" { "fmt" } else { name },
+                subcommand,
                 module_patterns.clone(),
                 PassThroughPlacement::BeforeSuffix,
                 (name == "format").then_some(false),
@@ -918,6 +918,17 @@ mod tests {
             ["build", "-race", "./..."].map(std::ffi::OsString::from)
         );
         assert_eq!(build.cwd, root.join_components(&["apps", "api"]));
+        let lint = resolve_go_cmd(&context, "lint", Some(&["-json".to_string()]), None);
+        assert_eq!(
+            lint.args,
+            ["vet", "-json", "./..."].map(std::ffi::OsString::from)
+        );
+        assert!(!context.native_tasks().contains_key("vet"));
+        assert!(
+            !native_tasks_for_workspace(&["./apps/api/...".to_string()])
+                .iter()
+                .any(|task| task.name() == "vet")
+        );
         assert_eq!(
             context
                 .native_tasks()

--- a/crates/turborepo-repository/src/go.rs
+++ b/crates/turborepo-repository/src/go.rs
@@ -886,7 +886,7 @@ mod tests {
             native_task,
             None,
             None,
-            Some(Path::new("/bin/go")),
+            Some(Path::new("go")),
             pass_through_args,
             override_command,
         )
@@ -896,7 +896,9 @@ mod tests {
 
     #[test]
     fn module_task_table_renders_commands_and_argument_placement() {
-        let root = AbsoluteSystemPathBuf::new("/repo").unwrap();
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPathBuf::try_from(tempdir.path()).unwrap();
+        assert!(root.as_std_path().is_absolute());
         let module = GoModule {
             module_path: "example.com/api".to_string(),
             manifest_path: root.join_components(&["apps", "api", GO_MOD]),
@@ -916,6 +918,7 @@ mod tests {
             build.args,
             ["build", "-race", "./..."].map(std::ffi::OsString::from)
         );
+        assert_eq!(build.program, std::ffi::OsString::from("go"));
         assert_eq!(build.cwd, root.join_components(&["apps", "api"]));
         let lint = resolve_go_cmd(&context, "lint", Some(&["-json".to_string()]), None);
         assert_eq!(

--- a/crates/turborepo-repository/src/go.rs
+++ b/crates/turborepo-repository/src/go.rs
@@ -36,6 +36,9 @@ pub const GO_WORK: &str = "go.work";
 /// The conventional file name for a Go module manifest.
 pub const GO_MOD: &str = "go.mod";
 
+/// Deterministic identity for the workspace-wide Go verification scope.
+pub const GO_WORKSPACE_NAME: &str = "go-workspace";
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("failed to run `{command}`: {source}")]
@@ -106,6 +109,8 @@ pub struct GoModule {
     pub manifest_path: AbsoluteSystemPathBuf,
     /// Direct internal relationships to other workspace modules.
     pub relationships: Vec<Relationship>,
+    /// Package pattern for the sole runnable `main` package, when unambiguous.
+    pub runnable_target: Option<String>,
 }
 
 /// The result of Go workspace discovery.
@@ -158,6 +163,14 @@ struct GoModModuleRef {
     #[serde(rename = "Version")]
     #[allow(dead_code)]
     version: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoListPackage {
+    #[serde(rename = "Dir")]
+    directory: String,
+    #[serde(rename = "Name")]
+    name: String,
 }
 
 fn run_go(
@@ -217,6 +230,48 @@ fn go_mod_graph(repo_root: &AbsoluteSystemPath) -> Result<String, Error> {
         });
     }
     Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+fn runnable_target(module_dir: &AbsoluteSystemPath) -> Result<Option<String>, Error> {
+    const COMMAND: &str = "go list -find -json ./...";
+
+    let output = run_go(
+        module_dir,
+        &["list", "-find", "-json", "./..."],
+        COMMAND,
+    )?;
+    // Runnable defaults are optional. If Go cannot classify every package
+    // without error, omit them rather than making workspace discovery fail.
+    if !output.status.success() {
+        return Ok(None);
+    }
+
+    let packages = serde_json::Deserializer::from_slice(&output.stdout)
+        .into_iter::<GoListPackage>();
+    let mut runnable = None;
+    for package in packages {
+        let package = package.map_err(|source| Error::CommandParse {
+            command: COMMAND,
+            source,
+        })?;
+        if package.name != "main" {
+            continue;
+        }
+        let Ok(relative) = Path::new(&package.directory).strip_prefix(module_dir.as_std_path())
+        else {
+            return Ok(None);
+        };
+        let relative = relative.to_string_lossy().replace('\\', "/");
+        let target = if relative.is_empty() {
+            ".".to_string()
+        } else {
+            format!("./{relative}")
+        };
+        if runnable.replace(target).is_some() {
+            return Ok(None);
+        }
+    }
+    Ok(runnable)
 }
 
 fn join_relative_path(
@@ -391,6 +446,7 @@ pub fn discover_workspace(repo_root: &AbsoluteSystemPath) -> Result<DiscoveredWo
             module_path,
             manifest_path: member_dir.join_component(GO_MOD),
             relationships: Vec::new(),
+            runnable_target: runnable_target(&member_dir)?,
         });
     }
 
@@ -415,6 +471,141 @@ pub fn discover_workspace(repo_root: &AbsoluteSystemPath) -> Result<DiscoveredWo
     Ok(DiscoveredWorkspace { modules })
 }
 
+fn go_command_task(
+    name: &'static str,
+    subcommand: &'static str,
+    targets: Vec<String>,
+    pass_through_placement: crate::native_tasks::PassThroughPlacement,
+    cache: Option<bool>,
+    entrypoint: crate::native_tasks::TaskEntrypoint,
+    cwd_policy: crate::native_tasks::WorkingDirectoryPolicy,
+) -> crate::native_tasks::NativeTask {
+    use crate::native_tasks::{
+        NativeCommandArguments, NativeCommandProgram, NativeTask, NativeTaskContract,
+    };
+
+    NativeTask::command_task(
+        name,
+        format!("go {subcommand} {}", targets.join(" ")),
+        NativeCommandProgram::Tool("go".to_string()),
+        NativeCommandArguments {
+            prefix: vec![subcommand.to_string()],
+            pass_through_placement,
+            pass_through_separator: None,
+            suffix: targets,
+        },
+        None,
+        cwd_policy,
+    )
+    .with_contract(NativeTaskContract::new(
+        toolchain::TaskDefaults { cache },
+        Some(entrypoint),
+        false,
+    ))
+}
+
+/// Build the conservative built-in task table for one Go module.
+pub fn native_tasks_for_module(module: &GoModule) -> Vec<crate::native_tasks::NativeTask> {
+    use crate::native_tasks::{
+        PassThroughPlacement, TaskEntrypoint, WorkingDirectoryPolicy,
+    };
+
+    let build_entrypoint = if module.runnable_target.is_some() {
+        TaskEntrypoint::Preferred
+    } else {
+        TaskEntrypoint::Candidate
+    };
+    let mut tasks = vec![
+        go_command_task(
+            "build",
+            "build",
+            vec!["./...".to_string()],
+            PassThroughPlacement::BeforeSuffix,
+            module.runnable_target.is_none().then_some(false),
+            build_entrypoint,
+            WorkingDirectoryPolicy::PackageDirectory,
+        ),
+        go_command_task(
+            "test",
+            "test",
+            vec!["./...".to_string()],
+            PassThroughPlacement::BeforeSuffix,
+            None,
+            TaskEntrypoint::Candidate,
+            WorkingDirectoryPolicy::PackageDirectory,
+        ),
+        go_command_task(
+            "vet",
+            "vet",
+            vec!["./...".to_string()],
+            PassThroughPlacement::BeforeSuffix,
+            None,
+            TaskEntrypoint::Candidate,
+            WorkingDirectoryPolicy::PackageDirectory,
+        ),
+        go_command_task(
+            "format",
+            "fmt",
+            vec!["./...".to_string()],
+            PassThroughPlacement::BeforeSuffix,
+            Some(false),
+            TaskEntrypoint::Candidate,
+            WorkingDirectoryPolicy::PackageDirectory,
+        ),
+    ];
+    if let Some(target) = &module.runnable_target {
+        for name in ["run", "dev"] {
+            tasks.push(go_command_task(
+                name,
+                "run",
+                vec![target.clone()],
+                PassThroughPlacement::AfterSuffix,
+                Some(false),
+                TaskEntrypoint::Candidate,
+                WorkingDirectoryPolicy::PackageDirectory,
+            ));
+        }
+    }
+    tasks
+}
+
+/// Build workspace-wide verification tasks over explicit module patterns.
+pub fn native_tasks_for_workspace(
+    module_patterns: &[String],
+) -> Vec<crate::native_tasks::NativeTask> {
+    use crate::native_tasks::{
+        NativeTask, NativeTaskContract, PassThroughPlacement, TaskEntrypoint,
+        WorkingDirectoryPolicy,
+    };
+
+    let mut module_patterns = module_patterns.to_vec();
+    module_patterns.sort();
+    module_patterns.dedup();
+    let mut tasks = ["test", "vet", "format"]
+        .into_iter()
+        .map(|name| {
+            go_command_task(
+                name,
+                if name == "format" { "fmt" } else { name },
+                module_patterns.clone(),
+                PassThroughPlacement::BeforeSuffix,
+                (name == "format").then_some(false),
+                TaskEntrypoint::PreferredOnly,
+                WorkingDirectoryPolicy::RepositoryRoot,
+            )
+        })
+        .collect::<Vec<_>>();
+    tasks.push(NativeTask::contract_task(
+        "build",
+        NativeTaskContract::new(
+            toolchain::TaskDefaults::default(),
+            Some(TaskEntrypoint::Excluded),
+            false,
+        ),
+    ));
+    tasks
+}
+
 fn package_from_module(module: &GoModule) -> DiscoveredPackage {
     let descriptor = PackageJson {
         name: Some(turborepo_errors::Spanned::new(module.module_path.clone())),
@@ -426,6 +617,8 @@ fn package_from_module(module: &GoModule) -> DiscoveredPackage {
         module.manifest_path.clone(),
     )
     .with_native_relationships(module.relationships.clone())
+    .with_native_tasks(native_tasks_for_module(module))
+    .with_task_contract(crate::task_contracts::ScopeTaskContract::go())
 }
 
 /// The Go repository contributor. Registered during graph construction when
@@ -459,7 +652,46 @@ impl RepositoryContributor for GoContributor {
                 .into_iter()
                 .collect();
 
-            let packages = workspace.modules.iter().map(package_from_module).collect();
+            let mut module_patterns = workspace
+                .modules
+                .iter()
+                .filter_map(|module| {
+                    let directory = module.manifest_path.parent()?;
+                    let directory =
+                        turbopath::AnchoredSystemPathBuf::new(&self.repo_root, directory).ok()?;
+                    Some(format!("./{}/...", directory.to_unix()))
+                })
+                .collect::<Vec<_>>();
+            module_patterns.sort();
+
+            let mut module_names = workspace
+                .modules
+                .iter()
+                .map(|module| module.module_path.clone())
+                .collect::<Vec<_>>();
+            module_names.sort();
+            let workspace_relationships = module_names
+                .into_iter()
+                .map(|name| Relationship::internal(name, DependencyKind::Production))
+                .collect();
+
+            let mut packages = workspace
+                .modules
+                .iter()
+                .map(package_from_module)
+                .collect::<Vec<_>>();
+            if !packages.is_empty() {
+                packages.push(
+                    DiscoveredPackage::aggregate(
+                        GO_WORKSPACE_NAME.to_string(),
+                        PackageJson::default(),
+                        self.repo_root.join_component(GO_WORK),
+                    )
+                    .with_native_relationships(workspace_relationships)
+                    .with_native_tasks(native_tasks_for_workspace(&module_patterns))
+                    .with_task_contract(crate::task_contracts::ScopeTaskContract::go()),
+                );
+            }
 
             Ok(DiscoveredPackages::new(packages, workspace_roots))
         })
@@ -629,5 +861,130 @@ mod tests {
             HashSet::from(["example.com/api".to_string(), "example.com/lib".to_string()]);
         let relationships = relationships_from_mod_graph(graph, &module_paths).unwrap();
         assert_eq!(relationships["example.com/api"].len(), 1);
+    }
+
+    fn task_context<'a>(
+        root: &'a AbsoluteSystemPath,
+        name: &str,
+        directory: &'a str,
+        tasks: Vec<crate::native_tasks::NativeTask>,
+        kind: crate::package_graph::PackageTaskContextKind,
+    ) -> crate::package_graph::PackageTaskContext<'a> {
+        crate::package_graph::PackageTaskContext::new_for_test_with_native_tasks(
+            name.into(),
+            root,
+            turbopath::AnchoredSystemPath::new(directory).unwrap(),
+            kind,
+            Some(&ToolchainId::GO),
+            Some(tasks),
+            Some(crate::task_contracts::ScopeTaskContract::go()),
+        )
+    }
+
+    fn resolve_go_cmd(
+        context: &crate::package_graph::PackageTaskContext<'_>,
+        task: &str,
+        pass_through_args: Option<&[String]>,
+        override_command: Option<&[String]>,
+    ) -> crate::toolchain::TaskCommand {
+        let native_task = context.native_tasks().get(task).expect("native Go task");
+        crate::native_tasks::resolve_task_command(
+            context,
+            native_task,
+            None,
+            None,
+            Some(Path::new("/bin/go")),
+            pass_through_args,
+            override_command,
+        )
+        .unwrap()
+        .expect("Go command resolves")
+    }
+
+    #[test]
+    fn module_task_table_renders_commands_and_argument_placement() {
+        let root = AbsoluteSystemPathBuf::new("/repo").unwrap();
+        let module = GoModule {
+            module_path: "example.com/api".to_string(),
+            manifest_path: root.join_components(&["apps", "api", GO_MOD]),
+            relationships: Vec::new(),
+            runnable_target: Some("./cmd/api".to_string()),
+        };
+        let context = task_context(
+            &root,
+            &module.module_path,
+            "apps/api",
+            native_tasks_for_module(&module),
+            crate::package_graph::PackageTaskContextKind::Package,
+        );
+
+        let build = resolve_go_cmd(
+            &context,
+            "build",
+            Some(&["-race".to_string()]),
+            None,
+        );
+        assert_eq!(
+            build.args,
+            ["build", "-race", "./..."].map(std::ffi::OsString::from)
+        );
+        assert_eq!(build.cwd, root.join_components(&["apps", "api"]));
+        assert_eq!(
+            context
+                .native_tasks()
+                .get("build")
+                .unwrap()
+                .contract()
+                .entrypoint(),
+            Some(crate::native_tasks::TaskEntrypoint::Preferred)
+        );
+
+        let run = resolve_go_cmd(
+            &context,
+            "run",
+            Some(&["--port".to_string(), "3000".to_string()]),
+            None,
+        );
+        assert_eq!(
+            run.args,
+            ["run", "./cmd/api", "--port", "3000"].map(std::ffi::OsString::from)
+        );
+
+    }
+
+    #[test]
+    fn ambiguous_main_packages_do_not_register_run_defaults() {
+        if !go_available() {
+            return;
+        }
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPathBuf::try_from(tempdir.path()).unwrap();
+        write_workspace(&root, &[("apps/api", "example.com/api", "")]);
+        for command in ["first", "second"] {
+            join_relative_path(&root, &format!("apps/api/cmd/{command}"))
+                .unwrap()
+                .create_dir_all()
+                .unwrap();
+            join_relative_path(&root, &format!("apps/api/cmd/{command}/main.go"))
+                .unwrap()
+                .create_with_contents("package main\nfunc main() {}\n")
+                .unwrap();
+        }
+
+        let workspace = discover_workspace(&root).expect("workspace discovery succeeds");
+        let module = &workspace.modules[0];
+        assert_eq!(module.runnable_target, None);
+        let tasks = native_tasks_for_module(module);
+        assert!(!tasks.iter().any(|task| matches!(task.name(), "run" | "dev")));
+        assert_eq!(
+            tasks
+                .iter()
+                .find(|task| task.name() == "build")
+                .unwrap()
+                .contract()
+                .entrypoint(),
+            Some(crate::native_tasks::TaskEntrypoint::Candidate)
+        );
     }
 }

--- a/crates/turborepo-repository/src/go.rs
+++ b/crates/turborepo-repository/src/go.rs
@@ -109,7 +109,8 @@ pub struct GoModule {
     pub manifest_path: AbsoluteSystemPathBuf,
     /// Direct internal relationships to other workspace modules.
     pub relationships: Vec<Relationship>,
-    /// Package pattern for the sole runnable `main` package, when unambiguous.
+    /// Package pattern for the sole `main` package used by the `dev` task, when
+    /// unambiguous.
     pub runnable_target: Option<String>,
 }
 
@@ -236,8 +237,8 @@ fn runnable_target(module_dir: &AbsoluteSystemPath) -> Result<Option<String>, Er
     const COMMAND: &str = "go list -find -json ./...";
 
     let output = run_go(module_dir, &["list", "-find", "-json", "./..."], COMMAND)?;
-    // Runnable defaults are optional. If Go cannot classify every package
-    // without error, omit them rather than making workspace discovery fail.
+    // The native dev default is optional. If Go cannot classify every package
+    // without error, omit it rather than making workspace discovery fail.
     if !output.status.success() {
         return Ok(None);
     }
@@ -548,17 +549,15 @@ pub fn native_tasks_for_module(module: &GoModule) -> Vec<crate::native_tasks::Na
         ),
     ];
     if let Some(target) = &module.runnable_target {
-        for name in ["run", "dev"] {
-            tasks.push(go_command_task(
-                name,
-                "run",
-                vec![target.clone()],
-                PassThroughPlacement::AfterSuffix,
-                Some(false),
-                TaskEntrypoint::Candidate,
-                WorkingDirectoryPolicy::PackageDirectory,
-            ));
-        }
+        tasks.push(go_command_task(
+            "dev",
+            "run",
+            vec![target.clone()],
+            PassThroughPlacement::AfterSuffix,
+            Some(false),
+            TaskEntrypoint::Candidate,
+            WorkingDirectoryPolicy::PackageDirectory,
+        ));
     }
     tasks
 }
@@ -939,20 +938,21 @@ mod tests {
             Some(crate::native_tasks::TaskEntrypoint::Preferred)
         );
 
-        let run = resolve_go_cmd(
+        let dev = resolve_go_cmd(
             &context,
-            "run",
+            "dev",
             Some(&["--port".to_string(), "3000".to_string()]),
             None,
         );
         assert_eq!(
-            run.args,
+            dev.args,
             ["run", "./cmd/api", "--port", "3000"].map(std::ffi::OsString::from)
         );
+        assert!(context.native_tasks().get("run").is_none());
     }
 
     #[test]
-    fn ambiguous_main_packages_do_not_register_run_defaults() {
+    fn ambiguous_main_packages_do_not_register_dev_default() {
         if !go_available() {
             return;
         }
@@ -975,11 +975,8 @@ mod tests {
         let module = &workspace.modules[0];
         assert_eq!(module.runnable_target, None);
         let tasks = native_tasks_for_module(module);
-        assert!(
-            !tasks
-                .iter()
-                .any(|task| matches!(task.name(), "run" | "dev"))
-        );
+        assert!(!tasks.iter().any(|task| task.name() == "dev"));
+        assert!(!tasks.iter().any(|task| task.name() == "run"));
         assert_eq!(
             tasks
                 .iter()

--- a/crates/turborepo-repository/src/go.rs
+++ b/crates/turborepo-repository/src/go.rs
@@ -235,19 +235,15 @@ fn go_mod_graph(repo_root: &AbsoluteSystemPath) -> Result<String, Error> {
 fn runnable_target(module_dir: &AbsoluteSystemPath) -> Result<Option<String>, Error> {
     const COMMAND: &str = "go list -find -json ./...";
 
-    let output = run_go(
-        module_dir,
-        &["list", "-find", "-json", "./..."],
-        COMMAND,
-    )?;
+    let output = run_go(module_dir, &["list", "-find", "-json", "./..."], COMMAND)?;
     // Runnable defaults are optional. If Go cannot classify every package
     // without error, omit them rather than making workspace discovery fail.
     if !output.status.success() {
         return Ok(None);
     }
 
-    let packages = serde_json::Deserializer::from_slice(&output.stdout)
-        .into_iter::<GoListPackage>();
+    let packages =
+        serde_json::Deserializer::from_slice(&output.stdout).into_iter::<GoListPackage>();
     let mut runnable = None;
     for package in packages {
         let package = package.map_err(|source| Error::CommandParse {
@@ -506,9 +502,7 @@ fn go_command_task(
 
 /// Build the conservative built-in task table for one Go module.
 pub fn native_tasks_for_module(module: &GoModule) -> Vec<crate::native_tasks::NativeTask> {
-    use crate::native_tasks::{
-        PassThroughPlacement, TaskEntrypoint, WorkingDirectoryPolicy,
-    };
+    use crate::native_tasks::{PassThroughPlacement, TaskEntrypoint, WorkingDirectoryPolicy};
 
     let build_entrypoint = if module.runnable_target.is_some() {
         TaskEntrypoint::Preferred
@@ -918,12 +912,7 @@ mod tests {
             crate::package_graph::PackageTaskContextKind::Package,
         );
 
-        let build = resolve_go_cmd(
-            &context,
-            "build",
-            Some(&["-race".to_string()]),
-            None,
-        );
+        let build = resolve_go_cmd(&context, "build", Some(&["-race".to_string()]), None);
         assert_eq!(
             build.args,
             ["build", "-race", "./..."].map(std::ffi::OsString::from)
@@ -949,7 +938,6 @@ mod tests {
             run.args,
             ["run", "./cmd/api", "--port", "3000"].map(std::ffi::OsString::from)
         );
-
     }
 
     #[test]
@@ -976,7 +964,11 @@ mod tests {
         let module = &workspace.modules[0];
         assert_eq!(module.runnable_target, None);
         let tasks = native_tasks_for_module(module);
-        assert!(!tasks.iter().any(|task| matches!(task.name(), "run" | "dev")));
+        assert!(
+            !tasks
+                .iter()
+                .any(|task| matches!(task.name(), "run" | "dev"))
+        );
         assert_eq!(
             tasks
                 .iter()

--- a/crates/turborepo-repository/src/go.rs
+++ b/crates/turborepo-repository/src/go.rs
@@ -923,7 +923,7 @@ mod tests {
             lint.args,
             ["vet", "-json", "./..."].map(std::ffi::OsString::from)
         );
-        assert!(!context.native_tasks().contains_key("vet"));
+        assert!(context.native_tasks().get("vet").is_none());
         assert!(
             !native_tasks_for_workspace(&["./apps/api/...".to_string()])
                 .iter()

--- a/crates/turborepo-repository/src/task_contracts.rs
+++ b/crates/turborepo-repository/src/task_contracts.rs
@@ -55,6 +55,7 @@ pub enum CommandMapTarget {
     JavaScript,
     Rust,
     Python,
+    Go,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -80,7 +81,10 @@ impl CommandMapTarget {
     fn matches(self, key: &str) -> bool {
         matches!(
             (self, key),
-            (Self::JavaScript, "javascript") | (Self::Rust, "rust") | (Self::Python, "python")
+            (Self::JavaScript, "javascript")
+                | (Self::Rust, "rust")
+                | (Self::Python, "python")
+                | (Self::Go, "go")
         )
     }
 }
@@ -125,6 +129,24 @@ impl ScopeTaskContract {
             entrypoint_domain: None,
             prune_package_mode: Some(PrunePackageMode::JavaScript),
             dependency_source_inputs: DependencySourceInputs::Exclude,
+            dynamic: None,
+            static_defaults: BTreeMap::new(),
+            static_io: BTreeMap::new(),
+            static_entrypoints: BTreeMap::new(),
+        }
+    }
+
+    /// Go module and workspace scopes with static native task tables.
+    pub fn go() -> Self {
+        Self {
+            derives_io: false,
+            defaults: TaskDefaults::default(),
+            environment: None,
+            toolchain: Some(ToolchainId::GO),
+            command_map_target: Some(CommandMapTarget::Go),
+            entrypoint_domain: Some(TaskEntrypointDomain(Cow::Borrowed("go"))),
+            prune_package_mode: None,
+            dependency_source_inputs: DependencySourceInputs::Unknown,
             dynamic: None,
             static_defaults: BTreeMap::new(),
             static_io: BTreeMap::new(),

--- a/crates/turborepo/tests/go_workspace_test.rs
+++ b/crates/turborepo/tests/go_workspace_test.rs
@@ -290,7 +290,7 @@ fn test_go_native_tasks_and_workspace_aggregate() {
         ],
     );
     let dev = dry_run_task(&output, "example.com/api#dev");
-    assert_eq!(dev["command"], "go run . --port 3000");
+    assert_eq!(dev["command"], "go run .");
 
     let tasks = package_task_names(tempdir.path(), "example.com/api");
     assert!(tasks.iter().any(|task| task == "dev"), "tasks: {tasks:?}");

--- a/crates/turborepo/tests/go_workspace_test.rs
+++ b/crates/turborepo/tests/go_workspace_test.rs
@@ -49,7 +49,8 @@ fn assert_command_success(output: &std::process::Output, context: &str) {
 
 fn dry_run_task(output: &std::process::Output, task_id: &str) -> serde_json::Value {
     assert_command_success(output, "Go task dry run");
-    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("dry run emits JSON");
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("dry run emits JSON");
     json["tasks"]
         .as_array()
         .and_then(|tasks| tasks.iter().find(|task| task["taskId"] == task_id))
@@ -231,25 +232,14 @@ fn test_go_native_tasks_and_workspace_aggregate() {
     )
     .unwrap();
 
-    let output = run_turbo(
-        tempdir.path(),
-        &["run", "test", "--dry-run=json"],
-    );
+    let output = run_turbo(tempdir.path(), &["run", "test", "--dry-run=json"]);
     let task = dry_run_task(&output, "go-workspace#test");
-    assert_eq!(
-        task["command"],
-        "go test ./apps/api/... ./packages/lib/..."
-    );
+    assert_eq!(task["command"], "go test ./apps/api/... ./packages/lib/...");
     assert_eq!(task["directory"], "");
 
     let output = run_turbo(
         tempdir.path(),
-        &[
-            "run",
-            "build",
-            "--filter=example.com/lib",
-            "--dry-run=json",
-        ],
+        &["run", "build", "--filter=example.com/lib", "--dry-run=json"],
     );
     let build = dry_run_task(&output, "example.com/lib#build");
     assert_eq!(build["command"], "go build ./...");
@@ -281,12 +271,7 @@ fn test_go_native_tasks_are_overrideable_and_excludable() {
 
     let output = run_turbo(
         tempdir.path(),
-        &[
-            "run",
-            "build",
-            "--filter=example.com/lib",
-            "--dry-run=json",
-        ],
+        &["run", "build", "--filter=example.com/lib", "--dry-run=json"],
     );
     let build = dry_run_task(&output, "example.com/lib#build");
     assert_eq!(build["command"], "go version");
@@ -310,8 +295,7 @@ fn test_go_native_tasks_are_overrideable_and_excludable() {
         ],
     );
     assert_command_success(&output, "query excluded Go tasks");
-    let json: serde_json::Value =
-        serde_json::from_slice(&output.stdout).expect("query emits JSON");
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("query emits JSON");
     let tasks = json["data"]["package"]["tasks"]["items"]
         .as_array()
         .expect("task items");

--- a/crates/turborepo/tests/go_workspace_test.rs
+++ b/crates/turborepo/tests/go_workspace_test.rs
@@ -240,6 +240,21 @@ fn test_go_native_tasks_and_workspace_aggregate() {
     assert_eq!(task["command"], "go test ./apps/api/... ./packages/lib/...");
     assert_eq!(task["directory"], "");
 
+    let output = run_turbo(tempdir.path(), &["run", "lint", "--dry-run=json"]);
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("dry run emits JSON");
+    assert_eq!(json["tasks"].as_array().map(Vec::len), Some(1));
+    let lint = dry_run_task(&output, "go-workspace#lint");
+    assert_eq!(lint["command"], "go vet ./apps/api/... ./packages/lib/...");
+    assert_eq!(lint["directory"], "");
+
+    let output = run_turbo(
+        tempdir.path(),
+        &["run", "lint", "--filter=example.com/lib", "--dry-run=json"],
+    );
+    let lint = dry_run_task(&output, "example.com/lib#lint");
+    assert_eq!(lint["command"], "go vet ./...");
+
     let output = run_turbo(
         tempdir.path(),
         &["run", "build", "--filter=example.com/lib", "--dry-run=json"],
@@ -266,7 +281,7 @@ fn test_go_native_tasks_are_overrideable_and_excludable() {
     "experimentalTaskCommand": true
   },
   "tasks": {
-    "build": { "command": { "go": ["go", "version"] } }
+    "lint": { "command": { "go": ["go", "version"] } }
   }
 }"#,
     )
@@ -274,10 +289,10 @@ fn test_go_native_tasks_are_overrideable_and_excludable() {
 
     let output = run_turbo(
         tempdir.path(),
-        &["run", "build", "--filter=example.com/lib", "--dry-run=json"],
+        &["run", "lint", "--filter=example.com/lib", "--dry-run=json"],
     );
-    let build = dry_run_task(&output, "example.com/lib#build");
-    assert_eq!(build["command"], "go version");
+    let lint = dry_run_task(&output, "example.com/lib#lint");
+    assert_eq!(lint["command"], "go version");
 
     fs::write(
         tempdir.path().join("apps/api/turbo.json"),
@@ -302,6 +317,8 @@ fn test_go_native_tasks_are_overrideable_and_excludable() {
     let tasks = json["data"]["package"]["tasks"]["items"]
         .as_array()
         .expect("task items");
+    assert!(tasks.iter().any(|task| task["name"] == "lint"));
+    assert!(!tasks.iter().any(|task| task["name"] == "vet"));
     assert!(!tasks.iter().any(|task| task["name"] == "run"));
     assert!(!tasks.iter().any(|task| task["name"] == "dev"));
 }

--- a/crates/turborepo/tests/go_workspace_test.rs
+++ b/crates/turborepo/tests/go_workspace_test.rs
@@ -47,6 +47,16 @@ fn assert_command_success(output: &std::process::Output, context: &str) {
     );
 }
 
+fn dry_run_task(output: &std::process::Output, task_id: &str) -> serde_json::Value {
+    assert_command_success(output, "Go task dry run");
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("dry run emits JSON");
+    json["tasks"]
+        .as_array()
+        .and_then(|tasks| tasks.iter().find(|task| task["taskId"] == task_id))
+        .cloned()
+        .unwrap_or_else(|| panic!("{task_id} in task graph"))
+}
+
 fn package_names(dir: &Path) -> Vec<String> {
     let output = run_turbo(dir, &["ls", "--output=json"]);
     assert_command_success(&output, "turbo ls");
@@ -201,4 +211,110 @@ fn test_pure_go_workspace_has_no_package_json() {
         !tempdir.path().join("package.json").exists(),
         "turbo must not create a package.json for a pure Go workspace"
     );
+}
+
+#[test]
+fn test_go_native_tasks_and_workspace_aggregate() {
+    if !go_available() {
+        return;
+    }
+
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_go_pure_workspace(tempdir.path());
+    fs::write(
+        tempdir.path().join("turbo.json"),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "futureFlags": { "experimentalGoWorkspaces": true },
+  "tasks": {}
+}"#,
+    )
+    .unwrap();
+
+    let output = run_turbo(
+        tempdir.path(),
+        &["run", "test", "--dry-run=json"],
+    );
+    let task = dry_run_task(&output, "go-workspace#test");
+    assert_eq!(
+        task["command"],
+        "go test ./apps/api/... ./packages/lib/..."
+    );
+    assert_eq!(task["directory"], "");
+
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "run",
+            "build",
+            "--filter=example.com/lib",
+            "--dry-run=json",
+        ],
+    );
+    let build = dry_run_task(&output, "example.com/lib#build");
+    assert_eq!(build["command"], "go build ./...");
+    assert_eq!(build["resolvedTaskDefinition"]["cache"], false);
+}
+
+#[test]
+fn test_go_native_tasks_are_overrideable_and_excludable() {
+    if !go_available() {
+        return;
+    }
+
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_go_pure_workspace(tempdir.path());
+    fs::write(
+        tempdir.path().join("turbo.json"),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "futureFlags": {
+    "experimentalGoWorkspaces": true,
+    "experimentalTaskCommand": true
+  },
+  "tasks": {
+    "build": { "command": { "go": ["go", "version"] } }
+  }
+}"#,
+    )
+    .unwrap();
+
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "run",
+            "build",
+            "--filter=example.com/lib",
+            "--dry-run=json",
+        ],
+    );
+    let build = dry_run_task(&output, "example.com/lib#build");
+    assert_eq!(build["command"], "go version");
+
+    fs::write(
+        tempdir.path().join("apps/api/turbo.json"),
+        r#"{
+  "extends": ["//"],
+  "tasks": {
+    "run": { "extends": false },
+    "dev": { "extends": false }
+  }
+}"#,
+    )
+    .unwrap();
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "query",
+            "query { package(name: \"example.com/api\") { tasks { items { name } } } }",
+        ],
+    );
+    assert_command_success(&output, "query excluded Go tasks");
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("query emits JSON");
+    let tasks = json["data"]["package"]["tasks"]["items"]
+        .as_array()
+        .expect("task items");
+    assert!(!tasks.iter().any(|task| task["name"] == "run"));
+    assert!(!tasks.iter().any(|task| task["name"] == "dev"));
 }

--- a/crates/turborepo/tests/go_workspace_test.rs
+++ b/crates/turborepo/tests/go_workspace_test.rs
@@ -233,6 +233,9 @@ fn test_go_native_tasks_and_workspace_aggregate() {
     .unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "test", "--dry-run=json"]);
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("dry run emits JSON");
+    assert_eq!(json["tasks"].as_array().map(Vec::len), Some(1));
     let task = dry_run_task(&output, "go-workspace#test");
     assert_eq!(task["command"], "go test ./apps/api/... ./packages/lib/...");
     assert_eq!(task["directory"], "");

--- a/crates/turborepo/tests/go_workspace_test.rs
+++ b/crates/turborepo/tests/go_workspace_test.rs
@@ -82,6 +82,20 @@ fn query_packages(dir: &Path) -> serde_json::Value {
     serde_json::from_slice(&output.stdout).expect("query emits JSON")
 }
 
+fn package_task_names(dir: &Path, package: &str) -> Vec<String> {
+    let query =
+        format!("query {{ package(name: \"{package}\") {{ tasks {{ items {{ name }} }} }} }}");
+    let output = run_turbo(dir, &["query", &query]);
+    assert_command_success(&output, "Go task catalog query");
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("query emits JSON");
+    json["data"]["package"]["tasks"]["items"]
+        .as_array()
+        .expect("task items")
+        .iter()
+        .map(|task| task["name"].as_str().expect("task name").to_string())
+        .collect()
+}
+
 #[test]
 fn test_pure_go_workspace_lists_modules() {
     if !go_available() {
@@ -262,6 +276,38 @@ fn test_go_native_tasks_and_workspace_aggregate() {
     let build = dry_run_task(&output, "example.com/lib#build");
     assert_eq!(build["command"], "go build ./...");
     assert_eq!(build["resolvedTaskDefinition"]["cache"], false);
+
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "run",
+            "dev",
+            "--filter=example.com/api",
+            "--dry-run=json",
+            "--",
+            "--port",
+            "3000",
+        ],
+    );
+    let dev = dry_run_task(&output, "example.com/api#dev");
+    assert_eq!(dev["command"], "go run . --port 3000");
+
+    let tasks = package_task_names(tempdir.path(), "example.com/api");
+    assert!(tasks.iter().any(|task| task == "dev"), "tasks: {tasks:?}");
+    assert!(tasks.iter().any(|task| task == "lint"), "tasks: {tasks:?}");
+    assert!(!tasks.iter().any(|task| task == "run"), "tasks: {tasks:?}");
+    assert!(!tasks.iter().any(|task| task == "vet"), "tasks: {tasks:?}");
+
+    let output = run_turbo(
+        tempdir.path(),
+        &["run", "run", "--filter=example.com/api", "--dry-run=json"],
+    );
+    assert!(!output.status.success(), "removed run task must fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Could not find task `run` in project"),
+        "unexpected stderr: {stderr}"
+    );
 }
 
 #[test]
@@ -281,7 +327,8 @@ fn test_go_native_tasks_are_overrideable_and_excludable() {
     "experimentalTaskCommand": true
   },
   "tasks": {
-    "lint": { "command": { "go": ["go", "version"] } }
+    "lint": { "command": { "go": ["go", "version"] } },
+    "dev": { "command": { "go": ["go", "env", "GOVERSION"] } }
   }
 }"#,
     )
@@ -294,31 +341,26 @@ fn test_go_native_tasks_are_overrideable_and_excludable() {
     let lint = dry_run_task(&output, "example.com/lib#lint");
     assert_eq!(lint["command"], "go version");
 
+    let output = run_turbo(
+        tempdir.path(),
+        &["run", "dev", "--filter=example.com/api", "--dry-run=json"],
+    );
+    let dev = dry_run_task(&output, "example.com/api#dev");
+    assert_eq!(dev["command"], "go env GOVERSION");
+
     fs::write(
         tempdir.path().join("apps/api/turbo.json"),
         r#"{
   "extends": ["//"],
   "tasks": {
-    "run": { "extends": false },
     "dev": { "extends": false }
   }
 }"#,
     )
     .unwrap();
-    let output = run_turbo(
-        tempdir.path(),
-        &[
-            "query",
-            "query { package(name: \"example.com/api\") { tasks { items { name } } } }",
-        ],
-    );
-    assert_command_success(&output, "query excluded Go tasks");
-    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("query emits JSON");
-    let tasks = json["data"]["package"]["tasks"]["items"]
-        .as_array()
-        .expect("task items");
-    assert!(tasks.iter().any(|task| task["name"] == "lint"));
-    assert!(!tasks.iter().any(|task| task["name"] == "vet"));
-    assert!(!tasks.iter().any(|task| task["name"] == "run"));
-    assert!(!tasks.iter().any(|task| task["name"] == "dev"));
+    let tasks = package_task_names(tempdir.path(), "example.com/api");
+    assert!(tasks.iter().any(|task| task == "lint"), "tasks: {tasks:?}");
+    assert!(!tasks.iter().any(|task| task == "vet"), "tasks: {tasks:?}");
+    assert!(!tasks.iter().any(|task| task == "run"), "tasks: {tasks:?}");
+    assert!(!tasks.iter().any(|task| task == "dev"), "tasks: {tasks:?}");
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Adds native Go task catalog definitions, scope contracts, runnable-target discovery, and command planning. Native executor wiring is intentionally handled separately.

Requires `futureFlags.experimentalGoWorkspaces`. Module packages use their Go module path as identity; the aggregate package is `go-workspace`.

#### Per-module mappings

Commands run from the module directory. Pass-through arguments precede `./...`, except for `dev`, where they follow the runnable target.

| Task | Command | Cache default | Entrypoint |
| --- | --- | --- | --- |
| `build` | `go build ./...` | `false` without one unambiguous runnable `main`; otherwise Turbo default | `Preferred` with exactly one runnable `main`; otherwise `Candidate` |
| `test` | `go test ./...` | Turbo default | `Candidate` |
| `lint` | `go vet ./...` | Turbo default | `Candidate` |
| `format` | `go fmt ./...` | `false` | `Candidate` |
| `dev` | `go run <target>` | `false` | `Candidate` |

`dev` is registered only when `go list -find -json ./...` discovers exactly one `main` package. The target is `.` for a module-root command or `./<relative-path>` otherwise. Discovery failures, zero or multiple main packages, and package paths outside the module omit the task. Native `run` and `vet` task keys are not registered.

#### Workspace aggregate mappings

Commands run from the repository root against sorted, deduplicated `./<module-dir>/...` targets.

| Task | Command | Cache default | Entrypoint |
| --- | --- | --- | --- |
| `test` | `go test <module-patterns...>` | Turbo default | `PreferredOnly` |
| `lint` | `go vet <module-patterns...>` | Turbo default | `PreferredOnly` |
| `format` | `go fmt <module-patterns...>` | `false` | `PreferredOnly` |
| `build` | No command; contract only | Turbo default | `Excluded` |

The aggregate package depends on every member module. The Go scope contract supports `tasks.<name>.command.go` overrides behind `experimentalTaskCommand`, package-level exclusions with `{ "extends": false }`, and currently derives no automatic inputs, outputs, environment hashing, or I/O contracts.

Closes TURBO-5957

### Testing Instructions

```bash
cargo fmt --all --check
cargo lint
cargo test -p turborepo-repository
cargo test -p turbo --test go_workspace_test
cargo test -p turborepo-lib
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93321fc5-6d9e-4a4a-b939-cfd623df17d1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93321fc5-6d9e-4a4a-b939-cfd623df17d1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

