### PR TITLE
test: Cover native Go execution end to end

### DIFF
--- a/crates/turborepo-repository/src/go.rs
+++ b/crates/turborepo-repository/src/go.rs
@@ -529,7 +529,7 @@ pub fn native_tasks_for_module(module: &GoModule) -> Vec<crate::native_tasks::Na
             WorkingDirectoryPolicy::PackageDirectory,
         ),
         go_command_task(
-            "vet",
+            "lint",
             "vet",
             vec!["./...".to_string()],
             PassThroughPlacement::BeforeSuffix,
@@ -575,12 +575,12 @@ pub fn native_tasks_for_workspace(
     let mut module_patterns = module_patterns.to_vec();
     module_patterns.sort();
     module_patterns.dedup();
-    let mut tasks = ["test", "vet", "format"]
+    let mut tasks = [("test", "test"), ("lint", "vet"), ("format", "fmt")]
         .into_iter()
-        .map(|name| {
+        .map(|(name, subcommand)| {
             go_command_task(
                 name,
-                if name == "format" { "fmt" } else { name },
+                subcommand,
                 module_patterns.clone(),
                 PassThroughPlacement::BeforeSuffix,
                 (name == "format").then_some(false),
@@ -918,6 +918,17 @@ mod tests {
             ["build", "-race", "./..."].map(std::ffi::OsString::from)
         );
         assert_eq!(build.cwd, root.join_components(&["apps", "api"]));
+        let lint = resolve_go_cmd(&context, "lint", Some(&["-json".to_string()]), None);
+        assert_eq!(
+            lint.args,
+            ["vet", "-json", "./..."].map(std::ffi::OsString::from)
+        );
+        assert!(!context.native_tasks().contains_key("vet"));
+        assert!(
+            !native_tasks_for_workspace(&["./apps/api/...".to_string()])
+                .iter()
+                .any(|task| task.name() == "vet")
+        );
         assert_eq!(
             context
                 .native_tasks()

--- a/crates/turborepo-repository/src/go.rs
+++ b/crates/turborepo-repository/src/go.rs
@@ -19,14 +19,18 @@ use std::{
 };
 
 use serde::Deserialize;
-use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
+use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
 
 use crate::{
+    native_tasks::{
+        NativeTaskContract, PassThroughPlacement, TaskEntrypoint, WorkingDirectoryPolicy,
+    },
     package_json::PackageJson,
     relationships::{DependencyKind, Relationship},
+    task_contracts::DependencySourceInputs,
     toolchain::{
-        self, DiscoverPackagesFuture, DiscoveredPackage, DiscoveredPackages, RepositoryContributor,
-        ToolchainId, WorkspaceRoot,
+        self, DerivedInputSafety, DerivedOutputs, DiscoverPackagesFuture, DiscoveredPackage,
+        DiscoveredPackages, RepositoryContributor, ToolchainId, WorkspaceRoot,
     },
 };
 
@@ -35,6 +39,10 @@ pub const GO_WORK: &str = "go.work";
 
 /// The conventional file name for a Go module manifest.
 pub const GO_MOD: &str = "go.mod";
+
+const GO_SUM: &str = "go.sum";
+const GO_WORK_SUM: &str = "go.work.sum";
+const GO_DIST_DIR: &str = "dist";
 
 /// Deterministic identity for the workspace-wide Go verification scope.
 pub const GO_WORKSPACE_NAME: &str = "go-workspace";
@@ -174,6 +182,16 @@ struct GoListPackage {
     name: String,
 }
 
+#[derive(Debug, Deserialize)]
+struct GoEnvironment {
+    #[serde(rename = "GOOS")]
+    target_os: String,
+    #[serde(rename = "GOCACHE")]
+    build_cache: String,
+    #[serde(rename = "GOMODCACHE")]
+    module_cache: String,
+}
+
 fn run_go(
     repo_root: &AbsoluteSystemPath,
     args: &[&str],
@@ -231,6 +249,25 @@ fn go_mod_graph(repo_root: &AbsoluteSystemPath) -> Result<String, Error> {
         });
     }
     Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+fn go_environment(repo_root: &AbsoluteSystemPath) -> Result<GoEnvironment, Error> {
+    const COMMAND: &str = "go env -json GOOS GOCACHE GOMODCACHE";
+    let output = run_go(
+        repo_root,
+        &["env", "-json", "GOOS", "GOCACHE", "GOMODCACHE"],
+        COMMAND,
+    )?;
+    if !output.status.success() {
+        return Err(Error::CommandFailed {
+            command: COMMAND,
+            stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        });
+    }
+    serde_json::from_slice(&output.stdout).map_err(|source| Error::CommandParse {
+        command: COMMAND,
+        source,
+    })
 }
 
 fn runnable_target(module_dir: &AbsoluteSystemPath) -> Result<Option<String>, Error> {
@@ -477,9 +514,7 @@ fn go_command_task(
     entrypoint: crate::native_tasks::TaskEntrypoint,
     cwd_policy: crate::native_tasks::WorkingDirectoryPolicy,
 ) -> crate::native_tasks::NativeTask {
-    use crate::native_tasks::{
-        NativeCommandArguments, NativeCommandProgram, NativeTask, NativeTaskContract,
-    };
+    use crate::native_tasks::{NativeCommandArguments, NativeCommandProgram, NativeTask};
 
     NativeTask::command_task(
         name,
@@ -501,22 +536,51 @@ fn go_command_task(
     ))
 }
 
-/// Build the conservative built-in task table for one Go module.
-pub fn native_tasks_for_module(module: &GoModule) -> Vec<crate::native_tasks::NativeTask> {
-    use crate::native_tasks::{PassThroughPlacement, TaskEntrypoint, WorkingDirectoryPolicy};
+fn runnable_output_name(module: &GoModule) -> Option<String> {
+    let target = module.runnable_target.as_deref()?;
+    if target == "." {
+        return module
+            .module_path
+            .rsplit('/')
+            .find(|component| !component.is_empty())
+            .map(str::to_string);
+    }
+    target
+        .trim_end_matches('/')
+        .rsplit('/')
+        .find(|component| !component.is_empty() && *component != ".")
+        .map(str::to_string)
+}
 
+/// Build the conservative built-in task table for one Go module.
+pub fn native_tasks_for_module(
+    module: &GoModule,
+    target_os: &str,
+) -> Vec<crate::native_tasks::NativeTask> {
     let build_entrypoint = if module.runnable_target.is_some() {
         TaskEntrypoint::Preferred
     } else {
         TaskEntrypoint::Candidate
     };
+    let output_name = runnable_output_name(module);
+    let build_targets = match (&module.runnable_target, &output_name) {
+        (Some(target), Some(output_name)) => {
+            let extension = if target_os == "windows" { ".exe" } else { "" };
+            vec![
+                "-o".to_string(),
+                format!("{GO_DIST_DIR}/{output_name}{extension}"),
+                target.clone(),
+            ]
+        }
+        _ => vec!["./...".to_string()],
+    };
     let mut tasks = vec![
         go_command_task(
             "build",
             "build",
-            vec!["./...".to_string()],
+            build_targets,
             PassThroughPlacement::BeforeSuffix,
-            module.runnable_target.is_none().then_some(false),
+            output_name.is_none().then_some(false),
             build_entrypoint,
             WorkingDirectoryPolicy::PackageDirectory,
         ),
@@ -566,10 +630,7 @@ pub fn native_tasks_for_module(module: &GoModule) -> Vec<crate::native_tasks::Na
 pub fn native_tasks_for_workspace(
     module_patterns: &[String],
 ) -> Vec<crate::native_tasks::NativeTask> {
-    use crate::native_tasks::{
-        NativeTask, NativeTaskContract, PassThroughPlacement, TaskEntrypoint,
-        WorkingDirectoryPolicy,
-    };
+    use crate::native_tasks::NativeTask;
 
     let mut module_patterns = module_patterns.to_vec();
     module_patterns.sort();
@@ -599,7 +660,196 @@ pub fn native_tasks_for_workspace(
     tasks
 }
 
-fn package_from_module(module: &GoModule) -> DiscoveredPackage {
+/// Go variables that alter compilation, package selection, tests, or target
+/// platform. Credentials, proxy settings, and machine-local cache paths are
+/// deliberately excluded.
+pub const HASHED_ENV_VARS: &[&str] = &[
+    "GO111MODULE",
+    "GO386",
+    "GOAMD64",
+    "GOARCH",
+    "GOARM",
+    "GOARM64",
+    "GOCACHEPROG",
+    "GCCGO",
+    "GOEXPERIMENT",
+    "GOFLAGS",
+    "GOMIPS",
+    "GOMIPS64",
+    "GOOS",
+    "GOTOOLCHAIN",
+    "GOWASM",
+    "CGO_ENABLED",
+    "CC",
+    "CXX",
+    "CGO_CFLAGS",
+    "CGO_CPPFLAGS",
+    "CGO_CXXFLAGS",
+    "CGO_FFLAGS",
+    "CGO_LDFLAGS",
+    "PKG_CONFIG",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum GoContractKind {
+    Module { output_name: Option<String> },
+    Workspace,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GoTaskContract {
+    kind: GoContractKind,
+    target_os: String,
+    cache_prefixes: Vec<String>,
+}
+
+impl GoTaskContract {
+    fn module(module: &GoModule, target_os: &str, cache_prefixes: &[String]) -> Self {
+        Self {
+            kind: GoContractKind::Module {
+                output_name: runnable_output_name(module),
+            },
+            target_os: target_os.to_string(),
+            cache_prefixes: cache_prefixes.to_vec(),
+        }
+    }
+
+    fn workspace(target_os: &str, cache_prefixes: &[String]) -> Self {
+        Self {
+            kind: GoContractKind::Workspace,
+            target_os: target_os.to_string(),
+            cache_prefixes: cache_prefixes.to_vec(),
+        }
+    }
+
+    pub(crate) fn dependency_source_inputs(&self) -> DependencySourceInputs {
+        match &self.kind {
+            GoContractKind::Module { .. } => DependencySourceInputs::Include,
+            GoContractKind::Workspace => DependencySourceInputs::Exclude,
+        }
+    }
+
+    pub(crate) fn derived_task_io(
+        &self,
+        _package: &crate::package_graph::PackageTaskContext<'_>,
+        task: &str,
+        path_to_root: &str,
+        dependencies: &[crate::package_graph::PackageTaskContext<'_>],
+        wants_automatic_inputs: bool,
+        context: &toolchain::TaskIOContext<'_>,
+    ) -> Option<toolchain::DerivedTaskIO> {
+        if !matches!(task, "build" | "test" | "lint" | "format" | "dev") {
+            return None;
+        }
+
+        let root_input = |path: &str| {
+            if path_to_root.is_empty() {
+                path.to_string()
+            } else {
+                format!("{path_to_root}/{path}")
+            }
+        };
+        let mut io = toolchain::DerivedTaskIO {
+            input_globs: [GO_WORK, GO_WORK_SUM].map(root_input).to_vec(),
+            env: HASHED_ENV_VARS
+                .iter()
+                .map(|name| name.to_string())
+                .collect(),
+            forbidden_output_prefixes: vec![root_input(".git"), root_input(".turbo")],
+            ..Default::default()
+        };
+        for prefix in &self.cache_prefixes {
+            let prefix = root_input(prefix);
+            io.input_globs.push(format!("!{prefix}/**"));
+            io.forbidden_output_prefixes.push(prefix);
+        }
+
+        if wants_automatic_inputs {
+            match &self.kind {
+                GoContractKind::Module { .. } => {
+                    io.package_default_inputs = Some(true);
+                    io.input_globs.push(format!("!{GO_DIST_DIR}/**"));
+                }
+                GoContractKind::Workspace => io.package_default_inputs = Some(false),
+            }
+            for dependency in dependencies {
+                match dependency.task_contract().dependency_source_inputs() {
+                    DependencySourceInputs::Include => {
+                        let directory = root_input(dependency.directory().to_unix().as_str());
+                        io.input_globs.extend([
+                            format!("{directory}/**"),
+                            format!("!{directory}/.git/**"),
+                            format!("!{directory}/.turbo/**"),
+                            format!("!{directory}/{GO_DIST_DIR}/**"),
+                        ]);
+                    }
+                    DependencySourceInputs::Exclude => {}
+                    DependencySourceInputs::Unknown => {
+                        io.input_safety = DerivedInputSafety::Untracked;
+                        io.cache_reason =
+                            Some("a Go dependency has unclassified source inputs".to_string());
+                    }
+                }
+            }
+            io.input_globs.sort();
+            io.input_globs.dedup();
+        }
+
+        if task == "build" {
+            io.outputs = match &self.kind {
+                GoContractKind::Module {
+                    output_name: Some(output_name),
+                } if context.task_args.is_none_or(<[_]>::is_empty) => {
+                    let extension = if self.target_os == "windows" {
+                        ".exe"
+                    } else {
+                        ""
+                    };
+                    DerivedOutputs::Resolved(vec![format!(
+                        "{GO_DIST_DIR}/{output_name}{extension}"
+                    )])
+                }
+                GoContractKind::Module {
+                    output_name: Some(_),
+                } => {
+                    io.cache_reason =
+                        Some("Go build arguments can change the derived binary output".to_string());
+                    DerivedOutputs::Unavailable
+                }
+                GoContractKind::Module { output_name: None } => {
+                    io.cache_reason = Some(
+                        "Go library builds have no stable outputs for Turborepo to restore"
+                            .to_string(),
+                    );
+                    DerivedOutputs::Unavailable
+                }
+                GoContractKind::Workspace => DerivedOutputs::Resolved(Vec::new()),
+            };
+        }
+        Some(io)
+    }
+}
+
+fn go_cache_prefixes(repo_root: &AbsoluteSystemPath, environment: &GoEnvironment) -> Vec<String> {
+    let mut prefixes = Vec::new();
+    for path in [&environment.build_cache, &environment.module_cache] {
+        let path = AbsoluteSystemPathBuf::from_unknown(repo_root, path);
+        if let Ok(prefix) = AnchoredSystemPathBuf::new(repo_root, &path)
+            && prefix.components().next().is_some()
+        {
+            prefixes.push(prefix.to_unix().to_string());
+        }
+    }
+    prefixes.sort();
+    prefixes.dedup();
+    prefixes
+}
+
+fn package_from_module(
+    module: &GoModule,
+    target_os: &str,
+    cache_prefixes: &[String],
+) -> DiscoveredPackage {
     let descriptor = PackageJson {
         name: Some(turborepo_errors::Spanned::new(module.module_path.clone())),
         ..Default::default()
@@ -610,8 +860,10 @@ fn package_from_module(module: &GoModule) -> DiscoveredPackage {
         module.manifest_path.clone(),
     )
     .with_native_relationships(module.relationships.clone())
-    .with_native_tasks(native_tasks_for_module(module))
-    .with_task_contract(crate::task_contracts::ScopeTaskContract::go())
+    .with_native_tasks(native_tasks_for_module(module, target_os))
+    .with_task_contract(crate::task_contracts::ScopeTaskContract::go(
+        GoTaskContract::module(module, target_os, cache_prefixes),
+    ))
 }
 
 /// The Go repository contributor. Registered during graph construction when
@@ -636,6 +888,10 @@ impl RepositoryContributor for GoContributor {
             let workspace =
                 turborepo_rayon_compat::block_in_place(|| discover_workspace(&self.repo_root))
                     .map_err(|error| toolchain::Error::Failed(Box::new(error)))?;
+            let environment =
+                turborepo_rayon_compat::block_in_place(|| go_environment(&self.repo_root))
+                    .map_err(|error| toolchain::Error::Failed(Box::new(error)))?;
+            let cache_prefixes = go_cache_prefixes(&self.repo_root, &environment);
 
             let workspace_roots = self
                 .repo_root
@@ -671,7 +927,7 @@ impl RepositoryContributor for GoContributor {
             let mut packages = workspace
                 .modules
                 .iter()
-                .map(package_from_module)
+                .map(|module| package_from_module(module, &environment.target_os, &cache_prefixes))
                 .collect::<Vec<_>>();
             if !packages.is_empty() {
                 packages.push(
@@ -682,7 +938,12 @@ impl RepositoryContributor for GoContributor {
                     )
                     .with_native_relationships(workspace_relationships)
                     .with_native_tasks(native_tasks_for_workspace(&module_patterns))
-                    .with_task_contract(crate::task_contracts::ScopeTaskContract::go()),
+                    .with_task_contract(
+                        crate::task_contracts::ScopeTaskContract::go(GoTaskContract::workspace(
+                            &environment.target_os,
+                            &cache_prefixes,
+                        )),
+                    ),
                 );
             }
 
@@ -862,6 +1123,7 @@ mod tests {
         directory: &'a str,
         tasks: Vec<crate::native_tasks::NativeTask>,
         kind: crate::package_graph::PackageTaskContextKind,
+        contract: crate::task_contracts::ScopeTaskContract,
     ) -> crate::package_graph::PackageTaskContext<'a> {
         crate::package_graph::PackageTaskContext::new_for_test_with_native_tasks(
             name.into(),
@@ -870,7 +1132,7 @@ mod tests {
             kind,
             Some(&ToolchainId::GO),
             Some(tasks),
-            Some(crate::task_contracts::ScopeTaskContract::go()),
+            Some(contract),
         )
     }
 
@@ -894,6 +1156,19 @@ mod tests {
         .expect("Go command resolves")
     }
 
+    fn task_cache(
+        context: &crate::package_graph::PackageTaskContext<'_>,
+        task: &str,
+    ) -> Option<bool> {
+        context
+            .native_tasks()
+            .get(task)
+            .expect("native Go task")
+            .contract()
+            .defaults()
+            .cache
+    }
+
     #[test]
     fn module_task_table_renders_commands_and_argument_placement() {
         let root = AbsoluteSystemPathBuf::new("/repo").unwrap();
@@ -907,14 +1182,19 @@ mod tests {
             &root,
             &module.module_path,
             "apps/api",
-            native_tasks_for_module(&module),
+            native_tasks_for_module(&module, "linux"),
             crate::package_graph::PackageTaskContextKind::Package,
+            crate::task_contracts::ScopeTaskContract::go(GoTaskContract::module(
+                &module,
+                "linux",
+                &[],
+            )),
         );
 
         let build = resolve_go_cmd(&context, "build", Some(&["-race".to_string()]), None);
         assert_eq!(
             build.args,
-            ["build", "-race", "./..."].map(std::ffi::OsString::from)
+            ["build", "-race", "-o", "dist/api", "./cmd/api"].map(std::ffi::OsString::from)
         );
         assert_eq!(build.cwd, root.join_components(&["apps", "api"]));
         let lint = resolve_go_cmd(&context, "lint", Some(&["-json".to_string()]), None);
@@ -974,7 +1254,7 @@ mod tests {
         let workspace = discover_workspace(&root).expect("workspace discovery succeeds");
         let module = &workspace.modules[0];
         assert_eq!(module.runnable_target, None);
-        let tasks = native_tasks_for_module(module);
+        let tasks = native_tasks_for_module(module, "linux");
         assert!(!tasks.iter().any(|task| task.name() == "dev"));
         assert!(!tasks.iter().any(|task| task.name() == "run"));
         assert_eq!(
@@ -985,6 +1265,128 @@ mod tests {
                 .contract()
                 .entrypoint(),
             Some(crate::native_tasks::TaskEntrypoint::Candidate)
+        );
+    }
+
+    #[test]
+    fn task_contracts_derive_module_executable_and_workspace_io() {
+        let root = AbsoluteSystemPathBuf::new("/repo").unwrap();
+        let executable = GoModule {
+            module_path: "example.com/api".to_string(),
+            manifest_path: root.join_components(&["apps", "api", GO_MOD]),
+            relationships: Vec::new(),
+            runnable_target: Some(".".to_string()),
+        };
+        let library = GoModule {
+            module_path: "example.com/lib".to_string(),
+            manifest_path: root.join_components(&["packages", "lib", GO_MOD]),
+            relationships: Vec::new(),
+            runnable_target: None,
+        };
+        let cache_prefixes = vec![".cache/go-build".to_string(), ".cache/go-mod".to_string()];
+        let executable_contract = GoTaskContract::module(&executable, "linux", &cache_prefixes);
+        let library_contract = GoTaskContract::module(&library, "linux", &cache_prefixes);
+        let package = task_context(
+            &root,
+            &executable.module_path,
+            "apps/api",
+            native_tasks_for_module(&executable, "linux"),
+            crate::package_graph::PackageTaskContextKind::Package,
+            crate::task_contracts::ScopeTaskContract::go(executable_contract.clone()),
+        );
+        let dependency = task_context(
+            &root,
+            &library.module_path,
+            "packages/lib",
+            native_tasks_for_module(&library, "linux"),
+            crate::package_graph::PackageTaskContextKind::Package,
+            crate::task_contracts::ScopeTaskContract::go(library_contract.clone()),
+        );
+        let environment = toolchain::TaskIOEnvironment::default();
+        let context = toolchain::TaskIOContext {
+            task_args: None,
+            environment: &environment,
+        };
+
+        let executable_io = executable_contract
+            .derived_task_io(&package, "build", "../..", &[dependency], true, &context)
+            .expect("executable build derives IO");
+        assert_eq!(executable_io.package_default_inputs, Some(true));
+        for input in [
+            "../../go.work",
+            "../../packages/lib/**",
+            "!../../.cache/go-build/**",
+        ] {
+            assert!(executable_io.input_globs.iter().any(|glob| glob == input));
+        }
+        assert!(executable_io.env.contains(&"GOOS".to_string()));
+        assert!(!executable_io.env.contains(&"GOPROXY".to_string()));
+        assert_eq!(
+            executable_io.outputs,
+            DerivedOutputs::Resolved(vec!["dist/api".to_string()])
+        );
+        assert!(
+            executable_io
+                .forbidden_output_prefixes
+                .contains(&"../../.cache/go-build".to_string())
+        );
+        assert_eq!(task_cache(&package, "build"), None);
+
+        let library_context = task_context(
+            &root,
+            &library.module_path,
+            "packages/lib",
+            native_tasks_for_module(&library, "linux"),
+            crate::package_graph::PackageTaskContextKind::Package,
+            crate::task_contracts::ScopeTaskContract::go(library_contract.clone()),
+        );
+        let library_io = library_contract
+            .derived_task_io(&library_context, "build", "../..", &[], true, &context)
+            .expect("library build derives IO");
+        assert_eq!(library_io.outputs, DerivedOutputs::Unavailable);
+        assert_eq!(task_cache(&library_context, "build"), Some(false));
+
+        let workspace_contract = GoTaskContract::workspace("linux", &cache_prefixes);
+        let workspace = task_context(
+            &root,
+            GO_WORKSPACE_NAME,
+            "",
+            native_tasks_for_workspace(&[
+                "./apps/api/...".to_string(),
+                "./packages/lib/...".to_string(),
+            ]),
+            crate::package_graph::PackageTaskContextKind::Aggregate,
+            crate::task_contracts::ScopeTaskContract::go(workspace_contract.clone()),
+        );
+        let aggregate_io = workspace_contract
+            .derived_task_io(
+                &workspace,
+                "lint",
+                "",
+                &[package, library_context],
+                true,
+                &context,
+            )
+            .expect("workspace lint derives IO");
+        assert_eq!(aggregate_io.package_default_inputs, Some(false));
+        for input in ["apps/api/**", "packages/lib/**"] {
+            assert!(aggregate_io.input_globs.iter().any(|glob| glob == input));
+        }
+        assert_eq!(aggregate_io.outputs, DerivedOutputs::Resolved(Vec::new()));
+        assert_eq!(task_cache(&workspace, "lint"), None);
+    }
+
+    #[test]
+    fn cache_prefixes_remain_inside_the_repository() {
+        let root = AbsoluteSystemPathBuf::new("/repo").unwrap();
+        let environment = GoEnvironment {
+            target_os: "linux".to_string(),
+            build_cache: "/repo/.cache/go-build".to_string(),
+            module_cache: "/home/user/go/pkg/mod".to_string(),
+        };
+        assert_eq!(
+            go_cache_prefixes(&root, &environment),
+            vec![".cache/go-build".to_string()]
         );
     }
 }

--- a/crates/turborepo-repository/src/go.rs
+++ b/crates/turborepo-repository/src/go.rs
@@ -1272,7 +1272,8 @@ mod tests {
 
     #[test]
     fn task_contracts_derive_module_executable_and_workspace_io() {
-        let root = AbsoluteSystemPathBuf::new("/repo").unwrap();
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPathBuf::try_from(tempdir.path()).unwrap();
         let executable = GoModule {
             module_path: "example.com/api".to_string(),
             manifest_path: root.join_components(&["apps", "api", GO_MOD]),
@@ -1380,11 +1381,18 @@ mod tests {
 
     #[test]
     fn cache_prefixes_remain_inside_the_repository() {
-        let root = AbsoluteSystemPathBuf::new("/repo").unwrap();
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPathBuf::try_from(tempdir.path()).unwrap();
+        let build_cache = root.join_components(&[".cache", "go-build"]).to_string();
+        let module_cache_tempdir = tempfile::tempdir().unwrap();
+        let module_cache = AbsoluteSystemPathBuf::try_from(module_cache_tempdir.path())
+            .unwrap()
+            .join_components(&["go", "pkg", "mod"])
+            .to_string();
         let environment = GoEnvironment {
             target_os: "linux".to_string(),
-            build_cache: "/repo/.cache/go-build".to_string(),
-            module_cache: "/home/user/go/pkg/mod".to_string(),
+            build_cache,
+            module_cache,
         };
         assert_eq!(
             go_cache_prefixes(&root, &environment),

--- a/crates/turborepo-repository/src/go.rs
+++ b/crates/turborepo-repository/src/go.rs
@@ -886,7 +886,7 @@ mod tests {
             native_task,
             None,
             None,
-            Some(Path::new("/bin/go")),
+            Some(Path::new("go")),
             pass_through_args,
             override_command,
         )
@@ -896,7 +896,9 @@ mod tests {
 
     #[test]
     fn module_task_table_renders_commands_and_argument_placement() {
-        let root = AbsoluteSystemPathBuf::new("/repo").unwrap();
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPathBuf::try_from(tempdir.path()).unwrap();
+        assert!(root.as_std_path().is_absolute());
         let module = GoModule {
             module_path: "example.com/api".to_string(),
             manifest_path: root.join_components(&["apps", "api", GO_MOD]),
@@ -916,6 +918,7 @@ mod tests {
             build.args,
             ["build", "-race", "./..."].map(std::ffi::OsString::from)
         );
+        assert_eq!(build.program, std::ffi::OsString::from("go"));
         assert_eq!(build.cwd, root.join_components(&["apps", "api"]));
         let lint = resolve_go_cmd(&context, "lint", Some(&["-json".to_string()]), None);
         assert_eq!(

--- a/crates/turborepo-repository/src/go.rs
+++ b/crates/turborepo-repository/src/go.rs
@@ -689,6 +689,10 @@ pub const HASHED_ENV_VARS: &[&str] = &[
     "PKG_CONFIG",
 ];
 
+/// Machine-local Go variables required by task execution but excluded from
+/// task hashes.
+pub(crate) const PROJECTED_ONLY_ENV_VARS: &[&str] = &["GOCACHE"];
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum GoContractKind {
     Module { output_name: Option<String> },
@@ -1297,6 +1301,12 @@ mod tests {
             crate::package_graph::PackageTaskContextKind::Package,
             crate::task_contracts::ScopeTaskContract::go(executable_contract.clone()),
         );
+        assert!(
+            package
+                .task_contract()
+                .environment_vars()
+                .contains(&"GOCACHE")
+        );
         let dependency = task_context(
             &root,
             &library.module_path,
@@ -1323,6 +1333,7 @@ mod tests {
             assert!(executable_io.input_globs.iter().any(|glob| glob == input));
         }
         assert!(executable_io.env.contains(&"GOOS".to_string()));
+        assert!(!executable_io.env.contains(&"GOCACHE".to_string()));
         assert!(!executable_io.env.contains(&"GOPROXY".to_string()));
         assert_eq!(
             executable_io.outputs,

--- a/crates/turborepo-repository/src/go.rs
+++ b/crates/turborepo-repository/src/go.rs
@@ -36,6 +36,9 @@ pub const GO_WORK: &str = "go.work";
 /// The conventional file name for a Go module manifest.
 pub const GO_MOD: &str = "go.mod";
 
+/// Deterministic identity for the workspace-wide Go verification scope.
+pub const GO_WORKSPACE_NAME: &str = "go-workspace";
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("failed to run `{command}`: {source}")]
@@ -106,6 +109,8 @@ pub struct GoModule {
     pub manifest_path: AbsoluteSystemPathBuf,
     /// Direct internal relationships to other workspace modules.
     pub relationships: Vec<Relationship>,
+    /// Package pattern for the sole runnable `main` package, when unambiguous.
+    pub runnable_target: Option<String>,
 }
 
 /// The result of Go workspace discovery.
@@ -158,6 +163,14 @@ struct GoModModuleRef {
     #[serde(rename = "Version")]
     #[allow(dead_code)]
     version: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoListPackage {
+    #[serde(rename = "Dir")]
+    directory: String,
+    #[serde(rename = "Name")]
+    name: String,
 }
 
 fn run_go(
@@ -217,6 +230,48 @@ fn go_mod_graph(repo_root: &AbsoluteSystemPath) -> Result<String, Error> {
         });
     }
     Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+fn runnable_target(module_dir: &AbsoluteSystemPath) -> Result<Option<String>, Error> {
+    const COMMAND: &str = "go list -find -json ./...";
+
+    let output = run_go(
+        module_dir,
+        &["list", "-find", "-json", "./..."],
+        COMMAND,
+    )?;
+    // Runnable defaults are optional. If Go cannot classify every package
+    // without error, omit them rather than making workspace discovery fail.
+    if !output.status.success() {
+        return Ok(None);
+    }
+
+    let packages = serde_json::Deserializer::from_slice(&output.stdout)
+        .into_iter::<GoListPackage>();
+    let mut runnable = None;
+    for package in packages {
+        let package = package.map_err(|source| Error::CommandParse {
+            command: COMMAND,
+            source,
+        })?;
+        if package.name != "main" {
+            continue;
+        }
+        let Ok(relative) = Path::new(&package.directory).strip_prefix(module_dir.as_std_path())
+        else {
+            return Ok(None);
+        };
+        let relative = relative.to_string_lossy().replace('\\', "/");
+        let target = if relative.is_empty() {
+            ".".to_string()
+        } else {
+            format!("./{relative}")
+        };
+        if runnable.replace(target).is_some() {
+            return Ok(None);
+        }
+    }
+    Ok(runnable)
 }
 
 fn join_relative_path(
@@ -391,6 +446,7 @@ pub fn discover_workspace(repo_root: &AbsoluteSystemPath) -> Result<DiscoveredWo
             module_path,
             manifest_path: member_dir.join_component(GO_MOD),
             relationships: Vec::new(),
+            runnable_target: runnable_target(&member_dir)?,
         });
     }
 
@@ -415,6 +471,141 @@ pub fn discover_workspace(repo_root: &AbsoluteSystemPath) -> Result<DiscoveredWo
     Ok(DiscoveredWorkspace { modules })
 }
 
+fn go_command_task(
+    name: &'static str,
+    subcommand: &'static str,
+    targets: Vec<String>,
+    pass_through_placement: crate::native_tasks::PassThroughPlacement,
+    cache: Option<bool>,
+    entrypoint: crate::native_tasks::TaskEntrypoint,
+    cwd_policy: crate::native_tasks::WorkingDirectoryPolicy,
+) -> crate::native_tasks::NativeTask {
+    use crate::native_tasks::{
+        NativeCommandArguments, NativeCommandProgram, NativeTask, NativeTaskContract,
+    };
+
+    NativeTask::command_task(
+        name,
+        format!("go {subcommand} {}", targets.join(" ")),
+        NativeCommandProgram::Tool("go".to_string()),
+        NativeCommandArguments {
+            prefix: vec![subcommand.to_string()],
+            pass_through_placement,
+            pass_through_separator: None,
+            suffix: targets,
+        },
+        None,
+        cwd_policy,
+    )
+    .with_contract(NativeTaskContract::new(
+        toolchain::TaskDefaults { cache },
+        Some(entrypoint),
+        false,
+    ))
+}
+
+/// Build the conservative built-in task table for one Go module.
+pub fn native_tasks_for_module(module: &GoModule) -> Vec<crate::native_tasks::NativeTask> {
+    use crate::native_tasks::{
+        PassThroughPlacement, TaskEntrypoint, WorkingDirectoryPolicy,
+    };
+
+    let build_entrypoint = if module.runnable_target.is_some() {
+        TaskEntrypoint::Preferred
+    } else {
+        TaskEntrypoint::Candidate
+    };
+    let mut tasks = vec![
+        go_command_task(
+            "build",
+            "build",
+            vec!["./...".to_string()],
+            PassThroughPlacement::BeforeSuffix,
+            module.runnable_target.is_none().then_some(false),
+            build_entrypoint,
+            WorkingDirectoryPolicy::PackageDirectory,
+        ),
+        go_command_task(
+            "test",
+            "test",
+            vec!["./...".to_string()],
+            PassThroughPlacement::BeforeSuffix,
+            None,
+            TaskEntrypoint::Candidate,
+            WorkingDirectoryPolicy::PackageDirectory,
+        ),
+        go_command_task(
+            "vet",
+            "vet",
+            vec!["./...".to_string()],
+            PassThroughPlacement::BeforeSuffix,
+            None,
+            TaskEntrypoint::Candidate,
+            WorkingDirectoryPolicy::PackageDirectory,
+        ),
+        go_command_task(
+            "format",
+            "fmt",
+            vec!["./...".to_string()],
+            PassThroughPlacement::BeforeSuffix,
+            Some(false),
+            TaskEntrypoint::Candidate,
+            WorkingDirectoryPolicy::PackageDirectory,
+        ),
+    ];
+    if let Some(target) = &module.runnable_target {
+        for name in ["run", "dev"] {
+            tasks.push(go_command_task(
+                name,
+                "run",
+                vec![target.clone()],
+                PassThroughPlacement::AfterSuffix,
+                Some(false),
+                TaskEntrypoint::Candidate,
+                WorkingDirectoryPolicy::PackageDirectory,
+            ));
+        }
+    }
+    tasks
+}
+
+/// Build workspace-wide verification tasks over explicit module patterns.
+pub fn native_tasks_for_workspace(
+    module_patterns: &[String],
+) -> Vec<crate::native_tasks::NativeTask> {
+    use crate::native_tasks::{
+        NativeTask, NativeTaskContract, PassThroughPlacement, TaskEntrypoint,
+        WorkingDirectoryPolicy,
+    };
+
+    let mut module_patterns = module_patterns.to_vec();
+    module_patterns.sort();
+    module_patterns.dedup();
+    let mut tasks = ["test", "vet", "format"]
+        .into_iter()
+        .map(|name| {
+            go_command_task(
+                name,
+                if name == "format" { "fmt" } else { name },
+                module_patterns.clone(),
+                PassThroughPlacement::BeforeSuffix,
+                (name == "format").then_some(false),
+                TaskEntrypoint::PreferredOnly,
+                WorkingDirectoryPolicy::RepositoryRoot,
+            )
+        })
+        .collect::<Vec<_>>();
+    tasks.push(NativeTask::contract_task(
+        "build",
+        NativeTaskContract::new(
+            toolchain::TaskDefaults::default(),
+            Some(TaskEntrypoint::Excluded),
+            false,
+        ),
+    ));
+    tasks
+}
+
 fn package_from_module(module: &GoModule) -> DiscoveredPackage {
     let descriptor = PackageJson {
         name: Some(turborepo_errors::Spanned::new(module.module_path.clone())),
@@ -426,6 +617,8 @@ fn package_from_module(module: &GoModule) -> DiscoveredPackage {
         module.manifest_path.clone(),
     )
     .with_native_relationships(module.relationships.clone())
+    .with_native_tasks(native_tasks_for_module(module))
+    .with_task_contract(crate::task_contracts::ScopeTaskContract::go())
 }
 
 /// The Go repository contributor. Registered during graph construction when
@@ -459,7 +652,46 @@ impl RepositoryContributor for GoContributor {
                 .into_iter()
                 .collect();
 
-            let packages = workspace.modules.iter().map(package_from_module).collect();
+            let mut module_patterns = workspace
+                .modules
+                .iter()
+                .filter_map(|module| {
+                    let directory = module.manifest_path.parent()?;
+                    let directory =
+                        turbopath::AnchoredSystemPathBuf::new(&self.repo_root, directory).ok()?;
+                    Some(format!("./{}/...", directory.to_unix()))
+                })
+                .collect::<Vec<_>>();
+            module_patterns.sort();
+
+            let mut module_names = workspace
+                .modules
+                .iter()
+                .map(|module| module.module_path.clone())
+                .collect::<Vec<_>>();
+            module_names.sort();
+            let workspace_relationships = module_names
+                .into_iter()
+                .map(|name| Relationship::internal(name, DependencyKind::Production))
+                .collect();
+
+            let mut packages = workspace
+                .modules
+                .iter()
+                .map(package_from_module)
+                .collect::<Vec<_>>();
+            if !packages.is_empty() {
+                packages.push(
+                    DiscoveredPackage::aggregate(
+                        GO_WORKSPACE_NAME.to_string(),
+                        PackageJson::default(),
+                        self.repo_root.join_component(GO_WORK),
+                    )
+                    .with_native_relationships(workspace_relationships)
+                    .with_native_tasks(native_tasks_for_workspace(&module_patterns))
+                    .with_task_contract(crate::task_contracts::ScopeTaskContract::go()),
+                );
+            }
 
             Ok(DiscoveredPackages::new(packages, workspace_roots))
         })
@@ -629,5 +861,130 @@ mod tests {
             HashSet::from(["example.com/api".to_string(), "example.com/lib".to_string()]);
         let relationships = relationships_from_mod_graph(graph, &module_paths).unwrap();
         assert_eq!(relationships["example.com/api"].len(), 1);
+    }
+
+    fn task_context<'a>(
+        root: &'a AbsoluteSystemPath,
+        name: &str,
+        directory: &'a str,
+        tasks: Vec<crate::native_tasks::NativeTask>,
+        kind: crate::package_graph::PackageTaskContextKind,
+    ) -> crate::package_graph::PackageTaskContext<'a> {
+        crate::package_graph::PackageTaskContext::new_for_test_with_native_tasks(
+            name.into(),
+            root,
+            turbopath::AnchoredSystemPath::new(directory).unwrap(),
+            kind,
+            Some(&ToolchainId::GO),
+            Some(tasks),
+            Some(crate::task_contracts::ScopeTaskContract::go()),
+        )
+    }
+
+    fn resolve_go_cmd(
+        context: &crate::package_graph::PackageTaskContext<'_>,
+        task: &str,
+        pass_through_args: Option<&[String]>,
+        override_command: Option<&[String]>,
+    ) -> crate::toolchain::TaskCommand {
+        let native_task = context.native_tasks().get(task).expect("native Go task");
+        crate::native_tasks::resolve_task_command(
+            context,
+            native_task,
+            None,
+            None,
+            Some(Path::new("/bin/go")),
+            pass_through_args,
+            override_command,
+        )
+        .unwrap()
+        .expect("Go command resolves")
+    }
+
+    #[test]
+    fn module_task_table_renders_commands_and_argument_placement() {
+        let root = AbsoluteSystemPathBuf::new("/repo").unwrap();
+        let module = GoModule {
+            module_path: "example.com/api".to_string(),
+            manifest_path: root.join_components(&["apps", "api", GO_MOD]),
+            relationships: Vec::new(),
+            runnable_target: Some("./cmd/api".to_string()),
+        };
+        let context = task_context(
+            &root,
+            &module.module_path,
+            "apps/api",
+            native_tasks_for_module(&module),
+            crate::package_graph::PackageTaskContextKind::Package,
+        );
+
+        let build = resolve_go_cmd(
+            &context,
+            "build",
+            Some(&["-race".to_string()]),
+            None,
+        );
+        assert_eq!(
+            build.args,
+            ["build", "-race", "./..."].map(std::ffi::OsString::from)
+        );
+        assert_eq!(build.cwd, root.join_components(&["apps", "api"]));
+        assert_eq!(
+            context
+                .native_tasks()
+                .get("build")
+                .unwrap()
+                .contract()
+                .entrypoint(),
+            Some(crate::native_tasks::TaskEntrypoint::Preferred)
+        );
+
+        let run = resolve_go_cmd(
+            &context,
+            "run",
+            Some(&["--port".to_string(), "3000".to_string()]),
+            None,
+        );
+        assert_eq!(
+            run.args,
+            ["run", "./cmd/api", "--port", "3000"].map(std::ffi::OsString::from)
+        );
+
+    }
+
+    #[test]
+    fn ambiguous_main_packages_do_not_register_run_defaults() {
+        if !go_available() {
+            return;
+        }
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPathBuf::try_from(tempdir.path()).unwrap();
+        write_workspace(&root, &[("apps/api", "example.com/api", "")]);
+        for command in ["first", "second"] {
+            join_relative_path(&root, &format!("apps/api/cmd/{command}"))
+                .unwrap()
+                .create_dir_all()
+                .unwrap();
+            join_relative_path(&root, &format!("apps/api/cmd/{command}/main.go"))
+                .unwrap()
+                .create_with_contents("package main\nfunc main() {}\n")
+                .unwrap();
+        }
+
+        let workspace = discover_workspace(&root).expect("workspace discovery succeeds");
+        let module = &workspace.modules[0];
+        assert_eq!(module.runnable_target, None);
+        let tasks = native_tasks_for_module(module);
+        assert!(!tasks.iter().any(|task| matches!(task.name(), "run" | "dev")));
+        assert_eq!(
+            tasks
+                .iter()
+                .find(|task| task.name() == "build")
+                .unwrap()
+                .contract()
+                .entrypoint(),
+            Some(crate::native_tasks::TaskEntrypoint::Candidate)
+        );
     }
 }

--- a/crates/turborepo-repository/src/go.rs
+++ b/crates/turborepo-repository/src/go.rs
@@ -109,7 +109,8 @@ pub struct GoModule {
     pub manifest_path: AbsoluteSystemPathBuf,
     /// Direct internal relationships to other workspace modules.
     pub relationships: Vec<Relationship>,
-    /// Package pattern for the sole runnable `main` package, when unambiguous.
+    /// Package pattern for the sole `main` package used by the `dev` task, when
+    /// unambiguous.
     pub runnable_target: Option<String>,
 }
 
@@ -236,8 +237,8 @@ fn runnable_target(module_dir: &AbsoluteSystemPath) -> Result<Option<String>, Er
     const COMMAND: &str = "go list -find -json ./...";
 
     let output = run_go(module_dir, &["list", "-find", "-json", "./..."], COMMAND)?;
-    // Runnable defaults are optional. If Go cannot classify every package
-    // without error, omit them rather than making workspace discovery fail.
+    // The native dev default is optional. If Go cannot classify every package
+    // without error, omit it rather than making workspace discovery fail.
     if !output.status.success() {
         return Ok(None);
     }
@@ -548,17 +549,15 @@ pub fn native_tasks_for_module(module: &GoModule) -> Vec<crate::native_tasks::Na
         ),
     ];
     if let Some(target) = &module.runnable_target {
-        for name in ["run", "dev"] {
-            tasks.push(go_command_task(
-                name,
-                "run",
-                vec![target.clone()],
-                PassThroughPlacement::AfterSuffix,
-                Some(false),
-                TaskEntrypoint::Candidate,
-                WorkingDirectoryPolicy::PackageDirectory,
-            ));
-        }
+        tasks.push(go_command_task(
+            "dev",
+            "run",
+            vec![target.clone()],
+            PassThroughPlacement::AfterSuffix,
+            Some(false),
+            TaskEntrypoint::Candidate,
+            WorkingDirectoryPolicy::PackageDirectory,
+        ));
     }
     tasks
 }
@@ -939,20 +938,21 @@ mod tests {
             Some(crate::native_tasks::TaskEntrypoint::Preferred)
         );
 
-        let run = resolve_go_cmd(
+        let dev = resolve_go_cmd(
             &context,
-            "run",
+            "dev",
             Some(&["--port".to_string(), "3000".to_string()]),
             None,
         );
         assert_eq!(
-            run.args,
+            dev.args,
             ["run", "./cmd/api", "--port", "3000"].map(std::ffi::OsString::from)
         );
+        assert!(context.native_tasks().get("run").is_none());
     }
 
     #[test]
-    fn ambiguous_main_packages_do_not_register_run_defaults() {
+    fn ambiguous_main_packages_do_not_register_dev_default() {
         if !go_available() {
             return;
         }
@@ -975,11 +975,8 @@ mod tests {
         let module = &workspace.modules[0];
         assert_eq!(module.runnable_target, None);
         let tasks = native_tasks_for_module(module);
-        assert!(
-            !tasks
-                .iter()
-                .any(|task| matches!(task.name(), "run" | "dev"))
-        );
+        assert!(!tasks.iter().any(|task| task.name() == "dev"));
+        assert!(!tasks.iter().any(|task| task.name() == "run"));
         assert_eq!(
             tasks
                 .iter()

--- a/crates/turborepo-repository/src/go.rs
+++ b/crates/turborepo-repository/src/go.rs
@@ -1234,6 +1234,46 @@ mod tests {
     }
 
     #[test]
+    fn windows_module_executable_contract_uses_exe_suffix() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPathBuf::try_from(tempdir.path()).unwrap();
+        let module = GoModule {
+            module_path: "example.com/api".to_string(),
+            manifest_path: root.join_components(&["apps", "api", GO_MOD]),
+            relationships: Vec::new(),
+            runnable_target: Some(".".to_string()),
+        };
+        let contract = GoTaskContract::module(&module, "windows", &[]);
+        let package = task_context(
+            &root,
+            &module.module_path,
+            "apps/api",
+            native_tasks_for_module(&module, "windows"),
+            crate::package_graph::PackageTaskContextKind::Package,
+            crate::task_contracts::ScopeTaskContract::go(contract.clone()),
+        );
+
+        let build = resolve_go_cmd(&package, "build", None, None);
+        assert_eq!(
+            build.args,
+            ["build", "-o", "dist/api.exe", "."].map(std::ffi::OsString::from)
+        );
+
+        let environment = toolchain::TaskIOEnvironment::default();
+        let context = toolchain::TaskIOContext {
+            task_args: None,
+            environment: &environment,
+        };
+        let io = contract
+            .derived_task_io(&package, "build", "../..", &[], true, &context)
+            .expect("Windows executable build derives IO");
+        assert_eq!(
+            io.outputs,
+            DerivedOutputs::Resolved(vec!["dist/api.exe".to_string()])
+        );
+    }
+
+    #[test]
     fn ambiguous_main_packages_do_not_register_dev_default() {
         if !go_available() {
             return;

--- a/crates/turborepo-repository/src/go.rs
+++ b/crates/turborepo-repository/src/go.rs
@@ -235,19 +235,15 @@ fn go_mod_graph(repo_root: &AbsoluteSystemPath) -> Result<String, Error> {
 fn runnable_target(module_dir: &AbsoluteSystemPath) -> Result<Option<String>, Error> {
     const COMMAND: &str = "go list -find -json ./...";
 
-    let output = run_go(
-        module_dir,
-        &["list", "-find", "-json", "./..."],
-        COMMAND,
-    )?;
+    let output = run_go(module_dir, &["list", "-find", "-json", "./..."], COMMAND)?;
     // Runnable defaults are optional. If Go cannot classify every package
     // without error, omit them rather than making workspace discovery fail.
     if !output.status.success() {
         return Ok(None);
     }
 
-    let packages = serde_json::Deserializer::from_slice(&output.stdout)
-        .into_iter::<GoListPackage>();
+    let packages =
+        serde_json::Deserializer::from_slice(&output.stdout).into_iter::<GoListPackage>();
     let mut runnable = None;
     for package in packages {
         let package = package.map_err(|source| Error::CommandParse {
@@ -506,9 +502,7 @@ fn go_command_task(
 
 /// Build the conservative built-in task table for one Go module.
 pub fn native_tasks_for_module(module: &GoModule) -> Vec<crate::native_tasks::NativeTask> {
-    use crate::native_tasks::{
-        PassThroughPlacement, TaskEntrypoint, WorkingDirectoryPolicy,
-    };
+    use crate::native_tasks::{PassThroughPlacement, TaskEntrypoint, WorkingDirectoryPolicy};
 
     let build_entrypoint = if module.runnable_target.is_some() {
         TaskEntrypoint::Preferred
@@ -918,12 +912,7 @@ mod tests {
             crate::package_graph::PackageTaskContextKind::Package,
         );
 
-        let build = resolve_go_cmd(
-            &context,
-            "build",
-            Some(&["-race".to_string()]),
-            None,
-        );
+        let build = resolve_go_cmd(&context, "build", Some(&["-race".to_string()]), None);
         assert_eq!(
             build.args,
             ["build", "-race", "./..."].map(std::ffi::OsString::from)
@@ -949,7 +938,6 @@ mod tests {
             run.args,
             ["run", "./cmd/api", "--port", "3000"].map(std::ffi::OsString::from)
         );
-
     }
 
     #[test]
@@ -976,7 +964,11 @@ mod tests {
         let module = &workspace.modules[0];
         assert_eq!(module.runnable_target, None);
         let tasks = native_tasks_for_module(module);
-        assert!(!tasks.iter().any(|task| matches!(task.name(), "run" | "dev")));
+        assert!(
+            !tasks
+                .iter()
+                .any(|task| matches!(task.name(), "run" | "dev"))
+        );
         assert_eq!(
             tasks
                 .iter()

--- a/crates/turborepo-repository/src/go.rs
+++ b/crates/turborepo-repository/src/go.rs
@@ -923,7 +923,7 @@ mod tests {
             lint.args,
             ["vet", "-json", "./..."].map(std::ffi::OsString::from)
         );
-        assert!(!context.native_tasks().contains_key("vet"));
+        assert!(context.native_tasks().get("vet").is_none());
         assert!(
             !native_tasks_for_workspace(&["./apps/api/...".to_string()])
                 .iter()

--- a/crates/turborepo-repository/src/go.rs
+++ b/crates/turborepo-repository/src/go.rs
@@ -1301,12 +1301,7 @@ mod tests {
             crate::package_graph::PackageTaskContextKind::Package,
             crate::task_contracts::ScopeTaskContract::go(executable_contract.clone()),
         );
-        assert!(
-            package
-                .task_contract()
-                .environment_vars()
-                .contains(&"GOCACHE")
-        );
+        assert!(package.task_contract().env_vars().contains(&"GOCACHE"));
         let dependency = task_context(
             &root,
             &library.module_path,

--- a/crates/turborepo-repository/src/go.rs
+++ b/crates/turborepo-repository/src/go.rs
@@ -40,7 +40,6 @@ pub const GO_WORK: &str = "go.work";
 /// The conventional file name for a Go module manifest.
 pub const GO_MOD: &str = "go.mod";
 
-const GO_SUM: &str = "go.sum";
 const GO_WORK_SUM: &str = "go.work.sum";
 const GO_DIST_DIR: &str = "dist";
 
@@ -532,7 +531,7 @@ fn go_command_task(
     .with_contract(NativeTaskContract::new(
         toolchain::TaskDefaults { cache },
         Some(entrypoint),
-        false,
+        true,
     ))
 }
 

--- a/crates/turborepo-repository/src/task_contracts.rs
+++ b/crates/turborepo-repository/src/task_contracts.rs
@@ -93,6 +93,7 @@ impl CommandMapTarget {
 enum DynamicTaskContract {
     Cargo(crate::cargo::CargoTaskContract),
     Python(crate::uv::UvTaskContract),
+    Go(crate::go::GoTaskContract),
 }
 
 /// Per-scope task-contract observation produced at repository construction.
@@ -136,18 +137,22 @@ impl ScopeTaskContract {
         }
     }
 
-    /// Go module and workspace scopes with static native task tables.
-    pub fn go() -> Self {
+    /// Go module and workspace scopes with derived native task contracts.
+    pub(crate) fn go(contract: crate::go::GoTaskContract) -> Self {
+        let dependency_source_inputs = contract.dependency_source_inputs();
         Self {
-            derives_io: false,
+            derives_io: true,
             defaults: TaskDefaults::default(),
-            environment: None,
+            environment: Some(TaskEnvironmentRequirement::new(
+                TaskEnvironmentDomain(Cow::Borrowed("go-task-io")),
+                crate::go::HASHED_ENV_VARS.to_vec(),
+            )),
             toolchain: Some(ToolchainId::GO),
             command_map_target: Some(CommandMapTarget::Go),
             entrypoint_domain: Some(TaskEntrypointDomain(Cow::Borrowed("go"))),
             prune_package_mode: None,
-            dependency_source_inputs: DependencySourceInputs::Unknown,
-            dynamic: None,
+            dependency_source_inputs,
+            dynamic: Some(DynamicTaskContract::Go(contract)),
             static_defaults: BTreeMap::new(),
             static_io: BTreeMap::new(),
             static_entrypoints: BTreeMap::new(),
@@ -334,6 +339,14 @@ impl ScopeTaskContract {
                 context,
             ),
             DynamicTaskContract::Python(contract) => contract.derived_task_io(
+                package,
+                task,
+                path_to_root,
+                dependencies,
+                wants_automatic_inputs,
+                context,
+            ),
+            DynamicTaskContract::Go(contract) => contract.derived_task_io(
                 package,
                 task,
                 path_to_root,

--- a/crates/turborepo-repository/src/task_contracts.rs
+++ b/crates/turborepo-repository/src/task_contracts.rs
@@ -140,12 +140,14 @@ impl ScopeTaskContract {
     /// Go module and workspace scopes with derived native task contracts.
     pub(crate) fn go(contract: crate::go::GoTaskContract) -> Self {
         let dependency_source_inputs = contract.dependency_source_inputs();
+        let mut environment_vars = crate::go::HASHED_ENV_VARS.to_vec();
+        environment_vars.extend(crate::go::PROJECTED_ONLY_ENV_VARS);
         Self {
             derives_io: true,
             defaults: TaskDefaults::default(),
             environment: Some(TaskEnvironmentRequirement::new(
                 TaskEnvironmentDomain(Cow::Borrowed("go-task-io")),
-                crate::go::HASHED_ENV_VARS.to_vec(),
+                environment_vars,
             )),
             toolchain: Some(ToolchainId::GO),
             command_map_target: Some(CommandMapTarget::Go),

--- a/crates/turborepo-repository/src/task_contracts.rs
+++ b/crates/turborepo-repository/src/task_contracts.rs
@@ -55,6 +55,7 @@ pub enum CommandMapTarget {
     JavaScript,
     Rust,
     Python,
+    Go,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -80,7 +81,10 @@ impl CommandMapTarget {
     fn matches(self, key: &str) -> bool {
         matches!(
             (self, key),
-            (Self::JavaScript, "javascript") | (Self::Rust, "rust") | (Self::Python, "python")
+            (Self::JavaScript, "javascript")
+                | (Self::Rust, "rust")
+                | (Self::Python, "python")
+                | (Self::Go, "go")
         )
     }
 }
@@ -125,6 +129,24 @@ impl ScopeTaskContract {
             entrypoint_domain: None,
             prune_package_mode: Some(PrunePackageMode::JavaScript),
             dependency_source_inputs: DependencySourceInputs::Exclude,
+            dynamic: None,
+            static_defaults: BTreeMap::new(),
+            static_io: BTreeMap::new(),
+            static_entrypoints: BTreeMap::new(),
+        }
+    }
+
+    /// Go module and workspace scopes with static native task tables.
+    pub fn go() -> Self {
+        Self {
+            derives_io: false,
+            defaults: TaskDefaults::default(),
+            environment: None,
+            toolchain: Some(ToolchainId::GO),
+            command_map_target: Some(CommandMapTarget::Go),
+            entrypoint_domain: Some(TaskEntrypointDomain(Cow::Borrowed("go"))),
+            prune_package_mode: None,
+            dependency_source_inputs: DependencySourceInputs::Unknown,
             dynamic: None,
             static_defaults: BTreeMap::new(),
             static_io: BTreeMap::new(),

--- a/crates/turborepo-task-executor/src/command.rs
+++ b/crates/turborepo-task-executor/src/command.rs
@@ -175,6 +175,8 @@ pub struct ToolchainCommandProvider<'a, M = crate::NoMfeConfig> {
     cargo_binary: std::sync::OnceLock<Result<std::path::PathBuf, which::Error>>,
     /// Lazily resolved uv binary path for Python framing.
     uv_binary: std::sync::OnceLock<Result<std::path::PathBuf, which::Error>>,
+    /// Lazily resolved go binary path for Go framing.
+    go_binary: std::sync::OnceLock<Result<std::path::PathBuf, which::Error>>,
 }
 
 impl<'a, M: MfeConfigProvider> ToolchainCommandProvider<'a, M> {
@@ -194,6 +196,7 @@ impl<'a, M: MfeConfigProvider> ToolchainCommandProvider<'a, M> {
             package_manager_binary: std::sync::OnceLock::new(),
             cargo_binary: std::sync::OnceLock::new(),
             uv_binary: std::sync::OnceLock::new(),
+            go_binary: std::sync::OnceLock::new(),
         }
     }
 
@@ -219,6 +222,13 @@ impl<'a, M: MfeConfigProvider> ToolchainCommandProvider<'a, M> {
 
     fn uv_binary(&self) -> Result<Option<&std::path::Path>, CommandProviderError> {
         match self.uv_binary.get_or_init(|| which::which("uv")) {
+            Ok(path) => Ok(Some(path.as_path())),
+            Err(_) => Ok(None),
+        }
+    }
+
+    fn go_binary(&self) -> Result<Option<&std::path::Path>, CommandProviderError> {
+        match self.go_binary.get_or_init(|| which::which("go")) {
             Ok(path) => Ok(Some(path.as_path())),
             Err(_) => Ok(None),
         }
@@ -275,6 +285,9 @@ impl<'a, M: MfeConfigProvider, E: From<CommandProviderError>> CommandProvider<E>
                     }
                     Some(NativeCommandProgram::Tool(tool)) if tool == "uv" => {
                         (None, self.uv_binary()?)
+                    }
+                    Some(NativeCommandProgram::Tool(tool)) if tool == "go" => {
+                        (None, self.go_binary()?)
                     }
                     Some(NativeCommandProgram::Tool(_)) | None => (None, None),
                 }

--- a/crates/turborepo/tests/go_workspace_test.rs
+++ b/crates/turborepo/tests/go_workspace_test.rs
@@ -58,6 +58,22 @@ fn dry_run_task(output: &std::process::Output, task_id: &str) -> serde_json::Val
         .unwrap_or_else(|| panic!("{task_id} in task graph"))
 }
 
+fn task_hash(dir: &Path, package: &str, task: &str) -> String {
+    let output = run_turbo(
+        dir,
+        &[
+            "run",
+            task,
+            &format!("--filter={package}"),
+            "--dry-run=json",
+        ],
+    );
+    dry_run_task(&output, &format!("{package}#{task}"))["hash"]
+        .as_str()
+        .expect("task has a hash")
+        .to_string()
+}
+
 fn package_names(dir: &Path) -> Vec<String> {
     let output = run_turbo(dir, &["ls", "--output=json"]);
     assert_command_success(&output, "turbo ls");
@@ -271,6 +287,19 @@ fn test_go_native_tasks_and_workspace_aggregate() {
 
     let output = run_turbo(
         tempdir.path(),
+        &["run", "build", "--filter=example.com/api", "--dry-run=json"],
+    );
+    let build = dry_run_task(&output, "example.com/api#build");
+    assert_eq!(build["command"], "go build -o dist/api .");
+    assert_eq!(build["resolvedTaskDefinition"]["cache"], true);
+    assert!(
+        build["resolvedTaskDefinition"]["outputs"]
+            .as_array()
+            .is_some_and(|outputs| outputs.iter().any(|output| output == "dist/api"))
+    );
+
+    let output = run_turbo(
+        tempdir.path(),
         &["run", "build", "--filter=example.com/lib", "--dry-run=json"],
     );
     let build = dry_run_task(&output, "example.com/lib#build");
@@ -307,6 +336,35 @@ fn test_go_native_tasks_and_workspace_aggregate() {
     assert!(
         stderr.contains("Could not find task `run` in project"),
         "unexpected stderr: {stderr}"
+    );
+}
+
+#[test]
+fn test_go_task_hash_tracks_source_but_not_unrelated_siblings() {
+    if !go_available() {
+        return;
+    }
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_go_pure_workspace(tempdir.path());
+    let original = task_hash(tempdir.path(), "example.com/api", "build");
+
+    fs::write(tempdir.path().join("unrelated.txt"), "unrelated\n").unwrap();
+    assert_eq!(
+        original,
+        task_hash(tempdir.path(), "example.com/api", "build"),
+        "repository-root siblings outside the module must not affect its hash"
+    );
+
+    fs::write(
+        tempdir.path().join("apps/api/main.go"),
+        "package main\n\nimport \"example.com/lib\"\n\nfunc main() { lib.Greet(); \
+         println(\"changed\") }\n",
+    )
+    .unwrap();
+    assert_ne!(
+        original,
+        task_hash(tempdir.path(), "example.com/api", "build"),
+        "module source changes must affect its task hash"
     );
 }
 

--- a/crates/turborepo/tests/go_workspace_test.rs
+++ b/crates/turborepo/tests/go_workspace_test.rs
@@ -6,6 +6,7 @@ mod common;
 use std::{fs, path::Path};
 
 use common::setup;
+use turbopath::RelativeUnixPath;
 
 const AMBIENT_GO_ENV: &[&str] = &[
     "GO111MODULE",
@@ -310,19 +311,17 @@ fn test_go_native_tasks_and_workspace_aggregate() {
         &["run", "build", "--filter=example.com/api", "--dry-run=json"],
     );
     let build = dry_run_task(&output, "example.com/api#build");
-    assert_eq!(
-        build["command"],
-        if cfg!(windows) {
-            "go build -o dist/api.exe ."
-        } else {
-            "go build -o dist/api ."
-        }
-    );
+    let expected_output = RelativeUnixPath::new("dist")
+        .unwrap()
+        .join_component(&format!("api{}", std::env::consts::EXE_SUFFIX));
+    assert_eq!(build["command"], format!("go build -o {expected_output} ."));
     assert_eq!(build["resolvedTaskDefinition"]["cache"], true);
     assert!(
         build["resolvedTaskDefinition"]["outputs"]
             .as_array()
-            .is_some_and(|outputs| outputs.iter().any(|output| output == "dist/api"))
+            .is_some_and(|outputs| outputs
+                .iter()
+                .any(|output| output == expected_output.as_str()))
     );
 
     let output = run_turbo(

--- a/crates/turborepo/tests/go_workspace_test.rs
+++ b/crates/turborepo/tests/go_workspace_test.rs
@@ -290,7 +290,7 @@ fn test_go_native_tasks_and_workspace_aggregate() {
         ],
     );
     let dev = dry_run_task(&output, "example.com/api#dev");
-    assert_eq!(dev["command"], "go run . --port 3000");
+    assert_eq!(dev["command"], "go run .");
 
     let tasks = package_task_names(tempdir.path(), "example.com/api");
     assert!(tasks.iter().any(|task| task == "dev"), "tasks: {tasks:?}");

--- a/crates/turborepo/tests/go_workspace_test.rs
+++ b/crates/turborepo/tests/go_workspace_test.rs
@@ -49,7 +49,8 @@ fn assert_command_success(output: &std::process::Output, context: &str) {
 
 fn dry_run_task(output: &std::process::Output, task_id: &str) -> serde_json::Value {
     assert_command_success(output, "Go task dry run");
-    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("dry run emits JSON");
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("dry run emits JSON");
     json["tasks"]
         .as_array()
         .and_then(|tasks| tasks.iter().find(|task| task["taskId"] == task_id))
@@ -231,25 +232,14 @@ fn test_go_native_tasks_and_workspace_aggregate() {
     )
     .unwrap();
 
-    let output = run_turbo(
-        tempdir.path(),
-        &["run", "test", "--dry-run=json"],
-    );
+    let output = run_turbo(tempdir.path(), &["run", "test", "--dry-run=json"]);
     let task = dry_run_task(&output, "go-workspace#test");
-    assert_eq!(
-        task["command"],
-        "go test ./apps/api/... ./packages/lib/..."
-    );
+    assert_eq!(task["command"], "go test ./apps/api/... ./packages/lib/...");
     assert_eq!(task["directory"], "");
 
     let output = run_turbo(
         tempdir.path(),
-        &[
-            "run",
-            "build",
-            "--filter=example.com/lib",
-            "--dry-run=json",
-        ],
+        &["run", "build", "--filter=example.com/lib", "--dry-run=json"],
     );
     let build = dry_run_task(&output, "example.com/lib#build");
     assert_eq!(build["command"], "go build ./...");
@@ -281,12 +271,7 @@ fn test_go_native_tasks_are_overrideable_and_excludable() {
 
     let output = run_turbo(
         tempdir.path(),
-        &[
-            "run",
-            "build",
-            "--filter=example.com/lib",
-            "--dry-run=json",
-        ],
+        &["run", "build", "--filter=example.com/lib", "--dry-run=json"],
     );
     let build = dry_run_task(&output, "example.com/lib#build");
     assert_eq!(build["command"], "go version");
@@ -310,8 +295,7 @@ fn test_go_native_tasks_are_overrideable_and_excludable() {
         ],
     );
     assert_command_success(&output, "query excluded Go tasks");
-    let json: serde_json::Value =
-        serde_json::from_slice(&output.stdout).expect("query emits JSON");
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("query emits JSON");
     let tasks = json["data"]["package"]["tasks"]["items"]
         .as_array()
         .expect("task items");

--- a/crates/turborepo/tests/go_workspace_test.rs
+++ b/crates/turborepo/tests/go_workspace_test.rs
@@ -240,6 +240,21 @@ fn test_go_native_tasks_and_workspace_aggregate() {
     assert_eq!(task["command"], "go test ./apps/api/... ./packages/lib/...");
     assert_eq!(task["directory"], "");
 
+    let output = run_turbo(tempdir.path(), &["run", "lint", "--dry-run=json"]);
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("dry run emits JSON");
+    assert_eq!(json["tasks"].as_array().map(Vec::len), Some(1));
+    let lint = dry_run_task(&output, "go-workspace#lint");
+    assert_eq!(lint["command"], "go vet ./apps/api/... ./packages/lib/...");
+    assert_eq!(lint["directory"], "");
+
+    let output = run_turbo(
+        tempdir.path(),
+        &["run", "lint", "--filter=example.com/lib", "--dry-run=json"],
+    );
+    let lint = dry_run_task(&output, "example.com/lib#lint");
+    assert_eq!(lint["command"], "go vet ./...");
+
     let output = run_turbo(
         tempdir.path(),
         &["run", "build", "--filter=example.com/lib", "--dry-run=json"],
@@ -266,7 +281,7 @@ fn test_go_native_tasks_are_overrideable_and_excludable() {
     "experimentalTaskCommand": true
   },
   "tasks": {
-    "build": { "command": { "go": ["go", "version"] } }
+    "lint": { "command": { "go": ["go", "version"] } }
   }
 }"#,
     )
@@ -274,10 +289,10 @@ fn test_go_native_tasks_are_overrideable_and_excludable() {
 
     let output = run_turbo(
         tempdir.path(),
-        &["run", "build", "--filter=example.com/lib", "--dry-run=json"],
+        &["run", "lint", "--filter=example.com/lib", "--dry-run=json"],
     );
-    let build = dry_run_task(&output, "example.com/lib#build");
-    assert_eq!(build["command"], "go version");
+    let lint = dry_run_task(&output, "example.com/lib#lint");
+    assert_eq!(lint["command"], "go version");
 
     fs::write(
         tempdir.path().join("apps/api/turbo.json"),
@@ -302,6 +317,8 @@ fn test_go_native_tasks_are_overrideable_and_excludable() {
     let tasks = json["data"]["package"]["tasks"]["items"]
         .as_array()
         .expect("task items");
+    assert!(tasks.iter().any(|task| task["name"] == "lint"));
+    assert!(!tasks.iter().any(|task| task["name"] == "vet"));
     assert!(!tasks.iter().any(|task| task["name"] == "run"));
     assert!(!tasks.iter().any(|task| task["name"] == "dev"));
 }

--- a/crates/turborepo/tests/go_workspace_test.rs
+++ b/crates/turborepo/tests/go_workspace_test.rs
@@ -10,6 +10,7 @@ use common::setup;
 const AMBIENT_GO_ENV: &[&str] = &[
     "GO111MODULE",
     "GOARCH",
+    "GOCACHE",
     "GOENV",
     "GOEXPERIMENT",
     "GOFLAGS",
@@ -41,11 +42,13 @@ fn setup_go_monorepo(dir: &Path) {
 
 fn run_turbo(dir: &Path, args: &[&str]) -> std::process::Output {
     let config_dir = tempfile::tempdir().expect("failed to create config tempdir");
+    let go_cache_dir = tempfile::tempdir().expect("failed to create Go cache tempdir");
     let mut command = common::turbo_command(dir);
     for name in AMBIENT_GO_ENV {
         command.env_remove(name);
     }
     command
+        .env("GOCACHE", go_cache_dir.path())
         .env("GOENV", "off")
         .env("GOTOOLCHAIN", "local")
         .env("TURBO_CONFIG_DIR_PATH", config_dir.path());
@@ -307,7 +310,14 @@ fn test_go_native_tasks_and_workspace_aggregate() {
         &["run", "build", "--filter=example.com/api", "--dry-run=json"],
     );
     let build = dry_run_task(&output, "example.com/api#build");
-    assert_eq!(build["command"], "go build -o dist/api .");
+    assert_eq!(
+        build["command"],
+        if cfg!(windows) {
+            "go build -o dist/api.exe ."
+        } else {
+            "go build -o dist/api ."
+        }
+    );
     assert_eq!(build["resolvedTaskDefinition"]["cache"], true);
     assert!(
         build["resolvedTaskDefinition"]["outputs"]

--- a/crates/turborepo/tests/go_workspace_test.rs
+++ b/crates/turborepo/tests/go_workspace_test.rs
@@ -290,12 +290,14 @@ fn test_go_native_tasks_and_workspace_aggregate() {
         &["run", "build", "--filter=example.com/api", "--dry-run=json"],
     );
     let build = dry_run_task(&output, "example.com/api#build");
-    assert_eq!(build["command"], "go build -o dist/api .");
+    let executable = if cfg!(windows) { "api.exe" } else { "api" };
+    let output_path = format!("dist/{executable}");
+    assert_eq!(build["command"], format!("go build -o {output_path} ."));
     assert_eq!(build["resolvedTaskDefinition"]["cache"], true);
     assert!(
         build["resolvedTaskDefinition"]["outputs"]
             .as_array()
-            .is_some_and(|outputs| outputs.iter().any(|output| output == "dist/api"))
+            .is_some_and(|outputs| outputs.iter().any(|output| output == &output_path))
     );
 
     let output = run_turbo(

--- a/crates/turborepo/tests/go_workspace_test.rs
+++ b/crates/turborepo/tests/go_workspace_test.rs
@@ -47,6 +47,16 @@ fn assert_command_success(output: &std::process::Output, context: &str) {
     );
 }
 
+fn dry_run_task(output: &std::process::Output, task_id: &str) -> serde_json::Value {
+    assert_command_success(output, "Go task dry run");
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("dry run emits JSON");
+    json["tasks"]
+        .as_array()
+        .and_then(|tasks| tasks.iter().find(|task| task["taskId"] == task_id))
+        .cloned()
+        .unwrap_or_else(|| panic!("{task_id} in task graph"))
+}
+
 fn package_names(dir: &Path) -> Vec<String> {
     let output = run_turbo(dir, &["ls", "--output=json"]);
     assert_command_success(&output, "turbo ls");
@@ -201,4 +211,110 @@ fn test_pure_go_workspace_has_no_package_json() {
         !tempdir.path().join("package.json").exists(),
         "turbo must not create a package.json for a pure Go workspace"
     );
+}
+
+#[test]
+fn test_go_native_tasks_and_workspace_aggregate() {
+    if !go_available() {
+        return;
+    }
+
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_go_pure_workspace(tempdir.path());
+    fs::write(
+        tempdir.path().join("turbo.json"),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "futureFlags": { "experimentalGoWorkspaces": true },
+  "tasks": {}
+}"#,
+    )
+    .unwrap();
+
+    let output = run_turbo(
+        tempdir.path(),
+        &["run", "test", "--dry-run=json"],
+    );
+    let task = dry_run_task(&output, "go-workspace#test");
+    assert_eq!(
+        task["command"],
+        "go test ./apps/api/... ./packages/lib/..."
+    );
+    assert_eq!(task["directory"], "");
+
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "run",
+            "build",
+            "--filter=example.com/lib",
+            "--dry-run=json",
+        ],
+    );
+    let build = dry_run_task(&output, "example.com/lib#build");
+    assert_eq!(build["command"], "go build ./...");
+    assert_eq!(build["resolvedTaskDefinition"]["cache"], false);
+}
+
+#[test]
+fn test_go_native_tasks_are_overrideable_and_excludable() {
+    if !go_available() {
+        return;
+    }
+
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_go_pure_workspace(tempdir.path());
+    fs::write(
+        tempdir.path().join("turbo.json"),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "futureFlags": {
+    "experimentalGoWorkspaces": true,
+    "experimentalTaskCommand": true
+  },
+  "tasks": {
+    "build": { "command": { "go": ["go", "version"] } }
+  }
+}"#,
+    )
+    .unwrap();
+
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "run",
+            "build",
+            "--filter=example.com/lib",
+            "--dry-run=json",
+        ],
+    );
+    let build = dry_run_task(&output, "example.com/lib#build");
+    assert_eq!(build["command"], "go version");
+
+    fs::write(
+        tempdir.path().join("apps/api/turbo.json"),
+        r#"{
+  "extends": ["//"],
+  "tasks": {
+    "run": { "extends": false },
+    "dev": { "extends": false }
+  }
+}"#,
+    )
+    .unwrap();
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "query",
+            "query { package(name: \"example.com/api\") { tasks { items { name } } } }",
+        ],
+    );
+    assert_command_success(&output, "query excluded Go tasks");
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("query emits JSON");
+    let tasks = json["data"]["package"]["tasks"]["items"]
+        .as_array()
+        .expect("task items");
+    assert!(!tasks.iter().any(|task| task["name"] == "run"));
+    assert!(!tasks.iter().any(|task| task["name"] == "dev"));
 }

--- a/crates/turborepo/tests/go_workspace_test.rs
+++ b/crates/turborepo/tests/go_workspace_test.rs
@@ -7,6 +7,17 @@ use std::{fs, path::Path};
 
 use common::setup;
 
+const AMBIENT_GO_ENV: &[&str] = &[
+    "GO111MODULE",
+    "GOARCH",
+    "GOENV",
+    "GOEXPERIMENT",
+    "GOFLAGS",
+    "GOOS",
+    "GOTOOLCHAIN",
+    "GOWORK",
+];
+
 fn go_available() -> bool {
     let available = which::which("go").is_ok();
     if !available {
@@ -31,7 +42,13 @@ fn setup_go_monorepo(dir: &Path) {
 fn run_turbo(dir: &Path, args: &[&str]) -> std::process::Output {
     let config_dir = tempfile::tempdir().expect("failed to create config tempdir");
     let mut command = common::turbo_command(dir);
-    command.env("TURBO_CONFIG_DIR_PATH", config_dir.path());
+    for name in AMBIENT_GO_ENV {
+        command.env_remove(name);
+    }
+    command
+        .env("GOENV", "off")
+        .env("GOTOOLCHAIN", "local")
+        .env("TURBO_CONFIG_DIR_PATH", config_dir.path());
     command
         .args(args)
         .output()
@@ -421,4 +438,168 @@ fn test_go_native_tasks_are_overrideable_and_excludable() {
     assert!(!tasks.iter().any(|task| task == "vet"), "tasks: {tasks:?}");
     assert!(!tasks.iter().any(|task| task == "run"), "tasks: {tasks:?}");
     assert!(!tasks.iter().any(|task| task == "dev"), "tasks: {tasks:?}");
+}
+
+#[test]
+fn test_native_go_tasks_execute_cache_restore_and_pass_through_args() {
+    if !go_available() {
+        return;
+    }
+
+    let unfiltered = tempfile::tempdir().unwrap();
+    setup_go_pure_workspace(unfiltered.path());
+    for task in ["build", "test", "lint"] {
+        let output = run_turbo(unfiltered.path(), &["run", task, "--log-order=grouped"]);
+        assert_command_success(&output, &format!("unfiltered Go {task}"));
+    }
+    assert!(
+        unfiltered
+            .path()
+            .join("apps/api/dist")
+            .join(if cfg!(windows) { "api.exe" } else { "api" })
+            .exists(),
+        "unfiltered native build must produce the runnable binary"
+    );
+
+    let filtered = tempfile::tempdir().unwrap();
+    setup_go_pure_workspace(filtered.path());
+    let build_args = [
+        "run",
+        "build",
+        "--filter=example.com/api",
+        "--log-order=grouped",
+    ];
+    let binary = filtered
+        .path()
+        .join("apps/api/dist")
+        .join(if cfg!(windows) { "api.exe" } else { "api" });
+
+    let output = run_turbo(filtered.path(), &build_args);
+    assert_command_success(&output, "cold filtered Go build");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("cache miss"),
+        "expected cache miss: {stdout}"
+    );
+    assert!(binary.exists(), "native build must produce {binary:?}");
+
+    let output = run_turbo(filtered.path(), &build_args);
+    assert_command_success(&output, "warm filtered Go build");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("FULL TURBO"),
+        "second build must hit cache: {stdout}"
+    );
+
+    fs::remove_dir_all(binary.parent().expect("binary output directory")).unwrap();
+    let output = run_turbo(filtered.path(), &build_args);
+    assert_command_success(&output, "restored filtered Go build");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("FULL TURBO"),
+        "restoration must come from cache: {stdout}"
+    );
+    assert!(binary.exists(), "cache hit must restore the binary");
+
+    let output = run_turbo(
+        filtered.path(),
+        &[
+            "run",
+            "dev",
+            "--filter=example.com/api",
+            "--",
+            "passed-to-go",
+        ],
+    );
+    assert_command_success(&output, "native Go dev with pass-through argument");
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("passed-to-go"),
+        "go run must receive pass-through arguments: {output:?}"
+    );
+}
+
+#[test]
+fn test_go_format_override_exclusion_and_failure_propagation() {
+    if !go_available() {
+        return;
+    }
+
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_go_pure_workspace(tempdir.path());
+    let library = tempdir.path().join("packages/lib/lib.go");
+    fs::write(&library, "package lib\nfunc   Greet( ){ }\n").unwrap();
+    let output = run_turbo(
+        tempdir.path(),
+        &["run", "format", "--filter=example.com/lib"],
+    );
+    assert_command_success(&output, "filtered native Go format");
+    assert_eq!(
+        fs::read_to_string(&library).unwrap(),
+        "package lib\n\nfunc Greet() {}\n"
+    );
+
+    fs::write(
+        tempdir.path().join("turbo.json"),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "futureFlags": {
+    "experimentalGoWorkspaces": true,
+    "experimentalTaskCommand": true
+  },
+  "tasks": {
+    "build": { "command": { "go": ["go", "version"] } }
+  }
+}"#,
+    )
+    .unwrap();
+    let output = run_turbo(
+        tempdir.path(),
+        &["run", "build", "--filter=example.com/api"],
+    );
+    assert_command_success(&output, "authored Go build override");
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("go version go"),
+        "the authored command must execute: {output:?}"
+    );
+    assert!(
+        !tempdir.path().join("apps/api/dist").exists(),
+        "the native build must not shadow the authored command"
+    );
+
+    fs::write(
+        tempdir.path().join("apps/api/turbo.json"),
+        r#"{
+  "extends": ["//"],
+  "tasks": {
+    "build": { "extends": false }
+  }
+}"#,
+    )
+    .unwrap();
+    let tasks = package_task_names(tempdir.path(), "example.com/api");
+    assert!(
+        !tasks.iter().any(|task| task == "build"),
+        "package task exclusion must remove the inherited command: {tasks:?}"
+    );
+
+    fs::write(
+        tempdir.path().join("packages/lib/lib_test.go"),
+        "package lib\n\nimport \"testing\"\n\nfunc TestFailure(t *testing.T) { \
+         t.Fatal(\"intentional failure\") }\n",
+    )
+    .unwrap();
+    let output = run_turbo(tempdir.path(), &["run", "test", "--filter=example.com/lib"]);
+    assert!(
+        !output.status.success(),
+        "a failing Go test must fail the Turbo task"
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("intentional failure"),
+        "Go failure output must propagate: {combined}"
+    );
 }

--- a/crates/turborepo/tests/go_workspace_test.rs
+++ b/crates/turborepo/tests/go_workspace_test.rs
@@ -233,6 +233,9 @@ fn test_go_native_tasks_and_workspace_aggregate() {
     .unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "test", "--dry-run=json"]);
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("dry run emits JSON");
+    assert_eq!(json["tasks"].as_array().map(Vec::len), Some(1));
     let task = dry_run_task(&output, "go-workspace#test");
     assert_eq!(task["command"], "go test ./apps/api/... ./packages/lib/...");
     assert_eq!(task["directory"], "");

--- a/crates/turborepo/tests/go_workspace_test.rs
+++ b/crates/turborepo/tests/go_workspace_test.rs
@@ -82,6 +82,20 @@ fn query_packages(dir: &Path) -> serde_json::Value {
     serde_json::from_slice(&output.stdout).expect("query emits JSON")
 }
 
+fn package_task_names(dir: &Path, package: &str) -> Vec<String> {
+    let query =
+        format!("query {{ package(name: \"{package}\") {{ tasks {{ items {{ name }} }} }} }}");
+    let output = run_turbo(dir, &["query", &query]);
+    assert_command_success(&output, "Go task catalog query");
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("query emits JSON");
+    json["data"]["package"]["tasks"]["items"]
+        .as_array()
+        .expect("task items")
+        .iter()
+        .map(|task| task["name"].as_str().expect("task name").to_string())
+        .collect()
+}
+
 #[test]
 fn test_pure_go_workspace_lists_modules() {
     if !go_available() {
@@ -262,6 +276,38 @@ fn test_go_native_tasks_and_workspace_aggregate() {
     let build = dry_run_task(&output, "example.com/lib#build");
     assert_eq!(build["command"], "go build ./...");
     assert_eq!(build["resolvedTaskDefinition"]["cache"], false);
+
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "run",
+            "dev",
+            "--filter=example.com/api",
+            "--dry-run=json",
+            "--",
+            "--port",
+            "3000",
+        ],
+    );
+    let dev = dry_run_task(&output, "example.com/api#dev");
+    assert_eq!(dev["command"], "go run . --port 3000");
+
+    let tasks = package_task_names(tempdir.path(), "example.com/api");
+    assert!(tasks.iter().any(|task| task == "dev"), "tasks: {tasks:?}");
+    assert!(tasks.iter().any(|task| task == "lint"), "tasks: {tasks:?}");
+    assert!(!tasks.iter().any(|task| task == "run"), "tasks: {tasks:?}");
+    assert!(!tasks.iter().any(|task| task == "vet"), "tasks: {tasks:?}");
+
+    let output = run_turbo(
+        tempdir.path(),
+        &["run", "run", "--filter=example.com/api", "--dry-run=json"],
+    );
+    assert!(!output.status.success(), "removed run task must fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Could not find task `run` in project"),
+        "unexpected stderr: {stderr}"
+    );
 }
 
 #[test]
@@ -281,7 +327,8 @@ fn test_go_native_tasks_are_overrideable_and_excludable() {
     "experimentalTaskCommand": true
   },
   "tasks": {
-    "lint": { "command": { "go": ["go", "version"] } }
+    "lint": { "command": { "go": ["go", "version"] } },
+    "dev": { "command": { "go": ["go", "env", "GOVERSION"] } }
   }
 }"#,
     )
@@ -294,31 +341,26 @@ fn test_go_native_tasks_are_overrideable_and_excludable() {
     let lint = dry_run_task(&output, "example.com/lib#lint");
     assert_eq!(lint["command"], "go version");
 
+    let output = run_turbo(
+        tempdir.path(),
+        &["run", "dev", "--filter=example.com/api", "--dry-run=json"],
+    );
+    let dev = dry_run_task(&output, "example.com/api#dev");
+    assert_eq!(dev["command"], "go env GOVERSION");
+
     fs::write(
         tempdir.path().join("apps/api/turbo.json"),
         r#"{
   "extends": ["//"],
   "tasks": {
-    "run": { "extends": false },
     "dev": { "extends": false }
   }
 }"#,
     )
     .unwrap();
-    let output = run_turbo(
-        tempdir.path(),
-        &[
-            "query",
-            "query { package(name: \"example.com/api\") { tasks { items { name } } } }",
-        ],
-    );
-    assert_command_success(&output, "query excluded Go tasks");
-    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("query emits JSON");
-    let tasks = json["data"]["package"]["tasks"]["items"]
-        .as_array()
-        .expect("task items");
-    assert!(tasks.iter().any(|task| task["name"] == "lint"));
-    assert!(!tasks.iter().any(|task| task["name"] == "vet"));
-    assert!(!tasks.iter().any(|task| task["name"] == "run"));
-    assert!(!tasks.iter().any(|task| task["name"] == "dev"));
+    let tasks = package_task_names(tempdir.path(), "example.com/api");
+    assert!(tasks.iter().any(|task| task == "lint"), "tasks: {tasks:?}");
+    assert!(!tasks.iter().any(|task| task == "vet"), "tasks: {tasks:?}");
+    assert!(!tasks.iter().any(|task| task == "run"), "tasks: {tasks:?}");
+    assert!(!tasks.iter().any(|task| task == "dev"), "tasks: {tasks:?}");
 }

--- a/turborepo-tests/integration/fixtures/go_monorepo/turbo.json
+++ b/turborepo-tests/integration/fixtures/go_monorepo/turbo.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://turborepo.dev/schema.json",
-  "futureFlags": { "experimentalGoWorkspaces": true },
+  "futureFlags": {
+    "experimentalGoWorkspaces": true,
+    "experimentalTaskCommand": true
+  },
   "tasks": {
     "build": {
       "outputs": ["dist/**"],

--- a/turborepo-tests/integration/fixtures/go_pure_workspace/.gitignore
+++ b/turborepo-tests/integration/fixtures/go_pure_workspace/.gitignore
@@ -1,1 +1,2 @@
 .turbo
+dist

--- a/turborepo-tests/integration/fixtures/go_pure_workspace/apps/api/main.go
+++ b/turborepo-tests/integration/fixtures/go_pure_workspace/apps/api/main.go
@@ -1,7 +1,15 @@
 package main
 
-import "example.com/lib"
+import (
+	"fmt"
+	"os"
+
+	"example.com/lib"
+)
 
 func main() {
 	lib.Greet()
+	if len(os.Args) > 1 {
+		fmt.Println(os.Args[1])
+	}
 }

--- a/turborepo-tests/integration/fixtures/go_pure_workspace/turbo.json
+++ b/turborepo-tests/integration/fixtures/go_pure_workspace/turbo.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://turborepo.dev/schema.json",
-  "futureFlags": { "experimentalGoWorkspaces": true },
+  "futureFlags": {
+    "experimentalGoWorkspaces": true,
+    "experimentalTaskCommand": true
+  },
   "tasks": {
     "build": {
       "dependsOn": ["^build"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Resolve the Go executable through the shared task executor and add end-to-end coverage for native Go task execution, caching, restoration, overrides, exclusions, failures, formatting, and pass-through arguments.

Closes TURBO-5959

### Testing Instructions

```bash
cargo test -p turbo --test go_workspace_test
cargo test -p turborepo-task-executor
cargo test -p turbo --test uv_workspace_test
cargo test -p turbo --test cargo_workspace_test
cargo fmt --all --check
cargo lint
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93321fc5-6d9e-4a4a-b939-cfd623df17d1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93321fc5-6d9e-4a4a-b939-cfd623df17d1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

