### PR TITLE
docs(skills): fix the dependencies-only filter caret position

### DIFF
--- a/skills/turborepo/references/filtering/RULE.md
+++ b/skills/turborepo/references/filtering/RULE.md
@@ -108,7 +108,7 @@ Multiple filters combine as a union (packages matching ANY filter run).
 | `pkg...`    | Package AND all its dependencies       |
 | `...pkg`    | Package AND all its dependents         |
 | `...pkg...` | Dependencies, package, AND dependents  |
-| `^pkg...`   | Only dependencies (exclude pkg itself) |
+| `pkg^...`   | Only dependencies (exclude pkg itself) |
 | `...^pkg`   | Only dependents (exclude pkg itself)   |
 
 ### Negation


### PR DESCRIPTION
### Description

`skills/turborepo/references/filtering/RULE.md` documents the "only dependencies, exclude the package itself" filter as `^pkg...`. Turbo parses that as a package literally named `^pkg` and fails:

```
$ turbo run build --filter='^@repo/data...'
  x No package found with name '^@repo/data' in workspace
```

The caret goes adjacent to the ellipsis. `pkg^...` is the working form:

```
$ turbo run build --filter='@repo/data^...' --dry-run=json
  "packages": ["@repo/auth", "@repo/typescript-config", "@repo/vitest-config"]
```

This matches `^`'s documented meaning in the [`turbo run` reference](https://turborepo.com/docs/reference/run#filter) — "Omit the target from the selection when using `...`" — where the caret modifies the adjacent `...`, not the package name.

The neighbouring row, `...^pkg` for dependents-only, is already correct, and `patterns.md` only ever uses that valid form, so this is a single-cell fix.

An agent following the current table writes a filter that fails the job outright, which is how this surfaced.

### Testing Instructions

Against turbo 2.10.12 in any workspace:

1. `turbo run build --filter='<pkg>^...' --dry-run=json` lists `<pkg>`'s dependencies without `<pkg>` itself.
2. `turbo run build --filter='^<pkg>...'` errors with `No package found with name '^<pkg>'`.
