### PR TITLE
perf: Parse CLI exits before starting worker pools

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -266,6 +266,14 @@ pub fn run(
     color_config: ColorConfig,
     query_server: Option<Arc<dyn turborepo_query_api::QueryServer>>,
 ) -> Result<i32, Error> {
+    // Help, version, and argument errors exit during parsing. Handle them
+    // before creating worker threads, but after the shim has selected the
+    // correct local binary and configured diagnostics.
+    let cli_args = {
+        let _span = tracing::info_span!("cli_arg_parsing").entered();
+        Args::new(env::args_os().collect())
+    };
+
     // Initialize rayon's global pool before the tokio runtime so we
     // control thread count and avoid lazy initialization during a hot path.
     init_rayon_pool();
@@ -275,7 +283,13 @@ pub fn run(
         .build()
         .map_err(Error::Runtime)?;
 
-    let result = runtime.block_on(run_main(repo_state, logger, color_config, query_server));
+    let result = runtime.block_on(run_main(
+        cli_args,
+        repo_state,
+        logger,
+        color_config,
+        query_server,
+    ));
 
     // `Runtime::drop` joins blocking-pool threads with no deadline. Detached
     // best-effort work — most notably a telemetry flush whose DNS lookup
@@ -293,6 +307,7 @@ pub fn run(
 
 #[tracing::instrument(skip_all)]
 async fn run_main(
+    mut cli_args: Args,
     repo_state: Option<RepoState>,
     #[allow(unused_variables)] logger: &TurboSubscriber,
     color_config: ColorConfig,
@@ -301,10 +316,6 @@ async fn run_main(
     let _cli_run_span = tracing::info_span!("cli_run").entered();
     let http_client = SharedHttpClient::new();
 
-    let mut cli_args = {
-        let _span = tracing::info_span!("cli_arg_parsing").entered();
-        Args::new(env::args_os().collect())
-    };
     let version = get_version();
 
     // Initialize telemetry immediately so events are captured from startup.

--- a/crates/turborepo/tests/command_test.rs
+++ b/crates/turborepo/tests/command_test.rs
@@ -41,6 +41,35 @@ fn test_version_flag_matches_version_txt() {
 }
 
 #[test]
+fn test_parser_exits_before_starting_worker_pools() {
+    let tempdir = tempfile::tempdir().unwrap();
+    // Tokio rejects zero workers when constructing a runtime. Parser-only
+    // invocations must still succeed (or report their own argument error).
+    for (args, code, expected) in [
+        (vec!["--version"], 0, version_txt()),
+        (vec!["--help"], 0, "Usage: turbo".to_string()),
+        (vec!["run", "--help"], 0, "Usage:".to_string()),
+        (vec!["--bad-flag"], 1, "--bad-flag".to_string()),
+    ] {
+        let output = common::run_turbo_with_env(
+            tempdir.path(),
+            &args,
+            &[
+                ("TOKIO_WORKER_THREADS", "0"),
+                ("TURBO_LOG_VERBOSITY", "info"),
+            ],
+        );
+        let combined = common::combined_output(&output);
+        assert_eq!(output.status.code(), Some(code), "{args:?}: {combined}");
+        assert!(combined.contains(&expected), "{args:?}: {combined}");
+        assert!(
+            !combined.contains("initializing rayon global pool"),
+            "parser-only invocation initialized rayon: {combined}"
+        );
+    }
+}
+
+#[test]
 fn test_short_v_flag_errors() {
     let tempdir = tempfile::tempdir().unwrap();
     let output = run_turbo(tempdir.path(), &["-v"]);


### PR DESCRIPTION
### Description

Layer 1 of 11 in the startup-performance stack, split from #13970. Each PR is based on the previous layer so its diff contains only this optimization. The top layer preserves the original combined source tree.

Handle help, version, and argument-error exits before creating Rayon/Tokio worker pools. Keep parsing after shim selection and diagnostics setup, so local-version selection is unchanged. Actual task execution still initializes both pools with the same concurrency settings.

### Testing Instructions

Release timing of parser-only invocations showed version startup roughly 7–11% faster in the initial investigation. This is not a general `turbo run` speedup. The regression case uses an invalid Tokio worker count to ensure parser-only exits never construct a runtime.

#### Measurement limits

- Measurements used optimized binaries, randomized paired before/after runs, warm OS/local caches, and synthetic npm fixtures. CPU/heap/syscall profiling was separate from wall-time timing.
- Early batches had an unborn Git HEAD; later normalization and matcher-reuse batches used committed fixtures. Results from separate batches are not cumulative.
- Windows runtime performance remains unmeasured. No worker-pool sizes or task concurrency defaults are reduced.
