### PR TITLE
perf: Skip work for disabled telemetry

### DIFF
--- a/crates/turborepo-telemetry/src/config.rs
+++ b/crates/turborepo-telemetry/src/config.rs
@@ -195,18 +195,7 @@ impl TelemetryConfig {
     }
 
     pub fn is_enabled(&self) -> bool {
-        let do_not_track = env::var(DO_NOT_TRACK_ENV_VAR).unwrap_or("0".to_string());
-        let turbo_telemetry_disabled = env::var(DISABLED_ENV_VAR).unwrap_or("0".to_string());
-
-        if do_not_track == "1"
-            || do_not_track == "true"
-            || turbo_telemetry_disabled == "1"
-            || turbo_telemetry_disabled == "true"
-        {
-            return false;
-        }
-
-        self.config.telemetry_enabled
+        !is_disabled_by_env() && self.config.telemetry_enabled
     }
 
     pub fn is_telemetry_warning_enabled() -> bool {
@@ -271,6 +260,12 @@ fn write_new_config(file_path: &AbsoluteSystemPath) -> Result<(), ConfigError> {
         .create_with_contents(serialized)
         .map_err(|e| ConfigError::Message(e.to_string()))?;
     Ok(())
+}
+
+pub(crate) fn is_disabled_by_env() -> bool {
+    [DO_NOT_TRACK_ENV_VAR, DISABLED_ENV_VAR]
+        .iter()
+        .any(|name| matches!(env::var(name).as_deref(), Ok("1" | "true")))
 }
 
 pub fn is_debug() -> bool {

--- a/crates/turborepo-telemetry/src/events/command.rs
+++ b/crates/turborepo-telemetry/src/events/command.rs
@@ -24,11 +24,18 @@ impl Identifiable for CommandEventBuilder {
 
 impl EventBuilder for CommandEventBuilder {
     fn with_parent<U: Identifiable>(mut self, parent_event: &U) -> Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.parent_id = Some(parent_event.get_id().clone());
         self
     }
 
     fn track(&self, event: Event) {
+        if crate::is_disabled() {
+            return;
+        }
+
         if self.is_ci && !event.send_in_ci {
             return;
         }
@@ -63,6 +70,15 @@ pub enum LoginMethod {
 
 impl CommandEventBuilder {
     pub fn new(command: &str) -> Self {
+        if crate::is_disabled() {
+            return Self {
+                id: String::new(),
+                command: String::new(),
+                parent_id: None,
+                is_ci: false,
+            };
+        }
+
         Self {
             id: Uuid::new_v4().to_string(),
             command: command.to_string(),
@@ -72,6 +88,9 @@ impl CommandEventBuilder {
     }
 
     pub fn track_call(&self) -> &Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.track(Event {
             key: "command".to_string(),
             value: "called".to_string(),
@@ -83,6 +102,9 @@ impl CommandEventBuilder {
 
     // args
     pub fn track_arg_usage(&self, arg: &str, is_set: bool) -> &Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.track(Event {
             key: format!("arg:{arg}"),
             value: if is_set { "set" } else { "default" }.to_string(),
@@ -93,6 +115,9 @@ impl CommandEventBuilder {
     }
 
     pub fn track_arg_value(&self, arg: &str, val: impl Display, is_sensitive: EventType) -> &Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.track(Event {
             key: format!("arg:{arg}"),
             value: val.to_string(),
@@ -104,6 +129,9 @@ impl CommandEventBuilder {
 
     // ui
     pub fn track_ui_mode(&self, val: impl Display) -> &Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.track(Event {
             key: "ui".to_string(),
             value: val.to_string(),
@@ -115,6 +143,9 @@ impl CommandEventBuilder {
 
     // telemetry
     pub fn track_telemetry_config(&self, enabled: bool) -> &Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.track(Event {
             key: "action".to_string(),
             value: if enabled { "enabled" } else { "disabled" }.to_string(),
@@ -126,6 +157,9 @@ impl CommandEventBuilder {
 
     // gen
     pub fn track_generator_option(&self, option: &str) -> &Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.track(Event {
             key: "option".to_string(),
             value: option.to_string(),
@@ -136,6 +170,9 @@ impl CommandEventBuilder {
     }
 
     pub fn track_generator_tag(&self, tag: &str) -> &Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.track(Event {
             key: "tag".to_string(),
             value: tag.to_string(),
@@ -147,6 +184,9 @@ impl CommandEventBuilder {
 
     // login
     pub fn track_login_method(&self, method: LoginMethod) -> &Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.track(Event {
             key: "method".to_string(),
             value: match method {
@@ -162,6 +202,9 @@ impl CommandEventBuilder {
 
     // Successful/Failed logins
     pub fn track_login_success(&self, succeeded: bool) -> &Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.track(Event {
             key: "success".to_string(),
             value: succeeded.to_string(),

--- a/crates/turborepo-telemetry/src/events/generic.rs
+++ b/crates/turborepo-telemetry/src/events/generic.rs
@@ -36,11 +36,18 @@ impl Identifiable for GenericEventBuilder {
 
 impl EventBuilder for GenericEventBuilder {
     fn with_parent<U: Identifiable>(mut self, parent_event: &U) -> Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.parent_id = Some(parent_event.get_id().clone());
         self
     }
 
     fn track(&self, event: Event) {
+        if crate::is_disabled() {
+            return;
+        }
+
         if self.is_ci && !event.send_in_ci {
             return;
         }
@@ -65,6 +72,14 @@ impl EventBuilder for GenericEventBuilder {
 
 impl Default for GenericEventBuilder {
     fn default() -> Self {
+        if crate::is_disabled() {
+            return Self {
+                id: String::new(),
+                parent_id: None,
+                is_ci: false,
+            };
+        }
+
         Self {
             id: Uuid::new_v4().to_string(),
             parent_id: None,
@@ -80,6 +95,9 @@ impl GenericEventBuilder {
     }
 
     pub fn track_start(&self) -> &Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.track(Event {
             key: "execution".to_string(),
             value: "started".to_string(),
@@ -90,6 +108,9 @@ impl GenericEventBuilder {
     }
 
     pub fn track_end(&self) -> &Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.track(Event {
             key: "execution".to_string(),
             value: "ended".to_string(),
@@ -100,6 +121,9 @@ impl GenericEventBuilder {
     }
 
     pub fn track_platform(&self, platform: &str) -> &Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.track(Event {
             key: "platform".to_string(),
             value: platform.to_string(),
@@ -110,6 +134,9 @@ impl GenericEventBuilder {
     }
 
     pub fn track_cpus(&self, cpus: usize) -> &Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.track(Event {
             key: "cpu_count".to_string(),
             value: cpus.to_string(),
@@ -120,6 +147,9 @@ impl GenericEventBuilder {
     }
 
     pub fn track_version(&self, version: &str) -> &Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.track(Event {
             key: "turbo_version".to_string(),
             value: version.to_string(),
@@ -131,6 +161,9 @@ impl GenericEventBuilder {
 
     // args
     pub fn track_arg_usage(&self, arg: &str, is_set: bool) -> &Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.track(Event {
             key: format!("arg:{arg}"),
             value: if is_set { "set" } else { "default" }.to_string(),
@@ -141,6 +174,9 @@ impl GenericEventBuilder {
     }
 
     pub fn track_arg_value(&self, arg: &str, val: impl Display, is_sensitive: EventType) -> &Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.track(Event {
             key: format!("arg:{arg}"),
             value: val.to_string(),
@@ -152,6 +188,9 @@ impl GenericEventBuilder {
 
     // run data
     pub fn track_is_linked(&self, is_linked: bool) -> &Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.track(Event {
             key: "is_linked".to_string(),
             value: if is_linked { "true" } else { "false" }.to_string(),
@@ -162,6 +201,9 @@ impl GenericEventBuilder {
     }
 
     pub fn track_remote_cache(&self, cache_url: &str) -> &Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.track(Event {
             key: "remote_cache_url".to_string(),
             value: cache_url.to_string(),
@@ -176,6 +218,9 @@ impl GenericEventBuilder {
     }
 
     pub fn track_ci(&self, ci: Option<&'static str>) -> &Self {
+        if crate::is_disabled() {
+            return self;
+        }
         if let Some(ci) = ci {
             self.track(Event {
                 key: "ci".to_string(),
@@ -189,6 +234,9 @@ impl GenericEventBuilder {
     }
 
     pub fn track_ai_agent(&self, agent: Option<&'static str>) -> &Self {
+        if crate::is_disabled() {
+            return self;
+        }
         if let Some(agent) = agent {
             self.track(Event {
                 key: "ai_agent".to_string(),
@@ -201,6 +249,9 @@ impl GenericEventBuilder {
     }
 
     pub fn track_run_type(&self, is_dry: bool) -> &Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.track(Event {
             key: "run_type".to_string(),
             value: if is_dry { "dry" } else { "full" }.to_string(),
@@ -211,6 +262,9 @@ impl GenericEventBuilder {
     }
 
     pub fn track_daemon_init(&self, status: DaemonInitStatus) -> &Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.track(Event {
             key: "daemon_status".to_string(),
             value: match status {
@@ -227,6 +281,9 @@ impl GenericEventBuilder {
 
     // errors
     pub fn track_error(&self, error: TrackedErrors) -> &Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.track(Event {
             key: "error".to_string(),
             value: error.to_string(),

--- a/crates/turborepo-telemetry/src/events/repo.rs
+++ b/crates/turborepo-telemetry/src/events/repo.rs
@@ -26,11 +26,18 @@ impl Identifiable for RepoEventBuilder {
 
 impl EventBuilder for RepoEventBuilder {
     fn with_parent<U: Identifiable>(mut self, parent_event: &U) -> Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.parent_id = Some(parent_event.get_id().clone());
         self
     }
 
     fn track(&self, event: Event) {
+        if crate::is_disabled() {
+            return;
+        }
+
         let val = match event.is_sensitive {
             EventType::Sensitive => TelemetryConfig::one_way_hash(&event.value),
             EventType::NonSensitive => event.value.to_string(),
@@ -53,6 +60,15 @@ impl EventBuilder for RepoEventBuilder {
 // events
 impl RepoEventBuilder {
     pub fn new(repo_identifier: &str) -> Self {
+        if crate::is_disabled() {
+            return Self {
+                id: String::new(),
+                repo: String::new(),
+                parent_id: None,
+                is_ci: false,
+            };
+        }
+
         Self {
             id: Uuid::new_v4().to_string(),
             repo: TelemetryConfig::one_way_hash(repo_identifier),
@@ -62,6 +78,9 @@ impl RepoEventBuilder {
     }
 
     pub fn track_package_manager(&self, name: String) -> &Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.track(Event {
             key: "package_manager".to_string(),
             value: name.to_string(),
@@ -72,6 +91,9 @@ impl RepoEventBuilder {
     }
 
     pub fn track_type(&self, repo_type: RepoType) -> &Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.track(Event {
             key: "repo_type".to_string(),
             value: match repo_type {
@@ -85,6 +107,9 @@ impl RepoEventBuilder {
     }
 
     pub fn track_size(&self, size: usize) -> &Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.track(Event {
             key: "workspace_count".to_string(),
             value: size.to_string(),

--- a/crates/turborepo-telemetry/src/events/task.rs
+++ b/crates/turborepo-telemetry/src/events/task.rs
@@ -39,11 +39,18 @@ impl Identifiable for PackageTaskEventBuilder {
 
 impl EventBuilder for PackageTaskEventBuilder {
     fn with_parent<U: Identifiable>(mut self, parent_event: &U) -> Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.parent_id = Some(parent_event.get_id().clone());
         self
     }
 
     fn track(&self, event: Event) {
+        if crate::is_disabled() {
+            return;
+        }
+
         if self.is_ci && !event.send_in_ci {
             return;
         }
@@ -64,6 +71,10 @@ impl EventBuilder for PackageTaskEventBuilder {
     }
 
     fn child(&self) -> Self {
+        if crate::is_disabled() {
+            return Self::new("", "");
+        }
+
         // `package` and `task` are already obfuscated where required by
         // `new`; reuse them instead of re-deriving (re-hashing them would
         // also mislabel the child with double-hashed values).
@@ -79,6 +90,16 @@ impl EventBuilder for PackageTaskEventBuilder {
 
 impl PackageTaskEventBuilder {
     pub fn new(package: &str, task: &str) -> Self {
+        if crate::is_disabled() {
+            return Self {
+                id: String::new(),
+                package: String::new(),
+                task: String::new(),
+                parent_id: None,
+                is_ci: false,
+            };
+        }
+
         // don't obfuscate the package in development mode
         let package = if cfg!(debug_assertions) {
             package.to_string()
@@ -104,6 +125,9 @@ impl PackageTaskEventBuilder {
 
     // event methods
     pub fn track_framework(&self, framework: String) -> &Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.track(Event {
             key: "framework".to_string(),
             value: framework,
@@ -114,6 +138,9 @@ impl PackageTaskEventBuilder {
     }
 
     pub fn track_env_mode(&self, mode: &str) -> &Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.track(Event {
             key: "env_mode".to_string(),
             value: mode.to_string(),
@@ -124,6 +151,9 @@ impl PackageTaskEventBuilder {
     }
 
     pub fn track_file_hash_method(&self, method: FileHashMethod) -> &Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.track(Event {
             key: "file_hash_method".to_string(),
             value: match method {
@@ -138,6 +168,9 @@ impl PackageTaskEventBuilder {
 
     // errors
     pub fn track_error(&self, error: TrackedErrors) -> &Self {
+        if crate::is_disabled() {
+            return self;
+        }
         self.track(Event {
             key: "error".to_string(),
             value: error.to_string(),

--- a/crates/turborepo-telemetry/src/lib.rs
+++ b/crates/turborepo-telemetry/src/lib.rs
@@ -48,20 +48,36 @@ pub enum Error {
 pub type TelemetrySender = mpsc::UnboundedSender<TelemetryEvent>;
 
 /// The handle on the `Worker` tokio thread, along with a channel
-/// to indicate to the thread that it should shut down.
+/// to indicate to the thread that it should shut down. Inert when disabled.
 pub struct TelemetryHandle {
+    worker: Option<WorkerHandle>,
+}
+
+struct WorkerHandle {
     exit_ch: oneshot::Receiver<()>,
     handle: JoinHandle<()>,
 }
 
-static SENDER_INSTANCE: OnceLock<TelemetrySender> = OnceLock::new();
+// None means initialization has not happened, not that the user opted out.
+enum TelemetryState {
+    Disabled,
+    Enabled(TelemetrySender),
+}
+
+static TELEMETRY_STATE: OnceLock<TelemetryState> = OnceLock::new();
+
+// Only explicit opt-out makes builders inert. Before initialization, preserve
+// event construction and the missing-initialization diagnostic in `telem`.
+fn is_disabled() -> bool {
+    matches!(TELEMETRY_STATE.get(), Some(TelemetryState::Disabled))
+}
 
 // A global instance of the TelemetrySender.
 pub fn telem(event: events::TelemetryEvent) {
-    let sender = SENDER_INSTANCE.get();
-    match sender {
-        Some(s) => {
-            let result = s.send(event);
+    match TELEMETRY_STATE.get() {
+        Some(TelemetryState::Disabled) => {}
+        Some(TelemetryState::Enabled(sender)) => {
+            let result = sender.send(event);
             if let Err(err) = result {
                 debug!("failed to send telemetry event. error: {}", err)
             }
@@ -82,9 +98,12 @@ fn init(
     color_config: ColorConfig,
 ) -> Result<(TelemetryHandle, TelemetrySender, bool), Box<dyn std::error::Error>> {
     let (tx, rx) = mpsc::unbounded_channel();
+    if !config.is_enabled() {
+        return Ok((TelemetryHandle { worker: None }, tx, false));
+    }
     let (cancel_tx, cancel_rx) = oneshot::channel();
     config.show_alert(color_config);
-    let enabled = config.is_enabled();
+    let enabled = true;
 
     let session_id = Uuid::new_v4();
     let worker = Worker {
@@ -100,8 +119,10 @@ fn init(
     let handle = worker.start();
 
     let telemetry_handle = TelemetryHandle {
-        exit_ch: cancel_rx,
-        handle,
+        worker: Some(WorkerHandle {
+            exit_ch: cancel_rx,
+            handle,
+        }),
     };
 
     // return
@@ -118,23 +139,52 @@ pub fn init_telemetry(
     client: impl telemetry::TelemetryClient + Clone + Send + Sync + 'static,
     color_config: ColorConfig,
 ) -> Result<(TelemetryHandle, bool), Box<dyn std::error::Error>> {
-    // make sure we're not already initialized
-    if SENDER_INSTANCE.get().is_some() {
+    init_with_state(
+        &TELEMETRY_STATE,
+        client,
+        color_config,
+        TelemetryConfig::with_default_config_path,
+    )
+}
+
+fn init_with_state(
+    state: &OnceLock<TelemetryState>,
+    client: impl telemetry::TelemetryClient + Clone + Send + Sync + 'static,
+    color_config: ColorConfig,
+    load_config: impl FnOnce() -> Result<TelemetryConfig, ConfigError>,
+) -> Result<(TelemetryHandle, bool), Box<dyn std::error::Error>> {
+    if state.get().is_some() {
         debug!("telemetry already initialized");
         return Err(Box::new(Error::AlreadyInitialized()));
     }
-    let config = TelemetryConfig::with_default_config_path()?;
-    let (handle, sender, enabled) = init(config, client, color_config)?;
-    SENDER_INSTANCE
-        .set(sender)
+
+    let (handle, new_state, enabled) = if config::is_disabled_by_env() {
+        (
+            TelemetryHandle { worker: None },
+            TelemetryState::Disabled,
+            false,
+        )
+    } else {
+        let (handle, sender, enabled) = init(load_config()?, client, color_config)?;
+        let new_state = if enabled {
+            TelemetryState::Enabled(sender)
+        } else {
+            TelemetryState::Disabled
+        };
+        (handle, new_state, enabled)
+    };
+    state
+        .set(new_state)
         .map_err(|_| Box::new(Error::AlreadyInitialized()) as Box<dyn std::error::Error>)?;
     Ok((handle, enabled))
 }
 
 impl TelemetryHandle {
     async fn close(self) -> Result<(), Error> {
-        drop(self.exit_ch);
-        self.handle.await?;
+        if let Some(worker) = self.worker {
+            drop(worker.exit_ch);
+            worker.handle.await?;
+        }
 
         Ok(())
     }
@@ -142,6 +192,9 @@ impl TelemetryHandle {
     /// Closes the handle with an explicit timeout. If the handle fails to close
     /// within that timeout, it will log an error and drop the handle.
     pub async fn close_with_timeout(self) {
+        if self.worker.is_none() {
+            return;
+        }
         if let Err(err) = tokio::time::timeout(EVENT_TIMEOUT, self.close()).await {
             debug!("failed to close telemetry handle. error: {}", err)
         } else {
@@ -320,6 +373,170 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let path = AbsoluteSystemPathBuf::try_from(temp_dir.path()).unwrap();
         (temp_dir, path)
+    }
+
+    // Each scenario gets its own process so environment variables and the global
+    // OnceLock cannot race with other tests.
+    #[test]
+    fn test_telemetry_state() {
+        use std::{fmt, process::Command};
+
+        use crate::{
+            TELEMETRY_STATE, TelemetryState,
+            events::{
+                EventBuilder, EventType, Identifiable, command::CommandEventBuilder,
+                generic::GenericEventBuilder, repo::RepoEventBuilder,
+                task::PackageTaskEventBuilder,
+            },
+            init_telemetry,
+        };
+
+        let Ok(scenario) = std::env::var("TURBO_TELEMETRY_TEST_SCENARIO") else {
+            for scenario in [
+                "uninitialized",
+                "failed-init",
+                "config",
+                "enabled",
+                "dnt-1",
+                "dnt-true",
+                "turbo-1",
+                "turbo-true",
+            ] {
+                let (_tmp, dir) = temp_dir();
+                let mut command = Command::new(std::env::current_exe().unwrap());
+                command
+                    .args(["--exact", "tests::test_telemetry_state", "--nocapture"])
+                    .env_remove("DO_NOT_TRACK")
+                    .env_remove("TURBO_TELEMETRY_DISABLED")
+                    .env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1")
+                    .env("TURBO_CONFIG_DIR_PATH", dir.as_str())
+                    .env("TURBO_TELEMETRY_TEST_SCENARIO", scenario);
+                if let Some(value) = scenario.strip_prefix("dnt-") {
+                    command.env("DO_NOT_TRACK", value);
+                } else if let Some(value) = scenario.strip_prefix("turbo-") {
+                    command.env("TURBO_TELEMETRY_DISABLED", value);
+                }
+                let output = command.output().unwrap();
+                assert!(output.status.success(), "{scenario}: {output:?}");
+            }
+            return;
+        };
+
+        let config_path =
+            AbsoluteSystemPathBuf::new(std::env::var("TURBO_CONFIG_DIR_PATH").unwrap())
+                .unwrap()
+                .join_components(&["turborepo", "telemetry.json"]);
+        if scenario == "uninitialized" {
+            assert!(TELEMETRY_STATE.get().is_none());
+            assert!(!crate::is_disabled());
+            assert!(!GenericEventBuilder::new().get_id().is_empty());
+            return;
+        }
+        if scenario == "failed-init" {
+            let state = std::sync::OnceLock::new();
+            for _ in 0..2 {
+                let result =
+                    super::init_with_state(&state, SlowClient, ColorConfig::new(false), || {
+                        Err(crate::config::ConfigError::Message("test failure".into()))
+                    });
+                assert!(result.is_err());
+                assert!(state.get().is_none());
+            }
+            return;
+        }
+        if scenario == "config" {
+            TelemetryConfig::new(config_path.clone())
+                .unwrap()
+                .disable()
+                .unwrap();
+        }
+        let runtime = (scenario == "enabled").then(|| tokio::runtime::Runtime::new().unwrap());
+        let _guard = runtime.as_ref().map(|runtime| runtime.enter());
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let client = DummyClient {
+            events: Default::default(),
+            tx,
+        };
+        let (handle, enabled) = init_telemetry(client.clone(), ColorConfig::new(false)).unwrap();
+        assert_eq!(enabled, scenario == "enabled");
+        assert_eq!(handle.worker.is_some(), enabled);
+        assert!(init_telemetry(client.clone(), ColorConfig::new(false)).is_err());
+
+        if enabled {
+            assert!(matches!(
+                TELEMETRY_STATE.get(),
+                Some(TelemetryState::Enabled(_))
+            ));
+            let parent = GenericEventBuilder::new();
+            let task = PackageTaskEventBuilder::new("package", "build").with_parent(&parent);
+            assert!(!task.get_id().is_empty());
+            task.track_env_mode("strict");
+            task.child().track_env_mode("loose");
+            runtime.as_ref().unwrap().block_on(handle.close()).unwrap();
+            runtime.as_ref().unwrap().block_on(async {
+                tokio::time::timeout(Duration::from_secs(1), rx.recv())
+                    .await
+                    .unwrap()
+                    .unwrap();
+            });
+            let events = client.events();
+            assert_eq!(events.len(), 1);
+            let [TelemetryEvent::Task(first), TelemetryEvent::Task(child)] = events[0].as_slice()
+            else {
+                panic!("expected two task events");
+            };
+            assert_eq!(first.parent_id.as_ref(), Some(parent.get_id()));
+            assert_eq!(child.parent_id.as_ref(), Some(task.get_id()));
+            assert_eq!(first.package, child.package);
+            assert_eq!(first.task, "build");
+            assert_eq!(child.task, "build");
+            assert_eq!(first.key, "env_mode");
+            assert_eq!(first.value, "strict");
+            assert_eq!(child.value, "loose");
+            // The existing process cache must survive removal of the config.
+            let hash = TelemetryConfig::one_way_hash("sensitive");
+            config_path.remove_file().unwrap();
+            assert_eq!(hash, TelemetryConfig::one_way_hash("sensitive"));
+            assert!(!config_path.exists());
+            return;
+        }
+
+        assert!(matches!(
+            TELEMETRY_STATE.get(),
+            Some(TelemetryState::Disabled)
+        ));
+        struct MustNotFormat;
+        impl fmt::Display for MustNotFormat {
+            fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+                panic!("disabled telemetry formatted an event");
+            }
+        }
+        let generic = GenericEventBuilder::new();
+        let command = CommandEventBuilder::new("run").with_parent(&generic);
+        let repo = RepoEventBuilder::new("private-repo").with_parent(&generic);
+        let task =
+            PackageTaskEventBuilder::new("private-package", "private-task").with_parent(&repo);
+        generic.track_arg_value("test", MustNotFormat, EventType::Sensitive);
+        command.track_arg_value("test", MustNotFormat, EventType::Sensitive);
+        command.track_ui_mode(MustNotFormat);
+        repo.track_size(2);
+        task.track_env_mode("strict");
+        assert!(generic.child().get_id().is_empty());
+        assert!(command.child().get_id().is_empty());
+        assert!(repo.child().get_id().is_empty());
+        assert!(task.child().get_id().is_empty());
+        // Direct events are also silently ignored, not queued.
+        crate::telem(TelemetryEvent::Generic(TelemetryGenericEvent {
+            id: String::new(),
+            parent_id: None,
+            key: String::new(),
+            value: String::new(),
+        }));
+        futures::executor::block_on(handle.close_with_timeout());
+        assert!(client.events().is_empty());
+        if scenario != "config" {
+            assert!(!config_path.exists(), "environment opt-out touched config");
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
<!-- startup-recovery-20260908 -->
### Review scope

Independent optimization targeting `main`, with exactly one feature commit. No other optimization PR is a prerequisite.

Recovered after the bundled #13970 merge was reverted by #13982. The separately merged parser optimization #13971 remains on `main`. This is not part of a cumulative optimization stack.

The timing figures below are historical measurements from the original incremental benchmark sequence. They have not been remeasured on these newly independent branches and are not additive.
<!-- /startup-recovery-20260908 -->

### Description

Make explicitly disabled telemetry inert. Environment opt-out skips config loading; disabled telemetry creates no worker and avoids event UUID generation, formatting, hashing, and shutdown timers. Preserve enabled behavior and distinguish opt-out from missing initialization.

### Testing Instructions

The startup investigation traced work performed even when telemetry was disabled. End-to-end run measurements did not establish a consistent standalone speedup for this layer; this removes avoidable opt-out work rather than claiming the combined benchmark gains. Enabled-mode measurements used a closed local proxy to exclude external network variability.

#### Measurement limits

- Measurements used optimized binaries, randomized paired before/after runs, warm OS/local caches, and synthetic npm fixtures. CPU/heap/syscall profiling was separate from wall-time timing.
- Early batches had an unborn Git HEAD; later normalization and matcher-reuse batches used committed fixtures. Results from separate batches are not cumulative.
- Windows runtime performance remains unmeasured. No worker-pool sizes or task concurrency defaults are reduced.
