### PR TITLE
perf: Fast-path numeric package manager versions

### DIFF
--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -1032,6 +1032,28 @@ impl PackageManager {
     }
 
     pub fn parse_package_manager_string(manager: &Spanned<String>) -> Result<(&str, &str), Error> {
+        // Most invocations have a plain numeric version here. Avoid compiling
+        // the Unicode regex (including its large digit tables) on the startup
+        // path. This accepts only a subset of the legacy pattern; everything
+        // else still goes through it, preserving validation and diagnostics.
+        if let Some((name, version)) = manager.split_once('@')
+            && matches!(name, "aube" | "bun" | "npm" | "nub" | "pnpm" | "yarn")
+        {
+            let mut components = version.split('.');
+            let numeric = |part: Option<&str>| {
+                part.is_some_and(|part| {
+                    !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit())
+                })
+            };
+            if numeric(components.next())
+                && numeric(components.next())
+                && numeric(components.next())
+                && components.next().is_none()
+            {
+                return Ok((name, version));
+            }
+        }
+
         let package_manager_pattern = regex!(
             r"\A(?P<manager>aube|bun|npm|nub|pnpm|yarn)@(?P<version>\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?|https?://\S+)\z"
         );
@@ -1739,6 +1761,53 @@ mod tests {
 
             assert_eq!(received_manager, case.expected_manager);
             assert_eq!(received_version, case.expected_version);
+        }
+    }
+
+    #[test]
+    fn package_manager_fast_path_preserves_legacy_parser() {
+        let legacy = regex::Regex::new(
+            r"\A(?P<manager>aube|bun|npm|nub|pnpm|yarn)@(?P<version>\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?|https?://\S+)\z",
+        )
+        .unwrap();
+        for name in ["npm", "pnpm", "yarn", "bun", "nub", "aube", "pip", " npm"] {
+            for version in [
+                "1.2.3",
+                "0.0.0",
+                "10.20.30",
+                "1.2.3-alpha.1+sha512.abc",
+                "01.02.03",
+                "99999999999999999999999.2.3",
+                "١.٢.٣",
+                "1.2.3-01",
+                "1.2.3-.",
+                "1.2.3+..",
+                "1.2.3-",
+                "1.2.3+",
+                "1.2",
+                "latest",
+                "v1.2.3",
+                "1.2.3\n",
+                "1.2.3suffix",
+                "https://example.com/a@b",
+                "http://例.example/x",
+                "https://",
+                "https://example.com/\u{a0}",
+                "https://example.com/\n",
+            ] {
+                let input = Spanned::new(format!("{name}@{version}"));
+                let expected = legacy.captures(&input).map(|captures| {
+                    (
+                        captures.name("manager").unwrap().as_str(),
+                        captures.name("version").unwrap().as_str(),
+                    )
+                });
+                assert_eq!(
+                    PackageManager::parse_package_manager_string(&input).ok(),
+                    expected,
+                    "{input:?}"
+                );
+            }
         }
     }
 


### PR DESCRIPTION
<!-- startup-recovery-20260908 -->
### Review scope

Independent optimization targeting `main`, with exactly one feature commit. No other optimization PR is a prerequisite.

Recovered after the bundled #13970 merge was reverted by #13982. The separately merged parser optimization #13971 remains on `main`. This is not part of a cumulative optimization stack.

The timing figures below are historical measurements from the original incremental benchmark sequence. They have not been remeasured on these newly independent branches and are not additive.
<!-- /startup-recovery-20260908 -->

### Description

Accept ordinary numeric package-manager versions without initializing the Unicode validation regex. All other inputs use the existing parser and diagnostics, including URLs, prerelease/build labels, and non-ASCII input. Compare the fast path with the original expression in regression coverage.

### Testing Instructions

DHAT attributed approximately 1 MB of startup allocations to the package-manager validation path. Bypassing it for ordinary versions removed that work; an isolated reliable wall-time improvement was not demonstrated. Do not attribute the later combined cache-hit speedups to this layer alone.

#### Measurement limits

- Measurements used optimized binaries, randomized paired before/after runs, warm OS/local caches, and synthetic npm fixtures. CPU/heap/syscall profiling was separate from wall-time timing.
- Early batches had an unborn Git HEAD; later normalization and matcher-reuse batches used committed fixtures. Results from separate batches are not cumulative.
- Windows runtime performance remains unmeasured. No worker-pool sizes or task concurrency defaults are reduced.
