### PR TITLE
perf: Avoid regexes for simple environment matching

### DIFF
--- a/crates/turborepo-env/src/lib.rs
+++ b/crates/turborepo-env/src/lib.rs
@@ -346,8 +346,83 @@ impl EnvironmentVariableMap {
         }
     }
 
+    /// Match the builtin passthrough list once against this environment
+    /// snapshot. Callers should reuse the resulting map across tasks, not
+    /// rematch per task.
+    pub fn builtin_pass_through_env(&self) -> Result<EnvironmentVariableMap, Error> {
+        // Windows regexes use Unicode case folding, not ASCII-only comparisons.
+        #[cfg(windows)]
+        {
+            let compiled = CompiledWildcards::compile(BUILTIN_PASS_THROUGH_ENV)?;
+            Ok(self.from_compiled_wildcards(&compiled))
+        }
+        #[cfg(not(windows))]
+        {
+            let mut output = EnvironmentVariableMap::default();
+            // The builtin list contains only literals and literal prefixes followed
+            // by one star. A test below guards this invariant.
+            for pattern in BUILTIN_PASS_THROUGH_ENV {
+                if let Some(prefix) = pattern.strip_suffix('*') {
+                    for (name, value) in &self.0 {
+                        if name
+                            .strip_prefix(prefix)
+                            .is_some_and(|suffix| !suffix.contains('\n'))
+                        {
+                            // Regex `.*` matches Unicode and CR, but not LF.
+                            output.insert(name.clone(), value.clone());
+                        }
+                    }
+                } else if let Some((name, value)) = self.get_key_value(*pattern) {
+                    output.insert(name.clone(), value.clone());
+                }
+            }
+            Ok(output)
+        }
+    }
+
     // returns a WildcardMaps after processing wildcards against it.
     fn wildcard_map_from_wildcards(
+        &self,
+        wildcard_patterns: &[impl AsRef<str>],
+    ) -> Result<WildcardMaps, Error> {
+        #[cfg(not(windows))]
+        {
+            // Normalize only the leading include/exclude marker. Leave all other
+            // escaping and wildcard syntax to the existing regex implementation.
+            let literal_patterns = || {
+                wildcard_patterns.iter().map(|pattern| {
+                    let pattern = pattern.as_ref();
+                    if let Some(rest) = pattern.strip_prefix('!') {
+                        (true, rest)
+                    } else if pattern.starts_with("\\!") {
+                        (false, &pattern[1..])
+                    } else {
+                        (false, pattern)
+                    }
+                })
+            };
+            if literal_patterns().all(|(_, pattern)| !pattern.contains(['*', '\\'])) {
+                let mut output = WildcardMaps {
+                    inclusions: EnvironmentVariableMap::default(),
+                    exclusions: EnvironmentVariableMap::default(),
+                };
+                for (excluded, pattern) in literal_patterns() {
+                    if let Some((name, value)) = self.get_key_value(pattern) {
+                        let map = if excluded {
+                            &mut output.exclusions
+                        } else {
+                            &mut output.inclusions
+                        };
+                        map.insert(name.clone(), value.clone());
+                    }
+                }
+                return Ok(output);
+            }
+        }
+        self.wildcard_map_from_wildcards_regex(wildcard_patterns)
+    }
+
+    fn wildcard_map_from_wildcards_regex(
         &self,
         wildcard_patterns: &[impl AsRef<str>],
     ) -> Result<WildcardMaps, Error> {
@@ -780,6 +855,95 @@ mod tests {
                 "values differ for key {key}"
             );
         }
+    }
+
+    #[test]
+    fn test_builtin_pass_through_fast_path_shape() {
+        for pattern in BUILTIN_PASS_THROUGH_ENV {
+            let literal = pattern.strip_suffix('*').unwrap_or(pattern);
+            assert!(!literal.contains(['*', '\\']));
+            assert!(!literal.starts_with('!'));
+        }
+    }
+
+    #[test]
+    fn test_builtin_pass_through_matches_regex() {
+        let mut env = EnvironmentVariableMap::default();
+        for pattern in BUILTIN_PASS_THROUGH_ENV {
+            let base = pattern.strip_suffix('*').unwrap_or(pattern);
+            for suffix in [
+                "", "suffix", "é東京", "\r", "\n", "a\nb", "\r\n", "\u{2028}", "*",
+            ] {
+                let name = format!("{base}{suffix}");
+                env.insert(name.clone(), format!("value:{name}"));
+            }
+            env.insert(base.to_lowercase(), "lowercase".into());
+            env.insert(format!("BEFORE_{base}"), "not a prefix match".into());
+        }
+        // Unicode simple case folding on Windows must remain regex-based.
+        env.insert("DOCKER_HOST".into(), "kelvin".into());
+        env.insert("ſHELL".into(), "long s".into());
+        env.insert("ProgramFiles(x86)".into(), "literal parentheses".into());
+        let compiled = CompiledWildcards::compile(BUILTIN_PASS_THROUGH_ENV).unwrap();
+        assert_eq!(
+            env.builtin_pass_through_env().unwrap(),
+            env.from_compiled_wildcards(&compiled)
+        );
+    }
+
+    #[test_case(&[] ; "empty list")]
+    #[test_case(&["FOO", "!FOOD", "MISSING", "FOO"] ; "literals and independent exclusion")]
+    #[test_case(&["FOO", "!FOO"] ; "exclusion wins")]
+    #[test_case(&["!FOO"] ; "only exclusion")]
+    #[test_case(&["", "!"] ; "empty names")]
+    #[test_case(&["\\!BANG", "!!BANG"] ; "literal bang and exclusion")]
+    #[test_case(&["ProgramFiles(x86)", "A.B+$^[]{}?", "é東京", "A\nB", "A\rB"] ; "literal regex syntax and unicode")]
+    #[test_case(&["SHELL", "DOCKER_HOST"] ; "windows unicode folding")]
+    #[test_case(&["FOO*", "!FOOD", "BAR"] ; "wildcard fallback")]
+    #[test_case(&["*", "!FOO*"] ; "all wildcard fallback")]
+    #[test_case(&["FOO\\*", "\\\\*", "A\\B", "\\!BANG*"] ; "escape fallback")]
+    #[test_case(&["F**O*", "*é*", "!A*B"] ; "arbitrary wildcard fallback")]
+    fn test_wildcard_fast_path_matches_regex(patterns: &[&str]) {
+        let env = EnvironmentVariableMap::from(
+            [
+                "",
+                "FOO",
+                "FOOD",
+                "FOOBAR",
+                "BAR",
+                "!BANG",
+                "!BANG_MORE",
+                "FOO*",
+                "\\*",
+                "A\\B",
+                "ProgramFiles(x86)",
+                "A.B+$^[]{}?",
+                "é東京",
+                "A\nB",
+                "A\rB",
+                "FOO\n",
+                "FOO\r",
+                "foo",
+                "SHELL",
+                "shell",
+                "ſHELL",
+                "DOCKER_HOST",
+                "DOCKER_HOST",
+            ]
+            .into_iter()
+            .enumerate()
+            .map(|(i, name)| (name.to_owned(), i.to_string()))
+            .collect::<HashMap<_, _>>(),
+        );
+        let actual = env
+            .wildcard_map_from_wildcards_unresolved(patterns)
+            .unwrap();
+        // Keep the old implementation as an independent oracle, including its
+        // unresolved exclusions (which can remove framework-inferred values).
+        let expected = env.wildcard_map_from_wildcards_regex(patterns).unwrap();
+        assert_eq!(actual.inclusions, expected.inclusions);
+        assert_eq!(actual.exclusions, expected.exclusions);
+        assert_eq!(env.from_wildcards(patterns).unwrap(), expected.resolve());
     }
 
     #[test]

--- a/crates/turborepo-task-hash/src/lib.rs
+++ b/crates/turborepo-task-hash/src/lib.rs
@@ -25,10 +25,7 @@ use turbopath::{
 };
 use turborepo_cache::CacheHitMetadata;
 use turborepo_engine::TaskNode;
-use turborepo_env::{
-    BUILTIN_PASS_THROUGH_ENV, BySource, CompiledWildcards, DetailedMap, EnvironmentVariableMap,
-    WildcardMapCache,
-};
+use turborepo_env::{BySource, DetailedMap, EnvironmentVariableMap, WildcardMapCache};
 use turborepo_frameworks::{Framework, Slug as FrameworkSlug, infer_framework};
 use turborepo_hash::{FileHashes, TaskHashable, TurboHash};
 use turborepo_repository::package_graph::{PackageGraph, PackageName, PackageTaskContext};
@@ -374,9 +371,8 @@ impl<'a, R: RunOptsHashInfo> TaskHasher<'a, R> {
             expanded_hashes,
         } = package_inputs_hashes;
 
-        let builtin_pass_through_env = CompiledWildcards::compile(BUILTIN_PASS_THROUGH_ENV)
-            .ok()
-            .map(|compiled| env_at_execution_start.from_compiled_wildcards(&compiled))
+        let builtin_pass_through_env = env_at_execution_start
+            .builtin_pass_through_env()
             .unwrap_or_default();
 
         Self {


### PR DESCRIPTION
<!-- startup-recovery-20260908 -->
### Review scope

Independent optimization targeting `main`, with exactly one feature commit. No other optimization PR is a prerequisite.

Recovered after the bundled #13970 merge was reverted by #13982. The separately merged parser optimization #13971 remains on `main`. This is not part of a cumulative optimization stack.

The timing figures below are historical measurements from the original incremental benchmark sequence. They have not been remeasured on these newly independent branches and are not additive.
<!-- /startup-recovery-20260908 -->

### Description

Match builtin environment names/prefixes and literal-only selection lists without compiling regexes. Match builtin passthrough variables once per environment snapshot, not per task. Preserve exclusion precedence, escaping, LF behavior, and Windows Unicode case-folding through the existing regex fallback.

### Testing Instructions

DHAT identified environment-matcher compilation as startup allocation work. This layer was measured together with package-manager parsing and config lookup caching: that combined Linux batch improved 50-package cache hits 15.2% and 500-package hits 10.8%. Those are combined results, not an isolated claim for environment matching. Before/after task-hash validation was used to guard cache-key compatibility.

#### Measurement limits

- Measurements used optimized binaries, randomized paired before/after runs, warm OS/local caches, and synthetic npm fixtures. CPU/heap/syscall profiling was separate from wall-time timing.
- Early batches had an unborn Git HEAD; later normalization and matcher-reuse batches used committed fixtures. Results from separate batches are not cumulative.
- Windows runtime performance remains unmeasured. No worker-pool sizes or task concurrency defaults are reduced.
