### PR TITLE
perf: Cache workspace configuration lookups

### DIFF
--- a/crates/turborepo-turbo-json/src/loader.rs
+++ b/crates/turborepo-turbo-json/src/loader.rs
@@ -4,7 +4,7 @@
 //! including strategies for loading turbo.json in different contexts (single
 //! package, workspace, etc.).
 
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::OnceLock};
 
 use tracing::debug;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPath};
@@ -248,7 +248,8 @@ enum LoadTurboJsonPath<'a> {
 #[derive(Debug, Clone)]
 pub struct TurboJsonLoader<U: TurboJsonUpdater = NoOpUpdater> {
     reader: TurboJsonReader,
-    cache: FixedMap<PackageName, TurboJson>,
+    // None records a missing file only for workspaces without an updater.
+    cache: FixedMap<PackageName, Option<TurboJson>>,
     strategy: Strategy<U>,
 }
 
@@ -262,6 +263,8 @@ enum Strategy<U: TurboJsonUpdater> {
     Workspace {
         // Map of package names to their package specific turbo.json
         packages: HashMap<PackageName, AbsoluteSystemPathBuf>,
+        // Scoped to this loader, so watch rebuilds resolve the root again.
+        physical_repo_root: OnceLock<Option<AbsoluteSystemPathBuf>>,
         updater: Option<U>,
     },
     WorkspaceNoTurboJson {
@@ -291,6 +294,7 @@ impl TurboJsonLoader<NoOpUpdater> {
             cache: FixedMap::new(packages.keys().cloned()),
             strategy: Strategy::Workspace {
                 packages,
+                physical_repo_root: OnceLock::new(),
                 updater: None,
             },
         }
@@ -355,7 +359,7 @@ impl TurboJsonLoader<NoOpUpdater> {
         let cache = FixedMap::from_iter(
             turbo_jsons
                 .into_iter()
-                .map(|(key, value)| (key, Some(value))),
+                .map(|(key, value)| (key, Some(Some(value)))),
         );
         // This never gets read from so we populate it with root
         let repo_root = match AbsoluteSystemPath::new(if cfg!(windows) { "C:\\" } else { "/" }) {
@@ -387,6 +391,7 @@ impl<U: TurboJsonUpdater> TurboJsonLoader<U> {
             cache: FixedMap::new(packages.keys().cloned()),
             strategy: Strategy::Workspace {
                 packages,
+                physical_repo_root: OnceLock::new(),
                 updater: Some(updater),
             },
         }
@@ -408,18 +413,26 @@ impl<U: TurboJsonUpdater> TurboJsonLoader<U> {
         }
     }
 
-    /// Load a turbo.json for a given package
+    /// Load a turbo.json for a given package.
+    ///
+    /// Successful loads and missing workspace configs without an updater are
+    /// cached for this loader's lifetime. Construct a fresh loader after
+    /// changes.
     pub fn load(&self, package: &PackageName) -> Result<&TurboJson, U::Error>
     where
         U::Error: From<LoaderError>,
     {
         if let Ok(Some(turbo_json)) = self.cache.get(package) {
-            return Ok(turbo_json);
+            return turbo_json
+                .as_ref()
+                .ok_or_else(|| LoaderError::TurboJson(Error::NoTurboJSON).into());
         }
         let turbo_json = self.uncached_load(package)?;
         self.cache
-            .insert(package, turbo_json)
-            .map_err(|_| LoaderError::TurboJson(Error::NoTurboJSON).into())
+            .insert(package, Some(turbo_json))
+            .ok()
+            .and_then(Option::as_ref)
+            .ok_or_else(|| LoaderError::TurboJson(Error::NoTurboJSON).into())
     }
 
     /// Pre-warm the cache by loading all package turbo.json files in parallel.
@@ -460,7 +473,11 @@ impl<U: TurboJsonUpdater> TurboJsonLoader<U> {
                         .map_err(|e| e.into())
                 }
             }
-            Strategy::Workspace { packages, updater } => {
+            Strategy::Workspace {
+                packages,
+                physical_repo_root,
+                updater,
+            } => {
                 let turbo_json_path = packages.get(package).ok_or_else(|| {
                     Into::<U::Error>::into(LoaderError::TurboJson(Error::NoTurboJSON))
                 })?;
@@ -474,7 +491,12 @@ impl<U: TurboJsonUpdater> TurboJsonLoader<U> {
                     && turbo_json_path
                         .to_realpath()
                         .ok()
-                        .zip(reader.repo_root().to_realpath().ok())
+                        .as_ref()
+                        .zip(
+                            physical_repo_root
+                                .get_or_init(|| reader.repo_root().to_realpath().ok())
+                                .as_ref(),
+                        )
                         .map(|(pkg_real, root_real)| pkg_real == root_real)
                         .unwrap_or(false);
                 let is_root = package == &PackageName::Root || is_package_at_root;
@@ -488,8 +510,13 @@ impl<U: TurboJsonUpdater> TurboJsonLoader<U> {
                     is_root,
                 );
                 if let Some(updater) = updater {
+                    // Updaters may synthesize a config from a missing file or fail
+                    // independently. Do not cache their errors or bypass retries.
                     updater.update_turbo_json(package, turbo_json)
                 } else {
+                    if matches!(&turbo_json, Err(err) if err.is_no_turbo_json()) {
+                        let _ = self.cache.insert(package, None);
+                    }
                     turbo_json.map_err(|e| e.into())
                 }
             }
@@ -992,6 +1019,12 @@ mod tests {
             .create_with_contents(r#"{"extends": ["//"], "tasks": {"build": {}}}"#)
             .unwrap();
 
+        // Missing configs are cached for the run; watch rebuilds use a fresh loader.
+        let loader = TurboJsonLoader::workspace(
+            TurboJsonReader::new(repo_root.to_owned()),
+            repo_root.join_component(CONFIG_FILE),
+            [(PackageName::from("a"), &*pkg_a_dir)].into_iter(),
+        );
         let turbo_json = loader.load(&PackageName::from("a")).unwrap();
         assert_eq!(turbo_json.tasks.len(), 1);
     }
@@ -1457,6 +1490,199 @@ mod tests {
             !pkg_json.global_env.is_empty(),
             "globalEnv should be parsed when symlink points to repo root"
         );
+    }
+
+    #[test_case(CONFIG_FILE)]
+    #[test_case(CONFIG_FILE_JSONC)]
+    fn test_preload_caches_missing_config_until_fresh_loader(config_file: &str) {
+        let root_dir = tempdir().unwrap();
+        let repo_root = AbsoluteSystemPath::from_std_path(root_dir.path()).unwrap();
+        let pkg_dir = repo_root.join_component("pkg");
+        pkg_dir.create_dir_all().unwrap();
+        let directory = package_directory(repo_root, pkg_dir.as_std_path());
+        let package = PackageName::from("pkg");
+        let reader = TurboJsonReader::new(repo_root.to_owned());
+        let make_loader = || {
+            TurboJsonLoader::workspace(
+                reader.clone(),
+                repo_root.join_component(CONFIG_FILE),
+                [(package.clone(), &*directory)].into_iter(),
+            )
+        };
+        let loader = make_loader();
+        loader.preload_all();
+        assert!(matches!(loader.cache.get(&package), Ok(Some(None))));
+        assert!(loader.load(&package).unwrap_err().is_no_turbo_json());
+
+        // A cached absence must not read a newly created file, while a fresh
+        // loader (as constructed by watch rebuilds) must see it.
+        fs::write(pkg_dir.join_component(config_file), r#"{"extends":["//"]}"#).unwrap();
+        assert!(loader.load(&package).unwrap_err().is_no_turbo_json());
+        assert!(
+            loader
+                .clone()
+                .load(&package)
+                .unwrap_err()
+                .is_no_turbo_json()
+        );
+        assert!(make_loader().load(&package).is_ok());
+    }
+
+    #[test_case(false ; "parse error")]
+    #[test_case(true ; "io error")]
+    fn test_workspace_errors_are_retried(is_directory: bool) {
+        let root_dir = tempdir().unwrap();
+        let repo_root = AbsoluteSystemPath::from_std_path(root_dir.path()).unwrap();
+        let pkg_dir = repo_root.join_component("pkg");
+        pkg_dir.create_dir_all().unwrap();
+        let config = pkg_dir.join_component(CONFIG_FILE);
+        if is_directory {
+            config.create_dir_all().unwrap();
+        } else {
+            fs::write(&config, "not json").unwrap();
+        }
+        let directory = package_directory(repo_root, pkg_dir.as_std_path());
+        let package = PackageName::from("pkg");
+        let loader = TurboJsonLoader::workspace(
+            TurboJsonReader::new(repo_root.to_owned()),
+            repo_root.join_component(CONFIG_FILE),
+            [(package.clone(), &*directory)].into_iter(),
+        );
+        loader.preload_all();
+        assert!(!loader.load(&package).unwrap_err().is_no_turbo_json());
+        assert!(matches!(loader.cache.get(&package), Ok(None)));
+        if is_directory {
+            fs::remove_dir(&config).unwrap();
+        }
+        fs::write(&config, r#"{"extends":["//"]}"#).unwrap();
+        assert!(loader.load(&package).is_ok());
+    }
+
+    #[test_case(false ; "missing config can be synthesized")]
+    #[test_case(true ; "present config updater failure")]
+    fn test_updater_errors_are_retried_after_preload(present: bool) {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        #[derive(Debug, thiserror::Error)]
+        enum UpdateError {
+            #[error(transparent)]
+            Load(#[from] LoaderError),
+            #[error("updater attempt {0} failed")]
+            Rejected(usize),
+        }
+
+        struct Updater {
+            calls: AtomicUsize,
+            present: bool,
+        }
+        impl TurboJsonUpdater for Updater {
+            type Error = UpdateError;
+
+            fn update_turbo_json(
+                &self,
+                package: &PackageName,
+                turbo_json: Result<TurboJson, LoaderError>,
+            ) -> Result<TurboJson, Self::Error> {
+                if matches!(package, PackageName::Root) {
+                    return turbo_json.map_err(Into::into);
+                }
+                assert_eq!(turbo_json.is_ok(), self.present);
+                let turbo_json = turbo_json.or_else(|err| {
+                    if err.is_no_turbo_json() {
+                        Ok(TurboJson::default())
+                    } else {
+                        Err(err)
+                    }
+                })?;
+                let attempt = self.calls.fetch_add(1, Ordering::SeqCst);
+                if attempt < 2 {
+                    Err(UpdateError::Rejected(attempt))
+                } else {
+                    Ok(turbo_json)
+                }
+            }
+        }
+
+        let root_dir = tempdir().unwrap();
+        let repo_root = AbsoluteSystemPath::from_std_path(root_dir.path()).unwrap();
+        let pkg_dir = repo_root.join_component("pkg");
+        pkg_dir.create_dir_all().unwrap();
+        if present {
+            fs::write(pkg_dir.join_component(CONFIG_FILE), r#"{"extends":["//"]}"#).unwrap();
+        }
+        let directory = package_directory(repo_root, pkg_dir.as_std_path());
+        let package = PackageName::from("pkg");
+        let loader = TurboJsonLoader::workspace_with_updater(
+            TurboJsonReader::new(repo_root.to_owned()),
+            repo_root.join_component(CONFIG_FILE),
+            [(package.clone(), &*directory)].into_iter(),
+            Updater {
+                calls: AtomicUsize::new(0),
+                present,
+            },
+        );
+        loader.preload_all();
+        assert!(matches!(
+            loader.load(&package),
+            Err(UpdateError::Rejected(1))
+        ));
+        let loaded = loader.load(&package).unwrap();
+        assert!(std::ptr::eq(loaded, loader.load(&package).unwrap()));
+        let Strategy::Workspace {
+            updater: Some(updater),
+            ..
+        } = &loader.strategy
+        else {
+            unreachable!();
+        };
+        assert_eq!(updater.calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_fresh_loader_resolves_retargeted_repo_root() {
+        let root_dir = tempdir().unwrap();
+        let base = AbsoluteSystemPath::from_std_path(root_dir.path()).unwrap();
+        let repo_root = base.join_component("repo");
+        let directory = AnchoredSystemPathBuf::try_from("alias").unwrap();
+        let package = PackageName::from("alias");
+        let reader = TurboJsonReader::new(repo_root.clone());
+        let make_loader = || {
+            TurboJsonLoader::workspace(
+                reader.clone(),
+                repo_root.join_component(CONFIG_FILE),
+                [(package.clone(), &*directory)].into_iter(),
+            )
+        };
+        for name in ["first", "second"] {
+            let physical_root = base.join_component(name);
+            physical_root.create_dir_all().unwrap();
+            fs::write(
+                physical_root.join_component(CONFIG_FILE),
+                r#"{"globalEnv":["CI"]}"#,
+            )
+            .unwrap();
+            physical_root
+                .join_component("alias")
+                .symlink_to_dir(physical_root.as_str())
+                .unwrap();
+            if repo_root.exists() {
+                fs::remove_file(&repo_root).unwrap();
+            }
+            repo_root.symlink_to_dir(physical_root.as_str()).unwrap();
+            let loader = make_loader();
+            assert_eq!(loader.load(&package).unwrap().global_env, ["CI"]);
+            let Strategy::Workspace {
+                physical_repo_root, ..
+            } = &loader.strategy
+            else {
+                unreachable!();
+            };
+            assert_eq!(
+                physical_repo_root.get(),
+                Some(&Some(physical_root.to_realpath().unwrap()))
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
<!-- startup-recovery-20260908 -->
### Review scope

Independent optimization targeting `main`, with exactly one feature commit. No other optimization PR is a prerequisite.

Recovered after the bundled #13970 merge was reverted by #13982. The separately merged parser optimization #13971 remains on `main`. This is not part of a cumulative optimization stack.

The timing figures below are historical measurements from the original incremental benchmark sequence. They have not been remeasured on these newly independent branches and are not additive.
<!-- /startup-recovery-20260908 -->

### Description

Memoize missing workspace configs when no updater is present, and resolve the physical repository root once per loader. Preserve updater retries and synthesized configs; do not cache parse/I/O errors. Fresh loaders rediscover changed configs and symlink targets.

### Testing Instructions

Linux strace on a 50-package fixture showed missing `turbo.json`/`turbo.jsonc` opens falling from 300 to 100: each of 100 distinct paths was opened once rather than three times. Root/path caching reduced readlink probes by 947 in that batch. Timing was combined with parser/environment changes, so their 15.2%/10.8% cache-hit gains are not attributed solely to this PR. This layer intentionally retains the pre-deferred-read flow; a later layer moves schema/physical checks after successful reads.

#### Measurement limits

- Measurements used optimized binaries, randomized paired before/after runs, warm OS/local caches, and synthetic npm fixtures. CPU/heap/syscall profiling was separate from wall-time timing.
- Early batches had an unborn Git HEAD; later normalization and matcher-reuse batches used committed fixtures. Results from separate batches are not cumulative.
- Windows runtime performance remains unmeasured. No worker-pool sizes or task concurrency defaults are reduced.
