### PR TITLE
perf: Reuse canonical paths during repository discovery

### DIFF
--- a/crates/turborepo-repository/src/knowledge.rs
+++ b/crates/turborepo-repository/src/knowledge.rs
@@ -288,6 +288,10 @@ impl RepositoryKnowledge {
         observations: &[PackageScopeObservation],
         workspace_root_observations: &[WorkspaceRootObservation],
     ) -> Result<Self, Error> {
+        // Physical identity is a snapshot for this build. Reuse the root and
+        // each manifest's resolution for containment and duplicate detection
+        // instead of walking the same filesystem paths for both checks.
+        let physical_repository_root = canonical_physical_path(repository_root.as_std_path());
         let root_definition_path = AnchoredSystemPathBuf::from_raw("package.json")?;
         let root_javascript_scope =
             root_javascript_name.map(|user_facing_name| RootJavaScriptScope {
@@ -304,8 +308,11 @@ impl RepositoryKnowledge {
         let mut definitions = HashMap::<String, AnchoredSystemPathBuf>::new();
         let mut definition_owners =
             HashMap::<std::path::PathBuf, (String, ToolchainId, ScopeKind)>::new();
-        let workspace_roots =
-            validate_workspace_roots(repository_root, workspace_root_observations)?;
+        let workspace_roots = validate_workspace_roots(
+            repository_root,
+            physical_repository_root.as_deref(),
+            workspace_root_observations,
+        )?;
 
         for observation in observations {
             if !workspace_roots
@@ -319,7 +326,14 @@ impl RepositoryKnowledge {
         }
 
         for observation in observations {
-            if !path_is_contained(repository_root, &observation.definition_path) {
+            let physical_definition_path =
+                canonical_physical_path(observation.definition_path.as_std_path());
+            if !path_is_contained(
+                repository_root,
+                &observation.definition_path,
+                physical_repository_root.as_deref(),
+                physical_definition_path.as_deref(),
+            ) {
                 return Err(Error::DefinitionOutsideRepository {
                     path: observation.definition_path.clone(),
                     repository_root: repository_root.to_owned(),
@@ -332,9 +346,8 @@ impl RepositoryKnowledge {
                 repository_root,
                 &observation.definition_path,
             );
-            let physical_definition_path =
-                canonical_physical_path(observation.definition_path.as_std_path())
-                    .unwrap_or_else(|| observation.definition_path.as_std_path().to_owned());
+            let physical_definition_path = physical_definition_path
+                .unwrap_or_else(|| observation.definition_path.as_std_path().to_owned());
             if identity == "//" {
                 return Err(Error::ReservedRootIdentity {
                     path: definition_path,
@@ -404,6 +417,7 @@ impl RepositoryKnowledge {
 
 fn validate_workspace_roots(
     repository_root: &AbsoluteSystemPath,
+    physical_repository_root: Option<&std::path::Path>,
     observations: &[WorkspaceRootObservation],
 ) -> Result<Vec<WorkspaceRootKnowledge>, Error> {
     let mut accepted =
@@ -411,7 +425,17 @@ fn validate_workspace_roots(
     let mut roots = Vec::with_capacity(observations.len());
 
     for observation in observations {
-        if !path_is_contained(repository_root, observation.path()) {
+        let physical_path = if observation.path() == repository_root {
+            physical_repository_root.map(std::path::Path::to_owned)
+        } else {
+            canonical_physical_path(observation.path().as_std_path())
+        };
+        if !path_is_contained(
+            repository_root,
+            observation.path(),
+            physical_repository_root,
+            physical_path.as_deref(),
+        ) {
             return Err(Error::WorkspaceRootOutsideRepository {
                 kind: observation.kind().to_string(),
                 path: observation.path().to_owned(),
@@ -423,8 +447,8 @@ fn validate_workspace_roots(
         if anchored_path.as_str() == "." {
             anchored_path = AnchoredSystemPathBuf::default();
         }
-        let physical_path = canonical_physical_path(observation.path().as_std_path())
-            .unwrap_or_else(|| observation.path().as_std_path().to_owned());
+        let physical_path =
+            physical_path.unwrap_or_else(|| observation.path().as_std_path().to_owned());
         if let Some((accepted_kind, accepted_physical_path, accepted_path)) =
             accepted.get(&observation.producer)
         {
@@ -460,15 +484,14 @@ fn validate_workspace_roots(
 fn path_is_contained(
     repository_root: &AbsoluteSystemPath,
     definition_path: &AbsoluteSystemPath,
+    physical_repository_root: Option<&std::path::Path>,
+    physical_definition_path: Option<&std::path::Path>,
 ) -> bool {
     if !repository_root.contains(definition_path) {
         return false;
     }
 
-    match (
-        canonical_physical_path(repository_root.as_std_path()),
-        canonical_physical_path(definition_path.as_std_path()),
-    ) {
+    match (physical_repository_root, physical_definition_path) {
         (Some(repository_root), Some(definition_path)) => {
             definition_path.starts_with(repository_root)
         }
@@ -477,6 +500,12 @@ fn path_is_contained(
 }
 
 fn canonical_physical_path(path: &std::path::Path) -> Option<std::path::PathBuf> {
+    // Discovery normally supplies existing manifests. Canonicalization already
+    // checks existence, so don't issue a separate metadata lookup first.
+    if let Ok(canonical) = dunce::canonicalize(path) {
+        return Some(canonical);
+    }
+
     let mut existing = path.to_owned();
     let mut missing = Vec::new();
     while !existing.exists() {
@@ -772,6 +801,86 @@ mod tests {
         );
 
         assert!(matches!(result, Err(Error::DuplicateDefinitionPath { .. })));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn physical_identity_checks_follow_symlinks_on_each_build() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPathBuf::try_from(temp.path()).unwrap();
+        let inside = root.join_component("inside");
+        inside.create_dir_all().unwrap();
+        inside
+            .join_component("package.json")
+            .create_with_contents("{}")
+            .unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("package.json"), "{}").unwrap();
+        let alias = root.join_component("alias");
+        std::os::unix::fs::symlink(inside.as_std_path(), alias.as_std_path()).unwrap();
+        let roots = [WorkspaceRootObservation::new(
+            WorkspaceRoot::new("npm", root.clone()),
+            ToolchainId::JAVASCRIPT,
+        )];
+        let observations = [PackageScopeObservation {
+            identity: Some("app".to_string()),
+            name_source: None,
+            definition_path: alias.join_component("package.json"),
+            toolchain: ToolchainId::JAVASCRIPT,
+            scope_kind: ScopeKind::Package,
+        }];
+        assert!(RepositoryKnowledge::build(&root, None, &observations, &roots).is_ok());
+
+        std::fs::remove_file(alias.as_std_path()).unwrap();
+        std::os::unix::fs::symlink(outside.path(), alias.as_std_path()).unwrap();
+        assert!(matches!(
+            RepositoryKnowledge::build(&root, None, &observations, &roots),
+            Err(Error::DefinitionOutsideRepository { .. })
+        ));
+        // Missing files still resolve their existing symlinked parent for containment.
+        std::fs::remove_file(outside.path().join("package.json")).unwrap();
+        assert!(matches!(
+            RepositoryKnowledge::build(&root, None, &observations, &roots),
+            Err(Error::DefinitionOutsideRepository { .. })
+        ));
+        let outside_roots = [WorkspaceRootObservation::new(
+            WorkspaceRoot::new("npm", alias),
+            ToolchainId::JAVASCRIPT,
+        )];
+        assert!(matches!(
+            RepositoryKnowledge::build(&root, None, &[], &outside_roots),
+            Err(Error::WorkspaceRootOutsideRepository { .. })
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn physical_identity_detects_non_root_manifest_aliases() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPathBuf::try_from(temp.path()).unwrap();
+        let manifest = root.join_component("package.json");
+        manifest.create_with_contents("{}").unwrap();
+        let alias = root.join_component("alias.json");
+        std::os::unix::fs::symlink(manifest.as_std_path(), alias.as_std_path()).unwrap();
+        let observations = [manifest, alias]
+            .into_iter()
+            .enumerate()
+            .map(|(i, path)| PackageScopeObservation {
+                identity: Some(format!("app{i}")),
+                name_source: None,
+                definition_path: path,
+                toolchain: ToolchainId::JAVASCRIPT,
+                scope_kind: ScopeKind::Package,
+            })
+            .collect::<Vec<_>>();
+        let roots = [WorkspaceRootObservation::new(
+            WorkspaceRoot::new("npm", root.clone()),
+            ToolchainId::JAVASCRIPT,
+        )];
+        assert!(matches!(
+            RepositoryKnowledge::build(&root, None, &observations, &roots),
+            Err(Error::DuplicateDefinitionPath { .. })
+        ));
     }
 
     #[test]


### PR DESCRIPTION
<!-- startup-recovery-20260908 -->
### Review scope

Independent optimization targeting `main`, with exactly one feature commit. No other optimization PR is a prerequisite.

Recovered after the bundled #13970 merge was reverted by #13982. The separately merged parser optimization #13971 remains on `main`. This is not part of a cumulative optimization stack.

The timing figures below are historical measurements from the original incremental benchmark sequence. They have not been remeasured on these newly independent branches and are not additive.
<!-- /startup-recovery-20260908 -->

### Description

Resolve the physical repository root once per knowledge build, and reuse each manifest resolution for containment and duplicate-identity checks. Try canonicalization directly for existing files rather than statting them first; preserve the missing-path parent fallback and symlink validation.

### Testing Instructions

This was measured with the following deferred-config-check layer in a separate Linux FS A/B batch. Together they reduced 500-package readlink calls from 13,042 to 6,033 and statx calls from 6,070 to 4,566; cache hits improved 6.0% and dry runs 7.2%. These are paired synthetic-fixture batch results, not isolated per-layer or universal gains. Coverage includes symlink retargeting and aliases of the same manifest.

#### Measurement limits

- Measurements used optimized binaries, randomized paired before/after runs, warm OS/local caches, and synthetic npm fixtures. CPU/heap/syscall profiling was separate from wall-time timing.
- Early batches had an unborn Git HEAD; later normalization and matcher-reuse batches used committed fixtures. Results from separate batches are not cumulative.
- Windows runtime performance remains unmeasured. No worker-pool sizes or task concurrency defaults are reduced.

<sub>CLOSES TURBO-6045</sub>