### PR TITLE
perf: Defer filesystem checks for absent configs

### DIFF
--- a/crates/turborepo-turbo-json/src/lib.rs
+++ b/crates/turborepo-turbo-json/src/lib.rs
@@ -224,7 +224,17 @@ impl TurboJson {
         is_root: bool,
         future_flags: FutureFlags,
     ) -> Result<Option<TurboJson>, Error> {
-        let Some(raw_turbo_json) = RawTurboJson::read(repo_root, path, is_root)? else {
+        Self::read_with_root_check(repo_root, path, || is_root, future_flags)
+    }
+
+    pub(crate) fn read_with_root_check(
+        repo_root: &AbsoluteSystemPath,
+        path: &AbsoluteSystemPath,
+        is_root: impl FnOnce() -> bool,
+        future_flags: FutureFlags,
+    ) -> Result<Option<TurboJson>, Error> {
+        let Some(raw_turbo_json) = RawTurboJson::read_with_root_check(repo_root, path, is_root)?
+        else {
             return Ok(None);
         };
 

--- a/crates/turborepo-turbo-json/src/loader.rs
+++ b/crates/turborepo-turbo-json/src/loader.rs
@@ -4,7 +4,7 @@
 //! including strategies for loading turbo.json in different contexts (single
 //! package, workspace, etc.).
 
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::OnceLock};
 
 use tracing::debug;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPath};
@@ -248,7 +248,8 @@ enum LoadTurboJsonPath<'a> {
 #[derive(Debug, Clone)]
 pub struct TurboJsonLoader<U: TurboJsonUpdater = NoOpUpdater> {
     reader: TurboJsonReader,
-    cache: FixedMap<PackageName, TurboJson>,
+    // None records a missing file only for workspaces without an updater.
+    cache: FixedMap<PackageName, Option<TurboJson>>,
     strategy: Strategy<U>,
 }
 
@@ -262,6 +263,8 @@ enum Strategy<U: TurboJsonUpdater> {
     Workspace {
         // Map of package names to their package specific turbo.json
         packages: HashMap<PackageName, AbsoluteSystemPathBuf>,
+        // Scoped to this loader, so watch rebuilds resolve the root again.
+        physical_repo_root: OnceLock<Option<AbsoluteSystemPathBuf>>,
         updater: Option<U>,
     },
     WorkspaceNoTurboJson {
@@ -291,6 +294,7 @@ impl TurboJsonLoader<NoOpUpdater> {
             cache: FixedMap::new(packages.keys().cloned()),
             strategy: Strategy::Workspace {
                 packages,
+                physical_repo_root: OnceLock::new(),
                 updater: None,
             },
         }
@@ -355,7 +359,7 @@ impl TurboJsonLoader<NoOpUpdater> {
         let cache = FixedMap::from_iter(
             turbo_jsons
                 .into_iter()
-                .map(|(key, value)| (key, Some(value))),
+                .map(|(key, value)| (key, Some(Some(value)))),
         );
         // This never gets read from so we populate it with root
         let repo_root = match AbsoluteSystemPath::new(if cfg!(windows) { "C:\\" } else { "/" }) {
@@ -387,6 +391,7 @@ impl<U: TurboJsonUpdater> TurboJsonLoader<U> {
             cache: FixedMap::new(packages.keys().cloned()),
             strategy: Strategy::Workspace {
                 packages,
+                physical_repo_root: OnceLock::new(),
                 updater: Some(updater),
             },
         }
@@ -408,18 +413,26 @@ impl<U: TurboJsonUpdater> TurboJsonLoader<U> {
         }
     }
 
-    /// Load a turbo.json for a given package
+    /// Load a turbo.json for a given package.
+    ///
+    /// Successful loads and missing workspace configs without an updater are
+    /// cached for this loader's lifetime. Construct a fresh loader after
+    /// changes.
     pub fn load(&self, package: &PackageName) -> Result<&TurboJson, U::Error>
     where
         U::Error: From<LoaderError>,
     {
         if let Ok(Some(turbo_json)) = self.cache.get(package) {
-            return Ok(turbo_json);
+            return turbo_json
+                .as_ref()
+                .ok_or_else(|| LoaderError::TurboJson(Error::NoTurboJSON).into());
         }
         let turbo_json = self.uncached_load(package)?;
         self.cache
-            .insert(package, turbo_json)
-            .map_err(|_| LoaderError::TurboJson(Error::NoTurboJSON).into())
+            .insert(package, Some(turbo_json))
+            .ok()
+            .and_then(Option::as_ref)
+            .ok_or_else(|| LoaderError::TurboJson(Error::NoTurboJSON).into())
     }
 
     /// Pre-warm the cache by loading all package turbo.json files in parallel.
@@ -460,7 +473,11 @@ impl<U: TurboJsonUpdater> TurboJsonLoader<U> {
                         .map_err(|e| e.into())
                 }
             }
-            Strategy::Workspace { packages, updater } => {
+            Strategy::Workspace {
+                packages,
+                physical_repo_root,
+                updater,
+            } => {
                 let turbo_json_path = packages.get(package).ok_or_else(|| {
                     Into::<U::Error>::into(LoaderError::TurboJson(Error::NoTurboJSON))
                 })?;
@@ -474,7 +491,12 @@ impl<U: TurboJsonUpdater> TurboJsonLoader<U> {
                     && turbo_json_path
                         .to_realpath()
                         .ok()
-                        .zip(reader.repo_root().to_realpath().ok())
+                        .as_ref()
+                        .zip(
+                            physical_repo_root
+                                .get_or_init(|| reader.repo_root().to_realpath().ok())
+                                .as_ref(),
+                        )
                         .map(|(pkg_real, root_real)| pkg_real == root_real)
                         .unwrap_or(false);
                 let is_root = package == &PackageName::Root || is_package_at_root;
@@ -488,8 +510,13 @@ impl<U: TurboJsonUpdater> TurboJsonLoader<U> {
                     is_root,
                 );
                 if let Some(updater) = updater {
+                    // Updaters may synthesize a config from a missing file or fail
+                    // independently. Do not cache their errors or bypass retries.
                     updater.update_turbo_json(package, turbo_json)
                 } else {
+                    if matches!(&turbo_json, Err(err) if err.is_no_turbo_json()) {
+                        let _ = self.cache.insert(package, None);
+                    }
                     turbo_json.map_err(|e| e.into())
                 }
             }
@@ -992,6 +1019,12 @@ mod tests {
             .create_with_contents(r#"{"extends": ["//"], "tasks": {"build": {}}}"#)
             .unwrap();
 
+        // Missing configs are cached for the run; watch rebuilds use a fresh loader.
+        let loader = TurboJsonLoader::workspace(
+            TurboJsonReader::new(repo_root.to_owned()),
+            repo_root.join_component(CONFIG_FILE),
+            [(PackageName::from("a"), &*pkg_a_dir)].into_iter(),
+        );
         let turbo_json = loader.load(&PackageName::from("a")).unwrap();
         assert_eq!(turbo_json.tasks.len(), 1);
     }
@@ -1457,6 +1490,199 @@ mod tests {
             !pkg_json.global_env.is_empty(),
             "globalEnv should be parsed when symlink points to repo root"
         );
+    }
+
+    #[test_case(CONFIG_FILE)]
+    #[test_case(CONFIG_FILE_JSONC)]
+    fn test_preload_caches_missing_config_until_fresh_loader(config_file: &str) {
+        let root_dir = tempdir().unwrap();
+        let repo_root = AbsoluteSystemPath::from_std_path(root_dir.path()).unwrap();
+        let pkg_dir = repo_root.join_component("pkg");
+        pkg_dir.create_dir_all().unwrap();
+        let directory = package_directory(repo_root, pkg_dir.as_std_path());
+        let package = PackageName::from("pkg");
+        let reader = TurboJsonReader::new(repo_root.to_owned());
+        let make_loader = || {
+            TurboJsonLoader::workspace(
+                reader.clone(),
+                repo_root.join_component(CONFIG_FILE),
+                [(package.clone(), &*directory)].into_iter(),
+            )
+        };
+        let loader = make_loader();
+        loader.preload_all();
+        assert!(matches!(loader.cache.get(&package), Ok(Some(None))));
+        assert!(loader.load(&package).unwrap_err().is_no_turbo_json());
+
+        // A cached absence must not read a newly created file, while a fresh
+        // loader (as constructed by watch rebuilds) must see it.
+        fs::write(pkg_dir.join_component(config_file), r#"{"extends":["//"]}"#).unwrap();
+        assert!(loader.load(&package).unwrap_err().is_no_turbo_json());
+        assert!(
+            loader
+                .clone()
+                .load(&package)
+                .unwrap_err()
+                .is_no_turbo_json()
+        );
+        assert!(make_loader().load(&package).is_ok());
+    }
+
+    #[test_case(false ; "parse error")]
+    #[test_case(true ; "io error")]
+    fn test_workspace_errors_are_retried(is_directory: bool) {
+        let root_dir = tempdir().unwrap();
+        let repo_root = AbsoluteSystemPath::from_std_path(root_dir.path()).unwrap();
+        let pkg_dir = repo_root.join_component("pkg");
+        pkg_dir.create_dir_all().unwrap();
+        let config = pkg_dir.join_component(CONFIG_FILE);
+        if is_directory {
+            config.create_dir_all().unwrap();
+        } else {
+            fs::write(&config, "not json").unwrap();
+        }
+        let directory = package_directory(repo_root, pkg_dir.as_std_path());
+        let package = PackageName::from("pkg");
+        let loader = TurboJsonLoader::workspace(
+            TurboJsonReader::new(repo_root.to_owned()),
+            repo_root.join_component(CONFIG_FILE),
+            [(package.clone(), &*directory)].into_iter(),
+        );
+        loader.preload_all();
+        assert!(!loader.load(&package).unwrap_err().is_no_turbo_json());
+        assert!(matches!(loader.cache.get(&package), Ok(None)));
+        if is_directory {
+            fs::remove_dir(&config).unwrap();
+        }
+        fs::write(&config, r#"{"extends":["//"]}"#).unwrap();
+        assert!(loader.load(&package).is_ok());
+    }
+
+    #[test_case(false ; "missing config can be synthesized")]
+    #[test_case(true ; "present config updater failure")]
+    fn test_updater_errors_are_retried_after_preload(present: bool) {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        #[derive(Debug, thiserror::Error)]
+        enum UpdateError {
+            #[error(transparent)]
+            Load(#[from] LoaderError),
+            #[error("updater attempt {0} failed")]
+            Rejected(usize),
+        }
+
+        struct Updater {
+            calls: AtomicUsize,
+            present: bool,
+        }
+        impl TurboJsonUpdater for Updater {
+            type Error = UpdateError;
+
+            fn update_turbo_json(
+                &self,
+                package: &PackageName,
+                turbo_json: Result<TurboJson, LoaderError>,
+            ) -> Result<TurboJson, Self::Error> {
+                if matches!(package, PackageName::Root) {
+                    return turbo_json.map_err(Into::into);
+                }
+                assert_eq!(turbo_json.is_ok(), self.present);
+                let turbo_json = turbo_json.or_else(|err| {
+                    if err.is_no_turbo_json() {
+                        Ok(TurboJson::default())
+                    } else {
+                        Err(err)
+                    }
+                })?;
+                let attempt = self.calls.fetch_add(1, Ordering::SeqCst);
+                if attempt < 2 {
+                    Err(UpdateError::Rejected(attempt))
+                } else {
+                    Ok(turbo_json)
+                }
+            }
+        }
+
+        let root_dir = tempdir().unwrap();
+        let repo_root = AbsoluteSystemPath::from_std_path(root_dir.path()).unwrap();
+        let pkg_dir = repo_root.join_component("pkg");
+        pkg_dir.create_dir_all().unwrap();
+        if present {
+            fs::write(pkg_dir.join_component(CONFIG_FILE), r#"{"extends":["//"]}"#).unwrap();
+        }
+        let directory = package_directory(repo_root, pkg_dir.as_std_path());
+        let package = PackageName::from("pkg");
+        let loader = TurboJsonLoader::workspace_with_updater(
+            TurboJsonReader::new(repo_root.to_owned()),
+            repo_root.join_component(CONFIG_FILE),
+            [(package.clone(), &*directory)].into_iter(),
+            Updater {
+                calls: AtomicUsize::new(0),
+                present,
+            },
+        );
+        loader.preload_all();
+        assert!(matches!(
+            loader.load(&package),
+            Err(UpdateError::Rejected(1))
+        ));
+        let loaded = loader.load(&package).unwrap();
+        assert!(std::ptr::eq(loaded, loader.load(&package).unwrap()));
+        let Strategy::Workspace {
+            updater: Some(updater),
+            ..
+        } = &loader.strategy
+        else {
+            unreachable!();
+        };
+        assert_eq!(updater.calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_fresh_loader_resolves_retargeted_repo_root() {
+        let root_dir = tempdir().unwrap();
+        let base = AbsoluteSystemPath::from_std_path(root_dir.path()).unwrap();
+        let repo_root = base.join_component("repo");
+        let directory = AnchoredSystemPathBuf::try_from("alias").unwrap();
+        let package = PackageName::from("alias");
+        let reader = TurboJsonReader::new(repo_root.clone());
+        let make_loader = || {
+            TurboJsonLoader::workspace(
+                reader.clone(),
+                repo_root.join_component(CONFIG_FILE),
+                [(package.clone(), &*directory)].into_iter(),
+            )
+        };
+        for name in ["first", "second"] {
+            let physical_root = base.join_component(name);
+            physical_root.create_dir_all().unwrap();
+            fs::write(
+                physical_root.join_component(CONFIG_FILE),
+                r#"{"globalEnv":["CI"]}"#,
+            )
+            .unwrap();
+            physical_root
+                .join_component("alias")
+                .symlink_to_dir(physical_root.as_str())
+                .unwrap();
+            if repo_root.exists() {
+                fs::remove_file(&repo_root).unwrap();
+            }
+            repo_root.symlink_to_dir(physical_root.as_str()).unwrap();
+            let loader = make_loader();
+            assert_eq!(loader.load(&package).unwrap().global_env, ["CI"]);
+            let Strategy::Workspace {
+                physical_repo_root, ..
+            } = &loader.strategy
+            else {
+                unreachable!();
+            };
+            assert_eq!(
+                physical_repo_root.get(),
+                Some(&Some(physical_root.to_realpath().unwrap()))
+            );
+        }
     }
 
     #[test]

--- a/crates/turborepo-turbo-json/src/loader.rs
+++ b/crates/turborepo-turbo-json/src/loader.rs
@@ -140,6 +140,14 @@ impl TurboJsonReader {
         TurboJson::read(&self.repo_root, path, is_root, self.future_flags)
     }
 
+    fn read_with_root_check(
+        &self,
+        path: &AbsoluteSystemPath,
+        is_root: impl FnOnce() -> bool,
+    ) -> Result<Option<TurboJson>, Error> {
+        TurboJson::read_with_root_check(&self.repo_root, path, is_root, self.future_flags)
+    }
+
     /// Get the repo root path
     pub fn repo_root(&self) -> &AbsoluteSystemPath {
         &self.repo_root
@@ -171,18 +179,31 @@ pub fn load_from_path(
     turbo_json_path: TurboJsonPath,
     is_root: bool,
 ) -> Result<TurboJson, Error> {
+    load_from_path_with_root_check(reader, turbo_json_path, || is_root)
+}
+
+fn load_from_path_with_root_check(
+    reader: &TurboJsonReader,
+    turbo_json_path: TurboJsonPath,
+    is_root: impl Fn() -> bool,
+) -> Result<TurboJson, Error> {
+    // Both candidates must use the same schema, with at most one root check.
+    let root_check = OnceLock::new();
+    let is_root = || *root_check.get_or_init(&is_root);
     let result = match turbo_json_path {
         TurboJsonPath::Dir(turbo_json_dir_path) => {
             let turbo_json_path = turbo_json_dir_path.join_component(CONFIG_FILE);
             let turbo_jsonc_path = turbo_json_dir_path.join_component(CONFIG_FILE_JSONC);
 
             // Load both turbo.json and turbo.jsonc
-            let turbo_json = reader.read(&turbo_json_path, is_root);
-            let turbo_jsonc = reader.read(&turbo_jsonc_path, is_root);
+            let turbo_json = reader.read_with_root_check(&turbo_json_path, is_root);
+            let turbo_jsonc = reader.read_with_root_check(&turbo_jsonc_path, is_root);
 
             select_turbo_json(turbo_json_dir_path, turbo_json, turbo_jsonc)
         }
-        TurboJsonPath::File(turbo_json_path) => reader.read(turbo_json_path, is_root),
+        TurboJsonPath::File(turbo_json_path) => {
+            reader.read_with_root_check(turbo_json_path, is_root)
+        }
     };
 
     // Handle errors or success
@@ -487,19 +508,22 @@ impl<U: TurboJsonUpdater> TurboJsonLoader<U> {
                 // should treat it as root to use the correct schema.
                 // We use to_realpath() to resolve symlinks so that a symlinked
                 // package pointing to the repo root is also detected correctly.
-                let is_package_at_root = !matches!(package, PackageName::Root)
-                    && turbo_json_path
-                        .to_realpath()
-                        .ok()
-                        .as_ref()
-                        .zip(
-                            physical_repo_root
-                                .get_or_init(|| reader.repo_root().to_realpath().ok())
-                                .as_ref(),
-                        )
-                        .map(|(pkg_real, root_real)| pkg_real == root_real)
-                        .unwrap_or(false);
-                let is_root = package == &PackageName::Root || is_package_at_root;
+                // Defer both realpath calls until a config has been read. Missing
+                // configs need neither package nor root canonicalization.
+                let is_root = || {
+                    package == &PackageName::Root
+                        || turbo_json_path
+                            .to_realpath()
+                            .ok()
+                            .as_ref()
+                            .zip(
+                                physical_repo_root
+                                    .get_or_init(|| reader.repo_root().to_realpath().ok())
+                                    .as_ref(),
+                            )
+                            .map(|(pkg_real, root_real)| pkg_real == root_real)
+                            .unwrap_or(false)
+                };
                 let turbo_json = load_turbo_json_from_file(
                     reader,
                     if package == &PackageName::Root {
@@ -603,30 +627,13 @@ fn workspace_package_scripts<'a>(
 fn load_turbo_json_from_file(
     reader: &TurboJsonReader,
     turbo_json_path: LoadTurboJsonPath,
-    is_root: bool,
+    is_root: impl Fn() -> bool,
 ) -> Result<TurboJson, LoaderError> {
-    let result = match turbo_json_path {
-        LoadTurboJsonPath::Dir(turbo_json_dir_path) => {
-            let turbo_json_path = turbo_json_dir_path.join_component(CONFIG_FILE);
-            let turbo_jsonc_path = turbo_json_dir_path.join_component(CONFIG_FILE_JSONC);
-
-            // Load both turbo.json and turbo.jsonc
-            let turbo_json = reader.read(&turbo_json_path, is_root);
-            let turbo_jsonc = reader.read(&turbo_jsonc_path, is_root);
-
-            select_turbo_json(turbo_json_dir_path, turbo_json, turbo_jsonc)
-        }
-        LoadTurboJsonPath::File(turbo_json_path) => reader.read(turbo_json_path, is_root),
+    let path = match turbo_json_path {
+        LoadTurboJsonPath::Dir(path) => TurboJsonPath::Dir(path),
+        LoadTurboJsonPath::File(path) => TurboJsonPath::File(path),
     };
-
-    // Handle errors or success
-    match result {
-        // There was an error, and we don't have any chance of recovering
-        Err(e) => Err(LoaderError::TurboJson(e)),
-        Ok(None) => Err(LoaderError::TurboJson(Error::NoTurboJSON)),
-        // We're not synthesizing anything and there was no error, we're done
-        Ok(Some(turbo)) => Ok(turbo),
-    }
+    load_from_path_with_root_check(reader, path, is_root).map_err(LoaderError::TurboJson)
 }
 
 fn load_from_root_scripts(
@@ -1167,6 +1174,77 @@ mod tests {
         assert!(loader.load(&PackageName::Root).is_ok());
     }
 
+    #[test_case(None, None, 0 ; "both missing")]
+    #[test_case(Some("{}"), None, 1 ; "json only")]
+    #[test_case(None, Some("{}"), 1 ; "jsonc only")]
+    #[test_case(Some("{}"), Some("{}"), 1 ; "both valid")]
+    #[test_case(Some("invalid json"), None, 1 ; "json parse error")]
+    #[test_case(None, Some("invalid jsonc"), 1 ; "jsonc parse error")]
+    #[test_case(Some("invalid json"), Some("invalid jsonc"), 1 ; "both invalid")]
+    #[test_case(Some("invalid json"), Some("{}"), 1 ; "valid jsonc wins")]
+    #[test_case(Some("{}"), Some("invalid jsonc"), 1 ; "valid json wins")]
+    fn test_deferred_root_check_selection(
+        json: Option<&str>,
+        jsonc: Option<&str>,
+        expected_checks: usize,
+    ) {
+        use std::cell::Cell;
+
+        let tmp_dir = tempdir().unwrap();
+        let repo_root = AbsoluteSystemPath::from_std_path(tmp_dir.path()).unwrap();
+        let reader = TurboJsonReader::new(repo_root.to_owned());
+        for (name, contents) in [(CONFIG_FILE, json), (CONFIG_FILE_JSONC, jsonc)] {
+            if let Some(contents) = contents {
+                fs::write(repo_root.join_component(name), contents).unwrap();
+            }
+        }
+        let checks = Cell::new(0);
+        let result = load_from_path_with_root_check(&reader, TurboJsonPath::Dir(repo_root), || {
+            checks.set(checks.get() + 1);
+            true
+        });
+        assert_eq!(checks.get(), expected_checks);
+        // Compare against independently read/parsed candidates to retain the
+        // exact selection and diagnostic behavior, including invalid siblings.
+        // Parse errors capture backtraces, so compare their stable diagnostics
+        // rather than the call-site-dependent backtrace frames.
+        let expected = select_turbo_json(
+            repo_root,
+            reader.read(&repo_root.join_component(CONFIG_FILE), true),
+            reader.read(&repo_root.join_component(CONFIG_FILE_JSONC), true),
+        )
+        .and_then(|config| config.ok_or(Error::NoTurboJSON));
+        let comparable = |result: Result<TurboJson, Error>| {
+            result.map_err(|error| match error {
+                Error::Parse(error) => format!("{:?}", error.diagnostics),
+                error => format!("{error:?}"),
+            })
+        };
+        assert_eq!(comparable(result), comparable(expected));
+    }
+
+    #[test]
+    fn test_read_failure_skips_root_check() {
+        let tmp_dir = tempdir().unwrap();
+        let repo_root = AbsoluteSystemPath::from_std_path(tmp_dir.path()).unwrap();
+        let reader = TurboJsonReader::new(repo_root.to_owned());
+        let path = repo_root.join_component(CONFIG_FILE);
+        assert!(
+            reader
+                .read_with_root_check(&path, || panic!("missing file must not classify root"))
+                .unwrap()
+                .is_none()
+        );
+        path.create_dir_all().unwrap();
+        let result =
+            reader.read_with_root_check(&path, || panic!("failed read must not classify root"));
+        assert!(result.is_err());
+        assert_eq!(
+            format!("{result:?}"),
+            format!("{:?}", reader.read(&path, true))
+        );
+    }
+
     #[test]
     fn test_load_from_file_with_both_files_error_message() {
         let tmp_dir = tempdir().unwrap();
@@ -1181,7 +1259,7 @@ mod tests {
         turbo_jsonc_path.create_with_contents("{}").unwrap();
 
         // Test load_turbo_json_from_file with turbo.json path
-        let result = load_turbo_json_from_file(&reader, LoadTurboJsonPath::Dir(repo_root), true);
+        let result = load_turbo_json_from_file(&reader, LoadTurboJsonPath::Dir(repo_root), || true);
 
         // The function should return an error when both files exist
         assert!(result.is_err());
@@ -1513,6 +1591,13 @@ mod tests {
         loader.preload_all();
         assert!(matches!(loader.cache.get(&package), Ok(Some(None))));
         assert!(loader.load(&package).unwrap_err().is_no_turbo_json());
+        let Strategy::Workspace {
+            physical_repo_root, ..
+        } = &loader.strategy
+        else {
+            unreachable!();
+        };
+        assert!(physical_repo_root.get().is_none());
 
         // A cached absence must not read a newly created file, while a fresh
         // loader (as constructed by watch rebuilds) must see it.

--- a/crates/turborepo-turbo-json/src/raw.rs
+++ b/crates/turborepo-turbo-json/src/raw.rs
@@ -1103,6 +1103,15 @@ impl RawTurboJson {
         path: &AbsoluteSystemPath,
         is_root: bool,
     ) -> Result<Option<RawTurboJson>, Error> {
+        Self::read_with_root_check(repo_root, path, || is_root)
+    }
+
+    /// Resolve the schema only after successfully reading the file contents.
+    pub(crate) fn read_with_root_check(
+        repo_root: &AbsoluteSystemPath,
+        path: &AbsoluteSystemPath,
+        is_root: impl FnOnce() -> bool,
+    ) -> Result<Option<RawTurboJson>, Error> {
         let Some(contents) = path.read_existing_to_string()? else {
             return Ok(None);
         };
@@ -1114,7 +1123,7 @@ impl RawTurboJson {
             |relative| relative.to_string(),
         );
 
-        Ok(Some(if is_root {
+        Ok(Some(if is_root() {
             RawRootTurboJson::parse(&contents, &root_relative_path)?.try_into()?
         } else {
             RawTurboJson::from(RawPackageTurboJson::parse(&contents, &root_relative_path)?)


### PR DESCRIPTION
<!-- startup-recovery-20260908 -->
### Review scope

Depends on #13975: this change uses its per-loader `physical_repo_root` cache and extends its missing-config coverage. This PR targets `shew/startup-05-config-lookups`, so its diff contains only deferred filesystem checks. After #13975 lands, rebase this feature commit onto updated `main` before retargeting it. No other optimization PR is a prerequisite.

Recovered after the bundled #13970 merge was reverted by #13982. The separately merged parser optimization #13971 remains on `main`. This is not part of a cumulative optimization stack.

The timing figures below are historical measurements from the original incremental benchmark sequence. They have not been remeasured on these newly independent branches and are not additive.
<!-- /startup-recovery-20260908 -->

### Description

Resolve root-versus-package config schema only after reading config contents. Reuse explicit config-existence observations while preserving precedence and errors for conflicting configs. Avoid physical-path/schema work for absent configs without removing checks for files that are actually read.

### Testing Instructions

In the Linux FS batch with the preceding repository-canonicalization layer, 500-package cache hits improved 6.0% and dry runs 7.2%. Smaller and forced-run cases were inconclusive, including a 2.7% median slowdown for the per-package-config cache-hit fixture whose paired interval spanned zero. All 888 saved timing measurements were preserved when only the unfinished strace/perf phase was resumed. Do not add these percentages to earlier batches.

#### Measurement limits

- Measurements used optimized binaries, randomized paired before/after runs, warm OS/local caches, and synthetic npm fixtures. CPU/heap/syscall profiling was separate from wall-time timing.
- Early batches had an unborn Git HEAD; later normalization and matcher-reuse batches used committed fixtures. Results from separate batches are not cumulative.
- Windows runtime performance remains unmeasured. No worker-pool sizes or task concurrency defaults are reduced.
