### PR TITLE
perf: Compile workspace glob combinators directly

### DIFF
--- a/crates/turborepo-repository/src/workspaces.rs
+++ b/crates/turborepo-repository/src/workspaces.rs
@@ -79,6 +79,24 @@ fn any_with_contextual_error(
     })
 }
 
+fn compile_directory_globs(raw: &[String]) -> Result<Any<'static>, Error> {
+    let fixed: Vec<_> = raw
+        .iter()
+        .map(|pattern| fix_glob_pattern(pattern))
+        .collect();
+    match wax::any(fixed.iter().map(|pattern| pattern.as_ref())) {
+        Ok(combined) => Ok(combined.into_owned()),
+        Err(_) => {
+            // Preserve per-expression validation and error context on failure.
+            let globs = raw
+                .iter()
+                .map(glob_with_contextual_error)
+                .collect::<Result<Vec<_>, _>>()?;
+            any_with_contextual_error(globs, raw.to_vec())
+        }
+    }
+}
+
 impl WorkspaceGlobs {
     pub fn new<S: Into<String>>(inclusions: Vec<S>, exclusions: Vec<S>) -> Result<Self, Error> {
         // take ownership of the inputs
@@ -102,27 +120,18 @@ impl WorkspaceGlobs {
             .into_iter()
             .map(|s| s.into())
             .collect::<Vec<String>>();
-        let inclusion_globs = raw_inclusions
-            .iter()
-            .map(glob_with_contextual_error)
-            .collect::<Result<Vec<_>, _>>()?;
-        let exclusion_globs = raw_exclusions
-            .iter()
-            .map(glob_with_contextual_error)
-            .collect::<Result<Vec<_>, _>>()?;
+        // `wax::any` accepts expressions directly: compiling each Glob first
+        // builds regexes which the combinator immediately discards. Only compile
+        // the combined matcher on the successful path.
+        let directory_inclusions = compile_directory_globs(&raw_inclusions)?;
+        let directory_exclusions = compile_directory_globs(&raw_exclusions)?;
         let validated_exclusions = raw_exclusions
             .iter()
             .map(|e| ValidatedGlob::from_str(e))
             .collect::<Result<Vec<_>, _>>()?;
         Ok(Self {
-            directory_inclusions: any_with_contextual_error(
-                inclusion_globs,
-                raw_inclusions.clone(),
-            )?,
-            directory_exclusions: any_with_contextual_error(
-                exclusion_globs,
-                raw_exclusions.clone(),
-            )?,
+            directory_inclusions,
+            directory_exclusions,
             package_json_inclusions,
             validated_exclusions,
             raw_exclusions,
@@ -212,6 +221,71 @@ impl WorkspaceGlobs {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn combined_directory_globs_match_precompiled_globs() {
+        for patterns in [
+            vec![],
+            vec!["packages/*"],
+            vec!["apps/*", "packages/**", "tools/{cli,web}"],
+            vec!["**/node_modules/**", "**/.git", "**/.yarn"],
+            vec!["пакеты/?", "apps/[a-z]*", "**foo"],
+            vec![".", "packages/", "literal\\*"],
+        ] {
+            let raw: Vec<String> = patterns.iter().map(|s| s.to_string()).collect();
+            let old = any_with_contextual_error(
+                raw.iter()
+                    .map(glob_with_contextual_error)
+                    .collect::<Result<_, _>>()
+                    .unwrap(),
+                raw.clone(),
+            )
+            .unwrap();
+            let new = compile_directory_globs(&raw).unwrap();
+            for path in [
+                "",
+                ".",
+                "packages",
+                "packages/",
+                "packages/web",
+                "packages/a/b",
+                "apps/cli",
+                "tools/web",
+                "пакеты/猫",
+                "x/node_modules/pkg",
+                "node_modules/",
+                ".git",
+                "foo",
+                "afoo",
+                "literal*",
+                "apps/a\nb",
+            ] {
+                assert_eq!(
+                    new.is_match(path),
+                    old.is_match(path),
+                    "{patterns:?}: {path:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn combined_directory_globs_preserve_errors() {
+        for pattern in ["[", "{a,", "packages/**/**", "<a:0,0>"] {
+            let raw = vec!["packages/*".to_string(), pattern.to_string()];
+            let old = raw
+                .iter()
+                .map(glob_with_contextual_error)
+                .collect::<Result<Vec<_>, _>>()
+                .and_then(|globs| any_with_contextual_error(globs, raw.clone()));
+            let new = compile_directory_globs(&raw);
+            assert_eq!(
+                new.as_ref().err().map(ToString::to_string),
+                old.as_ref().err().map(ToString::to_string),
+                "{pattern}"
+            );
+        }
+    }
 
     #[test]
     fn test_workspace_globs_trailing_slash() {

--- a/crates/turborepo-wax/src/lib.rs
+++ b/crates/turborepo-wax/src/lib.rs
@@ -844,6 +844,16 @@ pub struct Any<'t> {
 }
 
 impl<'t> Any<'t> {
+    /// Clones borrowed token text into an owning combinator without recompiling
+    /// its regex. Useful when combining dynamically constructed expressions.
+    pub fn into_owned(self) -> Any<'static> {
+        let Any { tree, program } = self;
+        Any {
+            tree: tree.into_owned(),
+            program,
+        }
+    }
+
     fn compile(token: &Token<'t, ()>) -> Result<Regex, CompileError> {
         encode::compile([token])
     }
@@ -1086,6 +1096,23 @@ mod tests {
         );
         assert_eq!(crate::escape("左{}右"), "左\\{\\}右");
         assert_eq!(crate::escape("*中*"), "\\*中\\*");
+    }
+
+    #[test]
+    fn owned_any_outlives_source_expressions() {
+        let owned = {
+            let expressions = [String::from("packages/*"), String::from("工具/**")];
+            crate::any(expressions.iter().map(String::as_str))
+                .unwrap()
+                .into_owned()
+        };
+        assert!(owned.is_match("packages/web"));
+        assert!(owned.is_match("工具/猫/file"));
+        assert!(!owned.is_match("apps/web"));
+        // The owned token tree must remain usable by another combinator.
+        let nested = crate::any([owned]).unwrap();
+        assert!(nested.is_match("工具/猫/file"));
+        assert!(!nested.is_match("apps/web"));
     }
 
     #[test]


### PR DESCRIPTION
<!-- startup-recovery-20260908 -->
### Review scope

Independent optimization targeting `main`, with exactly one feature commit. No other optimization PR is a prerequisite.

Recovered after the bundled #13970 merge was reverted by #13982. The separately merged parser optimization #13971 remains on `main`. This is not part of a cumulative optimization stack.

The timing figures below are historical measurements from the original incremental benchmark sequence. They have not been remeasured on these newly independent branches and are not additive.
<!-- /startup-recovery-20260908 -->

### Description

Compile workspace directory-glob combinators directly from expressions instead of first compiling individual regexes that `wax::any` discards. Add an owning conversion for `Any` without recompiling. Retain the original per-expression validation/error fallback.

### Testing Instructions

DHAT showed another approximately 0.83 MB fewer allocations per 50-package invocation. Incremental Linux wall times were mostly neutral, with a modest roughly 2% improvement on the 500-package cache-hit fixture. Matching and task hashes were unchanged. This is not a speedup equal to the full workspace-compilation share in the CPU profile.

#### Measurement limits

- Measurements used optimized binaries, randomized paired before/after runs, warm OS/local caches, and synthetic npm fixtures. CPU/heap/syscall profiling was separate from wall-time timing.
- Early batches had an unborn Git HEAD; later normalization and matcher-reuse batches used committed fixtures. Results from separate batches are not cumulative.
- Windows runtime performance remains unmeasured. No worker-pool sizes or task concurrency defaults are reduced.
