### PR TITLE
perf: Skip unnecessary glob normalization

### DIFF
--- a/crates/turborepo-globwalk/src/lib.rs
+++ b/crates/turborepo-globwalk/src/lib.rs
@@ -132,6 +132,22 @@ pub fn fix_glob_pattern(pattern: &str) -> Cow<'_, str> {
         }
     };
 
+    // Most patterns already use standalone, non-consecutive globstars. None
+    // of the rewrites below can match those patterns (or patterns without a
+    // globstar), so avoid initializing their Unicode regexes on the common
+    // startup path. Ambiguous forms still use the original rewrites.
+    let mut previous_globstar = false;
+    let needs_rewrite = p0.split('/').any(|component| {
+        let globstar = component == "**";
+        let needs_rewrite =
+            (globstar && previous_globstar) || (!globstar && component.contains("**"));
+        previous_globstar = globstar;
+        needs_rewrite
+    });
+    if !needs_rewrite {
+        return p0;
+    }
+
     // Chain regex replacements, taking advantage of Cow<str>:
     // - If no match, replace() returns Cow::Borrowed pointing to the input
     // - If match, replace() returns Cow::Owned with the replacement
@@ -1319,6 +1335,62 @@ mod test {
     fn test_fix_glob_pattern(input: &str, expected: &str) {
         let output = fix_glob_pattern(input);
         assert_eq!(output.as_ref(), expected);
+    }
+
+    #[test]
+    fn glob_normalization_fast_path_matches_original_rewrites() {
+        let collapse = regex::Regex::new(r"\*\*(?:/\*\*)+").unwrap();
+        let suffix = regex::Regex::new(r"\*\*(?P<suffix>[^*/]+)").unwrap();
+        let prefix = regex::Regex::new(r"(?P<prefix>[^*/]+)\*\*").unwrap();
+        let check = |input: &str| {
+            #[cfg(not(windows))]
+            let normalized = std::borrow::Cow::Borrowed(input);
+            #[cfg(windows)]
+            let normalized = {
+                use path_slash::PathExt;
+                let converted = std::path::Path::new(input).to_slash().unwrap();
+                if (input.ends_with('/') || input.ends_with('\\')) && !converted.ends_with('/') {
+                    std::borrow::Cow::Owned(format!("{converted}/"))
+                } else {
+                    converted
+                }
+            };
+            let first = collapse.replace(&normalized, "**");
+            let second = suffix.replace(&first, "**/*$suffix");
+            let expected = prefix.replace(&second, "$prefix*/**");
+            assert_eq!(fix_glob_pattern(input), expected, "{input:?}");
+        };
+        for input in [
+            "",
+            "packages/*",
+            "**/node_modules/**",
+            "**//**",
+            "***x",
+            "x***",
+            "**/**/**",
+            "***/*/**",
+            "é**猫",
+            "**\n**",
+            r"packages\**\src\*",
+            "**{a,b}/[xy]/**",
+            "a**/b**/**c",
+            "packages/**/",
+        ] {
+            check(input);
+        }
+        // Exhaustive short inputs include overlapping globstars and Unicode
+        // boundaries, where a too-permissive fast path could skip a rewrite.
+        let alphabet = ["*", "/", "a", "猫"];
+        for len in 0..=7u32 {
+            for mut code in 0..4usize.pow(len) {
+                let mut input = String::new();
+                for _ in 0..len {
+                    input.push_str(alphabet[code % 4]);
+                    code /= 4;
+                }
+                check(&input);
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
<!-- startup-recovery-20260908 -->
### Review scope

Independent optimization targeting `main`, with exactly one feature commit. No other optimization PR is a prerequisite.

Recovered after the bundled #13970 merge was reverted by #13982. The separately merged parser optimization #13971 remains on `main`. This is not part of a cumulative optimization stack.

The timing figures below are historical measurements from the original incremental benchmark sequence. They have not been remeasured on these newly independent branches and are not additive.
<!-- /startup-recovery-20260908 -->

### Description

Skip the normalization regexes when globstars are already standalone and non-consecutive. None of the existing rewrites can match that shape. Preserve platform path normalization and use the original rewrite chain for ambiguous patterns, including overlapping globstars.

### Testing Instructions

The isolated normalization A/B showed modest Linux improvements on 50-package fixtures, with larger cases mostly neutral. A later combined batch with bounded root inference improved Linux 50-package cache hits 3.1%, per-config hits 4.3%, and dry runs 2.4%. These are incremental batches and must not be added together. Differential coverage exhaustively compares short ASCII/Unicode patterns with the original rewrites.

#### Measurement limits

- Measurements used optimized binaries, randomized paired before/after runs, warm OS/local caches, and synthetic npm fixtures. CPU/heap/syscall profiling was separate from wall-time timing.
- Early batches had an unborn Git HEAD; later normalization and matcher-reuse batches used committed fixtures. Results from separate batches are not cumulative.
- Windows runtime performance remains unmeasured. No worker-pool sizes or task concurrency defaults are reduced.
