### PR TITLE
perf: Stop inference after selecting a workspace root

### DIFF
--- a/crates/turborepo-repository/src/inference.rs
+++ b/crates/turborepo-repository/src/inference.rs
@@ -75,42 +75,40 @@ impl RepoState {
     /// returns: Result<RepoState, Error>
     #[tracing::instrument(skip_all)]
     pub fn infer(reference_dir: &AbsoluteSystemPath) -> Result<Self, Error> {
-        reference_dir
-            .ancestors()
-            .filter_map(|path| {
-                PackageJson::load(&path.join_component("package.json"))
-                    .ok()
-                    .map(|package_json| {
-                        // FIXME: We should save this package manager that we detected
-                        let package_manager =
-                            PackageManager::read_or_detect_package_manager(&package_json, path);
-                        let workspace_globs = package_manager
-                            .as_ref()
-                            .ok()
-                            .and_then(|mgr| mgr.get_workspace_globs(path).ok());
+        let candidates = reference_dir.ancestors().filter_map(|path| {
+            PackageJson::load(&path.join_component("package.json"))
+                .ok()
+                .map(|package_json| {
+                    let package_manager =
+                        PackageManager::read_or_detect_package_manager(&package_json, path);
+                    let workspace_globs = package_manager
+                        .as_ref()
+                        .ok()
+                        .and_then(|mgr| mgr.get_workspace_globs(path).ok());
 
-                        InferInfo {
-                            path: path.to_owned(),
-                            workspace_globs,
-                            package_manager,
-                            package_json,
-                        }
-                    })
-            })
-            .reduce(|current, candidate| {
-                if current.repo_mode() == RepoMode::MultiPackage {
-                    // We already have a multi-package root, go with that
-                    current
-                } else if candidate.is_workspace_root_of(&current.path) {
-                    // The next candidate is a multipackage root, and it contains current so it's
-                    // our root.
-                    candidate
-                } else {
-                    // keep the current single package, it's the closest in
-                    current
-                }
-            })
-            .map(|root| root.into())
+                    InferInfo {
+                        path: path.to_owned(),
+                        workspace_globs,
+                        package_manager,
+                        package_json,
+                    }
+                })
+        });
+        let mut root: Option<InferInfo> = None;
+        for candidate in candidates {
+            let selected = match root {
+                Some(current) if !candidate.is_workspace_root_of(&current.path) => current,
+                _ => candidate,
+            };
+            // Once a multi-package root is selected, no ancestor can replace
+            // it. Stop here rather than loading manifests and compiling globs
+            // for outer repositories whose results would be discarded.
+            if selected.repo_mode() == RepoMode::MultiPackage {
+                return Ok(selected.into());
+            }
+            root = Some(selected);
+        }
+        root.map(Into::into)
             .ok_or_else(|| Error::NotFound(reference_dir.to_owned()))
     }
 }
@@ -129,6 +127,47 @@ mod test {
             .to_realpath()
             .unwrap();
         (tmp_dir, dir)
+    }
+
+    #[test]
+    fn nested_workspace_keeps_nearest_selected_root() {
+        let (_tmp, root) = tmp_dir();
+        root.join_component("package.json")
+            .create_with_contents(
+                r#"{"name":"outer","packageManager":"npm@10.0.0","workspaces":["**"]}"#,
+            )
+            .unwrap();
+        let inner = root.join_component("inner");
+        inner.create_dir_all().unwrap();
+        inner
+            .join_component("package.json")
+            .create_with_contents(
+                r#"{"name":"inner","packageManager":"npm@10.0.0","workspaces":["packages/*"]}"#,
+            )
+            .unwrap();
+        let member = inner.join_components(&["packages", "app"]);
+        member.create_dir_all().unwrap();
+        member
+            .join_component("package.json")
+            .create_with_contents(r#"{"name":"app"}"#)
+            .unwrap();
+        let src = member.join_component("src");
+        src.create_dir_all().unwrap();
+        for invocation in [&inner, &member, &src] {
+            let inferred = RepoState::infer(invocation).unwrap();
+            assert_eq!(inferred.root, inner);
+            assert_eq!(inferred.mode, RepoMode::MultiPackage);
+        }
+
+        // Merely encountering a workspace isn't enough to stop: a standalone
+        // package excluded from the inner workspace may belong to the outer one.
+        let standalone = inner.join_component("standalone");
+        standalone.create_dir_all().unwrap();
+        standalone
+            .join_component("package.json")
+            .create_with_contents(r#"{"name":"standalone"}"#)
+            .unwrap();
+        assert_eq!(RepoState::infer(&standalone).unwrap().root, root);
     }
 
     #[test]


### PR DESCRIPTION
<!-- startup-recovery-20260908 -->
### Review scope

Independent optimization targeting `main`, with exactly one feature commit. No other optimization PR is a prerequisite.

Recovered after the bundled #13970 merge was reverted by #13982. The separately merged parser optimization #13971 remains on `main`. This is not part of a cumulative optimization stack.

The timing figures below are historical measurements from the original incremental benchmark sequence. They have not been remeasured on these newly independent branches and are not additive.
<!-- /startup-recovery-20260908 -->

### Description

Stop ancestor discovery once a multi-package root has been selected: later candidates cannot replace it under the existing selection rules. Continue searching outward when an intermediate workspace does not include the closest standalone package.

### Testing Instructions

Isolated macOS measurements showed modest gains, roughly 1% for 50-package cache hits; large and forced cases were mostly inconclusive. The combined normalization/inference batch used committed synthetic Git fixtures and showed about 1.5% faster macOS 50-package hits and 3.1% faster Linux hits. Root-selection regression coverage includes nested workspaces and excluded standalone packages. Task concurrency is unchanged.

#### Measurement limits

- Measurements used optimized binaries, randomized paired before/after runs, warm OS/local caches, and synthetic npm fixtures. CPU/heap/syscall profiling was separate from wall-time timing.
- Early batches had an unborn Git HEAD; later normalization and matcher-reuse batches used committed fixtures. Results from separate batches are not cumulative.
- Windows runtime performance remains unmeasured. No worker-pool sizes or task concurrency defaults are reduced.
