### PR TITLE
ci: Restrict release signing to main

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -15,6 +15,8 @@
 #
 # Canary releases run on an hourly schedule.
 # Manual releases are triggered via workflow_dispatch.
+# GitHub's manual-run branch selector cannot be restricted, so entry jobs are
+# gated to refs/heads/main. All release jobs depend on stage succeeding.
 #
 # RECOVERY: If a release fails and cleanup doesn't work, use the
 # 'clear-staging-branch' input to manually clear the stale staging branch.
@@ -109,7 +111,7 @@ jobs:
   check-skip:
     name: "Check Skip Conditions"
     runs-on: ubuntu-24.04
-    if: ${{ github.event_name == 'schedule' }}
+    if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'schedule' }}
     outputs:
       should_skip: ${{ steps.check.outputs.should_skip }}
     steps:
@@ -134,7 +136,7 @@ jobs:
 
   stage:
     needs: [check-skip]
-    if: ${{ always() && (github.event_name == 'workflow_dispatch' || needs.check-skip.outputs.should_skip != 'true') }}
+    if: ${{ always() && github.ref == 'refs/heads/main' && (github.event_name == 'workflow_dispatch' || needs.check-skip.outputs.should_skip != 'true') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
@@ -145,12 +147,6 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       previous-tag: ${{ steps.previous-tag.outputs.tag }}
     steps:
-      - name: Ensure release runs from default branch
-        if: ${{ github.ref_name != github.event.repository.default_branch }}
-        run: |
-          echo "::error::Release workflow must run from the default branch."
-          exit 1
-
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ inputs.sha || github.sha }}
@@ -360,6 +356,8 @@ jobs:
 
   build-rust:
     name: "Build Rust"
+    # Keep Apple credentials only in this environment, restricted to branch main.
+    environment: "Apple code signing (main-only)"
     needs: [stage]
     if: ${{ always() && needs.stage.result == 'success' }}
     strategy:


### PR DESCRIPTION
### Description

- Gate release entry jobs on `refs/heads/main` rather than rejecting other branches after allocating a runner.
- Assign the Rust build job to the existing **Apple code signing (main-only)** environment, whose deployment policy permits only the main branch and no tags.
- Keep SHA override ancestry validation in place.

The environment restriction protects signing credentials only after `APPLE_CERT_DATA`, `APPLE_CERT_PASSWORD`, and `APPLE_API_KEY` are added as environment secrets and their repository-level copies are removed. That migration is still pending and is not performed by this PR. GitHub's manual-run branch selector remains available.

### Testing Instructions

After migrating the secrets, confirm that a release dispatched from main can access the signing environment and that other branches cannot access its secrets. No release or signing run has been triggered for this change.