### PR TITLE
perf: Use binary search for resolution states

### DIFF
--- a/crates/turborepo-repository/src/external_resolution.rs
+++ b/crates/turborepo-repository/src/external_resolution.rs
@@ -360,6 +360,20 @@ pub enum ExternalResolutionData {
     Unavailable(ResolutionUnavailableReason),
 }
 
+impl ExternalResolutionData {
+    /// Finds a package resolution using the ordering established when a
+    /// generation is built.
+    pub fn package_resolution(&self, package: &str) -> Option<&PackageResolution> {
+        let Self::Resolved { packages, .. } = self else {
+            return None;
+        };
+        packages
+            .binary_search_by(|candidate| candidate.package().cmp(package))
+            .ok()
+            .map(|index| &packages[index])
+    }
+}
+
 /// Resolution knowledge available to package-scoped consumers.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PackageResolutionState {
@@ -940,6 +954,37 @@ mod tests {
         assert_eq!(declaration.package_name(), "package");
         assert_eq!(declaration.specifier(), "1.0.0");
         assert_eq!(declaration.kind(), DependencyKind::Production);
+    }
+
+    #[test]
+    fn resolved_package_lookup_uses_sorted_package_names() {
+        let data = resolved(vec![
+            PackageResolution::new("alpha", Vec::new()),
+            PackageResolution::new("middle", Vec::new()),
+            PackageResolution::new("zebra", Vec::new()),
+        ]);
+
+        assert_eq!(
+            data.package_resolution("alpha")
+                .map(PackageResolution::package),
+            Some("alpha")
+        );
+        assert_eq!(
+            data.package_resolution("middle")
+                .map(PackageResolution::package),
+            Some("middle")
+        );
+        assert_eq!(
+            data.package_resolution("zebra")
+                .map(PackageResolution::package),
+            Some("zebra")
+        );
+        assert_eq!(data.package_resolution("missing"), None);
+        assert_eq!(
+            ExternalResolutionData::Unavailable(ResolutionUnavailableReason::new("missing", ""))
+                .package_resolution("alpha"),
+            None
+        );
     }
 
     #[test]

--- a/crates/turborepo-repository/src/external_resolution.rs
+++ b/crates/turborepo-repository/src/external_resolution.rs
@@ -363,7 +363,7 @@ pub enum ExternalResolutionData {
 impl ExternalResolutionData {
     /// Finds a package resolution using the ordering established when a
     /// generation is built.
-    pub fn package_resolution(&self, package: &str) -> Option<&PackageResolution> {
+    pub(crate) fn package_resolution(&self, package: &str) -> Option<&PackageResolution> {
         let Self::Resolved { packages, .. } = self else {
             return None;
         };
@@ -855,6 +855,8 @@ pub(crate) fn compare_resolution_data(
 
 #[cfg(test)]
 mod tests {
+    use std::{hint::black_box, time::Instant};
+
     use turbopath::AbsoluteSystemPathBuf;
 
     use super::*;
@@ -985,6 +987,50 @@ mod tests {
                 .package_resolution("alpha"),
             None
         );
+    }
+
+    #[test]
+    #[ignore = "benchmark; run with cargo test --release -p turborepo-repository \
+                resolved_package_lookup_benchmark -- --ignored --nocapture"]
+    fn resolved_package_lookup_benchmark() {
+        for package_count in [100, 1_000, 5_000, 20_000] {
+            let data = resolved(
+                (0..package_count)
+                    .map(|index| PackageResolution::new(format!("package-{index:05}"), Vec::new()))
+                    .collect(),
+            );
+            let ExternalResolutionData::Resolved { packages, .. } = &data else {
+                unreachable!("resolved helper always returns resolved data");
+            };
+            let queries = (0..1_000)
+                .map(|index| format!("package-{:05}", index * package_count / 1_000))
+                .collect::<Vec<_>>();
+
+            let linear_started = Instant::now();
+            for package in &queries {
+                assert!(
+                    black_box(
+                        packages
+                            .iter()
+                            .find(|candidate| candidate.package() == package)
+                    )
+                    .is_some()
+                );
+            }
+            let linear_elapsed = linear_started.elapsed();
+
+            let binary_started = Instant::now();
+            for package in &queries {
+                assert!(black_box(data.package_resolution(package)).is_some());
+            }
+            let binary_elapsed = binary_started.elapsed();
+
+            println!(
+                "{package_count:>6} packages: linear {linear_elapsed:?}, binary \
+                 {binary_elapsed:?}, {:.1}x faster",
+                linear_elapsed.as_secs_f64() / binary_elapsed.as_secs_f64(),
+            );
+        }
     }
 
     #[test]

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -1197,13 +1197,9 @@ impl PackageGraph {
                         .and_then(|generation| generation.domain(domain_id))
                         .map_or(PackageResolutionState::Missing, |domain| {
                             match domain.data() {
-                                ExternalResolutionData::Resolved {
-                                    completeness,
-                                    packages,
-                                    ..
-                                } => packages
-                                    .iter()
-                                    .find(|package| package.package() == context.package().as_str())
+                                ExternalResolutionData::Resolved { completeness, .. } => domain
+                                    .data()
+                                    .package_resolution(context.package().as_str())
                                     .and_then(|package| package.fingerprint())
                                     .map_or(PackageResolutionState::Missing, |fingerprint| {
                                         PackageResolutionState::Resolved {


### PR DESCRIPTION
## Summary
- Search sorted package-resolution rows with binary search instead of linearly scanning them for every task namespace.
- Add a repeatable, opt-in release benchmark covering 100, 1,000, 5,000, and 20,000 packages.

## Benchmark
Ran `cargo test --release -p turborepo-repository resolved_package_lookup_benchmark -- --ignored --nocapture` locally:

| Packages | Linear scan | Binary search | Faster |
| ---: | ---: | ---: | ---: |
| 100 | 189.959 µs | 61.709 µs | 3.1× |
| 1,000 | 1.668292 ms | 51.541 µs | 32.4× |
| 5,000 | 4.665792 ms | 94.458 µs | 49.4× |
| 20,000 | 19.564875 ms | 142.5 µs | 137.3× |

Closes TURBO-5982