### PR TITLE
perf: Fast-path package-only filter selectors with --only

### DIFF
--- a/crates/turborepo-engine/src/builder.rs
+++ b/crates/turborepo-engine/src/builder.rs
@@ -51,6 +51,12 @@ pub struct EngineBuilder<'a, L: TurboJsonLoader> {
     tasks: Vec<Spanned<TaskName<'static>>>,
     root_enabled_tasks: HashSet<TaskName<'static>>,
     entrypoint_exclusions: HashSet<TaskId<'static>>,
+    /// When `--only` restricts execution, allowed tasks are computed from
+    /// this workspace set instead of `workspaces`. Callers that construct a
+    /// package-scoped engine (entrypoints from a subset of packages) use it
+    /// so topological `^task` dependencies in dependency packages stay
+    /// runnable, matching the repository-wide engine's allowed set.
+    allowed_workspaces: Option<Vec<PackageName>>,
     tasks_only: bool,
     add_all_tasks: bool,
     should_validate_engine: bool,
@@ -84,6 +90,7 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
             tasks: Vec::new(),
             root_enabled_tasks: HashSet::new(),
             entrypoint_exclusions: HashSet::new(),
+            allowed_workspaces: None,
             tasks_only: false,
             add_all_tasks: false,
             should_validate_engine: true,
@@ -144,6 +151,18 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         self
     }
 
+    /// Sets the workspace set used to compute the `--only` allowed tasks,
+    /// independently of the entrypoint workspaces. Pass the repository's
+    /// full task-namespace set when constructing a package-scoped engine so
+    /// `^task` dependencies in dependency packages remain reachable.
+    pub fn with_allowed_workspaces<I: IntoIterator<Item = PackageName>>(
+        mut self,
+        workspaces: I,
+    ) -> Self {
+        self.allowed_workspaces = Some(workspaces.into_iter().collect());
+        self
+    }
+
     pub fn with_tasks<I: IntoIterator<Item = Spanned<TaskName<'static>>>>(
         mut self,
         tasks: I,
@@ -174,8 +193,9 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
     // by CLI
     fn allowed_tasks(&self) -> Option<HashSet<TaskId<'static>>> {
         if self.tasks_only {
+            let workspaces = self.allowed_workspaces.as_ref().unwrap_or(&self.workspaces);
             Some(
-                self.workspaces
+                workspaces
                     .iter()
                     .cartesian_product(self.tasks.iter())
                     .filter_map(|(package, task_name)| {

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -483,6 +483,79 @@ impl RunBuilder {
         Ok((filtered_pkgs, filter_mode, unqualified_entrypoint_packages))
     }
 
+    /// Whether a `filterUsingTasks` run can resolve its task scope from the
+    /// package-level filter instead of constructing a repository-wide task
+    /// engine and pruning it after the fact.
+    ///
+    /// With `--only`, the engine is exactly `{package x requested task}` plus
+    /// `with` siblings, so a selector that only names packages selects the
+    /// same tasks whether the engine is built for every workspace or only for
+    /// the packages the filter resolves to. Every condition below is required
+    /// for that equivalence to hold; anything else keeps the general
+    /// full-graph path.
+    fn task_filter_can_use_package_scope(
+        &self,
+        pkg_dep_graph: &PackageGraph,
+        turbo_json_loader: &impl turborepo_engine::TurboJsonLoader,
+    ) -> bool {
+        // `--only` prunes the engine to {package x requested task}, which is
+        // what makes the package-scoped construction equivalent.
+        if !self.opts.run_opts.only {
+            return false;
+        }
+        // Affected selectors, watch reruns, all-tasks graphs, and package
+        // inference all require the repository-wide engine.
+        if self.opts.scope_opts.affected_range.is_some()
+            || self.changed_files_for_watch.is_some()
+            || self.add_all_tasks
+            || self.opts.scope_opts.pkg_inference_root.is_some()
+        {
+            return false;
+        }
+        // Strict entrypoint selection consults command participation across
+        // the whole engine, which the scoped engine cannot answer.
+        if self.opts.future_flags.strict_task_entrypoint_selection {
+            return false;
+        }
+        // Only plain package-name selectors (optionally excluded) resolve
+        // identically at the package and task level. Directory selectors, git
+        // ranges, and dependency/dependent expansion have task-level
+        // semantics.
+        if !self.opts.scope_opts.filter_patterns.iter().all(|pattern| {
+            pattern
+                .parse::<turborepo_scope::TargetSelector>()
+                .map(|selector| selector_selects_only_package_names(&selector))
+                .unwrap_or(false)
+        }) {
+            return false;
+        }
+        // Mixing `pkg#task` arguments with unqualified task arguments lets the
+        // scoped engine pick up tasks the task-level filter would prune.
+        let task_names: Vec<TaskName> = self
+            .opts
+            .run_opts
+            .tasks
+            .iter()
+            .map(|task| TaskName::from(task.as_str()))
+            .collect();
+        let qualified = task_names
+            .iter()
+            .filter(|task| task.package().is_some())
+            .count();
+        if qualified != 0 && qualified != task_names.len() {
+            return false;
+        }
+        // Native task contracts change entrypoint eligibility per package.
+        if pkg_dep_graph
+            .package_task_contexts()
+            .any(|context| context.task_contract().task_entrypoint_domain().is_some())
+        {
+            return false;
+        }
+        // `with` siblings can pull tasks of other packages into the engine.
+        repo_configs_have_no_with_declarations(pkg_dep_graph, turbo_json_loader)
+    }
+
     #[tracing::instrument(skip(self, signal_handler))]
     pub async fn build(
         self,
@@ -837,9 +910,16 @@ impl RunBuilder {
 
         // When filterUsingTasks is active, --affected is handled by the
         // same task-level filter rather than a separate codepath.
-        let use_task_level_filter = self.opts.future_flags.filter_using_tasks
+        let task_level_filter_requested = self.opts.future_flags.filter_using_tasks
             && (!self.opts.scope_opts.filter_patterns.is_empty()
                 || self.opts.scope_opts.affected_range.is_some());
+        // Narrow `--only` runs whose selectors only name packages resolve the
+        // same task scope from the package-level filter, so the engine can be
+        // constructed for the filtered packages instead of every package in
+        // the repository and pruned afterwards.
+        let use_package_scoped_task_filter = task_level_filter_requested
+            && self.task_filter_can_use_package_scope(&pkg_dep_graph, &turbo_json_loader);
+        let use_task_level_filter = task_level_filter_requested && !use_package_scoped_task_filter;
 
         let use_task_level_affected = !use_task_level_filter
             && self.opts.scope_opts.affected_range.is_some()
@@ -886,6 +966,11 @@ impl RunBuilder {
                     .filter(|name| name != &PackageName::Root),
             )
             .collect();
+        // The package-scoped filter path keeps the `--only` allowed-task set
+        // aligned with the repository-wide engine so `^task` dependencies in
+        // dependency packages remain reachable from the scoped entrypoints.
+        let package_scoped_allowed_workspaces: Option<Vec<PackageName>> =
+            use_package_scoped_task_filter.then(|| task_namespace_packages.clone());
         let mut scoped_entrypoint_exclusions = self.task_entrypoint_exclusions(
             &pkg_dep_graph,
             unqualified_entrypoint_packages.iter(),
@@ -950,6 +1035,7 @@ impl RunBuilder {
             &entrypoint_exclusions,
             &turbo_json_loader,
             &env_at_execution_start,
+            package_scoped_allowed_workspaces.as_deref(),
         )?;
 
         let task_access = {
@@ -981,6 +1067,7 @@ impl RunBuilder {
                 &entrypoint_exclusions,
                 &turbo_json_loader,
                 &env_at_execution_start,
+                package_scoped_allowed_workspaces.as_deref(),
             )?;
         }
 
@@ -1464,6 +1551,7 @@ impl RunBuilder {
     }
 
     #[tracing::instrument(skip_all)]
+    #[allow(clippy::too_many_arguments)]
     fn build_engine<'a>(
         &self,
         pkg_dep_graph: &PackageGraph,
@@ -1472,6 +1560,7 @@ impl RunBuilder {
         entrypoint_exclusions: &HashSet<TaskId<'static>>,
         turbo_json_loader: &impl turborepo_engine::TurboJsonLoader,
         environment: &EnvironmentVariableMap,
+        allowed_workspaces: Option<&[PackageName]>,
     ) -> Result<Engine, Error> {
         let tasks = self.opts.run_opts.tasks.iter().map(|task| {
             // TODO: Pull span info from command
@@ -1506,6 +1595,10 @@ impl RunBuilder {
             task_io_environment,
         )
         .with_tasks(tasks);
+
+        if let Some(allowed_workspaces) = allowed_workspaces {
+            builder = builder.with_allowed_workspaces(allowed_workspaces.iter().cloned());
+        }
 
         if self.add_all_tasks {
             builder = builder.add_all_tasks();
@@ -1559,6 +1652,49 @@ impl RunBuilder {
 
         Ok(engine)
     }
+}
+
+/// Whether a selector's semantics are purely package-level: it names
+/// packages (by name pattern, possibly for exclusion) and does not use
+/// directory selectors, git ranges, or dependency/dependent expansion.
+fn selector_selects_only_package_names(selector: &turborepo_scope::TargetSelector) -> bool {
+    !selector.name_pattern.is_empty()
+        && selector.parent_dir.is_none()
+        && selector.git_range.is_none()
+        && !selector.include_dependencies
+        && !selector.include_dependents
+        && !selector.exclude_self
+        && !selector.match_dependencies
+        && !selector.follow_prod_deps_only
+}
+
+/// Whether every turbo.json in the repository loads successfully and declares
+/// no `with` siblings. Configs are preloaded by this point, so this is an
+/// in-memory scan, and it only runs for otherwise eligible runs.
+fn repo_configs_have_no_with_declarations(
+    pkg_dep_graph: &PackageGraph,
+    turbo_json_loader: &impl turborepo_engine::TurboJsonLoader,
+) -> bool {
+    let packages = std::iter::once(PackageName::Root).chain(
+        pkg_dep_graph
+            .package_scope_directories()
+            .map(|(name, _)| name),
+    );
+    for package in packages {
+        match turbo_json_loader.load(&package) {
+            // Workspaces without a turbo.json fall back to the root chain.
+            Err(err) if err.is_no_turbo_json() => continue,
+            // A config that fails to load surfaces as an error while building
+            // the repository-wide engine; keep that behavior.
+            Err(_) => return false,
+            Ok(turbo_json) => {
+                if turbo_json.tasks.values().any(|def| def.with.is_some()) {
+                    return false;
+                }
+            }
+        }
+    }
+    true
 }
 
 /// Whether experimental Cargo package support is enabled, via
@@ -1843,5 +1979,39 @@ mod origins_match_tests {
     #[test]
     fn empty_url_returns_false() {
         assert!(!origins_match("", "https://vercel.com/api"));
+    }
+
+    #[test]
+    fn package_name_selectors_are_package_only() {
+        use std::str::FromStr;
+        for pattern in ["my-app", "@scope/pkg", "my-*", "!docs", "!@scope/*"] {
+            let selector = turborepo_scope::TargetSelector::from_str(pattern).unwrap();
+            assert!(
+                selector_selects_only_package_names(&selector),
+                "{pattern} should be usable by the package-scoped filter path"
+            );
+        }
+    }
+
+    #[test]
+    fn task_level_selectors_are_not_package_only() {
+        use std::str::FromStr;
+        for pattern in [
+            "my-app...",
+            "my-app^...",
+            "...my-app",
+            "...^my-app",
+            "my-app...[main]",
+            "[main]",
+            "{apps/my-app}",
+            "my-app{apps/my-app}",
+            "",
+        ] {
+            let selector = turborepo_scope::TargetSelector::from_str(pattern).unwrap();
+            assert!(
+                !selector_selects_only_package_names(&selector),
+                "{pattern} must stay on the general filter path"
+            );
+        }
     }
 }

--- a/crates/turborepo/tests/task_filter_package_scope_test.rs
+++ b/crates/turborepo/tests/task_filter_package_scope_test.rs
@@ -1,0 +1,281 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
+mod common;
+
+use std::{collections::HashSet, fs, path::Path};
+
+use common::{git, run_turbo, setup};
+
+/// Writes the shared fixture: `basic_monorepo` plus the scripts and task
+/// definitions used by these tests.
+///
+/// `filter_using_tasks` toggles the future flag. `declare_with` adds a
+/// `with` sibling to a task that no run in this file requests, which forces
+/// the repository-wide (general) filter path without changing any run's
+/// task set.
+fn setup_fixture(dir: &Path, filter_using_tasks: bool, declare_with: bool) {
+    setup::setup_integration_test(dir, "basic_monorepo", "npm@10.5.0", false).unwrap();
+
+    let mut app: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(dir.join("apps/my-app/package.json")).unwrap())
+            .unwrap();
+    app["scripts"]["test"] = "echo testing".into();
+    fs::write(
+        dir.join("apps/my-app/package.json"),
+        serde_json::to_string_pretty(&app).unwrap(),
+    )
+    .unwrap();
+
+    let mut another: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(dir.join("packages/another/package.json")).unwrap(),
+    )
+    .unwrap();
+    another["scripts"]["build"] = "echo building".into();
+    another["scripts"]["package:types"] = "echo checking package".into();
+    fs::write(
+        dir.join("packages/another/package.json"),
+        serde_json::to_string_pretty(&another).unwrap(),
+    )
+    .unwrap();
+
+    let mut turbo_json = serde_json::json!({
+        "futureFlags": {
+            "filterUsingTasks": filter_using_tasks
+        },
+        "tasks": {
+            "build": { "dependsOn": ["^build"] },
+            "test": { "dependsOn": ["build"] },
+            "package:types": {},
+            "package-checks": { "dependsOn": ["package:types"] }
+        }
+    });
+    if declare_with {
+        // The task is never requested and no task depends on it, so the
+        // sibling is never scheduled. Its mere presence opts this repository
+        // out of the package-scoped filter path.
+        turbo_json["tasks"]["zzz-never-requested"] = serde_json::json!({ "with": ["another#dev"] });
+    }
+    fs::write(
+        dir.join("turbo.json"),
+        serde_json::to_string_pretty(&turbo_json).unwrap(),
+    )
+    .unwrap();
+    git(dir, &["add", "."]);
+    git(dir, &["commit", "-m", "package scope fixture", "--quiet"]);
+}
+
+/// Adds the inert `with` declaration to an existing fixture, switching
+/// subsequent runs to the general filter path.
+fn force_general_path(dir: &Path) {
+    let mut turbo_json: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(dir.join("turbo.json")).unwrap()).unwrap();
+    turbo_json["tasks"]["zzz-never-requested"] = serde_json::json!({ "with": ["another#dev"] });
+    fs::write(
+        dir.join("turbo.json"),
+        serde_json::to_string_pretty(&turbo_json).unwrap(),
+    )
+    .unwrap();
+}
+
+/// Runs `turbo run <args> --dry=json` and returns `(taskId, hash)` pairs.
+fn dry_task_records(dir: &Path, args: &[&str]) -> Vec<(String, String)> {
+    let mut command = vec!["run"];
+    command.extend_from_slice(args);
+    command.push("--dry=json");
+    let output = run_turbo(dir, &command);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "dry run failed: stdout={stdout}, stderr={stderr}"
+    );
+    let summary: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let mut records: Vec<(String, String)> = summary["tasks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|task| {
+            (
+                task["taskId"].as_str().unwrap().to_string(),
+                task["hash"]
+                    .as_str()
+                    .map(ToString::to_string)
+                    .unwrap_or_default(),
+            )
+        })
+        .collect();
+    records.sort();
+    records
+}
+
+fn dry_task_ids(dir: &Path, args: &[&str]) -> HashSet<String> {
+    dry_task_records(dir, args)
+        .into_iter()
+        .map(|(task_id, _)| task_id)
+        .collect()
+}
+
+/// Runs the same command on the package-scoped path and on the general path
+/// (by adding the inert `with` declaration) and asserts both paths produce
+/// the same tasks and hashes.
+fn assert_fast_path_matches_general_path(dir: &Path, args: &[&str]) -> Vec<(String, String)> {
+    let fast = dry_task_records(dir, args);
+    force_general_path(dir);
+    let general = dry_task_records(dir, args);
+    assert_eq!(
+        fast, general,
+        "package-scoped and general filter paths disagree for {args:?}"
+    );
+    fast
+}
+
+#[test]
+fn only_filter_matches_general_path_for_a_single_package() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_fixture(tempdir.path(), true, false);
+
+    let records = assert_fast_path_matches_general_path(
+        tempdir.path(),
+        &["build", "--filter=my-app", "--only"],
+    );
+    let task_ids: HashSet<_> = records.into_iter().map(|(task_id, _)| task_id).collect();
+    assert_eq!(
+        task_ids,
+        HashSet::from(["my-app#build".to_string(), "util#build".to_string()])
+    );
+}
+
+#[test]
+fn only_filter_matches_general_path_for_exclude_selectors() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_fixture(tempdir.path(), true, false);
+
+    let records = assert_fast_path_matches_general_path(
+        tempdir.path(),
+        &["build", "--filter=my-app", "--filter=!util", "--only"],
+    );
+    let task_ids: HashSet<_> = records.into_iter().map(|(task_id, _)| task_id).collect();
+    // Excluding `util` only removes it from the entrypoint set; its `build`
+    // task remains reachable as a `^build` dependency of `my-app#build`.
+    assert_eq!(
+        task_ids,
+        HashSet::from(["my-app#build".to_string(), "util#build".to_string()])
+    );
+}
+
+#[test]
+fn only_filter_matches_general_path_for_glob_selectors() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_fixture(tempdir.path(), true, false);
+
+    let records = assert_fast_path_matches_general_path(
+        tempdir.path(),
+        &["build", "--filter=my-*", "--only"],
+    );
+    let task_ids: HashSet<_> = records.into_iter().map(|(task_id, _)| task_id).collect();
+    assert_eq!(
+        task_ids,
+        HashSet::from(["my-app#build".to_string(), "util#build".to_string()])
+    );
+}
+
+#[test]
+fn only_filter_matches_general_path_for_a_task_without_a_command() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_fixture(tempdir.path(), true, false);
+
+    // `another` has no `test` script, but `test` is defined in the root
+    // turbo.json, so the task exists as an orchestration-only node.
+    let records = assert_fast_path_matches_general_path(
+        tempdir.path(),
+        &["test", "--filter=another", "--only"],
+    );
+    let task_ids: HashSet<_> = records.into_iter().map(|(task_id, _)| task_id).collect();
+    assert_eq!(task_ids, HashSet::from(["another#test".to_string()]));
+}
+
+#[test]
+fn only_filter_matches_general_path_for_qualified_task_arguments() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_fixture(tempdir.path(), true, false);
+
+    let records = assert_fast_path_matches_general_path(
+        tempdir.path(),
+        &["my-app#test", "--filter=util", "--only"],
+    );
+    let task_ids: HashSet<_> = records.into_iter().map(|(task_id, _)| task_id).collect();
+    assert_eq!(task_ids, HashSet::from(["my-app#test".to_string()]));
+}
+
+#[test]
+fn without_only_both_paths_stay_on_the_general_filter() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_fixture(tempdir.path(), true, false);
+
+    // Without `--only` the run must keep using the task-level filter, and
+    // toggling the inert `with` declaration must not change the result.
+    let records =
+        assert_fast_path_matches_general_path(tempdir.path(), &["build", "--filter=my-app"]);
+    let task_ids: HashSet<_> = records.into_iter().map(|(task_id, _)| task_id).collect();
+    assert_eq!(
+        task_ids,
+        HashSet::from(["my-app#build".to_string(), "util#build".to_string()])
+    );
+}
+
+#[test]
+fn only_filter_matches_package_level_default_path() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_fixture(tempdir.path(), true, false);
+    // `test` has no `^task` dependencies, so the task-level and package-level
+    // filter semantics coincide for it.
+    let scoped = dry_task_ids(tempdir.path(), &["test", "--filter=my-app", "--only"]);
+
+    // The package-scoped path produces the same tasks as the package-level
+    // filter used without the future flag.
+    let default_tempdir = tempfile::tempdir().unwrap();
+    setup_fixture(default_tempdir.path(), false, false);
+    let default = dry_task_ids(
+        default_tempdir.path(),
+        &["test", "--filter=my-app", "--only"],
+    );
+
+    assert_eq!(scoped, default);
+}
+
+#[test]
+fn only_filter_surfaces_missing_tasks_identically() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_fixture(tempdir.path(), true, false);
+
+    // No package defines `does-not-exist`, so both paths must report the
+    // same missing-task error.
+    let fast = run_turbo(
+        tempdir.path(),
+        &[
+            "run",
+            "does-not-exist",
+            "--filter=my-app",
+            "--only",
+            "--dry=json",
+        ],
+    );
+    force_general_path(tempdir.path());
+    let general = run_turbo(
+        tempdir.path(),
+        &[
+            "run",
+            "does-not-exist",
+            "--filter=my-app",
+            "--only",
+            "--dry=json",
+        ],
+    );
+
+    assert_eq!(fast.status.success(), general.status.success());
+    assert!(!fast.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&fast.stderr),
+        String::from_utf8_lossy(&general.stderr)
+    );
+}


### PR DESCRIPTION
Closes TURBO-6060

## What

When `futureFlags.filterUsingTasks` is enabled, any `--filter` forces the run to construct the task engine for every package in the repository and prune it afterwards. For `--only` runs whose selectors only name packages, the same task scope is provably reachable by resolving the package scope first and building the engine only for those packages — the same engine shape as a `pkg#task` qualified run.

The fast path activates only when every equivalence condition holds; anything else keeps the general full-graph path:

- `--only` is set, so the engine is exactly `{package x requested task}` plus `with` siblings
- No `--affected`, watch rerun, `add_all_tasks` graph, or package inference
- `strictTaskEntrypointSelection` is off, since it consults command participation across the whole engine
- Every selector is a plain package-name pattern (optionally excluded) — no `{directory}`, `[git-range]`, `...`, or `...^` expansion
- Task arguments are all qualified (`pkg#task`) or all unqualified, not mixed
- No native task-contract entrypoint domains (experimental cargo/python/go workspaces)
- No `with` declarations in any turbo.json, since they can pull other packages' tasks into the engine from unselected entrypoints; this also covers microfrontend-injected `with`

To keep topological `^task` dependencies runnable in dependency packages (for example `--filter=my-app --filter=!util --only build` still runs `util#build` as a dependency), the scoped engine computes its `--only` allowed-task set over the repository's task namespaces via `EngineBuilder::with_allowed_workspaces` instead of the scoped workspaces, matching the repository-wide engine.

## Before and after

Synthetic npm monorepo with 2,000 workspaces (40 root tasks; every package has its own `turbo.json` extending the root; each non-hub package depends on a hub). Binaries built with `cargo build --locked --profile release-turborepo -p turbo` from `main` and this branch; runs alternated with 2 warmup pairs, medians of 8; `--skip-infer`, telemetry disabled.

End-to-end wall clock (`--dry=json`):

| Scenario | Before | After | Delta |
| --- | --- | --- | --- |
| `run typecheck --filter=pkg-1777 --only` | 333.2 ms | 325.7 ms | -7.6 ms |
| `run build --filter=pkg-1777 --filter=!pkg-0007 --only` | 335.0 ms | 326.0 ms | -9.0 ms |
| `run typecheck --filter=pkg-17*` (100 packages) | 335.0 ms | 326.3 ms | -8.8 ms |
| `run typecheck` (unfiltered control) | 345.6 ms | 344.5 ms | -1.1 ms |

Profiled span totals for `run typecheck --filter=pkg-1777 --only` (medians of 3 `--profile` runs):

| Span | Before | After |
| --- | --- | --- |
| `engine_entrypoints` | 0.80 ms | 0.01 ms |
| `engine_traversal` | 9.80 ms | 0.65 ms |
| Combined engine work | 10.60 ms | 0.67 ms |

The combined engine work is the clean attribution for this change (about 15x less); the remaining wall-clock time is dominated by startup, package-graph construction, and `turbo_json_preload`.

Task IDs and hashes are byte-identical between the two binaries for every scenario above, including the excluded-dependency case and a 100-package glob.

## Verification

- `cargo test -p turbo --test task_filter_package_scope_test` — 8 tests comparing the fast and general paths on task IDs and hashes (single package, glob, exclusions, qualified task arguments, task without a command, missing-task errors, no-`--only` case, package-level default parity)
- `cargo test -p turbo --test task_entrypoints_test` — 12 passed
- `cargo test -p turbo --test affected_test` — 36 passed
- `cargo test -p turborepo-lib --lib selectors` — selector classification unit tests
- `cargo clippy -p turborepo-engine -p turborepo-lib --all-targets`
