### PR TITLE
perf: Scope untracked-file discovery to filtered runs

### DIFF
--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -7,7 +7,9 @@ use std::{
 
 use chrono::Local;
 use tracing::Instrument;
-use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, RelativeUnixPathBuf};
+use turbopath::{
+    AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPath, RelativeUnixPathBuf,
+};
 use turborepo_analytics::{start_analytics, AnalyticsHandle};
 use turborepo_api_client::{APIAuth, APIClient, CacheClient, SharedHttpClient};
 use turborepo_cache::{AsyncCache, CacheScmState, LazyScmState};
@@ -31,7 +33,7 @@ use turborepo_telemetry::events::{
     repo::{RepoEventBuilder, RepoType},
     EventBuilder, TrackedErrors,
 };
-use turborepo_types::{FilterMode, UIMode};
+use turborepo_types::{FilterMode, TaskDefinitionHashInfo, TaskInputs, UIMode};
 use turborepo_ui::ColorConfig;
 use turborepo_vercel_api::CachingStatusResponse;
 use url::Url;
@@ -355,6 +357,115 @@ impl RunBuilder {
         Ok(index_root.anchor(repo_root)?.to_unix())
     }
 
+    /// Whether this run might scope its untracked-file discovery to the
+    /// selected packages' directories.
+    ///
+    /// Decided from options alone, before any graph or engine work, so runs
+    /// that can never scope keep today's eager whole-repo scan without
+    /// waiting on a decision. Scoping requires a narrow explicit package
+    /// selection: include `--filter` patterns without `--affected`, no
+    /// package inference, no watch-mode changed files, not single-package
+    /// mode, no task-level filtering (which builds the engine across every
+    /// package before pruning), and not `--add-all-tasks`. Exclude-only
+    /// filters select (nearly) every package and cannot scope either.
+    fn untracked_scoping_candidate(&self) -> bool {
+        !self.opts.run_opts.single_package
+            && self
+                .opts
+                .scope_opts
+                .filter_patterns
+                .iter()
+                .any(|pattern| !pattern.starts_with('!'))
+            && self.opts.scope_opts.affected_range.is_none()
+            && self.opts.scope_opts.pkg_inference_root.is_none()
+            && self
+                .changed_files_for_watch
+                .as_ref()
+                .is_none_or(|files| files.is_empty())
+            && !self.add_all_tasks
+            && !self.opts.future_flags.filter_using_tasks
+    }
+
+    /// Directory prefixes, relative to the git root, that cover every file
+    /// input this run will hash; `None` when the run is not provably
+    /// package-scoped and untracked discovery must walk the whole repo.
+    ///
+    /// The run hashes files through the repo index for each participating
+    /// task's package directory (tasks without `inputs`, and
+    /// `$TURBO_DEFAULT$`, hash everything under the package) and for the
+    /// root package's internal dependencies, which fold into the global
+    /// hash that every task hash includes.
+    ///
+    /// Scoping is refused whenever a hashed input can reach outside those
+    /// directories: root tasks hash relative to the repo root,
+    /// `globalDependencies` reach the whole repo, and `$TURBO_ROOT$` or
+    /// `..`-relative input globs (the engine stores `$TURBO_ROOT$`
+    /// references in rewritten `../` form) escape their package.
+    fn untracked_scan_prefixes(
+        repo_root: &AbsoluteSystemPath,
+        git_root: Option<&AbsoluteSystemPath>,
+        engine: &Engine,
+        pkg_dep_graph: &PackageGraph,
+        root_turbo_json: &TurboJson,
+        filter_mode: &FilterMode,
+    ) -> Option<Vec<RelativeUnixPathBuf>> {
+        // Only an explicit include selection is narrow. Unfiltered and
+        // exclude-only runs select (nearly) every package and would gain
+        // nothing from scoping.
+        if filter_mode != &FilterMode::ExplicitSelection {
+            return None;
+        }
+        if !root_turbo_json.global_deps_for_hash().is_empty() {
+            return None;
+        }
+        // A manual SCM has no git root to anchor prefixes against (and its
+        // untracked population is a no-op); keep the whole-repo decision.
+        let git_root = git_root?;
+
+        let mut package_dirs: Vec<&AnchoredSystemPath> = Vec::new();
+        let mut seen_packages: HashSet<PackageName> = HashSet::new();
+        for task_id in engine.task_ids() {
+            let package = PackageName::from(task_id.package());
+            // Root tasks hash files relative to the repo root, which is not
+            // a package subtree.
+            if package == PackageName::Root {
+                return None;
+            }
+            if !seen_packages.insert(package.clone()) {
+                continue;
+            }
+            let definition = engine.task_definitions().get(task_id)?;
+            if !task_inputs_are_package_local(definition.inputs()) {
+                return None;
+            }
+            let context = pkg_dep_graph.package_task_context(&package)?;
+            package_dirs.push(context.directory());
+        }
+        // The root package's internal dependencies are hashed into the
+        // global hash for every monorepo run; cover their directories even
+        // when none of their tasks participate.
+        package_dirs.extend(pkg_dep_graph.root_internal_package_dependencies_paths());
+
+        let mut prefixes = Vec::with_capacity(package_dirs.len());
+        for dir in package_dirs {
+            let prefix = git_root.anchor(&repo_root.resolve(dir)).ok()?.to_unix();
+            // An empty prefix is the git root itself, not a package subtree.
+            if prefix.as_str().is_empty() {
+                return None;
+            }
+            prefixes.push(prefix);
+        }
+        prefixes.sort_unstable();
+        prefixes.dedup();
+        // `UntrackedScope` reads an empty prefix list as a full walk; an
+        // empty selection has nothing to hash, but keep the whole-repo scan
+        // so degenerate runs match non-scoped behavior exactly.
+        if prefixes.is_empty() {
+            return None;
+        }
+        Some(prefixes)
+    }
+
     /// Resolve the set of packages that should participate in this run.
     ///
     /// Starts with the result of scope resolution (which handles `--filter`
@@ -584,6 +695,24 @@ impl RunBuilder {
         // the set, and `UntrackedScope` deduplicates nested prefixes.
         // Scanning the repo-root prefix directly is equivalent and needs
         // nothing from the graph.
+        //
+        // Narrow filtered runs can do better: when every file input the run
+        // will hash is provably package-local, the walk only needs the
+        // selected packages' subtrees. That is only provable after the
+        // engine is built, so candidate runs hold the untracked population
+        // until the main flow sends its scope decision (below). Runs that
+        // cannot scope based on their options alone never wait, keeping
+        // today's eager whole-repo scan.
+        let untracked_scoping_candidate = self.untracked_scoping_candidate();
+        if !untracked_scoping_candidate {
+            tracing::debug!("untracked-file scan scope: whole repo (not a scoping candidate)");
+        }
+        let (untracked_scan_scope_tx, untracked_scan_scope_rx) = if untracked_scoping_candidate {
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            (Some(tx), Some(rx))
+        } else {
+            (None, None)
+        };
         let (scm_tx, scm_rx) = tokio::sync::oneshot::channel();
         let repo_index_task = {
             let repo_root = self.repo_root.clone();
@@ -611,25 +740,37 @@ impl RunBuilder {
                     scm.build_tracked_repo_index_eager()
                 };
                 let _ = scm_tx.send(scm.clone());
-                tracked_index.map(|mut index| {
-                    let _span = tracing::info_span!("populate_repo_index_untracked").entered();
+                let mut index = tracked_index?;
+                // Candidate runs wait here for the scope decision:
+                // `Some(prefixes)` walks only those subtrees (relative to
+                // the git root), while `None` is today's whole-repo scan.
+                // A dropped sender means the run failed before deciding;
+                // the whole-repo fallback matches non-scoped runs.
+                let scoped_prefixes = match untracked_scan_scope_rx {
+                    Some(rx) => rx.blocking_recv().ok().flatten(),
+                    None => None,
+                };
+                let prefixes = scoped_prefixes.unwrap_or_else(|| {
                     let index_root = scm.git_root().unwrap_or(&repo_root);
                     match Self::repo_prefix_for_repo_index(&repo_root, index_root) {
-                        Ok(repo_prefix) => {
-                            if let Err(e) =
-                                scm.populate_repo_index_untracked(&mut index, &[repo_prefix])
-                            {
-                                tracing::debug!("failed to populate untracked files: {e}");
-                            }
-                        }
+                        Ok(repo_prefix) => vec![repo_prefix],
                         Err(e) => {
                             tracing::debug!(
                                 "failed to compute repo prefix for untracked files: {e}"
                             );
+                            // Leave untracked entries unpopulated, as before.
+                            Vec::new()
                         }
                     }
-                    index
-                })
+                });
+                // The span covers the walk itself; how long the run had to
+                // wait for the population is visible in the
+                // `repo_index_untracked_await` barrier span.
+                let _span = tracing::info_span!("populate_repo_index_untracked").entered();
+                if let Err(e) = scm.populate_repo_index_untracked(&mut index, &prefixes) {
+                    tracing::debug!("failed to populate untracked files: {e}");
+                }
+                Some(index)
             })
         };
         // A pure native workspace (experimentalCargoWorkspaces,
@@ -1178,6 +1319,34 @@ impl RunBuilder {
             );
         }
 
+        // The engine is final: every task the run will hash is known. Send
+        // the untracked scan its scope. Provably package-local runs walk
+        // only the participating packages' directories (plus the root
+        // package's internal dependencies); everything else keeps today's
+        // whole-repo scan.
+        if let Some(scope_tx) = untracked_scan_scope_tx {
+            let scoped_prefixes = Self::untracked_scan_prefixes(
+                &self.repo_root,
+                scm.git_root(),
+                &engine,
+                &pkg_dep_graph,
+                &root_turbo_json,
+                &filter_mode,
+            );
+            match &scoped_prefixes {
+                Some(prefixes) => tracing::debug!(
+                    prefixes = prefixes.len(),
+                    "untracked-file scan scope: package directory prefixes"
+                ),
+                None => {
+                    tracing::debug!("untracked-file scan scope: whole repo (not provably scoped)")
+                }
+            }
+            // A send failure means the scan task is already gone; there is
+            // nothing left to decide.
+            let _ = scope_tx.send(scoped_prefixes);
+        }
+
         // Validate after all filtering so the persistent task count reflects
         // the actual tasks that will execute, not the full pre-filter engine.
         if !self.opts.run_opts.parallel && self.should_validate_engine {
@@ -1697,6 +1866,30 @@ fn repo_configs_have_no_with_declarations(
     true
 }
 
+/// Whether every file this task hashes stays inside its package directory.
+///
+/// `$TURBO_ROOT$` references are rewritten to `..`-relative globs before
+/// reaching the engine, so any `..` path segment (or a surviving
+/// `$TURBO_ROOT$` token) marks an input that escapes the package. Exclusion
+/// globs only remove files, and dependency-output globs hash freshly
+/// produced outputs without the repo index, so neither is checked. JIT
+/// globs are hashed through the repo index at visitation time and must obey
+/// the same rule as eager globs.
+fn task_inputs_are_package_local(inputs: &TaskInputs) -> bool {
+    inputs
+        .globs
+        .iter()
+        .chain(inputs.jit_globs.iter())
+        .filter(|glob| !glob.starts_with('!'))
+        .all(|glob| !glob_escapes_package(glob))
+}
+
+/// Whether an input glob, interpreted relative to the task's package
+/// directory, can match files outside that directory.
+fn glob_escapes_package(glob: &str) -> bool {
+    glob.contains("$TURBO_ROOT$") || glob.split('/').any(|segment| segment == "..")
+}
+
 /// Whether experimental Cargo package support is enabled, via
 /// `futureFlags.experimentalCargoWorkspaces` in the root turbo.json. The
 /// future flag is the only switch: it is repo-level configuration, so every
@@ -1884,6 +2077,77 @@ mod package_prefix_tests {
             RunBuilder::repo_prefix_for_repo_index(&repo_root, &repo_root).unwrap(),
             RelativeUnixPathBuf::new("").unwrap()
         );
+    }
+}
+
+#[cfg(test)]
+mod untracked_scoping_tests {
+    use super::*;
+
+    fn inputs(globs: &[&str]) -> TaskInputs {
+        TaskInputs {
+            globs: globs.iter().map(|g| g.to_string()).collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn default_and_package_relative_inputs_are_package_local() {
+        // A task with no `inputs` hashes everything under the package.
+        assert!(task_inputs_are_package_local(&TaskInputs::default()));
+        assert!(task_inputs_are_package_local(&inputs(&[
+            "src/**",
+            "README.md"
+        ])));
+        // Exclusions only remove files.
+        assert!(task_inputs_are_package_local(&inputs(&[
+            "src/**", "!dist/**"
+        ])));
+        assert!(task_inputs_are_package_local(&inputs(&["!../../dist/**"])));
+        // Literal names containing dots are not parent references.
+        assert!(task_inputs_are_package_local(&inputs(&[
+            "a..b.txt",
+            "v1.0.0.txt"
+        ])));
+    }
+
+    #[test]
+    fn escaping_inputs_are_not_package_local() {
+        // `$TURBO_ROOT$` is rewritten to `..`-relative paths in the engine.
+        assert!(!task_inputs_are_package_local(&inputs(&[
+            "../../config.json"
+        ])));
+        // Defensive: a surviving `$TURBO_ROOT$` token also escapes.
+        assert!(!task_inputs_are_package_local(&inputs(&[
+            "$TURBO_ROOT$/config.json"
+        ])));
+        assert!(!task_inputs_are_package_local(&inputs(&[".."])));
+        assert!(!task_inputs_are_package_local(&inputs(&[
+            "src/../../shared/**"
+        ])));
+        assert!(!task_inputs_are_package_local(&inputs(&["src/.."])));
+    }
+
+    #[test]
+    fn jit_globs_obey_the_same_rule() {
+        let mut jit = inputs(&[]);
+        jit.jit_globs = vec!["../generated/**".to_string()];
+        assert!(!task_inputs_are_package_local(&jit));
+
+        let mut jit_ok = inputs(&[]);
+        jit_ok.jit_globs = vec!["src/generated/**".to_string()];
+        assert!(task_inputs_are_package_local(&jit_ok));
+    }
+
+    #[test]
+    fn glob_escape_segments() {
+        assert!(glob_escapes_package("../x"));
+        assert!(glob_escapes_package("a/../x"));
+        assert!(glob_escapes_package("a/.."));
+        assert!(glob_escapes_package(".."));
+        assert!(!glob_escapes_package("a..b"));
+        assert!(!glob_escapes_package("src/**"));
+        assert!(!glob_escapes_package(""));
     }
 }
 

--- a/crates/turborepo/tests/untracked_scoping_test.rs
+++ b/crates/turborepo/tests/untracked_scoping_test.rs
@@ -1,0 +1,706 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
+mod common;
+
+use std::{fs, path::Path};
+
+use common::{git, run_turbo, setup};
+
+/// A turbo.json without `globalDependencies` (the `basic_monorepo` fixture
+/// declares `foo.txt`, which keeps the whole-repo scan) and without task
+/// inputs, so `build` hashes every file under each package.
+const PLAIN_TURBO_JSON: &str = r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "tasks": {
+    "build": {
+      "outputs": []
+    }
+  }
+}"#;
+
+fn setup_repo(dir: &Path, turbo_json: &str) {
+    setup::setup_integration_test(dir, "basic_monorepo", "npm@10.5.0", false).unwrap();
+    fs::write(dir.join("turbo.json"), turbo_json).unwrap();
+    git(dir, &["add", "."]);
+    git(
+        dir,
+        &[
+            "commit",
+            "-m",
+            "configure turbo.json",
+            "--quiet",
+            "--allow-empty",
+        ],
+    );
+}
+
+/// Run `turbo run ... --dry=json` and return `(taskId, hash)` pairs.
+fn task_hashes(dir: &Path, args: &[&str]) -> Vec<(String, String)> {
+    let mut full_args = vec!["run"];
+    full_args.extend_from_slice(args);
+    full_args.push("--dry=json");
+    let output = run_turbo(dir, &full_args);
+    assert!(
+        output.status.success(),
+        "turbo {:?} failed: {}",
+        full_args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("invalid dry=json output: {e}\n{stdout}"));
+    json["tasks"]
+        .as_array()
+        .expect("tasks array in dry=json output")
+        .iter()
+        .map(|task| {
+            (
+                task["taskId"].as_str().expect("taskId").to_string(),
+                task["hash"]
+                    .as_str()
+                    .unwrap_or_else(|| panic!("hash missing for {}", task["taskId"]))
+                    .to_string(),
+            )
+        })
+        .collect()
+}
+
+fn hash_of(hashes: &[(String, String)], task_id: &str) -> String {
+    hashes
+        .iter()
+        .find(|(id, _)| id == task_id)
+        .unwrap_or_else(|| panic!("missing {task_id} in {hashes:?}"))
+        .1
+        .clone()
+}
+
+/// Run turbo with `--verbosity=2` and return the debug log it wrote, so
+/// tests can assert on the chosen untracked-file scan scope.
+fn run_with_debug_log(dir: &Path, args: &[&str]) -> String {
+    let debug_dir = dir.join(".turbo").join("debug-logs");
+    fs::remove_dir_all(&debug_dir).ok();
+    let mut full_args = vec!["run"];
+    full_args.extend_from_slice(args);
+    full_args.push("--verbosity=2");
+    let output = run_turbo(dir, &full_args);
+    assert!(
+        output.status.success(),
+        "turbo {:?} failed: {}",
+        full_args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let mut logs: Vec<_> = fs::read_dir(&debug_dir)
+        .expect("debug-logs directory should exist after a verbose run")
+        .map(|entry| entry.unwrap().path())
+        .collect();
+    assert!(!logs.is_empty(), "expected a debug log to be written");
+    logs.sort();
+    fs::read_to_string(logs.pop().unwrap()).unwrap()
+}
+
+#[test]
+fn scoped_run_hashes_untracked_files_identically_to_whole_repo_scan() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_repo(tempdir.path(), PLAIN_TURBO_JSON);
+
+    // Untracked files: one inside the selected package's hashed inputs,
+    // plus others in an unselected package and at the repo root.
+    fs::write(
+        tempdir
+            .path()
+            .join("packages")
+            .join("util")
+            .join("untracked.ts"),
+        "untracked util source v1",
+    )
+    .unwrap();
+    fs::write(
+        tempdir
+            .path()
+            .join("apps")
+            .join("my-app")
+            .join("untracked-app.txt"),
+        "untracked app file",
+    )
+    .unwrap();
+    fs::write(tempdir.path().join("untracked-root.txt"), "root untracked").unwrap();
+
+    // The filtered run scopes the untracked scan to the selected package;
+    // the same task without a filter keeps today's whole-repo scan. Both
+    // must agree.
+    let scoped = task_hashes(tempdir.path(), &["build", "--filter=util", "--only"]);
+    let full = task_hashes(tempdir.path(), &["util#build"]);
+    assert_eq!(
+        hash_of(&scoped, "util#build"),
+        hash_of(&full, "util#build"),
+        "scoped scan must discover the same untracked files as the whole-repo scan"
+    );
+
+    // The untracked file is genuinely hashed: changing its content changes
+    // the scoped hash.
+    fs::write(
+        tempdir
+            .path()
+            .join("packages")
+            .join("util")
+            .join("untracked.ts"),
+        "untracked util source v2",
+    )
+    .unwrap();
+    let changed = task_hashes(tempdir.path(), &["build", "--filter=util", "--only"]);
+    assert_ne!(
+        hash_of(&scoped, "util#build"),
+        hash_of(&changed, "util#build"),
+        "untracked file inside the package inputs must affect the hash"
+    );
+
+    // Untracked-discovered and tracked-clean agree: restoring the content
+    // and committing the file reproduces the first hash, proving the
+    // untracked file was hashed with the same value the tracked index uses.
+    fs::write(
+        tempdir
+            .path()
+            .join("packages")
+            .join("util")
+            .join("untracked.ts"),
+        "untracked util source v1",
+    )
+    .unwrap();
+    git(tempdir.path(), &["add", "packages/util/untracked.ts"]);
+    git(
+        tempdir.path(),
+        &["commit", "-m", "track untracked.ts", "--quiet"],
+    );
+    let tracked = task_hashes(tempdir.path(), &["build", "--filter=util", "--only"]);
+    assert_eq!(
+        hash_of(&scoped, "util#build"),
+        hash_of(&tracked, "util#build"),
+        "untracked-discovered and tracked-clean hashes must match"
+    );
+
+    // Scope selection: the filtered run walks only package directories;
+    // the unfiltered run keeps the whole-repo scan.
+    let scoped_log = run_with_debug_log(tempdir.path(), &["build", "--filter=util", "--only"]);
+    assert!(
+        scoped_log.contains("untracked-file scan scope: package directory prefixes"),
+        "expected a scoped scan, log:\n{scoped_log}"
+    );
+    let full_log = run_with_debug_log(tempdir.path(), &["util#build"]);
+    assert!(
+        full_log.contains("untracked-file scan scope: whole repo"),
+        "expected a whole-repo scan, log:\n{full_log}"
+    );
+}
+
+#[test]
+fn scoped_run_covers_untracked_files_in_nested_packages() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_repo(tempdir.path(), PLAIN_TURBO_JSON);
+
+    // A workspace package nested two levels below `packages/`, an untracked
+    // source file inside it, and an untracked file in the parent directory
+    // that no task hashes.
+    let inner = tempdir.path().join("packages").join("group").join("inner");
+    fs::create_dir_all(inner.join("src")).unwrap();
+    fs::write(
+        inner.join("package.json"),
+        r#"{ "name": "inner", "version": "1.0.0", "scripts": { "build": "echo inner" } }"#,
+    )
+    .unwrap();
+    fs::write(inner.join("src").join("new.ts"), "nested untracked v1").unwrap();
+    fs::write(
+        tempdir
+            .path()
+            .join("packages")
+            .join("group")
+            .join("sibling.txt"),
+        "outside any package",
+    )
+    .unwrap();
+
+    let scoped = task_hashes(tempdir.path(), &["build", "--filter=inner", "--only"]);
+    let full = task_hashes(tempdir.path(), &["inner#build"]);
+    assert_eq!(
+        hash_of(&scoped, "inner#build"),
+        hash_of(&full, "inner#build"),
+        "scoped scan must cover nested package directories"
+    );
+
+    fs::write(inner.join("src").join("new.ts"), "nested untracked v2").unwrap();
+    let changed = task_hashes(tempdir.path(), &["build", "--filter=inner", "--only"]);
+    assert_ne!(
+        hash_of(&scoped, "inner#build"),
+        hash_of(&changed, "inner#build"),
+        "untracked file inside the nested package must affect the hash"
+    );
+
+    let log = run_with_debug_log(tempdir.path(), &["build", "--filter=inner", "--only"]);
+    assert!(
+        log.contains("untracked-file scan scope: package directory prefixes"),
+        "expected a scoped scan, log:\n{log}"
+    );
+}
+
+#[test]
+fn scoped_scan_respects_ancestor_and_nested_gitignore_rules() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_repo(tempdir.path(), PLAIN_TURBO_JSON);
+
+    // A tracked ancestor .gitignore (two levels above the package) and a
+    // tracked .gitignore inside the package itself.
+    fs::write(
+        tempdir.path().join("packages").join(".gitignore"),
+        "*.secret\n",
+    )
+    .unwrap();
+    fs::write(
+        tempdir
+            .path()
+            .join("packages")
+            .join("util")
+            .join(".gitignore"),
+        "local-only.txt\n",
+    )
+    .unwrap();
+    git(tempdir.path(), &["add", "."]);
+    git(
+        tempdir.path(),
+        &["commit", "-m", "add gitignores", "--quiet"],
+    );
+
+    fs::write(
+        tempdir
+            .path()
+            .join("packages")
+            .join("util")
+            .join("normal.txt"),
+        "hashed",
+    )
+    .unwrap();
+    fs::write(
+        tempdir
+            .path()
+            .join("packages")
+            .join("util")
+            .join("leaked.secret"),
+        "ignored by the ancestor .gitignore",
+    )
+    .unwrap();
+    fs::write(
+        tempdir
+            .path()
+            .join("packages")
+            .join("util")
+            .join("local-only.txt"),
+        "ignored by the package .gitignore",
+    )
+    .unwrap();
+
+    let with_ignored = task_hashes(tempdir.path(), &["build", "--filter=util", "--only"]);
+    let full = task_hashes(tempdir.path(), &["util#build"]);
+    assert_eq!(
+        hash_of(&with_ignored, "util#build"),
+        hash_of(&full, "util#build"),
+        "scoped and whole-repo scans must apply the same gitignore rules"
+    );
+
+    // Ignored files contribute nothing: removing them does not change the
+    // hash.
+    fs::remove_file(
+        tempdir
+            .path()
+            .join("packages")
+            .join("util")
+            .join("leaked.secret"),
+    )
+    .unwrap();
+    fs::remove_file(
+        tempdir
+            .path()
+            .join("packages")
+            .join("util")
+            .join("local-only.txt"),
+    )
+    .unwrap();
+    let without_ignored = task_hashes(tempdir.path(), &["build", "--filter=util", "--only"]);
+    assert_eq!(
+        hash_of(&with_ignored, "util#build"),
+        hash_of(&without_ignored, "util#build"),
+        "gitignored untracked files must not be hashed in scoped mode"
+    );
+
+    // The non-ignored untracked file does contribute.
+    fs::remove_file(
+        tempdir
+            .path()
+            .join("packages")
+            .join("util")
+            .join("normal.txt"),
+    )
+    .unwrap();
+    let without_normal = task_hashes(tempdir.path(), &["build", "--filter=util", "--only"]);
+    assert_ne!(
+        hash_of(&with_ignored, "util#build"),
+        hash_of(&without_normal, "util#build"),
+        "non-ignored untracked files must be hashed in scoped mode"
+    );
+
+    let log = run_with_debug_log(tempdir.path(), &["build", "--filter=util", "--only"]);
+    assert!(
+        log.contains("untracked-file scan scope: package directory prefixes"),
+        "expected a scoped scan, log:\n{log}"
+    );
+}
+
+#[test]
+fn global_dependencies_keep_whole_repo_scan() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_repo(
+        tempdir.path(),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "globalDependencies": ["foo.txt"],
+  "tasks": {
+    "build": {
+      "outputs": []
+    }
+  }
+}"#,
+    );
+
+    fs::write(
+        tempdir
+            .path()
+            .join("packages")
+            .join("util")
+            .join("untracked.ts"),
+        "untracked",
+    )
+    .unwrap();
+
+    let log = run_with_debug_log(tempdir.path(), &["build", "--filter=util", "--only"]);
+    assert!(
+        log.contains("untracked-file scan scope: whole repo (not provably scoped)"),
+        "globalDependencies must keep the whole-repo scan, log:\n{log}"
+    );
+
+    let scoped = task_hashes(tempdir.path(), &["build", "--filter=util", "--only"]);
+    let full = task_hashes(tempdir.path(), &["util#build"]);
+    assert_eq!(hash_of(&scoped, "util#build"), hash_of(&full, "util#build"));
+}
+
+#[test]
+fn turbo_root_inputs_keep_whole_repo_scan() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_repo(
+        tempdir.path(),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "tasks": {
+    "build": {
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/foo.txt"],
+      "outputs": []
+    }
+  }
+}"#,
+    );
+
+    fs::write(
+        tempdir
+            .path()
+            .join("packages")
+            .join("util")
+            .join("untracked.ts"),
+        "untracked",
+    )
+    .unwrap();
+
+    let log = run_with_debug_log(tempdir.path(), &["build", "--filter=util", "--only"]);
+    assert!(
+        log.contains("untracked-file scan scope: whole repo (not provably scoped)"),
+        "$TURBO_ROOT$ inputs must keep the whole-repo scan, log:\n{log}"
+    );
+
+    let scoped = task_hashes(tempdir.path(), &["build", "--filter=util", "--only"]);
+    let full = task_hashes(tempdir.path(), &["util#build"]);
+    assert_eq!(hash_of(&scoped, "util#build"), hash_of(&full, "util#build"));
+}
+
+#[test]
+fn participating_root_tasks_keep_whole_repo_scan() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_repo(
+        tempdir.path(),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "tasks": {
+    "build": {
+      "outputs": []
+    },
+    "//#build": {
+      "inputs": ["foo.txt"],
+      "outputs": []
+    }
+  }
+}"#,
+    );
+
+    fs::write(
+        tempdir
+            .path()
+            .join("packages")
+            .join("util")
+            .join("untracked.ts"),
+        "untracked",
+    )
+    .unwrap();
+
+    // The root task is defined but does not participate in a package-only
+    // selection, so the run still scopes.
+    let package_only = run_with_debug_log(tempdir.path(), &["build", "--filter=util", "--only"]);
+    assert!(
+        package_only.contains("untracked-file scan scope: package directory prefixes"),
+        "a non-participating root task must not prevent scoping, log:\n{package_only}"
+    );
+
+    // Requesting the root task pulls the repo root into the hashed inputs,
+    // so the scan must cover the whole repo.
+    let with_root = run_with_debug_log(tempdir.path(), &["//#build", "--filter=util"]);
+    assert!(
+        with_root.contains("untracked-file scan scope: whole repo"),
+        "a participating root task must keep the whole-repo scan, log:\n{with_root}"
+    );
+}
+
+#[test]
+fn affected_runs_keep_whole_repo_scan() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_repo(tempdir.path(), PLAIN_TURBO_JSON);
+    git(tempdir.path(), &["checkout", "-b", "my-branch"]);
+    fs::write(
+        tempdir
+            .path()
+            .join("packages")
+            .join("util")
+            .join("change.txt"),
+        "changed on my-branch",
+    )
+    .unwrap();
+    git(tempdir.path(), &["add", "."]);
+    git(tempdir.path(), &["commit", "-m", "change util", "--quiet"]);
+
+    let log = run_with_debug_log(tempdir.path(), &["build", "--affected"]);
+    assert!(
+        log.contains("untracked-file scan scope: whole repo"),
+        "--affected must keep the whole-repo scan, log:\n{log}"
+    );
+
+    let hashes = task_hashes(tempdir.path(), &["build", "--affected"]);
+    assert!(
+        hashes.iter().any(|(id, _)| id == "util#build"),
+        "expected util#build to be affected: {hashes:?}"
+    );
+}
+
+#[test]
+fn unfiltered_runs_keep_whole_repo_scan() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_repo(tempdir.path(), PLAIN_TURBO_JSON);
+    fs::write(
+        tempdir
+            .path()
+            .join("packages")
+            .join("util")
+            .join("untracked.ts"),
+        "untracked",
+    )
+    .unwrap();
+
+    let log = run_with_debug_log(tempdir.path(), &["build"]);
+    assert!(
+        log.contains("untracked-file scan scope: whole repo (not a scoping candidate)"),
+        "a run without filters must keep the whole-repo scan, log:\n{log}"
+    );
+
+    // The unfiltered run hashes the task exactly like the scoped filtered
+    // run for the same repo state.
+    let full = task_hashes(tempdir.path(), &["build"]);
+    let scoped = task_hashes(tempdir.path(), &["build", "--filter=util", "--only"]);
+    assert_eq!(hash_of(&full, "util#build"), hash_of(&scoped, "util#build"));
+}
+
+#[test]
+fn exclude_only_filters_keep_whole_repo_scan() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_repo(tempdir.path(), PLAIN_TURBO_JSON);
+    fs::write(
+        tempdir
+            .path()
+            .join("packages")
+            .join("util")
+            .join("untracked.ts"),
+        "untracked",
+    )
+    .unwrap();
+
+    // An exclude-only filter selects every remaining package, so it can
+    // never scope and must not wait on a scope decision.
+    let log = run_with_debug_log(tempdir.path(), &["build", "--filter=!util"]);
+    assert!(
+        log.contains("untracked-file scan scope: whole repo (not a scoping candidate)"),
+        "an exclude-only filter must keep the whole-repo scan, log:\n{log}"
+    );
+
+    let hashes = task_hashes(tempdir.path(), &["build", "--filter=!util"]);
+    assert!(
+        hashes.iter().any(|(id, _)| id == "my-app#build"),
+        "expected my-app#build to run: {hashes:?}"
+    );
+    assert!(
+        !hashes.iter().any(|(id, _)| id == "util#build"),
+        "util was excluded: {hashes:?}"
+    );
+}
+
+#[test]
+fn watch_runs_hash_untracked_files_throughout_the_session() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let test_dir = tempdir.path();
+
+    setup::copy_fixture("watch_test", test_dir).unwrap();
+    setup::setup_git(test_dir).unwrap();
+
+    // Marker files must not join the hashes.
+    let gitignore = test_dir.join(".gitignore");
+    let mut gi = fs::read_to_string(&gitignore).unwrap_or_default();
+    gi.push_str(".markers/\n");
+    fs::write(&gitignore, gi).unwrap();
+    git(test_dir, &["add", "."]);
+    git(test_dir, &["commit", "-m", "ignore markers", "--quiet"]);
+
+    // An untracked file inside the watched package exists before the first
+    // run; another one appears mid-session.
+    fs::write(
+        test_dir
+            .join("packages")
+            .join("a")
+            .join("untracked-input.txt"),
+        "untracked input v1",
+    )
+    .unwrap();
+
+    let marker_count = |expected: usize, timeout: std::time::Duration| {
+        let marker_dir = test_dir.join("packages").join("a").join(".markers");
+        let start = std::time::Instant::now();
+        loop {
+            let count = fs::read_dir(&marker_dir)
+                .map(|entries| entries.count())
+                .unwrap_or(0);
+            if count >= expected {
+                return count;
+            }
+            if start.elapsed() > timeout {
+                return count;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(200));
+        }
+    };
+
+    let turbo_bin = assert_cmd::cargo::cargo_bin("turbo");
+    let config_dir = test_dir.join(".turbo").join("test-config");
+    fs::create_dir_all(&config_dir).unwrap();
+    let mut cmd = std::process::Command::new(turbo_bin);
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        cmd.process_group(0);
+    }
+    for key in common::ambient_turbo_env_keys() {
+        cmd.env_remove(&key);
+    }
+    cmd.env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1")
+        .env("TURBO_GLOBAL_WARNING_DISABLED", "1")
+        .env("TURBO_PRINT_VERSION_DISABLED", "1")
+        .env("DO_NOT_TRACK", "1")
+        .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
+        .env("COREPACK_ENABLE_DOWNLOAD_PROMPT", "0")
+        .env("TURBO_CONFIG_DIR_PATH", &config_dir)
+        .env_remove("CI")
+        .env_remove("GITHUB_ACTIONS")
+        .current_dir(test_dir)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .args(["watch", "build", "--filter=pkg-a"]);
+    let child = cmd.spawn().expect("failed to spawn turbo watch");
+
+    fn stop_watch(child: &mut std::process::Child) {
+        #[cfg(unix)]
+        {
+            let pgid = nix::unistd::Pid::from_raw(-(child.id() as i32));
+            let _ = nix::sys::signal::kill(pgid, nix::sys::signal::Signal::SIGTERM);
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+            while matches!(child.try_wait(), Ok(None)) && std::time::Instant::now() < deadline {
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+            let _ = nix::sys::signal::kill(pgid, nix::sys::signal::Signal::SIGKILL);
+        }
+        #[cfg(windows)]
+        {
+            let _ = child.kill();
+        }
+        let _ = child.wait();
+    }
+
+    /// Stops the watch process even if an assertion below panics, so a
+    /// failing test cannot leak the child and its descendants.
+    struct WatchGuard(Option<std::process::Child>);
+    impl Drop for WatchGuard {
+        fn drop(&mut self) {
+            if let Some(mut child) = self.0.take() {
+                stop_watch(&mut child);
+            }
+        }
+    }
+
+    let mut guard = WatchGuard(Some(child));
+
+    // Initial run: the scoped-eligible filtered run must hash the untracked
+    // file and execute.
+    let after_initial = marker_count(1, std::time::Duration::from_secs(30));
+    assert!(
+        after_initial >= 1,
+        "initial watch run did not execute within timeout"
+    );
+
+    // A new untracked file triggers a rebuild, which reruns with watch-mode
+    // changed files (whole-repo scan).
+    fs::write(
+        test_dir.join("packages").join("a").join("untracked-2.txt"),
+        "untracked input v2",
+    )
+    .unwrap();
+    let after_untracked = marker_count(after_initial + 1, std::time::Duration::from_secs(30));
+    assert!(
+        after_untracked > after_initial,
+        "untracked file change did not trigger a rebuild"
+    );
+
+    // A tracked change still rebuilds.
+    fs::write(
+        test_dir.join("packages").join("a").join("src.js"),
+        "module.exports = { a: 43 };\n",
+    )
+    .unwrap();
+    git(test_dir, &["add", "."]);
+    git(test_dir, &["commit", "-m", "change src", "--quiet"]);
+    let after_tracked = marker_count(after_untracked + 1, std::time::Duration::from_secs(30));
+    assert!(
+        after_tracked > after_untracked,
+        "tracked file change did not trigger a rebuild"
+    );
+
+    // Stop eagerly; Drop is the safety net.
+    if let Some(mut child) = guard.0.take() {
+        stop_watch(&mut child);
+    }
+}


### PR DESCRIPTION
Closes TURBO-6061

## What changed

`RunBuilder::build` now defers the untracked-file population of the repo index until the run's package scope is known (after engine construction), and provably package-scoped runs walk only the required directory prefixes instead of the whole repository. Untracked discovery was the last pre-hashing step that always scanned the entire repo, even for `--filter=<package> --only` runs; on repos with many untracked files, its pre-hashing barrier dominated time to first dispatch.

Scoping conditions — any miss keeps today's whole-repo scan:

- A run is a scoping candidate only when its options alone allow a narrow explicit selection: at least one include `--filter` pattern, no `--affected`, no package inference root, no watch-mode changed files, not single-package mode, no `--add-all-tasks`, and `filterUsingTasks` off. Unfiltered, exclude-only, `--affected`, and watch-rebuild runs keep the eager whole-repo scan exactly as before, with no deferral.
- Once the engine is final, the run scopes only when every hashed input is provably package-local: the selection resolves to `ExplicitSelection`, `globalDependencies` is empty, no root task participates, and no participating task definition (including JIT globs) carries `$TURBO_ROOT$` or `..`-relative inputs. The engine stores `$TURBO_ROOT$` references rewritten to `../` form, so any `..` path segment marks an escaping input.
- The scoped walk covers the participating packages' directories (including packages pulled in through `dependsOn`) plus the root package's internal dependencies, which fold into the global hash that every task hash includes.
- If a run fails before deciding, the scan task falls back to the whole repo. `skip_repo_index_and_scm_state` still skips the scan entirely, and the tracked index build and SCM construction stay eager and overlapped.

Task hashes are unchanged: the prefix pruning in `find_untracked_files` is prefix-correct including ancestor and nested `.gitignore` handling, so untracked files inside hashed input globs are still discovered in scoped mode. Task IDs and hashes were verified byte-identical to `main`'s binary in every benchmarked and tested scenario.

One deliberate deviation: the SCM-state dirty hash (the `x-artifact-dirty-hash` metadata header, not a cache key) is computed from the repo index, so on scoped runs it reflects only the scanned subtrees. Task hashes and cache hit or miss behavior are unaffected.

## Results

Synthetic monorepo with 2,000 packages and roughly 38,000 untracked files (nested untracked directories, untracked files inside the selected package's hashed inputs, and a repo-root untracked tree outside every package), plus tracked `.gitignore` files at the repo root, in `packages/`, and inside individual packages. Eight measured pairs after two warmup pairs, alternating binaries, medians reported with `TURBO_TELEMETRY_DISABLED=1` and `--dry=json --skip-infer --no-update-notifier`.

| Scenario | Task IDs and hashes vs `main` | Median wall time (`main`) | Median wall time (branch) | Delta |
| --- | --- | --- | --- | --- |
| `run typecheck --filter=pkg-1777 --only` (1 package) | Identical | 980.1 ms | 169.9 ms | −810 ms (−83%) |
| `run typecheck --filter=...pkg-0007` (hub + 199 dependents) | Identical | 1533.9 ms | 572.1 ms | −962 ms (−63%) |
| `run typecheck` (unfiltered control) | Identical (2,000 tasks) | 4485.4 ms | 4526.4 ms | +41 ms (noise) |

`--profile` span medians (five runs per binary):

| Scenario | Binary | `repo_index_untracked_await` | `populate_repo_index_untracked` |
| --- | --- | --- | --- |
| Narrow filter | `main` | 728.1 ms | 946.3 ms |
| Narrow filter | branch | 8.5 ms | 8.5 ms |
| Dependents filter | `main` | 786.6 ms | 994.1 ms |
| Dependents filter | branch | 96.2 ms | 96.3 ms |
| Unfiltered control | `main` | 936.5 ms | 1191.3 ms |
| Unfiltered control | branch | 974.5 ms | 1283.3 ms |

The control executes the identical code path on both binaries; its span deltas are within run-to-run noise (a repeated measurement flipped the sign of both deltas). Also verified on this repository itself: a scoped run (`--filter=eslint-config-turbo`, 8 tasks) and the `$TURBO_ROOT$`-input fallback (`--filter=turbo`) produced task IDs and hashes identical to `main`'s binary.

## Verification

- `cargo test -p turbo --test untracked_scoping_test` — 10 passed. Covers untracked files hashed identically to the whole-repo scan (including untracked-discovered and tracked-clean agreement), untracked files in nested packages, ancestor and nested `.gitignore` rules in scoped mode, whole-repo fallback for `globalDependencies`, `$TURBO_ROOT$` inputs, participating root tasks, `--affected`, exclude-only filters, and unfiltered runs, plus a watch session hashing untracked files across initial and changed-file rebuilds.
- `cargo test -p turborepo-lib --lib` — 497 passed, including new unit tests for the package-local input rules.
- `cargo test -p turborepo-scm` — 210 passed.
- `cargo test -p turborepo-task-hash -p turborepo-engine` — 153 passed.
- `cargo test -p turbo --test affected_test --test affected_rdeps_test` — 37 passed.
- `cargo test -p turbo --test watch_test` — 18 passed.
- `cargo test -p turbo --test cargo_workspace_test` (untracked and filtered cargo-workspace tests) and `--test go_workspace_test` (untracked-input regression) — passed.
- `cargo test -p turbo --test gitignored_inputs_test --test global_deps_test --test global_inputs_test --test dry_json --test filter_run_test --test command_ls_test --test run_caching` — all passed.
- `cargo clippy -p turborepo-lib -p turbo --all-targets` — clean, with no new warnings.
- Benchmarks: both binaries built with `cargo build --locked --profile release-turborepo -p turbo` (`main` at b74be22355, branch at 217d1fb682); the `--dry=json` output was compared for every scenario, and task IDs and hashes were identical in all of them.
