### PR TITLE
perf: Stream custom repository downloads to disk

### DIFF
--- a/packages/turbo-utils/__tests__/examples.test.ts
+++ b/packages/turbo-utils/__tests__/examples.test.ts
@@ -13,7 +13,8 @@ import {
   rmSync,
   existsSync,
   readFileSync,
-  writeFileSync
+  writeFileSync,
+  readdirSync
 } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -937,6 +938,246 @@ describe("examples", () => {
         } else {
           delete process.env.GITHUB_TOKEN;
         }
+      }
+    });
+  });
+
+  describe("downloadAndExtractRepo", () => {
+    let testDir: string;
+    let sourceDir: string;
+    let downloadTempDirs: Array<string>;
+
+    beforeEach(() => {
+      const baseDir = join(
+        tmpdir(),
+        `turbo-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      );
+      testDir = join(baseDir, "extract");
+      sourceDir = join(baseDir, "source");
+      mkdirSync(testDir, { recursive: true });
+      mkdirSync(sourceDir, { recursive: true });
+      downloadTempDirs = listDownloadTempDirs();
+    });
+
+    afterEach(() => {
+      const baseDir = join(testDir, "..");
+      rmSync(baseDir, { recursive: true, force: true });
+    });
+
+    /**
+     * Lists leftover `turbo-download-` temporary directories so tests can
+     * assert that failed downloads clean up after themselves.
+     */
+    function listDownloadTempDirs(): Array<string> {
+      return readdirSync(tmpdir()).filter((name) =>
+        name.startsWith("turbo-download-")
+      );
+    }
+
+    /**
+     * Helper to create a mock tarball response body rooted at "tarroot",
+     * mirroring the codeload.github.com archive layout.
+     */
+    async function createMockTarballBody(
+      files: Array<{
+        path: string;
+        content?: string;
+        type?: "file" | "directory";
+      }>
+    ): Promise<ReadableStream<Uint8Array>> {
+      const tarSourceDir = join(sourceDir, "tarroot");
+      mkdirSync(tarSourceDir, { recursive: true });
+
+      for (const file of files) {
+        const fullPath = join(tarSourceDir, file.path);
+        if (file.type === "directory") {
+          mkdirSync(fullPath, { recursive: true });
+        } else {
+          mkdirSync(join(fullPath, ".."), { recursive: true });
+          writeFileSync(fullPath, file.content ?? "");
+        }
+      }
+
+      const passThrough = new PassThrough();
+
+      tar
+        .create(
+          {
+            gzip: true,
+            cwd: sourceDir
+          },
+          ["tarroot"]
+        )
+        .pipe(passThrough);
+
+      return Readable.toWeb(
+        Readable.from(passThrough)
+      ) as ReadableStream<Uint8Array>;
+    }
+
+    it("streams the archive to disk and extracts the selected directory", async () => {
+      const mockBody = await createMockTarballBody([
+        { path: "examples/basic", type: "directory" },
+        { path: "examples/basic/package.json", content: "{}" },
+        { path: "examples/basic/README.md", content: "# Example" },
+        { path: "assets", type: "directory" },
+        { path: "assets/large.bin", content: "unselected payload" }
+      ]);
+
+      global.fetch = jest.fn(() =>
+        Promise.resolve({ ok: true, body: mockBody } as Response)
+      ) as typeof fetch;
+
+      await downloadAndExtractRepo(testDir, {
+        username: "test-user",
+        name: "test-repo",
+        branch: "main",
+        filePath: "examples/basic"
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://codeload.github.com/test-user/test-repo/tar.gz/main",
+        expect.any(Object)
+      );
+      expect(readFileSync(join(testDir, "package.json"), "utf-8")).toBe("{}");
+      expect(readFileSync(join(testDir, "README.md"), "utf-8")).toBe(
+        "# Example"
+      );
+      // Files outside the selected directory are not extracted.
+      expect(existsSync(join(testDir, "large.bin"))).toBe(false);
+    });
+
+    it("extracts the whole repository when no file path is selected", async () => {
+      const mockBody = await createMockTarballBody([
+        { path: "file.txt", content: "Hello World" },
+        { path: "subdir", type: "directory" },
+        { path: "subdir/nested.txt", content: "Nested content" }
+      ]);
+
+      global.fetch = jest.fn(() =>
+        Promise.resolve({ ok: true, body: mockBody } as Response)
+      ) as typeof fetch;
+
+      await downloadAndExtractRepo(testDir, {
+        username: "test-user",
+        name: "test-repo",
+        branch: "main",
+        filePath: ""
+      });
+
+      expect(readFileSync(join(testDir, "file.txt"), "utf-8")).toBe(
+        "Hello World"
+      );
+      expect(readFileSync(join(testDir, "subdir", "nested.txt"), "utf-8")).toBe(
+        "Nested content"
+      );
+    });
+
+    it("throws on a non-ok response without creating a temporary directory", async () => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({ ok: false, status: 404, body: null } as Response)
+      ) as typeof fetch;
+
+      await expect(
+        downloadAndExtractRepo(testDir, {
+          username: "test-user",
+          name: "test-repo",
+          branch: "main",
+          filePath: ""
+        })
+      ).rejects.toThrow("Failed to download: 404");
+
+      expect(listDownloadTempDirs()).toEqual(downloadTempDirs);
+    });
+
+    it("cleans up the temporary archive when the body transfer fails", async () => {
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          // First bytes of a gzip stream before the connection dies.
+          controller.enqueue(new Uint8Array([31, 139]));
+          controller.error(new Error("Connection reset mid-download"));
+        }
+      });
+
+      global.fetch = jest.fn(() =>
+        Promise.resolve({ ok: true, body } as Response)
+      ) as typeof fetch;
+
+      await expect(
+        downloadAndExtractRepo(testDir, {
+          username: "test-user",
+          name: "test-repo",
+          branch: "main",
+          filePath: ""
+        })
+      ).rejects.toThrow("Connection reset mid-download");
+
+      expect(listDownloadTempDirs()).toEqual(downloadTempDirs);
+    });
+
+    it("cleans up the temporary archive when extraction fails", async () => {
+      // A complete body whose payload is not a gzip archive, so extraction
+      // fails after the download itself has succeeded.
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3, 4]));
+          controller.close();
+        }
+      });
+
+      global.fetch = jest.fn(() =>
+        Promise.resolve({ ok: true, body } as Response)
+      ) as typeof fetch;
+
+      await expect(
+        downloadAndExtractRepo(testDir, {
+          username: "test-user",
+          name: "test-repo",
+          branch: "main",
+          filePath: ""
+        })
+      ).rejects.toThrow("TAR_BAD_ARCHIVE: Unrecognized archive format");
+
+      expect(listDownloadTempDirs()).toEqual(downloadTempDirs);
+    });
+
+    it("aborts a stalled body transfer when the download timeout elapses", async () => {
+      jest.useFakeTimers({ doNotFake: ["setImmediate", "queueMicrotask"] });
+      try {
+        let downloadSignal: AbortSignal | undefined;
+        global.fetch = jest.fn(
+          (_input: RequestInfo | URL, init?: RequestInit) => {
+            downloadSignal = init?.signal ?? undefined;
+            const body = new ReadableStream<Uint8Array>({
+              start(controller) {
+                // Deliver a first chunk, then stall without ending the body.
+                controller.enqueue(new Uint8Array([31]));
+                downloadSignal?.addEventListener("abort", () => {
+                  controller.error(new Error("This operation was aborted"));
+                });
+              }
+            });
+            return Promise.resolve({ ok: true, body } as Response);
+          }
+        ) as typeof fetch;
+
+        const promise = downloadAndExtractRepo(testDir, {
+          username: "test-user",
+          name: "test-repo",
+          branch: "main",
+          filePath: ""
+        });
+
+        expect(downloadSignal?.aborted).toBe(false);
+
+        // The timeout must stay armed while the body is stalled.
+        await jest.advanceTimersByTimeAsync(120_000);
+
+        expect(downloadSignal?.aborted).toBe(true);
+        await expect(promise).rejects.toThrow("This operation was aborted");
+        expect(listDownloadTempDirs()).toEqual(downloadTempDirs);
+      } finally {
+        jest.useRealTimers();
       }
     });
   });

--- a/packages/turbo-utils/src/examples.ts
+++ b/packages/turbo-utils/src/examples.ts
@@ -3,7 +3,7 @@ import { pipeline } from "node:stream/promises";
 import type { ReadableStream } from "node:stream/web";
 import { createGunzip } from "node:zlib";
 import { createWriteStream, mkdirSync, rmSync, cpSync } from "node:fs";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import { dirname, resolve, relative, join, isAbsolute } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
@@ -442,33 +442,53 @@ export async function downloadAndExtractRepo(
 ) {
   const url = `https://codeload.github.com/${username}/${name}/tar.gz/${branch}`;
 
-  const response = await fetchWithTimeout(url, {}, DOWNLOAD_TIMEOUT);
-  if (!response.ok || !response.body) {
-    throw new Error(`Failed to download: ${response.status}`);
-  }
-  const buffer = Buffer.from(await response.arrayBuffer());
+  // The timeout has to stay armed until the entire response body has been
+  // written to disk. Clearing it once the headers arrive (like
+  // fetchWithTimeout does) would leave the body transfer unbounded.
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => {
+    controller.abort();
+  }, DOWNLOAD_TIMEOUT);
 
-  const tempDir = await mkdtemp(join(tmpdir(), "turbo-download-"));
-  const tempFile = join(tempDir, "archive.tar.gz");
-
-  // Extract from file (sync but fast)
-  let rootPath: string | null = null;
   try {
-    await writeFile(tempFile, Uint8Array.from(buffer), { flag: "wx" });
-    await extract({
-      file: tempFile,
-      cwd: root,
-      strip: filePath ? filePath.split("/").length + 1 : 1,
-      filter: (p: string) => {
-        if (rootPath === null) {
-          const pathSegments = p.split("/");
-          rootPath = pathSegments.length ? pathSegments[0] : null;
-        }
-        return p.startsWith(`${rootPath}${filePath ? `/${filePath}/` : "/"}`);
-      }
+    const response = await fetch(url, {
+      ...buildFetchInit(url),
+      signal: controller.signal
     });
+    if (!response.ok || !response.body) {
+      throw new Error(`Failed to download: ${response.status}`);
+    }
+
+    const tempDir = await mkdtemp(join(tmpdir(), "turbo-download-"));
+    const tempFile = join(tempDir, "archive.tar.gz");
+
+    try {
+      // Stream the archive to disk with backpressure instead of buffering
+      // the full response body in memory and copying it again on write.
+      await pipeline(
+        Readable.fromWeb(response.body as ReadableStream),
+        createWriteStream(tempFile, { flags: "wx" })
+      );
+
+      // Extract from file (sync but fast)
+      let rootPath: string | null = null;
+      await extract({
+        file: tempFile,
+        cwd: root,
+        strip: filePath ? filePath.split("/").length + 1 : 1,
+        filter: (p: string) => {
+          if (rootPath === null) {
+            const pathSegments = p.split("/");
+            rootPath = pathSegments.length ? pathSegments[0] : null;
+          }
+          return p.startsWith(`${rootPath}${filePath ? `/${filePath}/` : "/"}`);
+        }
+      });
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
   } finally {
-    await rm(tempDir, { recursive: true, force: true });
+    clearTimeout(timeoutId);
   }
 }
 


### PR DESCRIPTION
Closes TURBO-6058

## What changed

`downloadAndExtractRepo` fetched the entire compressed repository into an `ArrayBuffer`, wrapped it with `Buffer`, and then copied every byte again via `Uint8Array.from` before writing the temporary archive. Even when a small example directory was selected, the full repository tarball was buffered in memory and duplicated during the write.

The download now streams the response body into the temporary archive through `stream.pipeline` with backpressure, and extraction still runs from the completed archive on disk. Semantics are preserved:

- Proxy and GitHub auth handling still comes from `buildFetchInit`.
- Temporary directory handling, the `wx` creation flag, selected-directory
  filtering, error propagation, and cleanup are unchanged.
- `DOWNLOAD_TIMEOUT` now stays armed until the entire body has been written
  to disk, so a stalled body transfer aborts at 120s instead of waiting for
  undici's default 300s body timeout.

## Benchmark

Deterministic 64 MiB (67,134,289 bytes) incompressible tarball served by a local throttled HTTP server (128 KiB per 4ms), with `filePath` selecting a small directory - the ticket's motivating case. Each run executed the real `downloadAndExtractRepo` in a fresh `node --expose-gc` process (the hardcoded codeload URL was rewritten to the local server by a fetch wrapper; headers, dispatcher, and the abort signal passed through untouched). `main` was measured from a git worktree of `b74be22355`; both variants were compiled with the package tsconfig against identical dependencies. Medians of 6 alternating-order pairs after one warmup per variant:

| Metric (median of 6 runs) | main (`b74be22355`) | This PR |
| --- | --- | --- |
| Peak RSS | 452.7 MiB (474,726,400 B) | 221.5 MiB (232,357,888 B) |
| Peak `arrayBuffers` | 144.4 MiB | 80.4 MiB |
| Full-body `response.arrayBuffer()` reads | 1 x 67,134,289 B | 0 |
| Full-body `Uint8Array.from` copies | 1 x 67,134,289 B | 0 |
| Download + extract wall time | 2,360 ms | 2,322 ms |
| Leftover `turbo-download-` temp dirs | 0 | 0 |

Isolated phase probes (same server, fresh process each): streaming the body to a file via `pipeline` peaks at 24.5 MiB of `arrayBuffers`, while `response.arrayBuffer()` peaks at 80.9 MiB. `tar.extract` from the file - code identical in both revisions - peaks at 80.2 MiB, which is the residual peak in this PR's end-to-end runs; the download itself now stays at chunk scale.

Correctness:

- Extracted trees are byte-identical across every run of both variants (per-file sha256 matched the manifest).
- The on-disk temporary archive captured during cleanup has the same sha256 (70cac220ffa82f88faf5677941e177e23d63cded71949a52f57c0f0f48b501d1) on both variants, equal to the served tarball.
- With the server sending 1 MiB and then stalling, this PR rejects after 120.3s with `AbortError` and leaves no temp directories; `main` rejects only after 300.9s via undici's default body timeout (`TypeError: terminated`) because its timeout is cleared once headers arrive.

## Verification

- `pnpm exec jest` in `packages/turbo-utils`: 10 suites, 95 tests passed (6 new tests cover streamed extraction, whole-repo extraction, non-ok responses, cleanup on body error, cleanup on extraction failure, and timeout during a stalled body transfer).
- `pnpm exec tsc --noEmit -p tsconfig.json` in `packages/turbo-utils`: passed.
- `pnpm exec oxfmt --check` and `pnpm exec oxlint` on the touched files: clean.
- Affected `@turbo/utils` dependents all pass: create-turbo (45 tests), eslint-plugin-turbo (111), turbo-codemod (272), turbo-gen (37), turbo-ignore (74), turbo-workspaces (990).
