### PR TITLE
perf: Copy shared file dependencies once per destination during prune

### DIFF
--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -983,6 +983,17 @@ impl<'a> Prune<'a> {
                 .map(|name| PackageName::Other(name.clone())),
         );
 
+        // Several retained workspaces can declare the same `file:` dependency
+        // (e.g. two apps both using `file:../../vendor/sdk`). Every reference
+        // that survives the checks below resolves to the same anchored source
+        // path, so copying per reference would walk and copy the identical
+        // directory into the same destinations once per reference. Track the
+        // sources already copied so each distinct dependency is copied once
+        // per destination. Only exact normalized paths are deduplicated:
+        // overlapping ancestor/descendant paths and symlink aliases are not
+        // collapsed.
+        let mut copied_sources: HashSet<AnchoredSystemPathBuf> = HashSet::new();
+
         for workspace in all_workspaces {
             let context = self.package_context(&workspace)?;
             let workspace_abs_dir = self.root.resolve(context.directory());
@@ -1014,6 +1025,16 @@ impl<'a> Prune<'a> {
                     trace!("file: dependency {path_str} from {workspace} doesn't exist, skipping");
                     continue;
                 }
+
+                if copied_sources.contains(&anchored) {
+                    trace!(
+                        "file: dependency {path_str} from {workspace} -> {} was already copied, \
+                         skipping duplicate",
+                        anchored
+                    );
+                    continue;
+                }
+                copied_sources.insert(anchored.clone());
 
                 trace!(
                     "Copying file: dependency {path_str} from {workspace} -> {}",

--- a/crates/turborepo/tests/prune_test.rs
+++ b/crates/turborepo/tests/prune_test.rs
@@ -1297,3 +1297,146 @@ fn test_prune_standard_golden_inventory() {
         inventory_tree(&tempdir.path().join("out"))
     );
 }
+
+// --- file: dependencies ---
+
+/// Prepare the shared file-dependency fixture for a prune run: the shared
+/// vendored package gains a symlink, a read-only file, and a `.gitignore` with
+/// an ignored sibling.
+///
+/// The read-only file is the observable for "copied once per destination":
+/// re-copying the same source over an existing read-only destination file
+/// fails with `EACCES`, so a prune that duplicates shared `file:` dependency
+/// copies cannot succeed.
+///
+/// The ignore files are written here, after `setup_integration_test` has
+/// committed the fixture, so they don't affect how the fixture itself is
+/// checked into the repository.
+fn setup_shared_file_dependency(dir: &Path) {
+    let vendored_lib = dir.join("vendored/sdk/lib");
+    fs::write(vendored_lib.join(".gitignore"), "ignored.txt\n").unwrap();
+    fs::write(
+        vendored_lib.join("ignored.txt"),
+        "this file is gitignored and must not be copied\n",
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(
+            vendored_lib.join("readonly.txt"),
+            fs::Permissions::from_mode(0o444),
+        )
+        .unwrap();
+        std::os::unix::fs::symlink("index.js", vendored_lib.join("link.js")).unwrap();
+    }
+}
+
+fn assert_shared_file_dependency_copied(root: &Path, vendored_dir: &Path) {
+    // Shared dependency contents are identical to the source in every
+    // destination, including the read-only file.
+    for file in [
+        "package.json",
+        "lib/index.js",
+        "lib/data.txt",
+        "lib/readonly.txt",
+    ] {
+        let expected = fs::read_to_string(root.join("vendored/sdk").join(file)).unwrap();
+        let copied = fs::read_to_string(vendored_dir.join("vendored/sdk").join(file))
+            .unwrap_or_else(|error| {
+                panic!("missing {file} in {}: {error}", vendored_dir.display())
+            });
+        assert_eq!(copied, expected, "{file} should match the source");
+    }
+
+    // Ignore rules inside the vendored package are still respected.
+    assert!(
+        !vendored_dir.join("vendored/sdk/lib/ignored.txt").exists(),
+        "gitignored vendored file should not be copied into {}",
+        vendored_dir.display()
+    );
+    // The vendored .gitignore itself travels with the package.
+    assert!(vendored_dir.join("vendored/sdk/lib/.gitignore").exists());
+
+    // Symlinks inside the vendored package are copied as symlinks.
+    #[cfg(unix)]
+    {
+        let link = vendored_dir.join("vendored/sdk/lib/link.js");
+        assert!(
+            link.symlink_metadata().unwrap().file_type().is_symlink(),
+            "vendored symlink should be copied as a symlink"
+        );
+        assert_eq!(fs::read_link(&link).unwrap(), Path::new("index.js"));
+    }
+
+    // A `file:` dependency referenced by only one workspace is not
+    // over-deduplicated away.
+    assert!(
+        vendored_dir.join("vendored/other/asset.txt").exists(),
+        "single-workspace file: dependency should be copied into {}",
+        vendored_dir.display()
+    );
+}
+
+#[test]
+fn test_prune_docker_copies_shared_file_dependency_once_per_destination() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(
+        tempdir.path(),
+        "monorepo_with_shared_file_deps",
+        "pnpm@7.25.1",
+        false,
+    )
+    .unwrap();
+    setup_shared_file_dependency(tempdir.path());
+
+    // Retains web and docs, which both depend on `file:../../vendored/sdk`.
+    // Before shared sources were deduplicated, the second copy of the
+    // read-only vendored file into the same destination failed with
+    // `EACCES` on Unix.
+    let output = run_turbo(tempdir.path(), &["prune", "web", "docs", "--docker"]);
+    assert!(
+        output.status.success(),
+        "prune --docker failed: {}",
+        combined_output(&output)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Added web"));
+    assert!(stdout.contains("Added docs"));
+
+    let out = tempdir.path().join("out");
+    for destination in ["full", "json"] {
+        assert_shared_file_dependency_copied(tempdir.path(), &out.join(destination));
+    }
+    // Both retained workspaces are present in both destinations.
+    for destination in ["full", "json"] {
+        for app in ["web", "docs"] {
+            assert!(out.join(destination).join("apps").join(app).exists());
+        }
+    }
+}
+
+#[test]
+fn test_prune_copies_shared_file_dependency() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(
+        tempdir.path(),
+        "monorepo_with_shared_file_deps",
+        "pnpm@7.25.1",
+        false,
+    )
+    .unwrap();
+    setup_shared_file_dependency(tempdir.path());
+
+    let output = run_turbo(tempdir.path(), &["prune", "web", "docs"]);
+    assert!(
+        output.status.success(),
+        "prune failed: {}",
+        combined_output(&output)
+    );
+
+    assert_shared_file_dependency_copied(tempdir.path(), &tempdir.path().join("out"));
+    assert!(tempdir.path().join("out/apps/web").exists());
+    assert!(tempdir.path().join("out/apps/docs").exists());
+}

--- a/turborepo-tests/integration/fixtures/monorepo_with_shared_file_deps/apps/docs/package.json
+++ b/turborepo-tests/integration/fixtures/monorepo_with_shared_file_deps/apps/docs/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "docs",
+  "scripts": {
+    "build": "echo building docs"
+  },
+  "dependencies": {
+    "vendor-sdk": "file:../../vendored/sdk",
+    "vendor-other": "file:../../vendored/other"
+  }
+}

--- a/turborepo-tests/integration/fixtures/monorepo_with_shared_file_deps/apps/docs/src/index.js
+++ b/turborepo-tests/integration/fixtures/monorepo_with_shared_file_deps/apps/docs/src/index.js
@@ -1,0 +1,1 @@
+console.log('docs');

--- a/turborepo-tests/integration/fixtures/monorepo_with_shared_file_deps/apps/web/package.json
+++ b/turborepo-tests/integration/fixtures/monorepo_with_shared_file_deps/apps/web/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "web",
+  "scripts": {
+    "build": "echo building web"
+  },
+  "dependencies": {
+    "vendor-sdk": "file:../../vendored/sdk"
+  }
+}

--- a/turborepo-tests/integration/fixtures/monorepo_with_shared_file_deps/apps/web/src/index.js
+++ b/turborepo-tests/integration/fixtures/monorepo_with_shared_file_deps/apps/web/src/index.js
@@ -1,0 +1,1 @@
+console.log('web');

--- a/turborepo-tests/integration/fixtures/monorepo_with_shared_file_deps/package.json
+++ b/turborepo-tests/integration/fixtures/monorepo_with_shared_file_deps/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "file-deps-monorepo",
+  "private": true
+}

--- a/turborepo-tests/integration/fixtures/monorepo_with_shared_file_deps/pnpm-lock.yaml
+++ b/turborepo-tests/integration/fixtures/monorepo_with_shared_file_deps/pnpm-lock.yaml
@@ -1,0 +1,22 @@
+lockfileVersion: 5.4
+
+importers:
+
+  .:
+    specifiers: {}
+
+  apps/docs:
+    specifiers:
+      vendor-sdk: file:../../vendored/sdk
+      vendor-other: file:../../vendored/other
+    dependencies:
+      vendor-sdk: link:../../vendored/sdk
+      vendor-other: link:../../vendored/other
+
+  apps/web:
+    specifiers:
+      vendor-sdk: file:../../vendored/sdk
+    dependencies:
+      vendor-sdk: link:../../vendored/sdk
+
+packages:

--- a/turborepo-tests/integration/fixtures/monorepo_with_shared_file_deps/pnpm-workspace.yaml
+++ b/turborepo-tests/integration/fixtures/monorepo_with_shared_file_deps/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "apps/*"

--- a/turborepo-tests/integration/fixtures/monorepo_with_shared_file_deps/turbo.json
+++ b/turborepo-tests/integration/fixtures/monorepo_with_shared_file_deps/turbo.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://turborepo.dev/schema.json",
+  "tasks": {
+    "build": {
+      "outputs": []
+    }
+  }
+}

--- a/turborepo-tests/integration/fixtures/monorepo_with_shared_file_deps/vendored/other/asset.txt
+++ b/turborepo-tests/integration/fixtures/monorepo_with_shared_file_deps/vendored/other/asset.txt
@@ -1,0 +1,1 @@
+docs-only vendored payload

--- a/turborepo-tests/integration/fixtures/monorepo_with_shared_file_deps/vendored/other/package.json
+++ b/turborepo-tests/integration/fixtures/monorepo_with_shared_file_deps/vendored/other/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "vendor-other",
+  "version": "1.0.0"
+}

--- a/turborepo-tests/integration/fixtures/monorepo_with_shared_file_deps/vendored/sdk/lib/data.txt
+++ b/turborepo-tests/integration/fixtures/monorepo_with_shared_file_deps/vendored/sdk/lib/data.txt
@@ -1,0 +1,1 @@
+shared vendored payload

--- a/turborepo-tests/integration/fixtures/monorepo_with_shared_file_deps/vendored/sdk/lib/index.js
+++ b/turborepo-tests/integration/fixtures/monorepo_with_shared_file_deps/vendored/sdk/lib/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  name: 'vendor-sdk'
+};

--- a/turborepo-tests/integration/fixtures/monorepo_with_shared_file_deps/vendored/sdk/lib/readonly.txt
+++ b/turborepo-tests/integration/fixtures/monorepo_with_shared_file_deps/vendored/sdk/lib/readonly.txt
@@ -1,0 +1,1 @@
+read-only vendored payload

--- a/turborepo-tests/integration/fixtures/monorepo_with_shared_file_deps/vendored/sdk/package.json
+++ b/turborepo-tests/integration/fixtures/monorepo_with_shared_file_deps/vendored/sdk/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "vendor-sdk",
+  "version": "1.0.0",
+  "main": "lib/index.js"
+}


### PR DESCRIPTION
Closes TURBO-6056

## What changed

`copy_file_dependencies` walked and copied each retained workspace's `file:` dependency declarations independently, so two retained apps both using `file:../../vendor/sdk` walked and copied the identical vendored directory into `out/full` and `out/json` once per reference. Every duplicate copy re-walked the source tree and overwrote identical destination files, and a duplicate copy of a read-only file failed the whole prune with `EACCES`.

The function now records the normalized anchored source paths it has already copied and skips later declarations that resolve to the same path, so each distinct `file:` dependency is copied once per destination. Per-declaration parsing, containment, and existence checks are unchanged, and only exact normalized paths are deduplicated: overlapping ancestor/descendant paths and symlink aliases are still copied.

## Benchmark

Synthetic monorepo with two retained apps both depending on `file:../../vendor/sdk`, where the vendored tree holds 8,000 files (4 KiB each) across 40 directories. `turbo prune a b --docker` on Apple Silicon, alternating swapped-order runs, medians of 7 pairs after one warmup run per binary:

| Metric | Before (main) | After (fix) |
| --- | --- | --- |
| Prune wall time (median) | 7.43 s | 2.62 s (−64.7%) |
| File copies completed (`fclonefileat` ok) | 16,016 | 16,016 |
| Duplicate file copies (`fclonefileat` failing `EEXIST`, then re-copied in full) | 16,004 | 0 |
| Directory creations (`mkdir`) | 32,206 | 16,118 |

Before run times ranged 7.34–8.27 s and after run times ranged 2.24–2.85 s across the pairs. Copy counts were measured with a `DYLD_INSERT_LIBRARIES` interposer counting `fclonefileat`/`mkdir` calls: Rust's `std::fs::copy` attempts `fclonefileat` and, when the destination already exists, falls back to a full data re-copy, so each `EEXIST` count marks one redundant file copy of the vendored tree.

The pruned output is byte-identical before and after: `diff -r` is clean, all 16,019 output files match by sha256, and file and directory permissions match.

On `main`, pruning the new fixture fails with `Permission denied (os error 13)` in both Docker and standard modes because the duplicate copy cannot overwrite the read-only vendored file; with this change both modes succeed and produce contents identical to the source.

## Verification

- `cargo nextest run -p turbo --test prune_test` — 28 passed, including the two new shared file-dependency tests (Docker and standard prune).
- `cargo nextest run -p turbo --test go_workspace_test --test uv_workspace_test --test relationship_projection_contract` — 60 passed.
- `cargo nextest run -p turbo --test cargo_workspace_test` — 62 passed.
- `cargo test -p turborepo-lib --lib` — 493 passed.
- `cargo clippy -p turbo -p turborepo-lib --all-targets` — no warnings.
- `cargo fmt -p turbo -p turborepo-lib --check` — clean.
- Before/after binary comparison built with `cargo build --locked --profile release-turborepo -p turbo` (before binary from `main` at b74be22355):
  - Byte-identical pruned trees (content, layout, and permissions) on the benchmark monorepo.
  - On the fixture scenario, `main` fails with `EACCES` on the read-only shared file in both prune modes, while this branch succeeds with contents identical to the source, the gitignored vendored file excluded, the vendored symlink preserved, and the docs-only `file:` dependency still copied.
