### PR TITLE
perf: Cache Turbo config reads across ESLint rule invocations

### DIFF
--- a/packages/eslint-plugin-turbo/__tests__/lib/no-undeclared-env-vars/config-cache/config-cache.test.ts
+++ b/packages/eslint-plugin-turbo/__tests__/lib/no-undeclared-env-vars/config-cache/config-cache.test.ts
@@ -1,0 +1,336 @@
+import path from "node:path";
+import fs from "node:fs";
+import { Linter } from "eslint";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest
+} from "@jest/globals";
+import { setupTestFixtures } from "@turbo/test-utils";
+import { RULES } from "../../../../lib/constants";
+import rule, { clearCache } from "../../../../lib/rules/no-undeclared-env-vars";
+
+const FIXTURE = "workspace-configs-reload";
+
+const linter = new Linter();
+
+interface FsSnapshot {
+  configExistsSync: number;
+  configStatSync: number;
+  configReadFileSync: number;
+}
+
+function isTurboConfigPath(filePath: fs.PathLike | number): boolean {
+  return (
+    typeof filePath === "string" &&
+    /turbo\.jsonc?$/.test(path.basename(filePath))
+  );
+}
+
+/**
+ * Count filesystem operations that touch turbo.json/turbo.jsonc files. ESLint
+ * creates the rule once per source file, so these counters track exactly the
+ * per-file validation work the rule performs on configs.
+ */
+function instrumentFs() {
+  const counts: FsSnapshot = {
+    configExistsSync: 0,
+    configStatSync: 0,
+    configReadFileSync: 0
+  };
+  const originals = {
+    existsSync: fs.existsSync,
+    statSync: fs.statSync,
+    readFileSync: fs.readFileSync
+  };
+  // The module namespace types these functions as read-only, so swap them
+  // out through a mutable view for the duration of a test.
+  const mutableFs = fs as unknown as {
+    existsSync: typeof fs.existsSync;
+    statSync: typeof fs.statSync;
+    readFileSync: typeof fs.readFileSync;
+  };
+
+  mutableFs.existsSync = ((
+    ...args: Parameters<typeof fs.existsSync>
+  ): ReturnType<typeof fs.existsSync> => {
+    if (isTurboConfigPath(args[0])) {
+      counts.configExistsSync++;
+    }
+    return originals.existsSync(...args);
+  }) as typeof fs.existsSync;
+
+  mutableFs.statSync = ((
+    ...args: Parameters<typeof fs.statSync>
+  ): ReturnType<typeof fs.statSync> => {
+    if (isTurboConfigPath(args[0])) {
+      counts.configStatSync++;
+    }
+    return originals.statSync(...args);
+  }) as typeof fs.statSync;
+
+  mutableFs.readFileSync = ((
+    ...args: Parameters<typeof fs.readFileSync>
+  ): ReturnType<typeof fs.readFileSync> => {
+    if (isTurboConfigPath(args[0])) {
+      counts.configReadFileSync++;
+    }
+    return originals.readFileSync(...args);
+  }) as typeof fs.readFileSync;
+
+  return {
+    snapshot: (): FsSnapshot => ({ ...counts }),
+    restore: () => {
+      mutableFs.existsSync = originals.existsSync;
+      mutableFs.statSync = originals.statSync;
+      mutableFs.readFileSync = originals.readFileSync;
+    }
+  };
+}
+
+describe("turbo config cache in no-undeclared-env-vars", () => {
+  const { useFixture } = setupTestFixtures({
+    directory: path.join(__dirname, "../../../../")
+  });
+
+  // Controlled clock for the validation interval
+  let mockNow: number;
+
+  const lintFile = (
+    filename: string,
+    code: string,
+    cwd: string
+  ): Array<{ message: string }> =>
+    linter.verify(
+      code,
+      {
+        plugins: {
+          turbo: { rules: { [RULES.noUndeclaredEnvVars]: rule } }
+        },
+        languageOptions: { ecmaVersion: 2020, sourceType: "module" },
+        rules: {
+          "turbo/no-undeclared-env-vars": ["error", { cwd }]
+        }
+      },
+      { filename }
+    );
+
+  beforeEach(() => {
+    clearCache();
+    mockNow = 1_700_000_000_000;
+    jest.spyOn(Date, "now").mockImplementation(() => mockNow);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    clearCache();
+  });
+
+  it("does not re-validate turbo configs for every file in a batch", () => {
+    const { root: cwd } = useFixture({ fixture: FIXTURE });
+    const files = [
+      path.join(cwd, "apps/web/index.js"),
+      path.join(cwd, "apps/docs/index.js"),
+      path.join(cwd, "packages/ui/index.js")
+    ];
+    const code = "const { ENV_1 } = process.env;";
+
+    const instrument = instrumentFs();
+    try {
+      // The first file initializes the project cache
+      lintFile(files[0], code, cwd);
+      const afterFirstFile = instrument.snapshot();
+
+      // ESLint creates the rule once per source file
+      for (let i = 0; i < 24; i++) {
+        lintFile(files[i % files.length], code, cwd);
+      }
+      const afterBatch = instrument.snapshot();
+
+      // A batch of unchanged files performs no per-file config validation
+      expect(
+        afterBatch.configExistsSync - afterFirstFile.configExistsSync
+      ).toBe(0);
+      expect(afterBatch.configStatSync - afterFirstFile.configStatSync).toBe(0);
+      expect(
+        afterBatch.configReadFileSync - afterFirstFile.configReadFileSync
+      ).toBe(0);
+    } finally {
+      instrument.restore();
+    }
+  });
+
+  it("validates via stat metadata without reading config contents", () => {
+    const { root: cwd } = useFixture({ fixture: FIXTURE });
+    const webFile = path.join(cwd, "apps/web/index.js");
+    const code = "const { ENV_2 } = process.env;";
+
+    const instrument = instrumentFs();
+    try {
+      lintFile(webFile, code, cwd);
+      const afterInit = instrument.snapshot();
+
+      // A lint run after the validation interval (e.g. a later editor pass)
+      // sweeps the configs, but nothing changed so nothing is re-read
+      mockNow += 1_500;
+      lintFile(webFile, code, cwd);
+      const afterValidation = instrument.snapshot();
+
+      expect(
+        afterValidation.configStatSync - afterInit.configStatSync
+      ).toBeGreaterThan(0);
+      expect(
+        afterValidation.configReadFileSync - afterInit.configReadFileSync
+      ).toBe(0);
+
+      // Findings are still correct
+      expect(lintFile(webFile, code, cwd)).toEqual([]);
+    } finally {
+      instrument.restore();
+    }
+  });
+
+  it("serves cached configs within the interval and picks up same-size edits on the next validation", () => {
+    const { root: cwd } = useFixture({ fixture: FIXTURE });
+    const webFile = path.join(cwd, "apps/web/index.js");
+    const webConfigPath = path.join(cwd, "apps/web/turbo.json");
+    const original = fs.readFileSync(webConfigPath, "utf8");
+
+    try {
+      // ENV_2 is declared by apps/web/turbo.json
+      expect(lintFile(webFile, "const { ENV_2 } = process.env;", cwd)).toEqual(
+        []
+      );
+
+      // Same-size content change: ENV_2 -> ENV_4 (size is unchanged, mtime is not)
+      const edited = original.replace('"ENV_2"', '"ENV_4"');
+      expect(edited).not.toBe(original);
+      expect(edited).toHaveLength(original.length);
+      fs.writeFileSync(webConfigPath, edited);
+
+      // A lint run within the interval is served from the cached project
+      expect(lintFile(webFile, "const { ENV_4 } = process.env;", cwd)).toEqual([
+        expect.objectContaining({
+          message: expect.stringContaining("ENV_4 is not listed")
+        })
+      ]);
+
+      // The next lint run after the interval reloads the edited config
+      mockNow += 1_500;
+      expect(lintFile(webFile, "const { ENV_4 } = process.env;", cwd)).toEqual(
+        []
+      );
+      expect(lintFile(webFile, "const { ENV_2 } = process.env;", cwd)).toEqual([
+        expect.objectContaining({
+          message: expect.stringContaining("ENV_2 is not listed")
+        })
+      ]);
+    } finally {
+      fs.writeFileSync(webConfigPath, original);
+    }
+  });
+
+  it("detects removed and newly added workspace configs", () => {
+    const { root: cwd } = useFixture({ fixture: FIXTURE });
+    const docsFile = path.join(cwd, "apps/docs/index.js");
+    const docsConfigPath = path.join(cwd, "apps/docs/turbo.json");
+    const original = fs.readFileSync(docsConfigPath, "utf8");
+
+    try {
+      // ENV_3 is declared by apps/docs/turbo.json
+      expect(lintFile(docsFile, "const { ENV_3 } = process.env;", cwd)).toEqual(
+        []
+      );
+
+      // Remove the workspace config
+      fs.rmSync(docsConfigPath);
+      mockNow += 1_500;
+      expect(lintFile(docsFile, "const { ENV_3 } = process.env;", cwd)).toEqual(
+        [
+          expect.objectContaining({
+            message: "ENV_3 is not listed as a dependency in root turbo.json"
+          })
+        ]
+      );
+
+      // Re-add a config declaring a different variable
+      fs.writeFileSync(docsConfigPath, original.replace('"ENV_3"', '"ENV_5"'));
+      mockNow += 1_500;
+      expect(lintFile(docsFile, "const { ENV_5 } = process.env;", cwd)).toEqual(
+        []
+      );
+      expect(lintFile(docsFile, "const { ENV_3 } = process.env;", cwd)).toEqual(
+        [
+          expect.objectContaining({
+            message: expect.stringContaining("ENV_3 is not listed")
+          })
+        ]
+      );
+    } finally {
+      fs.writeFileSync(docsConfigPath, original);
+    }
+  });
+
+  it("detects edits to the root config on the next validation", () => {
+    const { root: cwd } = useFixture({ fixture: FIXTURE });
+    const docsFile = path.join(cwd, "apps/docs/index.js");
+    const rootConfigPath = path.join(cwd, "turbo.json");
+    const original = fs.readFileSync(rootConfigPath, "utf8");
+
+    try {
+      // CI is declared by the root turbo.json globalEnv
+      expect(lintFile(docsFile, "const { CI } = process.env;", cwd)).toEqual(
+        []
+      );
+
+      const edited = original.replace('"CI"', '"CI_2"');
+      expect(edited).not.toBe(original);
+      fs.writeFileSync(rootConfigPath, edited);
+
+      mockNow += 1_500;
+      expect(lintFile(docsFile, "const { CI_2 } = process.env;", cwd)).toEqual(
+        []
+      );
+      expect(lintFile(docsFile, "const { CI } = process.env;", cwd)).toEqual([
+        expect.objectContaining({
+          message: expect.stringContaining("CI is not listed")
+        })
+      ]);
+    } finally {
+      fs.writeFileSync(rootConfigPath, original);
+    }
+  });
+
+  it("produces identical findings with a warm cache as with a cold cache", () => {
+    const { root: cwd } = useFixture({ fixture: FIXTURE });
+    const files = [
+      {
+        file: path.join(cwd, "apps/web/index.js"),
+        code: "const { ENV_2, ENV_9 } = process.env;"
+      },
+      {
+        file: path.join(cwd, "apps/docs/index.js"),
+        code: "const { ENV_3, ENV_9 } = process.env;"
+      },
+      {
+        file: path.join(cwd, "packages/ui/index.js"),
+        code: "const { IS_SERVER, ENV_9 } = process.env;"
+      }
+    ];
+
+    // Warm: one shared project cache across the whole batch
+    const warm = files.map(({ file, code }) => lintFile(file, code, cwd));
+
+    // Cold: fresh caches for every file
+    const cold = files.map(({ file, code }) => {
+      clearCache();
+      mockNow += 1_500;
+      return lintFile(file, code, cwd);
+    });
+
+    expect(warm).toEqual(cold);
+  });
+});

--- a/packages/eslint-plugin-turbo/lib/rules/no-undeclared-env-vars.ts
+++ b/packages/eslint-plugin-turbo/lib/rules/no-undeclared-env-vars.ts
@@ -1,6 +1,5 @@
 import path from "node:path";
 import fs from "node:fs";
-import crypto from "node:crypto";
 import type { Rule } from "eslint";
 import type { Node, MemberExpression } from "estree";
 import {
@@ -20,15 +19,28 @@ const debug = process.env.RUNNER_DEBUG
     };
 
 // Module-level caches to share state across all files in a single ESLint run
+interface TurboConfigStat {
+  mtimeMs: number;
+  size: number;
+}
+
 interface CachedProject {
   project: Project;
-  turboConfigHashes: Map<string, string>;
-  configPaths: Array<string>;
+  turboConfigStats: Map<string, TurboConfigStat>;
+  lastValidatedAt: number;
 }
 
 const projectCache = new Map<string, CachedProject>();
 const frameworkEnvCache = new Map<string, Set<RegExp>>();
 const packageJsonDepCache = new Map<string, Set<string>>();
+
+// ESLint creates this rule once per source file. Without coalescing, every
+// creation re-scans all workspaces for turbo.json/turbo.jsonc, which turns
+// config validation into O(source files x workspace configs) filesystem work
+// even when nothing changed. Rate-limiting validation to one sweep per
+// interval amortizes it across a batch of files (a CLI lint run or an editor
+// lint pass), while subsequent lint runs still pick up config changes.
+const CONFIG_VALIDATION_INTERVAL_MS = 1_000;
 
 export interface RuleContextWithOptions extends Rule.RuleContext {
   options: Array<{
@@ -152,33 +164,6 @@ function findTurboConfigInDir(dirPath: string): string | null {
 }
 
 /**
- * Get all turbo config file paths that are currently loaded in the project
- */
-function getTurboConfigPaths(project: Project): Array<string> {
-  const paths: Array<string> = [];
-
-  // Add root turbo config if it exists and is loaded
-  if (project.projectRoot?.turboConfig) {
-    const configPath = findTurboConfigInDir(project.projectRoot.workspacePath);
-    if (configPath) {
-      paths.push(configPath);
-    }
-  }
-
-  // Add workspace turbo configs that are loaded
-  for (const workspace of project.projectWorkspaces) {
-    if (workspace.turboConfig) {
-      const configPath = findTurboConfigInDir(workspace.workspacePath);
-      if (configPath) {
-        paths.push(configPath);
-      }
-    }
-  }
-
-  return paths;
-}
-
-/**
  * Scan filesystem for all turbo.json/turbo.jsonc files across all workspaces.
  * This scans ALL workspaces regardless of whether they currently have turboConfig loaded,
  * allowing detection of newly created turbo.json files.
@@ -206,33 +191,74 @@ function scanForTurboConfigs(project: Project): Array<string> {
 }
 
 /**
- * Compute hashes for all turbo.config(c) files
+ * Get a cheap signature (mtime + size) for a turbo config file, or `null` if
+ * the file is missing or unreadable. Unlike content hashing, this never reads
+ * the file's contents.
  */
-function computeTurboConfigHashes(
-  configPaths: Array<string>
-): Map<string, string> {
-  const hashes = new Map<string, string>();
-
-  for (const configPath of configPaths) {
-    const content = fs.readFileSync(configPath, "utf-8");
-    const hash = crypto.createHash("md5").update(content).digest("hex");
-    hashes.set(configPath, hash);
+function getTurboConfigStat(filePath: string): TurboConfigStat | null {
+  try {
+    const stats = fs.statSync(filePath);
+    return { mtimeMs: stats.mtimeMs, size: stats.size };
+  } catch {
+    // File no longer exists or is unreadable
+    return null;
   }
-
-  return hashes;
 }
 
 /**
- * Check if a single config file has changed by comparing its hash
+ * Compute stat signatures for all turbo.config(c) files, skipping any that
+ * cannot be stat'ed
  */
-function hasConfigChanged(filePath: string, expectedHash: string): boolean {
-  try {
-    const content = fs.readFileSync(filePath, "utf-8");
-    const currentHash = crypto.createHash("md5").update(content).digest("hex");
-    return currentHash !== expectedHash;
-  } catch {
-    // File no longer exists or is unreadable
-    return true;
+function computeTurboConfigStats(
+  configPaths: Array<string>
+): Map<string, TurboConfigStat> {
+  const stats = new Map<string, TurboConfigStat>();
+
+  for (const configPath of configPaths) {
+    const stat = getTurboConfigStat(configPath);
+    if (stat) {
+      stats.set(configPath, stat);
+    }
+  }
+
+  return stats;
+}
+
+/**
+ * Reload the cached project and refresh the tracked turbo config stats
+ */
+function reloadCachedProject(cachedProject: CachedProject): void {
+  cachedProject.project.reload();
+  cachedProject.turboConfigStats = computeTurboConfigStats(
+    scanForTurboConfigs(cachedProject.project)
+  );
+}
+
+/**
+ * Check whether the cached project still matches the turbo configs on disk,
+ * reloading the project if any config was added, removed, or modified.
+ * Configs are compared by stat metadata (mtime + size) rather than content
+ * hashes so unchanged configs are never re-read.
+ */
+function validateCachedProject(cachedProject: CachedProject): void {
+  const currentStats = computeTurboConfigStats(
+    scanForTurboConfigs(cachedProject.project)
+  );
+  const previousStats = cachedProject.turboConfigStats;
+
+  const statsUnchanged =
+    currentStats.size === previousStats.size &&
+    [...currentStats].every(([configPath, stat]) => {
+      const previousStat = previousStats.get(configPath);
+      return (
+        previousStat !== undefined &&
+        previousStat.mtimeMs === stat.mtimeMs &&
+        previousStat.size === stat.size
+      );
+    });
+
+  if (!statsUnchanged) {
+    reloadCachedProject(cachedProject);
   }
 }
 
@@ -325,62 +351,31 @@ function create(context: RuleContextWithOptions): Rule.RuleListener {
   if (!cachedProject) {
     project = new Project(cwd);
     if (project.valid()) {
-      const configPaths = getTurboConfigPaths(project);
-      const hashes = computeTurboConfigHashes(configPaths);
       projectCache.set(projectKey, {
         project,
-        turboConfigHashes: hashes,
-        configPaths
+        turboConfigStats: computeTurboConfigStats(scanForTurboConfigs(project)),
+        lastValidatedAt: Date.now()
       });
       debug(`Cached new project for ${projectKey}`);
     }
   } else {
     project = cachedProject.project;
 
-    // Check if any turbo.json(c) configs have changed
-    try {
-      const currentConfigPaths = scanForTurboConfigs(project);
-
-      // Quick path comparison - cheapest check first
-      const pathsUnchanged =
-        currentConfigPaths.length === cachedProject.configPaths.length &&
-        currentConfigPaths.every((p, i) => p === cachedProject.configPaths[i]);
-
-      if (!pathsUnchanged) {
-        // Paths changed (added/removed configs), must reload
-        debug(`Turbo config paths changed for ${projectKey}, reloading...`);
-        const newHashes = computeTurboConfigHashes(currentConfigPaths);
-        project.reload();
-        cachedProject.turboConfigHashes = newHashes;
-        cachedProject.configPaths = currentConfigPaths;
-      } else {
-        // Paths unchanged - check if any file content changed (early exit on first change)
-        let contentChanged = false;
-        for (const [
-          filePath,
-          expectedHash
-        ] of cachedProject.turboConfigHashes) {
-          if (hasConfigChanged(filePath, expectedHash)) {
-            contentChanged = true;
-            break;
-          }
-        }
-
-        if (contentChanged) {
-          debug(`Turbo config content changed for ${projectKey}, reloading...`);
-          const newHashes = computeTurboConfigHashes(currentConfigPaths);
-          project.reload();
-          cachedProject.turboConfigHashes = newHashes;
-          cachedProject.configPaths = currentConfigPaths;
-        }
+    // ESLint invokes this rule once per source file, so only validate the
+    // cached project's turbo configs at most once per interval. Batches of
+    // unchanged files skip the filesystem entirely, while edits, added or
+    // removed configs, and subsequent lint runs (e.g. from a persistent
+    // editor) still trigger a reload.
+    const now = Date.now();
+    if (now - cachedProject.lastValidatedAt >= CONFIG_VALIDATION_INTERVAL_MS) {
+      cachedProject.lastValidatedAt = now;
+      try {
+        validateCachedProject(cachedProject);
+      } catch (error) {
+        // Config file was deleted or is unreadable, reload project
+        debug(`Error validating configs for ${projectKey}, reloading...`);
+        reloadCachedProject(cachedProject);
       }
-    } catch (error) {
-      // Config file was deleted or is unreadable, reload project
-      debug(`Error computing hashes for ${projectKey}, reloading...`);
-      project.reload();
-      const configPaths = scanForTurboConfigs(project);
-      cachedProject.turboConfigHashes = computeTurboConfigHashes(configPaths);
-      cachedProject.configPaths = configPaths;
     }
   }
 


### PR DESCRIPTION
Closes TURBO-6053

## What changed

ESLint creates `no-undeclared-env-vars` once per source file. The rule cached the `Project`, but every creation still scanned all workspaces for `turbo.json`/`turbo.jsonc` and re-read and MD5-hashed every config to validate the cache, so a warm cache still performed O(source files x workspace configs) synchronous filesystem work.

The rule now:

- Validates the cached project at most once per second instead of once per source file. A batch of unchanged files (a CLI lint run or an editor pass) skips the filesystem entirely, while subsequent lint runs and config edits still trigger revalidation.
- Compares configs by stat metadata (`mtimeMs` + `size`) instead of reading and hashing contents, so unchanged configs are never re-read. Added, removed, or modified configs (including same-size edits) still reload the project exactly as before.

Reload semantics are otherwise unchanged: path-set changes, stat mismatches, and unreadable configs all reload the project.

## Before and after

Linting 1,000 source files across 100 workspaces (101 turbo configs) through ESLint's `Linter`, which creates the rule once per file, counting filesystem operations that touch turbo config files:

| Metric | Before | After |
| --- | --- | --- |
| `readFileSync` on turbo configs | 101,102 | 102 |
| `existsSync` on turbo configs | 101,202 | 303 |
| `statSync` on turbo configs | 0 | 101 |
| MD5 hashes of config contents | 101,000 | 0 |
| Elapsed time | 2,189 ms | 281 ms (7.8x) |
| Findings | 1,000 | 1,000 (identical) |

The remaining reads are the one-time project initialization. Per-file work on configs drops from O(configs) to zero within a validation interval.

Behavior parity: an editor-style scenario (baseline, unchanged, same-size workspace edit, removed config, re-added config with new content, root config edit) produced identical findings on every phase for this branch and for `main`'s rule.

## Verification

- `pnpm exec jest` in `packages/eslint-plugin-turbo` — 117 passed, including 6 new tests: batch performs no per-file config validation, validation stats without reading contents, same-size edits reload on the next validation, removed/re-added workspace configs detected, root config edits detected, warm-cache findings equal cold-cache findings
- `pnpm exec tsc --noEmit -p tsconfig.json` — passed
- `oxfmt --check` and `oxlint` on touched files — clean
- Pre-push hooks passed (no `--no-verify`)
