### PR TITLE
perf: Borrow workspace entries during dependency lookup

### DIFF
--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -13,7 +13,7 @@ use turborepo_lockfiles::Lockfile;
 
 use super::{
     ExternalResolutionKnowledge, PackageGraph, PackageName, PackageNode,
-    dep_splitter::{DependencySplitter, WorkspacePathIndex},
+    dep_splitter::{DependencySplitter, WorkspaceNameIndex, WorkspacePathIndex},
     javascript,
 };
 use crate::{
@@ -1097,6 +1097,9 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
             .as_deref()
             .ok_or(Error::MissingRepositoryKnowledge)?;
         let path_index = WorkspacePathIndex::from_knowledge(knowledge);
+        // Built once so alias dependency lookups borrow workspace entries
+        // instead of allocating an owned `PackageName` per dependency query.
+        let name_index = WorkspaceNameIndex::from_workspaces(&self.assembler.package_jsons);
         // Compute once — for pnpm/Berry this reads a config file from disk.
         // Without hoisting, classifying each JavaScript descriptor would
         // redundantly read the same file. Cargo supplies classified internal
@@ -1148,6 +1151,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
                                 link_workspace_packages,
                                 entry.dependencies_with_kind(),
                                 &path_index,
+                                &name_index,
                                 catalogs.as_ref(),
                             )
                         }
@@ -1503,6 +1507,7 @@ impl Relationships {
         link_workspace_packages: bool,
         dependencies: I,
         path_index: &WorkspacePathIndex<'_>,
+        name_index: &WorkspaceNameIndex<'_>,
         catalogs: Option<&PnpmCatalogs>,
     ) -> Vec<Relationship> {
         let resolved_workspace_json_path = repo_root.resolve(workspace_json_path);
@@ -1517,6 +1522,7 @@ impl Relationships {
             workspaces,
             link_workspace_packages,
             path_index,
+            name_index,
             catalogs,
         );
         for (name, version, kind) in dependencies {

--- a/crates/turborepo-repository/src/package_graph/dep_splitter.rs
+++ b/crates/turborepo-repository/src/package_graph/dep_splitter.rs
@@ -38,11 +38,35 @@ impl<'a> WorkspacePathIndex<'a> {
     }
 }
 
+/// Reverse index from package name to its entry in the workspaces map, built
+/// once and shared across all `DependencySplitter` instances so alias
+/// dependency lookups borrow the entry instead of allocating an owned
+/// `PackageName` for every query.
+///
+/// The root sentinel is excluded: its `//` key is an internal encoding detail,
+/// not a name that a dependency specifier can target.
+pub struct WorkspaceNameIndex<'a>(HashMap<&'a str, (&'a PackageName, &'a PackageJson)>);
+
+impl<'a> WorkspaceNameIndex<'a> {
+    pub(crate) fn from_workspaces(workspaces: &'a HashMap<PackageName, PackageJson>) -> Self {
+        Self(
+            workspaces
+                .iter()
+                .filter_map(|(name, package_json)| match name {
+                    PackageName::Other(_) => Some((name.as_str(), (name, package_json))),
+                    PackageName::Root => None,
+                })
+                .collect(),
+        )
+    }
+}
+
 pub struct DependencySplitter<'a> {
     repo_root: &'a AbsoluteSystemPath,
     workspace_dir: &'a AbsoluteSystemPath,
     workspaces: &'a HashMap<PackageName, PackageJson>,
     path_index: &'a WorkspacePathIndex<'a>,
+    name_index: &'a WorkspaceNameIndex<'a>,
     link_workspace_packages: bool,
     catalogs: Option<&'a PnpmCatalogs>,
 }
@@ -54,6 +78,7 @@ impl<'a> DependencySplitter<'a> {
         workspaces: &'a HashMap<PackageName, PackageJson>,
         link_workspace_packages: bool,
         path_index: &'a WorkspacePathIndex<'a>,
+        name_index: &'a WorkspaceNameIndex<'a>,
         catalogs: Option<&'a PnpmCatalogs>,
     ) -> Self {
         Self {
@@ -61,12 +86,13 @@ impl<'a> DependencySplitter<'a> {
             workspace_dir,
             workspaces,
             path_index,
+            name_index,
             link_workspace_packages,
             catalogs,
         }
     }
 
-    pub fn is_internal(&self, name: &str, version: &str) -> Option<PackageName> {
+    pub fn is_internal(&self, name: &str, version: &str) -> Option<&'a PackageName> {
         // Resolve catalog: specifiers to their actual version strings
         let resolved;
         let version = if version.starts_with("catalog:") {
@@ -106,12 +132,10 @@ impl<'a> DependencySplitter<'a> {
     fn find_package(
         &self,
         specifier: WorkspacePackageSpecifier,
-    ) -> Option<(PackageName, &PackageJson)> {
+    ) -> Option<(&'a PackageName, &'a PackageJson)> {
         match specifier {
             WorkspacePackageSpecifier::Alias(name) => {
-                // TODO implement borrowing for workspaces to allow for zero copy queries
-                let package_name = PackageName::Other(name.to_string());
-                let info = self.workspaces.get(&package_name)?;
+                let (package_name, info) = *self.name_index.0.get(name)?;
                 Some((package_name, info))
             }
             WorkspacePackageSpecifier::Path(path) => {
@@ -121,21 +145,23 @@ impl<'a> DependencySplitter<'a> {
                 // Pnpm also doesn't support this so we defer to them to provide the error
                 // message.
                 let package_path = AnchoredSystemPathBuf::new(self.repo_root, package_path).ok()?;
-                let (name, info) = self.workspace(&package_path).or_else(|| {
+                self.workspace(&package_path).or_else(|| {
                     // Yarn4 allows for workspace root relative paths
                     let package_path = self.repo_root.join_unix_path(path);
                     let package_path =
                         AnchoredSystemPathBuf::new(self.repo_root, package_path).ok()?;
                     self.workspace(&package_path)
-                })?;
-                Some((name.clone(), info))
+                })
             }
         }
     }
 
-    fn workspace(&self, path: &AnchoredSystemPath) -> Option<(&PackageName, &PackageJson)> {
+    fn workspace(&self, path: &AnchoredSystemPath) -> Option<(&'a PackageName, &'a PackageJson)> {
         let name = self.path_index.0.get(path)?;
-        let info = self.workspaces.get(name)?;
+        // `get_key_value` borrows the workspace's own key, so the returned
+        // name lives as long as the workspaces map instead of the local
+        // lookup key cloned from the path index.
+        let (name, info) = self.workspaces.get_key_value(name)?;
         Some((name, info))
     }
 }
@@ -439,18 +465,21 @@ mod test {
         };
 
         let path_index = path_index();
+        let name_index = WorkspaceNameIndex::from_workspaces(&workspaces);
         let splitter = DependencySplitter {
             repo_root: &root,
             workspace_dir: &pkg_dir,
             workspaces: &workspaces,
             path_index: &path_index,
+            name_index: &name_index,
             link_workspace_packages,
             catalogs: None,
         };
 
+        let expected = expected.map(PackageName::from);
         assert_eq!(
             splitter.is_internal(dependency_name.unwrap_or("@scope/foo"), range),
-            expected.map(PackageName::from)
+            expected.as_ref()
         );
     }
 
@@ -522,17 +551,19 @@ mod test {
         };
         let catalogs = make_catalogs(&[("pkg-b", "workspace:*")], &[]);
         let path_index = path_index();
+        let name_index = WorkspaceNameIndex::from_workspaces(&workspaces);
         let splitter = DependencySplitter {
             repo_root: &root,
             workspace_dir: &pkg_dir,
             workspaces: &workspaces,
             path_index: &path_index,
+            name_index: &name_index,
             link_workspace_packages: false,
             catalogs: Some(&catalogs),
         };
         assert_eq!(
             splitter.is_internal("pkg-b", "catalog:"),
-            Some(PackageName::Other("pkg-b".to_string()))
+            Some(&PackageName::Other("pkg-b".to_string()))
         );
     }
 
@@ -558,17 +589,19 @@ mod test {
         };
         let catalogs = make_catalogs(&[], &[("internal", &[("pkg-b", "workspace:*")])]);
         let path_index = path_index();
+        let name_index = WorkspaceNameIndex::from_workspaces(&workspaces);
         let splitter = DependencySplitter {
             repo_root: &root,
             workspace_dir: &pkg_dir,
             workspaces: &workspaces,
             path_index: &path_index,
+            name_index: &name_index,
             link_workspace_packages: false,
             catalogs: Some(&catalogs),
         };
         assert_eq!(
             splitter.is_internal("pkg-b", "catalog:internal"),
-            Some(PackageName::Other("pkg-b".to_string()))
+            Some(&PackageName::Other("pkg-b".to_string()))
         );
     }
 
@@ -595,17 +628,19 @@ mod test {
         // catalog resolves to a semver range that matches the workspace package version
         let catalogs = make_catalogs(&[("pkg-b", "^1.0.0")], &[]);
         let path_index = path_index();
+        let name_index = WorkspaceNameIndex::from_workspaces(&workspaces);
         let splitter = DependencySplitter {
             repo_root: &root,
             workspace_dir: &pkg_dir,
             workspaces: &workspaces,
             path_index: &path_index,
+            name_index: &name_index,
             link_workspace_packages: true,
             catalogs: Some(&catalogs),
         };
         assert_eq!(
             splitter.is_internal("pkg-b", "catalog:"),
-            Some(PackageName::Other("pkg-b".to_string()))
+            Some(&PackageName::Other("pkg-b".to_string()))
         );
     }
 
@@ -622,11 +657,13 @@ mod test {
         // "react" is not a workspace package
         let catalogs = make_catalogs(&[("react", "^18.2.0")], &[]);
         let path_index = path_index();
+        let name_index = WorkspaceNameIndex::from_workspaces(&workspaces);
         let splitter = DependencySplitter {
             repo_root: &root,
             workspace_dir: &pkg_dir,
             workspaces: &workspaces,
             path_index: &path_index,
+            name_index: &name_index,
             link_workspace_packages: false,
             catalogs: Some(&catalogs),
         };
@@ -654,12 +691,14 @@ mod test {
             map
         };
         let path_index = path_index();
+        let name_index = WorkspaceNameIndex::from_workspaces(&workspaces);
         // No catalogs - catalog: specifier can't be resolved, treated as external
         let splitter = DependencySplitter {
             repo_root: &root,
             workspace_dir: &pkg_dir,
             workspaces: &workspaces,
             path_index: &path_index,
+            name_index: &name_index,
             link_workspace_packages: false,
             catalogs: None,
         };
@@ -689,17 +728,19 @@ mod test {
         // "catalog:default" should resolve to the default catalog
         let catalogs = make_catalogs(&[("pkg-b", "workspace:*")], &[]);
         let path_index = path_index();
+        let name_index = WorkspaceNameIndex::from_workspaces(&workspaces);
         let splitter = DependencySplitter {
             repo_root: &root,
             workspace_dir: &pkg_dir,
             workspaces: &workspaces,
             path_index: &path_index,
+            name_index: &name_index,
             link_workspace_packages: false,
             catalogs: Some(&catalogs),
         };
         assert_eq!(
             splitter.is_internal("pkg-b", "catalog:default"),
-            Some(PackageName::Other("pkg-b".to_string()))
+            Some(&PackageName::Other("pkg-b".to_string()))
         );
     }
 }

--- a/crates/turborepo-repository/src/package_graph/dep_splitter.rs
+++ b/crates/turborepo-repository/src/package_graph/dep_splitter.rs
@@ -743,4 +743,40 @@ mod test {
             Some(&PackageName::Other("pkg-b".to_string()))
         );
     }
+
+    #[test]
+    fn alias_lookup_never_resolves_the_root_sentinel() {
+        let root = AbsoluteSystemPathBuf::new(if cfg!(windows) {
+            "C:\\some\\repo"
+        } else {
+            "/some/repo"
+        })
+        .unwrap();
+        let pkg_dir = root.join_components(&["packages", "app-a"]);
+        let workspaces = {
+            let mut map = HashMap::new();
+            map.insert(
+                PackageName::Root,
+                PackageJson {
+                    version: Some("1.0.0".to_string()),
+                    ..Default::default()
+                },
+            );
+            map
+        };
+        let path_index = path_index();
+        let name_index = WorkspaceNameIndex::from_workspaces(&workspaces);
+        let splitter = DependencySplitter {
+            repo_root: &root,
+            workspace_dir: &pkg_dir,
+            workspaces: &workspaces,
+            path_index: &path_index,
+            name_index: &name_index,
+            link_workspace_packages: true,
+            catalogs: None,
+        };
+        // `//` is the internal root sentinel, not a name that a dependency
+        // specifier can target, so it must never resolve to the root package.
+        assert_eq!(splitter.is_internal("//", "workspace:*"), None);
+    }
 }

--- a/crates/turborepo-repository/src/package_graph/lockfile_closure.rs
+++ b/crates/turborepo-repository/src/package_graph/lockfile_closure.rs
@@ -15,7 +15,7 @@ use turborepo_lockfiles::{Lockfile, Package};
 
 use super::{
     PackageName,
-    dep_splitter::{DependencySplitter, WorkspacePathIndex},
+    dep_splitter::{DependencySplitter, WorkspaceNameIndex, WorkspacePathIndex},
 };
 use crate::{
     package_json::{DependencyKind, PackageJson},
@@ -89,6 +89,9 @@ pub fn external_packages(
     ));
     let link_workspace_packages = package_manager.link_workspace_packages(repo_root);
     let catalogs = package_manager.read_catalogs(repo_root);
+    // Built once so alias dependency lookups borrow workspace entries instead
+    // of allocating an owned `PackageName` per dependency query.
+    let name_index = WorkspaceNameIndex::from_workspaces(&workspaces);
 
     let external_dependencies: HashMap<String, BTreeMap<String, String>> = manifests
         .iter()
@@ -100,6 +103,7 @@ pub fn external_packages(
                 &workspaces,
                 link_workspace_packages,
                 &path_index,
+                &name_index,
                 catalogs.as_ref(),
             );
             // First declaration of a name wins, before the internal/external


### PR DESCRIPTION
## Summary
- Add `WorkspaceNameIndex`, a reverse index from package name to its workspace entry, built once per package graph and shared across every `DependencySplitter`, mirroring the existing `WorkspacePathIndex` pattern.
- Resolve alias dependency lookups through the index instead of allocating an owned `PackageName` (`name.to_string()`) for every `is_internal` query, and return borrowed workspace entries (`Option<&PackageName>`) so hits no longer clone the name either.
- `Workspace::workspace` path lookups now use `get_key_value` so the returned name borrows from the workspaces map instead of cloning the key from the path index.
- The root sentinel is excluded from the name index, so `//` can never be matched by an alias specifier, preserving the previous lookup semantics.

The remaining allocations on the classification path are the relationship strings themselves, which are owned by design.

Closes TURBO-5980

## Benchmark
Ran a temporary opt-in benchmark (median of 5 in-process samples after warmup, `--release`) on both `origin/main` and this change. Each sample constructs a synthetic monorepo of N packages where every package declares 12 internal `workspace:*` dependencies and 48 external dependencies, then classifies every dependency through `Relationships::classify`'s `DependencySplitter::is_internal` path:

| Packages | All dependencies queried (`link_workspace_packages = true`) |  |  | Only `workspace:` dependencies queried (default) |  |  |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
|  | Before | After | Faster | Before | After | Faster |
| 200 | 385.9 µs | 173.6 µs | 2.2× | 116.4 µs | 77.1 µs | 1.5× |
| 1,000 | 1.728 ms | 763.8 µs | 2.3× | 584.4 µs | 351.6 µs | 1.7× |
| 5,000 | 9.381 ms | 4.088 ms | 2.3× | 2.774 ms | 2.019 ms | 1.4× |

The one-time `WorkspaceNameIndex` construction is O(packages) and runs once per package graph, so its cost is amortized across all dependency queries, exactly like `WorkspacePathIndex`.

## Test plan
- The full `dep_splitter` suite (51 tests) passes, covering alias resolution, catalog resolution, path specifiers, and version matching through the new index.
- Added a regression test asserting an alias specifier can never resolve the `//` root sentinel.
- `cargo test -p turborepo-repository`: 489 passed; the only 2 failures (`go::tests`) are pre-existing on `origin/main` in this environment and unrelated to dependency splitting.
