### PR TITLE
perf: Binary search boundaries comments before each import

### DIFF
--- a/crates/turborepo-boundaries/src/lib.rs
+++ b/crates/turborepo-boundaries/src/lib.rs
@@ -425,16 +425,25 @@ impl BoundariesChecker {
         //   // @ts-ignore
         //   import { foo } from "bar";
         //
+        // Comments are collected in source order, so a binary search finds
+        // where the comments preceding the import end without evaluating the
+        // span predicate for every comment in the file on every import.
+        let leading = comments.partition_point(|c| c.span.end <= import_span.start);
+
         // To detect blank lines we check the gap between each comment and the
         // *next* item in the chain (initially the import, then the previous
-        // comment we visited). A blank line means >1 newline in that gap.
-        let leading = comments.iter().filter(|c| c.span.end <= import_span.start);
-
+        // comment we visited). A blank line means more than one newline in
+        // that gap, so counting stops as soon as two are found.
         let mut next_start = import_span.start;
 
-        for comment in leading.rev() {
+        for comment in comments[..leading].iter().rev() {
             let between = &source_text[comment.span.end as usize..next_start as usize];
-            if between.chars().filter(|&c| c == '\n').count() > 1 {
+            if between
+                .char_indices()
+                .filter(|&(_, c)| c == '\n')
+                .nth(1)
+                .is_some()
+            {
                 break;
             }
 
@@ -834,6 +843,70 @@ mod tests {
                 .iter()
                 .all(|import| import.import_type == ImportType::Value)
         );
+    }
+
+    fn ignored_comment_parts(
+        source: &str,
+    ) -> (Vec<turbo_trace::ImportResult>, Vec<Comment>, String) {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = AbsoluteSystemPath::new(tmp.path().to_str().unwrap())
+            .unwrap()
+            .join_component("index.ts");
+        let (imports, comments) = parse_with_comments(&path, source).unwrap();
+        (imports, comments, source.to_string())
+    }
+
+    #[test]
+    fn stacked_comments_before_an_import_are_walked_backwards() {
+        let (imports, comments, source) = ignored_comment_parts(
+            "// @ts-ignore\n// @boundaries-ignore implicit dependency\nimport { foo } from \
+             \"bar\";\n",
+        );
+        assert_eq!(imports.len(), 1);
+        let reason =
+            BoundariesChecker::get_ignored_comment(&comments, &source, imports[0].statement_span);
+        assert_eq!(reason.as_deref(), Some(" implicit dependency"));
+    }
+
+    #[test]
+    fn blank_line_between_comment_and_import_stops_the_walk() {
+        let (imports, comments, source) = ignored_comment_parts(
+            "// @boundaries-ignore separated by a blank line\n\nimport { foo } from \"bar\";\n",
+        );
+        assert_eq!(imports.len(), 1);
+        let reason =
+            BoundariesChecker::get_ignored_comment(&comments, &source, imports[0].statement_span);
+        assert_eq!(reason, None);
+    }
+
+    #[test]
+    fn comments_after_the_import_are_not_considered() {
+        // An import at the top of a file with many trailing comments must
+        // only inspect the comments that precede it.
+        let trailing: String = (0..50)
+            .map(|i| format!("// trailing comment {i}\n"))
+            .collect();
+        let source = format!(
+            "// @boundaries-ignore nearest comment\nimport {{ foo }} from \"bar\";\n{trailing}"
+        );
+        let (imports, comments, source) = ignored_comment_parts(&source);
+        assert_eq!(imports.len(), 1);
+        assert_eq!(comments.len(), 51);
+        let reason =
+            BoundariesChecker::get_ignored_comment(&comments, &source, imports[0].statement_span);
+        assert_eq!(reason.as_deref(), Some(" nearest comment"));
+    }
+
+    #[test]
+    fn blank_line_between_stacked_comments_stops_the_walk() {
+        let (imports, comments, source) = ignored_comment_parts(
+            "// @boundaries-ignore too far away\n// stacked comment\n\nimport { foo } from \
+             \"bar\";\n",
+        );
+        assert_eq!(imports.len(), 1);
+        let reason =
+            BoundariesChecker::get_ignored_comment(&comments, &source, imports[0].statement_span);
+        assert_eq!(reason, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Replace the full `filter` scan of a file's comment list with a `partition_point` binary search. Comments are collected in source order, so the comments ending before an import can be found in O(log C) instead of evaluating the span predicate against every comment in the file for every import, which made ignore detection O(imports × comments).
- Stop counting gap newlines at two. The blank-line check only needs to know whether the gap between a comment and the next item contains more than one newline, so it now short-circuits at the second newline instead of counting every character in the gap.

The backward walk, stacked-comment handling, blank-line termination, and returned reason are unchanged.

Closes TURBO-6033

## Benchmark
Ran a temporary opt-in benchmark (median of 5 in-process samples, `--release`) on both `origin/main` and this change. Each sample checks all imports of a parsed file 25 times through `get_ignored_comment`; "trailing" is 40 imports at the top of the file followed by N comments (the worst case for the old scan), and "interleaved" gives each import two preceding comments plus N trailing comments:

| Comments | Trailing: before | Trailing: after | Faster | Interleaved: before | Interleaved: after | Faster |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 500 | 145.9 µs | 5.5 µs | 26.5× | 180.6 µs | 46.3 µs | 3.9× |
| 2,000 | 517.0 µs | 7.0 µs | 73.9× | 568.8 µs | 50.2 µs | 11.3× |
| 8,000 | 2.060 ms | 9.3 µs | 221.0× | 2.096 ms | 58.4 µs | 35.9× |

The old implementation scales linearly with the number of comments after each import; the new one scales logarithmically, which is why the gap widens as comment density grows.

## Test plan
- Added tests covering stacked comments before an import, a blank line between the comment and the import, a blank line between stacked comments, and an import followed by many trailing comments that must not be considered.
- `cargo test -p turborepo-boundaries`: 71 passed, 0 failed.
