### PR TITLE
chore: Exclude turbo and @turbo/* from minimum release age

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,8 @@ packages:
 
 minimumReleaseAge: 2880
 minimumReleaseAgeExclude:
+  - turbo
+  - "@turbo/*"
   - next
   - "@next/*"
   - "@vercel/geistdocs"


### PR DESCRIPTION
### Description

We need to exclude ourselves from `minimumReleaseAge`.
