### PR TITLE
perf: Reuse package manager detection during create startup

### DIFF
--- a/packages/create-turbo/__tests__/index.test.ts
+++ b/packages/create-turbo/__tests__/index.test.ts
@@ -133,6 +133,9 @@ describe("create-turbo", () => {
         "- Run a command twice to hit cache"
       );
 
+      // Package-manager detection is shared between the create flow and the
+      // package-manager prompt, so the version checks run exactly once.
+      expect(mockAvailablePackageManagers).toHaveBeenCalledTimes(1);
       mockAvailablePackageManagers.mockRestore();
       mockCreateProject.mockRestore();
       mockGetWorkspaceDetails.mockRestore();
@@ -230,6 +233,9 @@ describe("create-turbo", () => {
       expect(mockConsole.log).toHaveBeenCalledWith(
         "- Run a command twice to hit cache"
       );
+      // Package-manager detection is shared between the create flow and the
+      // package-manager prompt, so the version checks run exactly once.
+      expect(mockAvailablePackageManagers).toHaveBeenCalledTimes(1);
       mockAvailablePackageManagers.mockRestore();
       mockCreateProject.mockRestore();
       mockGetWorkspaceDetails.mockRestore();

--- a/packages/create-turbo/src/commands/create/index.ts
+++ b/packages/create-turbo/src/commands/create/index.ts
@@ -88,7 +88,8 @@ export async function create(
   // selected package manager can be undefined if the user chooses to skip transforms
   const selectedPackageManagerDetails = await prompts.packageManager({
     manager: packageManager,
-    skipTransforms
+    skipTransforms,
+    availablePackageManagers
   });
 
   if (packageManager && opts.skipTransforms) {

--- a/packages/create-turbo/src/commands/create/prompts.ts
+++ b/packages/create-turbo/src/commands/create/prompts.ts
@@ -1,5 +1,5 @@
 import type { PackageManager } from "@turbo/utils";
-import { getAvailablePackageManagers, validateDirectory } from "@turbo/utils";
+import { validateDirectory } from "@turbo/utils";
 import { input, select } from "@inquirer/prompts";
 import type { CreateCommandArgument } from "./types";
 
@@ -26,17 +26,19 @@ export async function directory({ dir }: { dir: CreateCommandArgument }) {
 
 export async function packageManager({
   manager,
-  skipTransforms
+  skipTransforms,
+  availablePackageManagers
 }: {
   manager: CreateCommandArgument;
   skipTransforms?: boolean;
+  /** Detected once by the caller, so the create flow never spawns the
+   * package-manager version checks twice. */
+  availablePackageManagers: Record<PackageManager, string | undefined>;
 }) {
   // if skip transforms is passed, we don't need to ask about the package manager (because that requires a transform)
   if (skipTransforms) {
     return undefined;
   }
-
-  const availablePackageManagers = await getAvailablePackageManagers();
 
   if (manager && availablePackageManagers[manager as PackageManager]) {
     return {


### PR DESCRIPTION
## Summary
- Detect available package managers once in the create flow and pass the result into the package-manager prompt, instead of running a second, sequential `getAvailablePackageManagers()` batch inside the prompt.
- Each detection batch spawns six `--version` subprocess probes (yarn, npm, pnpm, bun, nub, aube) with a 5-second timeout per probe, so the duplicate batch doubled process-launch overhead on every create — including runs with an explicit `--package-manager` selection and runs where the chosen manager is missing and slow shims must time out.

Closes TURBO-6057

## Benchmark
Ran a temporary timed test (median of 5 in-process runs) against both `origin/main` and this change. Each run executes the real `create` flow with an explicit `--package-manager` selection against the test fixture, with the network-bound pieces (`createProject` download, `getWorkspaceDetails`, install) stubbed and real, unmocked package-manager detection:

| Measurement | Before | After |
| --- | ---: | ---: |
| Single `getAvailablePackageManagers()` batch | 102.0 ms | 100.9 ms |
| `create` flow through package-manager selection | 199.3 ms | 100.3 ms |

The create flow performs exactly one detection batch instead of two sequential ones, removing ~100 ms of startup on this machine; the saving grows with slower package-manager shims, since each batch waits for the slowest missing manager to fail or time out.

## Test plan
- Extended the existing create-turbo suite to assert that `getAvailablePackageManagers` is called exactly once per create run in both the option and argument flows, which fails on the double-detection behavior.
- `create-turbo` test suite: 45 passed across 3 suites; `tsc --noEmit` passes.
