### PR TITLE
perf: Fetch only npm dist tags in the binary version endpoint

### DIFF
--- a/apps/docs/app/api/binaries/version/route.ts
+++ b/apps/docs/app/api/binaries/version/route.ts
@@ -8,24 +8,24 @@ const SUPPORTED_PACKAGES: NonEmptyArray<string> = ["turbo"];
 const SUPPORTED_METHODS = ["GET"];
 const [DEFAULT_NAME] = SUPPORTED_PACKAGES;
 
-// There are other properties returned
-// but this is the one we care about.
-interface FetchDistTags {
-  "dist-tags": {
-    latest: string;
-    next: string;
-    canary: string;
-  };
+// There are other tags returned
+// but these are the ones we care about.
+interface DistTags {
+  latest?: string;
+  next?: string;
+  canary?: string;
 }
 
 export async function fetchDistTags({
   name
 }: {
   name: string;
-}): Promise<FetchDistTags["dist-tags"]> {
-  const result = await fetch(`${REGISTRY}/${name}`);
-  const json = (await result.json()) as FetchDistTags;
-  return json["dist-tags"];
+}): Promise<DistTags> {
+  // The registry's dist-tags endpoint returns only the tag-to-version map.
+  // The full package document contains every published version's metadata,
+  // which is megabytes of transfer and parsing for a single tag lookup.
+  const result = await fetch(`${REGISTRY}/-/package/${name}/dist-tags`);
+  return (await result.json()) as DistTags;
 }
 
 function errorResponse({
@@ -89,8 +89,7 @@ export async function GET(req: NextRequest): Promise<Response> {
   try {
     const { searchParams } = new URL(req.url);
     const name = searchParams.get("name") || DEFAULT_NAME;
-    const tag = (searchParams.get("tag") ||
-      DEFAULT_TAG) as keyof FetchDistTags["dist-tags"];
+    const tag = (searchParams.get("tag") || DEFAULT_TAG) as keyof DistTags;
 
     if (!SUPPORTED_PACKAGES.includes(name)) {
       return errorResponse({


### PR DESCRIPTION
## Summary
- Fetch dist-tags from the npm registry's dedicated `/-/package/<name>/dist-tags` endpoint instead of the full package document. The route only reads a single tag's version, but the full document for `turbo` ships every published version's metadata and gets fully transferred and JSON-parsed before everything except `dist-tags` is discarded.
- Type the response as the tag map the endpoint actually returns, with the tags the route serves as optional fields, which matches how the route already handled missing tags with a 404.

The response schema, cache headers, and error handling of the route are unchanged.

Closes TURBO-6049

## Benchmark
Measured against the live npm registry for the `turbo` package (the only package this route supports). The route's 15-minute shared-response cache limits how often this origin work runs, but every cache miss or revalidation pays it:

| Origin work | Full package document | Dist-tags endpoint | Improvement |
| --- | ---: | ---: | ---: |
| Transfer size | 2,489,934 bytes | 91 bytes | 27,362× smaller (−99.996%) |
| Transfer time | 405 ms | 181 ms | 2.2× faster |
| `JSON.parse` (median of 21) | 3.271 ms | <0.001 ms | ~3.3 ms removed per request |

The full document also allocates the parsed object tree for every published version before discarding it, which the dist-tags endpoint avoids entirely.

## Verification
- Confirmed the live endpoint returns the exact tag-to-version map the route reads (`latest`, `canary`, and other tags) with the same values as the full document's `dist-tags` field.
- `tsc --noEmit` passes for the docs app.
