### PR TITLE
perf: Reuse archive anchor during cache creation

### DIFF
--- a/crates/turborepo-cache/src/cache_archive/create.rs
+++ b/crates/turborepo-cache/src/cache_archive/create.rs
@@ -16,6 +16,22 @@ use crate::CacheError;
 /// Combined with PID, this guarantees uniqueness across concurrent tasks.
 static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
+#[cfg(unix)]
+struct ArchiveAnchor {
+    directory: fs::File,
+    real_path: AbsoluteSystemPathBuf,
+}
+
+#[cfg(unix)]
+impl ArchiveAnchor {
+    fn open(anchor: &AbsoluteSystemPath) -> Result<Self, CacheError> {
+        Ok(Self {
+            directory: fs::File::open(anchor.as_std_path())?,
+            real_path: anchor.to_realpath()?,
+        })
+    }
+}
+
 enum ArchiveSource {
     Regular {
         file: fs::File,
@@ -61,6 +77,10 @@ pub struct CacheWriter<'a> {
     temp_path: Option<AbsoluteSystemPathBuf>,
     /// The final destination path for the archive.
     final_path: Option<AbsoluteSystemPathBuf>,
+    // Retains a verified anchor for this archive so every output does not need
+    // to reopen and canonicalize the same root directory.
+    #[cfg(unix)]
+    anchor: Option<ArchiveAnchor>,
 }
 
 impl Drop for CacheWriter<'_> {
@@ -131,12 +151,16 @@ impl<'a> CacheWriter<'a> {
                 builder: tar::Builder::new(Box::new(zw)),
                 temp_path: None,
                 final_path: None,
+                #[cfg(unix)]
+                anchor: None,
             })
         } else {
             Ok(CacheWriter {
                 builder: tar::Builder::new(Box::new(writer)),
                 temp_path: None,
                 final_path: None,
+                #[cfg(unix)]
+                anchor: None,
             })
         }
     }
@@ -168,13 +192,31 @@ impl<'a> CacheWriter<'a> {
                 builder: tar::Builder::new(Box::new(zw)),
                 temp_path: Some(temp_path),
                 final_path: Some(path.to_owned()),
+                #[cfg(unix)]
+                anchor: None,
             })
         } else {
             Ok(CacheWriter {
                 builder: tar::Builder::new(Box::new(file_buffer)),
                 temp_path: Some(temp_path),
                 final_path: Some(path.to_owned()),
+                #[cfg(unix)]
+                anchor: None,
             })
+        }
+    }
+
+    #[cfg(unix)]
+    fn archive_anchor(
+        &mut self,
+        anchor: &AbsoluteSystemPath,
+    ) -> Result<&ArchiveAnchor, CacheError> {
+        if self.anchor.is_none() {
+            self.anchor = Some(ArchiveAnchor::open(anchor)?);
+        }
+        match self.anchor.as_ref() {
+            Some(anchor) => Ok(anchor),
+            None => unreachable!("archive anchor must be initialized"),
         }
     }
 
@@ -184,6 +226,9 @@ impl<'a> CacheWriter<'a> {
         anchor: &AbsoluteSystemPath,
         file_path: &AnchoredSystemPath,
     ) -> Result<(), CacheError> {
+        #[cfg(unix)]
+        let source = archive_source(self.archive_anchor(anchor)?, file_path)?;
+        #[cfg(not(unix))]
         let source = archive_source(anchor, file_path)?;
         let mut file_path = file_path.to_unix();
 
@@ -298,7 +343,7 @@ fn archive_source(
 
 #[cfg(unix)]
 fn archive_source(
-    anchor: &AbsoluteSystemPath,
+    anchor: &ArchiveAnchor,
     file_path: &AnchoredSystemPath,
 ) -> Result<ArchiveSource, CacheError> {
     use std::os::unix::io::AsRawFd;
@@ -328,14 +373,13 @@ fn archive_source(
 
 #[cfg(unix)]
 fn open_parent_dir(
-    anchor: &AbsoluteSystemPath,
+    anchor: &ArchiveAnchor,
     file_path: &AnchoredSystemPath,
 ) -> Result<(fs::File, String), CacheError> {
     use std::os::unix::io::AsRawFd;
 
-    let mut dir = fs::File::open(anchor.as_std_path())?;
-    let real_anchor = anchor.to_realpath()?;
-    let mut dir_path = real_anchor.clone();
+    let mut dir = anchor.directory.try_clone()?;
+    let mut dir_path = anchor.real_path.clone();
     let mut components = file_path.components().peekable();
 
     while let Some(component) = components.next() {
@@ -345,7 +389,7 @@ fn open_parent_dir(
         }
 
         let (next_dir, next_dir_path) = open_dir_at_allowing_internal_symlink(
-            &real_anchor,
+            &anchor.real_path,
             &dir_path,
             dir.as_raw_fd(),
             component,


### PR DESCRIPTION
Fixes TURBO-5987

Reuse one verified cache-archive root descriptor and canonical root path across all entries in a `CacheWriter`. Child components continue to use the existing `openat`/`O_NOFOLLOW` traversal and internal-symlink validation.

## Performance

Measured an end-to-end local cache miss for a no-op task with 10,000 existing tiny outputs under a depth-5 directory. Each sample removed `.turbo`, ran the release-profile Turbo binary with `--daemon=false`, and wrote a fresh local cache archive. The generated fixture and benchmark artifacts remained outside the repository.

`hyperfine 1.19.0`, 3 warmups and 5 measured samples per binary in each of four balanced AB/BA blocks (20 samples per binary), Apple M4 Max, 36 GiB RAM, macOS, `rustc 1.98.0-nightly`.

| Metric | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Pooled median save latency | 1,499.00 ms | 1,393.81 ms | 7.02% |
| Sample standard deviation | 20.84 ms | 18.29 ms | 12.2% lower |
| Block 1 median | 1,507.20 ms | 1,410.39 ms | 6.42% |
| Block 2 median | 1,494.84 ms | 1,388.85 ms | 7.09% |
| Block 3 median | 1,481.27 ms | 1,393.04 ms | 5.96% |
| Block 4 median | 1,498.18 ms | 1,394.59 ms | 6.91% |

Command:

```sh
hyperfine --warmup 3 --runs 5 --prepare 'rm -rf .turbo' \
  '/tmp/turbo-baseline run build --daemon=false --no-update-notifier >/dev/null' \
  '/tmp/turbo-candidate run build --daemon=false --no-update-notifier >/dev/null'
```

The candidate improved in every command order and every block. This workload isolates the many-file archive-save case; it does not claim the same percentage for cache restores or large individual files.
