### PR TITLE
perf: Bound remote-cache transfer memory instead of retaining whole artifacts

### DIFF
--- a/crates/turborepo-cache/Cargo.toml
+++ b/crates/turborepo-cache/Cargo.toml
@@ -16,7 +16,6 @@ filetime = "0.2"
 futures = { workspace = true }
 insta = { workspace = true }
 port_scanner = { workspace = true }
-tempfile = { workspace = true }
 test-case = { workspace = true }
 turborepo-vercel-api = { workspace = true }
 turborepo-vercel-api-mock = { workspace = true }
@@ -36,11 +35,12 @@ os_str_bytes = "6.5.0"
 path-clean = { workspace = true }
 petgraph = { workspace = true }
 pin-project = "1.1.5"
-reqwest = { workspace = true }
+reqwest = { workspace = true, features = ["stream"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 tar = "0.4.45"
+tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-stream = "0.1.15"

--- a/crates/turborepo-cache/src/http.rs
+++ b/crates/turborepo-cache/src/http.rs
@@ -1,7 +1,8 @@
 use std::{
     backtrace::Backtrace,
     collections::HashMap,
-    io::Write,
+    io::{Read, Seek, SeekFrom, Write},
+    pin::Pin,
     sync::{Arc, Mutex},
 };
 
@@ -22,6 +23,77 @@ use crate::{
 };
 
 pub type UploadMap = HashMap<String, UploadProgressQuery<10, 100>>;
+
+/// Artifacts smaller than this are kept in memory during transfers. Larger
+/// ones roll over to an anonymous temporary file (unlinked on creation where
+/// the platform supports it) so retained payload memory stays bounded no
+/// matter how large the compressed artifact is.
+const ARTIFACT_MEMORY_THRESHOLD: usize = 8 * 1024 * 1024;
+
+/// The compressed artifact body for an upload, shared across attempts so a
+/// retry after a token refresh resends byte-identical content without
+/// rebuilding the archive.
+enum ArtifactBody {
+    /// Small artifact held in memory; retries are a cheap `Bytes` refcount
+    /// bump.
+    InMemory(bytes::Bytes),
+    /// Large artifact spooled to an anonymous temporary file; retries read it
+    /// back from the start through a fresh handle in bounded chunks.
+    OnDisk(std::fs::File),
+}
+
+type UploadStream = Pin<
+    Box<
+        dyn futures::Stream<Item = Result<bytes::Bytes, turborepo_api_client::Error>> + Send + Sync,
+    >,
+>;
+
+impl ArtifactBody {
+    fn len(&self) -> usize {
+        match self {
+            ArtifactBody::InMemory(bytes) => bytes.len(),
+            ArtifactBody::OnDisk(file) => {
+                file.metadata().map(|meta| meta.len() as usize).unwrap_or(0)
+            }
+        }
+    }
+
+    fn generate_tag(
+        &self,
+        signer: &ArtifactSignatureAuthenticator,
+        hash: &str,
+    ) -> Result<String, SignatureError> {
+        match self {
+            ArtifactBody::InMemory(bytes) => signer.generate_tag(hash.as_bytes(), bytes),
+            ArtifactBody::OnDisk(file) => {
+                signer.generate_tag_reader(hash.as_bytes(), file, self.len() as u64)
+            }
+        }
+    }
+
+    fn stream(&self) -> turborepo_api_client::Result<UploadStream> {
+        match self {
+            ArtifactBody::InMemory(bytes) => Ok(Box::pin(chunked_byte_stream(
+                bytes.clone(),
+                HTTPCache::UPLOAD_CHUNK_BYTES,
+            ))),
+            ArtifactBody::OnDisk(file) => {
+                // `try_clone` hands us an independent handle; seek it to the
+                // start because signing (and any previous attempt) moved the
+                // shared offset.
+                let mut handle = file.try_clone()?;
+                handle.seek(SeekFrom::Start(0))?;
+                let reader = tokio_util::io::ReaderStream::with_capacity(
+                    tokio::fs::File::from_std(handle),
+                    HTTPCache::UPLOAD_CHUNK_BYTES,
+                );
+                Ok(Box::pin(futures::StreamExt::map(reader, |chunk| {
+                    chunk.map_err(turborepo_api_client::Error::from)
+                })))
+            }
+        }
+    }
+}
 
 fn replace_api_auth_token(api_auth: &mut APIAuth, token: SecretString) -> bool {
     if api_auth.token.expose() == token.expose() {
@@ -188,19 +260,37 @@ impl HTTPCache {
         files: &[AnchoredSystemPathBuf],
         duration: u64,
     ) -> Result<(), CacheError> {
-        let mut artifact_body = Vec::new();
-        self.write(&mut artifact_body, anchor, files).await?;
-        let body_len = artifact_body.len();
+        // Spool the compressed artifact: small artifacts stay in memory while
+        // large ones roll to an anonymous temporary file, so retained memory
+        // is bounded regardless of artifact size.
+        let mut spool = tempfile::spooled_tempfile(ARTIFACT_MEMORY_THRESHOLD);
+        {
+            let mut buffered = std::io::BufWriter::new(&mut spool);
+            self.write(&mut buffered, anchor, files).await?;
+            // BufWriter's Drop ignores flush errors; flush explicitly so a
+            // failed final write cannot be uploaded as a truncated artifact.
+            buffered.flush()?;
+        }
+        spool.seek(SeekFrom::Start(0))?;
+
+        let body = if spool.is_rolled() {
+            let mut file = spool.into_file()?;
+            // Rewind so signing reads the artifact from the start.
+            file.seek(SeekFrom::Start(0))?;
+            ArtifactBody::OnDisk(file)
+        } else {
+            let mut bytes = Vec::new();
+            spool.read_to_end(&mut bytes)?;
+            ArtifactBody::InMemory(bytes::Bytes::from(bytes))
+        };
+        let body = Arc::new(body);
+        let body_len = body.len();
 
         let tag = self
             .signer_verifier
             .as_ref()
-            .map(|signer| signer.generate_tag(hash.as_bytes(), &artifact_body))
+            .map(|signer| body.generate_tag(signer, hash))
             .transpose()?;
-
-        // Convert to Bytes once so retries are a cheap Arc bump instead of
-        // a full deep-copy of the artifact.
-        let artifact_bytes = bytes::Bytes::from(artifact_body);
 
         let resolved_scm = self.scm_state.get_resolved().await;
         let sha = resolved_scm.and_then(|s| s.sha.clone());
@@ -216,13 +306,15 @@ impl HTTPCache {
         self.execute_with_token_refresh(hash, |api_auth| {
             let client = &self.client;
             let tag_ref = tag_clone.as_deref();
-            let artifact_bytes_ref = artifact_bytes.clone(); // Arc bump, not a deep copy
+            let body_ref = body.clone();
             let uploads_ref = uploads_clone.clone();
             let sha_ref = sha_clone.clone();
             let dirty_hash_ref = dirty_hash_clone.clone();
 
             async move {
-                let stream = chunked_byte_stream(artifact_bytes_ref, Self::UPLOAD_CHUNK_BYTES);
+                // Each attempt gets a fresh bounded stream over the same
+                // spooled bytes, so retries send identical content.
+                let stream = body_ref.stream()?;
 
                 let (progress, query) = UploadProgress::<10, 100, _>::new(stream, Some(body_len));
 
@@ -371,40 +463,76 @@ impl HTTPCache {
         let sha = Self::get_header_string(&response, "x-artifact-sha");
         let dirty_hash = Self::get_header_string(&response, "x-artifact-dirty-hash");
 
-        let body = if let Some(signer_verifier) = &self.signer_verifier {
-            let expected_tag = response
+        let expected_tag = if self.signer_verifier.is_some() {
+            let tag = response
                 .headers()
                 .get("x-artifact-tag")
                 .ok_or(CacheError::ArtifactTagMissing(Backtrace::capture()))?;
 
-            let expected_tag = expected_tag
-                .to_str()
-                .map_err(|_| CacheError::InvalidTag(Backtrace::capture()))?
-                .to_string();
+            Some(
+                tag.to_str()
+                    .map_err(|_| CacheError::InvalidTag(Backtrace::capture()))?
+                    .to_string(),
+            )
+        } else {
+            None
+        };
 
-            let body = response.bytes().await.map_err(|e| {
-                CacheError::ApiClientError(
-                    Box::new(turborepo_api_client::Error::ReqwestError(e)),
-                    Backtrace::capture(),
-                )
-            })?;
-            let is_valid = signer_verifier.validate(hash.as_bytes(), &body, &expected_tag)?;
+        // Stream the response into a spool instead of collecting the whole
+        // body in memory. Small artifacts stay in memory; large ones roll to
+        // an anonymous temporary file that is cleaned up on drop. When the
+        // Content-Length is known (the common case) the signature is computed
+        // incrementally as chunks arrive.
+        let mut streaming_tag = match (&self.signer_verifier, response.content_length()) {
+            (Some(signer), Some(len)) => Some(signer.start_streaming_tag(hash.as_bytes(), len)?),
+            _ => None,
+        };
+        let mut spool = tempfile::spooled_tempfile(ARTIFACT_MEMORY_THRESHOLD);
+        let mut body_len: u64 = 0;
+        {
+            use tokio_stream::StreamExt;
+            let mut body_stream = response.bytes_stream();
+            while let Some(chunk) = body_stream.next().await {
+                let chunk = chunk.map_err(|e| {
+                    CacheError::ApiClientError(
+                        Box::new(turborepo_api_client::Error::ReqwestError(e)),
+                        Backtrace::capture(),
+                    )
+                })?;
+                if let Some(tag) = &mut streaming_tag {
+                    tag.update(&chunk);
+                }
+                spool.write_all(&chunk)?;
+                body_len += chunk.len() as u64;
+            }
+        }
+
+        // Verify the signature before any extraction; a rejected artifact is
+        // dropped with the spool and nothing is restored.
+        if let (Some(signer_verifier), Some(expected_tag)) = (&self.signer_verifier, &expected_tag)
+        {
+            let is_valid = match streaming_tag {
+                Some(tag) => tag.verify(expected_tag)?,
+                // The body length was not known up front, so verify from the
+                // spooled bytes now that the total is known.
+                None => {
+                    spool.seek(SeekFrom::Start(0))?;
+                    signer_verifier.validate_reader(
+                        hash.as_bytes(),
+                        &mut spool,
+                        body_len,
+                        expected_tag,
+                    )?
+                }
+            };
 
             if !is_valid {
                 return Err(CacheError::InvalidTag(Backtrace::capture()));
             }
+        }
 
-            body
-        } else {
-            response.bytes().await.map_err(|e| {
-                CacheError::ApiClientError(
-                    Box::new(turborepo_api_client::Error::ReqwestError(e)),
-                    Backtrace::capture(),
-                )
-            })?
-        };
-
-        let files = Self::restore_tar(&self.repo_root, &body)?;
+        spool.seek(SeekFrom::Start(0))?;
+        let files = Self::restore_tar(&self.repo_root, spool)?;
 
         self.log_fetch(analytics::CacheEvent::Hit, hash, duration);
         Ok(Some((
@@ -425,7 +553,7 @@ impl HTTPCache {
     #[tracing::instrument(skip_all)]
     pub(crate) fn restore_tar(
         root: &AbsoluteSystemPath,
-        body: &[u8],
+        body: impl Read,
     ) -> Result<Vec<AnchoredSystemPathBuf>, CacheError> {
         let mut cache_reader = CacheReader::from_reader(body, true)?;
         let (files, _manifest) = cache_reader.restore(root, None)?;
@@ -474,7 +602,7 @@ mod test {
     use futures::future::try_join_all;
     use insta::assert_snapshot;
     use tempfile::tempdir;
-    use turbopath::AbsoluteSystemPathBuf;
+    use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
     use turborepo_analytics::start_analytics;
     use turborepo_api_client::{APIClient, analytics};
     use turborepo_types::SecretString;
@@ -583,6 +711,94 @@ mod test {
 
         analytics_handle.close_with_timeout().await;
 
+        Ok(())
+    }
+
+    /// An artifact larger than the in-memory threshold must round-trip through
+    /// the disk-spooled upload and download paths byte-for-byte.
+    #[tokio::test]
+    async fn test_http_cache_large_artifact_spools_to_disk() -> Result<()> {
+        let port = port_scanner::request_open_port().unwrap();
+        let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+        let handle = tokio::spawn(start_test_server(port, Some(ready_tx)));
+
+        tokio::time::timeout(Duration::from_secs(5), ready_rx)
+            .await
+            .map_err(|_| anyhow::anyhow!("Test server failed to start within timeout"))??;
+
+        // 16 MiB of incompressible pseudo-random data, so the compressed
+        // artifact exceeds ARTIFACT_MEMORY_THRESHOLD and rolls to disk.
+        let mut contents = Vec::with_capacity(16 * 1024 * 1024);
+        let mut state: u64 = 0x9E3779B97F4A7C15;
+        while contents.len() < 16 * 1024 * 1024 {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            contents.extend_from_slice(&state.to_le_bytes());
+        }
+
+        let put_root = tempdir()?;
+        let put_root_path = AbsoluteSystemPathBuf::try_from(put_root.path())?;
+        let file_path = AnchoredSystemPathBuf::from_raw("big.bin")?;
+        std::fs::write(put_root_path.resolve(&file_path), &contents)?;
+
+        let hash = "large-artifact-hash";
+        let duration = 42;
+        let api_auth = APIAuth {
+            team_id: Some("my-team".to_string()),
+            token: SecretString::new("my-token".to_string()),
+            team_slug: None,
+        };
+        let opts = CacheOpts {
+            cache_dir: ".turbo/cache".into(),
+            cache: Default::default(),
+            workers: 0,
+            remote_cache_opts: None,
+            cache_max_age: None,
+            cache_max_size: None,
+        };
+
+        let make_cache = |root: &AbsoluteSystemPathBuf| {
+            HTTPCache::new(
+                APIClient::new(
+                    format!("http://localhost:{port}"),
+                    Some(Duration::from_secs(200)),
+                    None,
+                    "2.0.0",
+                    true,
+                )
+                .unwrap(),
+                &opts,
+                root.to_owned(),
+                api_auth.clone(),
+                None,
+                LazyScmState::resolved(None),
+            )
+            .unwrap()
+        };
+
+        let put_cache = make_cache(&put_root_path);
+        put_cache
+            .put(
+                &put_root_path,
+                hash,
+                std::slice::from_ref(&file_path),
+                duration,
+            )
+            .await?;
+
+        // Restore into a different root so the bytes must actually travel.
+        let fetch_root = tempdir()?;
+        let fetch_root_path = AbsoluteSystemPathBuf::try_from(fetch_root.path())?;
+        let fetch_cache = make_cache(&fetch_root_path);
+
+        let (metadata, received_files) = fetch_cache.fetch(hash).await?.unwrap();
+        assert_eq!(metadata.time_saved, duration);
+        assert_eq!(received_files.len(), 1);
+        let restored = std::fs::read(fetch_root_path.resolve(&received_files[0]))?;
+        assert_eq!(restored, contents);
+
+        handle.abort();
         Ok(())
     }
 

--- a/crates/turborepo-cache/src/signature_authentication.rs
+++ b/crates/turborepo-cache/src/signature_authentication.rs
@@ -1,4 +1,4 @@
-use std::env;
+use std::{env, io::Read};
 
 use base64::{Engine, prelude::BASE64_STANDARD};
 use hmac::{Hmac, Mac};
@@ -33,6 +33,8 @@ pub enum SignatureError {
     Base64EncodingError(#[from] base64::DecodeError),
     #[error(transparent)]
     Hmac(#[from] hmac::digest::InvalidLength),
+    #[error("I/O error while reading artifact body for signing: {0}")]
+    Io(#[from] std::io::Error),
 }
 
 #[derive(Debug)]
@@ -77,18 +79,74 @@ impl ArtifactSignatureAuthenticator {
             .into_raw_vec())
     }
 
-    fn get_tag_generator(
+    /// Writes every field that precedes the artifact body. The body is the
+    /// final length-prefixed field, so knowing `body_len` up front lets
+    /// callers stream the body in bounded chunks instead of holding the whole
+    /// artifact in memory.
+    fn start_tag_generator(
         &self,
         hash: &[u8],
-        artifact_body: &[u8],
+        body_len: u64,
     ) -> Result<HmacSha256, SignatureError> {
         let mut mac = HmacSha256::new_from_slice(&self.secret_key()?)?;
         update_message_field(&mut mac, SIGNATURE_MESSAGE_PREFIX);
         update_message_field(&mut mac, hash);
         update_message_field(&mut mac, &self.team_id);
-        update_message_field(&mut mac, artifact_body);
+        mac.update(&body_len.to_le_bytes());
 
         Ok(mac)
+    }
+
+    fn get_tag_generator(
+        &self,
+        hash: &[u8],
+        artifact_body: &[u8],
+    ) -> Result<HmacSha256, SignatureError> {
+        let mut mac = self.start_tag_generator(hash, artifact_body.len() as u64)?;
+        mac.update(artifact_body);
+
+        Ok(mac)
+    }
+
+    /// Starts an incremental tag computation for a body that will be fed in
+    /// chunks, e.g. while a download streams to disk.
+    pub fn start_streaming_tag(
+        &self,
+        hash: &[u8],
+        body_len: u64,
+    ) -> Result<StreamingTag, SignatureError> {
+        Ok(StreamingTag {
+            mac: self.start_tag_generator(hash, body_len)?,
+        })
+    }
+
+    /// Computes the tag for a body that is read in bounded chunks rather than
+    /// held in memory all at once.
+    #[tracing::instrument(skip_all)]
+    pub fn generate_tag_reader(
+        &self,
+        hash: &[u8],
+        mut artifact_body: impl Read,
+        body_len: u64,
+    ) -> Result<String, SignatureError> {
+        let tag = self.start_streaming_tag(hash, body_len)?;
+        let tag = tag.update_from_reader(&mut artifact_body)?;
+        Ok(tag.finalize_tag())
+    }
+
+    /// Validates a body that is read in bounded chunks rather than held in
+    /// memory all at once.
+    #[tracing::instrument(skip_all)]
+    pub fn validate_reader(
+        &self,
+        hash: &[u8],
+        mut artifact_body: impl Read,
+        body_len: u64,
+        expected_tag: &str,
+    ) -> Result<bool, SignatureError> {
+        let tag = self.start_streaming_tag(hash, body_len)?;
+        let tag = tag.update_from_reader(&mut artifact_body)?;
+        tag.verify(expected_tag)
     }
 
     #[tracing::instrument(skip_all)]
@@ -130,6 +188,42 @@ impl ArtifactSignatureAuthenticator {
 fn update_message_field(mac: &mut HmacSha256, field: &[u8]) {
     mac.update(&(field.len() as u64).to_le_bytes());
     mac.update(field);
+}
+
+/// An in-progress tag computation over an artifact body that arrives in
+/// bounded chunks. Produced by
+/// [`ArtifactSignatureAuthenticator::start_streaming_tag`], which has already
+/// absorbed the fixed message fields and the body's length prefix.
+pub struct StreamingTag {
+    mac: HmacSha256,
+}
+
+impl StreamingTag {
+    pub fn update(&mut self, chunk: &[u8]) {
+        self.mac.update(chunk);
+    }
+
+    pub fn update_from_reader(mut self, mut reader: impl Read) -> Result<Self, SignatureError> {
+        let mut buffer = [0u8; 64 * 1024];
+        loop {
+            let n = reader.read(&mut buffer)?;
+            if n == 0 {
+                break;
+            }
+            self.mac.update(&buffer[..n]);
+        }
+        Ok(self)
+    }
+
+    pub fn finalize_tag(self) -> String {
+        let output = self.mac.finalize();
+        BASE64_STANDARD.encode(output.into_bytes())
+    }
+
+    pub fn verify(self, expected_tag: &str) -> Result<bool, SignatureError> {
+        let expected_bytes = BASE64_STANDARD.decode(expected_tag)?;
+        Ok(self.mac.verify_slice(&expected_bytes).is_ok())
+    }
 }
 
 #[cfg(test)]
@@ -258,6 +352,71 @@ mod tests {
         for test_case in get_test_cases() {
             test_signature(test_case)?;
         }
+        Ok(())
+    }
+
+    #[test]
+    fn test_streaming_tag_matches_in_memory_tag() -> Result<()> {
+        let signature = ArtifactSignatureAuthenticator {
+            team_id: b"team-stream".to_vec(),
+            secret_key_override: Some(b"streaming-secret-key-that-is-long-enough".to_vec()),
+        };
+
+        // A body larger than the reader's internal chunk size, with bytes
+        // that do not repeat so chunk boundaries cannot mask ordering bugs.
+        let mut body = Vec::with_capacity(300_000);
+        let mut state: u64 = 0x853c49e6748fea9b;
+        for _ in 0..300_000 {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            body.push((state >> 32) as u8);
+        }
+
+        let expected = signature.generate_tag(b"stream-hash", &body)?;
+        let streamed =
+            signature.generate_tag_reader(b"stream-hash", &body[..], body.len() as u64)?;
+        assert_eq!(expected, streamed);
+
+        assert!(signature.validate_reader(
+            b"stream-hash",
+            &body[..],
+            body.len() as u64,
+            &expected
+        )?);
+
+        // An incremental tag fed with irregular chunk sizes must agree too.
+        let mut tag = signature.start_streaming_tag(b"stream-hash", body.len() as u64)?;
+        for chunk in body.chunks(7_777) {
+            tag.update(chunk);
+        }
+        assert!(tag.verify(&expected)?);
+
+        // Tampering with a single byte must fail validation.
+        let mut tampered = body.clone();
+        tampered[150_000] ^= 0xFF;
+        assert!(!signature.validate_reader(
+            b"stream-hash",
+            &tampered[..],
+            tampered.len() as u64,
+            &expected
+        )?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_streaming_tag_empty_body_matches_in_memory() -> Result<()> {
+        let signature = ArtifactSignatureAuthenticator {
+            team_id: b"team".to_vec(),
+            secret_key_override: Some(b"key".to_vec()),
+        };
+        let expected = signature.generate_tag(b"hash", b"")?;
+        assert_eq!(
+            signature.generate_tag_reader(b"hash", &b""[..], 0)?,
+            expected
+        );
+        assert!(signature.validate_reader(b"hash", &b""[..], 0, &expected)?);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Closes TURBO-6038.

Remote cache transfers previously retained entire compressed artifacts in memory: uploads compressed into a `Vec` before streaming, and downloads collected the full response body before signature verification and extraction. Concurrent large, poorly compressible artifacts retained the sum of their compressed sizes.

## Changes

- Artifact bodies now flow through a `SpooledTempFile` with an 8 MiB threshold: small artifacts stay in memory (same path as before), while large ones roll to an anonymous temporary file that is unlinked on close and cleaned up on every exit path, including errors.
- Uploads stream the spooled body in bounded 256 KiB chunks (zero-copy `Bytes` slices in memory, `ReaderStream` over the temp file on disk). Retries after token refresh re-create a fresh stream over the same spooled bytes, so resent content stays byte-identical and Content-Length is preserved.
- Downloads stream the response into the spool in bounded chunks. Artifact signatures are computed incrementally as chunks arrive when Content-Length is known, or from the spooled file otherwise; verification still completes before any extraction, and rejected artifacts restore nothing.
- `ArtifactSignatureAuthenticator` gains chunked reader/streaming tag variants that produce byte-identical tags to the in-memory API (the body is the final length-prefixed HMAC field, so prefixing the known length preserves the exact protocol semantics).

## Benchmarks

4 concurrent transfers of 64 MiB incompressible artifacts against the repo's mock server running as a separate process, so peak RSS reflects only cache client memory. Debug build, macOS, `/usr/bin/time -l` maximum resident set size. Benchmark harness was temporary and is not committed.

| Operation (4 × 64 MiB concurrent) | Before (peak RSS) | After (peak RSS) | Change |
| --- | --- | --- | --- |
| Upload | 292,978,688 B (279.4 MiB) | 132,726,784 B (126.6 MiB) | −54.7% |
| Download + restore | 578,371,584 B (551.6 MiB) | 154,583,040 B (147.4 MiB) | −73.3% |

Retained artifact payload memory is now bounded by the 8 MiB spool threshold per transfer rather than the full compressed artifact size.

## Verification

- `cargo test -p turborepo-cache`: 157 passed, 0 failed, including a new 16 MiB rolled-to-disk round-trip test through the mock server and streaming-tag equivalence tests.
- `cargo clippy -p turborepo-cache`: clean.
- Note: the pre-existing `signature`-filtered env-var tests race each other when run in parallel; that flake exists on `main` and is unrelated to this change.