### PR TITLE
perf: Build cache archives once for local and remote writes

### DIFF
--- a/crates/turborepo-cache/src/artifact_body.rs
+++ b/crates/turborepo-cache/src/artifact_body.rs
@@ -1,0 +1,175 @@
+use std::{
+    io::{Read, Seek, SeekFrom, Write},
+    pin::Pin,
+};
+
+use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf};
+
+use crate::{
+    CacheError,
+    cache_archive::CacheWriter,
+    signature_authentication::{ArtifactSignatureAuthenticator, SignatureError},
+};
+
+/// Artifacts smaller than this are kept in memory during transfers. Larger
+/// ones roll over to an anonymous temporary file (unlinked on creation where
+/// the platform supports it) so retained payload memory stays bounded no
+/// matter how large the compressed artifact is.
+pub(crate) const ARTIFACT_MEMORY_THRESHOLD: usize = 8 * 1024 * 1024;
+
+/// 256 KB chunk size for reading/writing artifact bodies. Larger chunks
+/// reduce per-chunk overhead (mutex locks in UploadProgress, hyper body
+/// framing) which improves throughput for large artifacts compared to small
+/// buffers.
+pub(crate) const ARTIFACT_CHUNK_BYTES: usize = 256 * 1024;
+
+/// The compressed artifact body, either in memory (small) or spooled to an
+/// anonymous temporary file (large). A single built archive can be shared by
+/// the local filesystem cache and the remote cache so identical bytes are
+/// installed, signed, and uploaded exactly once.
+pub(crate) enum ArtifactBody {
+    /// Small artifact held in memory; retries are a cheap `Bytes` refcount
+    /// bump.
+    InMemory(bytes::Bytes),
+    /// Large artifact spooled to an anonymous temporary file; consumers read
+    /// it back from the start through fresh handles in bounded chunks.
+    OnDisk(std::fs::File),
+}
+
+pub(crate) type UploadStream = Pin<
+    Box<
+        dyn futures::Stream<Item = Result<bytes::Bytes, turborepo_api_client::Error>> + Send + Sync,
+    >,
+>;
+
+impl ArtifactBody {
+    /// Builds the canonical compressed archive for `files` exactly once,
+    /// spooling to disk when it grows past the in-memory threshold.
+    pub(crate) fn from_files(
+        anchor: &AbsoluteSystemPath,
+        files: &[AnchoredSystemPathBuf],
+    ) -> Result<Self, CacheError> {
+        let mut spool = tempfile::spooled_tempfile(ARTIFACT_MEMORY_THRESHOLD);
+        {
+            let mut buffered = std::io::BufWriter::new(&mut spool);
+            let mut cache_archive = CacheWriter::from_writer(&mut buffered, true)?;
+            for file in files {
+                cache_archive.add_file(anchor, file)?;
+            }
+            // finish() writes the tar footer; dropping then auto-finishes the
+            // zstd stream into the buffer.
+            cache_archive.finish()?;
+            // BufWriter's Drop ignores flush errors; flush explicitly so a
+            // failed final write cannot be reused as a truncated artifact.
+            buffered.flush()?;
+        }
+        spool.seek(SeekFrom::Start(0))?;
+        Self::from_spool(spool)
+    }
+
+    /// Converts a spooled artifact into its shared representation, keeping
+    /// small artifacts in memory and large ones on disk.
+    pub(crate) fn from_spool(mut spool: tempfile::SpooledTempFile) -> Result<Self, CacheError> {
+        if spool.is_rolled() {
+            let mut file = spool.into_file()?;
+            // Rewind so the first consumer reads from the start.
+            file.seek(SeekFrom::Start(0))?;
+            Ok(ArtifactBody::OnDisk(file))
+        } else {
+            let mut bytes = Vec::new();
+            spool.read_to_end(&mut bytes)?;
+            Ok(ArtifactBody::InMemory(bytes::Bytes::from(bytes)))
+        }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        match self {
+            ArtifactBody::InMemory(bytes) => bytes.len(),
+            ArtifactBody::OnDisk(file) => {
+                file.metadata().map(|meta| meta.len() as usize).unwrap_or(0)
+            }
+        }
+    }
+
+    pub(crate) fn generate_tag(
+        &self,
+        signer: &ArtifactSignatureAuthenticator,
+        hash: &str,
+    ) -> Result<String, SignatureError> {
+        match self {
+            ArtifactBody::InMemory(bytes) => signer.generate_tag(hash.as_bytes(), bytes),
+            ArtifactBody::OnDisk(file) => {
+                signer.generate_tag_reader(hash.as_bytes(), file, self.len() as u64)
+            }
+        }
+    }
+
+    /// A fresh reader positioned at the start of the archive, independent of
+    /// where previous consumers stopped. Readers are cheap: a `Bytes`
+    /// refcount bump in memory or a `dup` of the spool file on disk. The
+    /// on-disk variant is buffered so consumers issuing small reads (like
+    /// tar header parsing) do not turn into per-block syscalls.
+    pub(crate) fn reader(&self) -> std::io::Result<Box<dyn Read + Send>> {
+        match self {
+            ArtifactBody::InMemory(bytes) => Ok(Box::new(std::io::Cursor::new(bytes.clone()))),
+            ArtifactBody::OnDisk(file) => {
+                let mut handle = file.try_clone()?;
+                handle.seek(SeekFrom::Start(0))?;
+                Ok(Box::new(std::io::BufReader::with_capacity(
+                    ARTIFACT_CHUNK_BYTES,
+                    handle,
+                )))
+            }
+        }
+    }
+
+    /// Copies the complete archive bytes to `writer`, reading from the start
+    /// in bounded chunks regardless of where previous consumers stopped.
+    pub(crate) fn copy_to(&self, mut writer: impl Write) -> Result<(), CacheError> {
+        std::io::copy(&mut self.reader()?, &mut writer)?;
+        Ok(())
+    }
+
+    /// A fresh bounded stream over the archive bytes, so every upload attempt
+    /// sends byte-identical content.
+    pub(crate) fn stream(&self) -> turborepo_api_client::Result<UploadStream> {
+        match self {
+            ArtifactBody::InMemory(bytes) => Ok(Box::pin(chunked_byte_stream(
+                bytes.clone(),
+                ARTIFACT_CHUNK_BYTES,
+            ))),
+            ArtifactBody::OnDisk(file) => {
+                // `try_clone` hands us an independent handle; seek it to the
+                // start because signing (and any previous attempt) moved the
+                // shared offset.
+                let mut handle = file.try_clone()?;
+                handle.seek(SeekFrom::Start(0))?;
+                let reader = tokio_util::io::ReaderStream::with_capacity(
+                    tokio::fs::File::from_std(handle),
+                    ARTIFACT_CHUNK_BYTES,
+                );
+                Ok(Box::pin(futures::StreamExt::map(reader, |chunk| {
+                    chunk.map_err(turborepo_api_client::Error::from)
+                })))
+            }
+        }
+    }
+}
+
+/// Yields zero-copy `Bytes` slices of `chunk_size` from an already-in-memory
+/// buffer. Each `.slice()` call is O(1) -- it bumps the `Bytes` refcount
+/// rather than copying data.
+fn chunked_byte_stream(
+    buf: bytes::Bytes,
+    chunk_size: usize,
+) -> impl futures::Stream<Item = Result<bytes::Bytes, turborepo_api_client::Error>> {
+    let len = buf.len();
+    futures::stream::unfold((buf, 0usize), move |(buf, offset)| async move {
+        if offset >= len {
+            return None;
+        }
+        let end = (offset + chunk_size).min(len);
+        let chunk = buf.slice(offset..end);
+        Some((Ok(chunk), (buf, end)))
+    })
+}

--- a/crates/turborepo-cache/src/fs.rs
+++ b/crates/turborepo-cache/src/fs.rs
@@ -18,6 +18,10 @@ pub struct FSCache {
     scm_state: LazyScmState,
 }
 
+/// Uniquifies temporary archive names for concurrent installs of distinct
+/// hashes within this process.
+static ARCHIVE_TEMP_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 #[derive(Debug, Deserialize, Serialize)]
 struct CacheMetadata {
     hash: String,
@@ -202,6 +206,70 @@ impl FSCache {
         }))
     }
 
+    /// Records a restore manifest for `files`, which must exist under
+    /// `anchor` (they either already do during a put, or have just been
+    /// restored there during a fetch).
+    fn build_manifest(
+        anchor: &AbsoluteSystemPath,
+        files: &[AnchoredSystemPathBuf],
+    ) -> crate::cache_archive::RestoreManifest {
+        let mut manifest = crate::cache_archive::RestoreManifest::new();
+        for file in files {
+            let source_path = anchor.resolve(file);
+            let unix_path = file.to_unix();
+            if let Ok(m) = source_path.symlink_metadata() {
+                if m.is_file() {
+                    let _ = manifest.record_file(unix_path.as_str().to_owned(), &source_path);
+                } else if m.is_dir() {
+                    manifest.record_dir(unix_path.as_str().to_owned());
+                }
+            }
+        }
+        manifest
+    }
+
+    /// Writes the `-manifest.json` and `-meta.json` sidecars for an installed
+    /// archive.
+    fn write_sidecars(
+        &self,
+        hash: &str,
+        manifest: &crate::cache_archive::RestoreManifest,
+        duration: u64,
+    ) -> Result<(), CacheError> {
+        // Write manifest alongside the archive so the first fetch() can
+        // skip decompression when outputs are still on disk.
+        let manifest_path = self
+            .cache_directory
+            .join_component(&format!("{hash}-manifest.json"));
+        let _ = manifest.write_atomic(&manifest_path);
+
+        // Write metadata file atomically using write-to-temp-then-rename pattern
+        let metadata_path = self
+            .cache_directory
+            .join_component(&format!("{hash}-meta.json"));
+
+        let resolved = self.scm_state.get();
+        let meta = CacheMetadata {
+            hash: hash.to_string(),
+            duration,
+            sha: resolved.and_then(|s| s.sha.clone()),
+            dirty_hash: resolved.and_then(|s| s.dirty_hash.clone()),
+        };
+
+        let meta_json = serde_json::to_string(&meta)
+            .map_err(|e| CacheError::InvalidMetadata(e, Backtrace::capture()))?;
+
+        // Write to temporary file then atomically rename
+        let temp_metadata_path = self
+            .cache_directory
+            .join_component(&format!(".{hash}-meta.json.{}.tmp", std::process::id()));
+
+        temp_metadata_path.create_with_contents(&meta_json)?;
+        temp_metadata_path.rename(&metadata_path)?;
+
+        Ok(())
+    }
+
     #[tracing::instrument(skip_all)]
     pub fn put(
         &self,
@@ -234,36 +302,50 @@ impl FSCache {
         // Finish the archive (performs atomic rename from temp to final path)
         cache_item.finish()?;
 
-        // Write manifest alongside the archive so the first fetch() can
-        // skip decompression when outputs are still on disk.
-        let manifest_path = self
+        self.write_sidecars(hash, &manifest, duration)?;
+
+        Ok(())
+    }
+
+    /// Atomically installs an already-built compressed archive, avoiding a
+    /// second read/compress pass when the same artifact has another
+    /// destination (a remote write or a verified remote download).
+    ///
+    /// `files` must already exist under `anchor` so the restore manifest can
+    /// be recorded from their current metadata.
+    #[tracing::instrument(skip_all)]
+    pub(crate) fn put_archive(
+        &self,
+        anchor: &AbsoluteSystemPath,
+        hash: &str,
+        files: &[AnchoredSystemPathBuf],
+        archive: &crate::artifact_body::ArtifactBody,
+        duration: u64,
+    ) -> Result<(), CacheError> {
+        let cache_path = self
             .cache_directory
-            .join_component(&format!("{hash}-manifest.json"));
-        let _ = manifest.write_atomic(&manifest_path);
+            .join_component(&format!("{hash}.tar.zst"));
 
-        // Write metadata file atomically using write-to-temp-then-rename pattern
-        let metadata_path = self
-            .cache_directory
-            .join_component(&format!("{hash}-meta.json"));
+        // Write to a temporary sibling and atomically rename, matching the
+        // publication semantics of CacheWriter::create.
+        let temp_path = self.cache_directory.join_component(&format!(
+            ".{hash}.tar.zst.{}.{}.tmp",
+            std::process::id(),
+            ARCHIVE_TEMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        ));
+        {
+            let file = temp_path.create()?;
+            // Match the 1 MiB flush granularity of CacheWriter::create so the
+            // copy does not turn into per-8-KiB write syscalls.
+            let mut buffered = std::io::BufWriter::with_capacity(2usize.pow(20), file);
+            archive.copy_to(&mut buffered)?;
+            // Flush explicitly; BufWriter's Drop would ignore the error.
+            std::io::Write::flush(&mut buffered)?;
+        }
+        temp_path.rename(&cache_path)?;
 
-        let resolved = self.scm_state.get();
-        let meta = CacheMetadata {
-            hash: hash.to_string(),
-            duration,
-            sha: resolved.and_then(|s| s.sha.clone()),
-            dirty_hash: resolved.and_then(|s| s.dirty_hash.clone()),
-        };
-
-        let meta_json = serde_json::to_string(&meta)
-            .map_err(|e| CacheError::InvalidMetadata(e, Backtrace::capture()))?;
-
-        // Write to temporary file then atomically rename
-        let temp_metadata_path = self
-            .cache_directory
-            .join_component(&format!(".{hash}-meta.json.{}.tmp", std::process::id()));
-
-        temp_metadata_path.create_with_contents(&meta_json)?;
-        temp_metadata_path.rename(&metadata_path)?;
+        let manifest = Self::build_manifest(anchor, files);
+        self.write_sidecars(hash, &manifest, duration)?;
 
         Ok(())
     }

--- a/crates/turborepo-cache/src/http.rs
+++ b/crates/turborepo-cache/src/http.rs
@@ -2,7 +2,6 @@ use std::{
     backtrace::Backtrace,
     collections::HashMap,
     io::{Read, Seek, SeekFrom, Write},
-    pin::Pin,
     sync::{Arc, Mutex},
 };
 
@@ -17,83 +16,13 @@ use turborepo_types::SecretString;
 
 use crate::{
     CacheError, CacheHitMetadata, CacheOpts, CacheSource, LazyScmState,
-    cache_archive::{CacheReader, CacheWriter},
+    artifact_body::{ARTIFACT_MEMORY_THRESHOLD, ArtifactBody},
+    cache_archive::CacheReader,
     signature_authentication::{ArtifactSignatureAuthenticator, SignatureError},
     upload_progress::{UploadProgress, UploadProgressQuery},
 };
 
 pub type UploadMap = HashMap<String, UploadProgressQuery<10, 100>>;
-
-/// Artifacts smaller than this are kept in memory during transfers. Larger
-/// ones roll over to an anonymous temporary file (unlinked on creation where
-/// the platform supports it) so retained payload memory stays bounded no
-/// matter how large the compressed artifact is.
-const ARTIFACT_MEMORY_THRESHOLD: usize = 8 * 1024 * 1024;
-
-/// The compressed artifact body for an upload, shared across attempts so a
-/// retry after a token refresh resends byte-identical content without
-/// rebuilding the archive.
-enum ArtifactBody {
-    /// Small artifact held in memory; retries are a cheap `Bytes` refcount
-    /// bump.
-    InMemory(bytes::Bytes),
-    /// Large artifact spooled to an anonymous temporary file; retries read it
-    /// back from the start through a fresh handle in bounded chunks.
-    OnDisk(std::fs::File),
-}
-
-type UploadStream = Pin<
-    Box<
-        dyn futures::Stream<Item = Result<bytes::Bytes, turborepo_api_client::Error>> + Send + Sync,
-    >,
->;
-
-impl ArtifactBody {
-    fn len(&self) -> usize {
-        match self {
-            ArtifactBody::InMemory(bytes) => bytes.len(),
-            ArtifactBody::OnDisk(file) => {
-                file.metadata().map(|meta| meta.len() as usize).unwrap_or(0)
-            }
-        }
-    }
-
-    fn generate_tag(
-        &self,
-        signer: &ArtifactSignatureAuthenticator,
-        hash: &str,
-    ) -> Result<String, SignatureError> {
-        match self {
-            ArtifactBody::InMemory(bytes) => signer.generate_tag(hash.as_bytes(), bytes),
-            ArtifactBody::OnDisk(file) => {
-                signer.generate_tag_reader(hash.as_bytes(), file, self.len() as u64)
-            }
-        }
-    }
-
-    fn stream(&self) -> turborepo_api_client::Result<UploadStream> {
-        match self {
-            ArtifactBody::InMemory(bytes) => Ok(Box::pin(chunked_byte_stream(
-                bytes.clone(),
-                HTTPCache::UPLOAD_CHUNK_BYTES,
-            ))),
-            ArtifactBody::OnDisk(file) => {
-                // `try_clone` hands us an independent handle; seek it to the
-                // start because signing (and any previous attempt) moved the
-                // shared offset.
-                let mut handle = file.try_clone()?;
-                handle.seek(SeekFrom::Start(0))?;
-                let reader = tokio_util::io::ReaderStream::with_capacity(
-                    tokio::fs::File::from_std(handle),
-                    HTTPCache::UPLOAD_CHUNK_BYTES,
-                );
-                Ok(Box::pin(futures::StreamExt::map(reader, |chunk| {
-                    chunk.map_err(turborepo_api_client::Error::from)
-                })))
-            }
-        }
-    }
-}
 
 fn replace_api_auth_token(api_auth: &mut APIAuth, token: SecretString) -> bool {
     if api_auth.token.expose() == token.expose() {
@@ -247,11 +176,6 @@ impl HTTPCache {
         }
     }
 
-    /// 256 KB upload chunk size. Larger chunks reduce per-chunk overhead
-    /// (mutex locks in UploadProgress, hyper body framing) which improves
-    /// throughput for large artifacts compared to the previous 8 KB default.
-    const UPLOAD_CHUNK_BYTES: usize = 256 * 1024;
-
     #[tracing::instrument(skip_all)]
     pub async fn put(
         &self,
@@ -263,26 +187,20 @@ impl HTTPCache {
         // Spool the compressed artifact: small artifacts stay in memory while
         // large ones roll to an anonymous temporary file, so retained memory
         // is bounded regardless of artifact size.
-        let mut spool = tempfile::spooled_tempfile(ARTIFACT_MEMORY_THRESHOLD);
-        {
-            let mut buffered = std::io::BufWriter::new(&mut spool);
-            self.write(&mut buffered, anchor, files).await?;
-            // BufWriter's Drop ignores flush errors; flush explicitly so a
-            // failed final write cannot be uploaded as a truncated artifact.
-            buffered.flush()?;
-        }
-        spool.seek(SeekFrom::Start(0))?;
+        let body = ArtifactBody::from_files(anchor, files)?;
+        self.put_body(hash, body, duration).await
+    }
 
-        let body = if spool.is_rolled() {
-            let mut file = spool.into_file()?;
-            // Rewind so signing reads the artifact from the start.
-            file.seek(SeekFrom::Start(0))?;
-            ArtifactBody::OnDisk(file)
-        } else {
-            let mut bytes = Vec::new();
-            spool.read_to_end(&mut bytes)?;
-            ArtifactBody::InMemory(bytes::Bytes::from(bytes))
-        };
+    /// Uploads an already-built archive. Shared with the local cache so a
+    /// combined local+remote write builds and compresses the artifact exactly
+    /// once.
+    #[tracing::instrument(skip_all)]
+    pub(crate) async fn put_body(
+        &self,
+        hash: &str,
+        body: ArtifactBody,
+        duration: u64,
+    ) -> Result<(), CacheError> {
         let body = Arc::new(body);
         let body_len = body.len();
 
@@ -344,21 +262,6 @@ impl HTTPCache {
         .await?;
 
         tracing::debug!("uploaded {}", hash);
-        Ok(())
-    }
-
-    #[tracing::instrument(skip_all)]
-    async fn write(
-        &self,
-        writer: impl Write,
-        anchor: &AbsoluteSystemPath,
-        files: &[AnchoredSystemPathBuf],
-    ) -> Result<(), CacheError> {
-        let mut cache_archive = CacheWriter::from_writer(writer, true)?;
-        for file in files {
-            cache_archive.add_file(anchor, file)?;
-        }
-
         Ok(())
     }
 
@@ -438,6 +341,23 @@ impl HTTPCache {
         &self,
         hash: &str,
     ) -> Result<Option<(CacheHitMetadata, Vec<AnchoredSystemPathBuf>)>, CacheError> {
+        Ok(self
+            .fetch_with_archive(hash)
+            .await?
+            .map(|(metadata, files, _body)| (metadata, files)))
+    }
+
+    /// Fetches and restores the artifact, also returning the verified archive
+    /// bytes so a lower-priority local cache can install the exact same bytes
+    /// without re-encoding them. The signature check completes before both
+    /// the restore and the handoff, so a rejected artifact is never restored
+    /// or installed locally.
+    #[tracing::instrument(skip_all)]
+    pub(crate) async fn fetch_with_archive(
+        &self,
+        hash: &str,
+    ) -> Result<Option<(CacheHitMetadata, Vec<AnchoredSystemPathBuf>, ArtifactBody)>, CacheError>
+    {
         let response = self
             .execute_with_token_refresh(hash, |api_auth| {
                 let client = &self.client;
@@ -532,7 +452,8 @@ impl HTTPCache {
         }
 
         spool.seek(SeekFrom::Start(0))?;
-        let files = Self::restore_tar(&self.repo_root, spool)?;
+        let body = ArtifactBody::from_spool(spool)?;
+        let files = Self::restore_tar(&self.repo_root, body.reader()?)?;
 
         self.log_fetch(analytics::CacheEvent::Hit, hash, duration);
         Ok(Some((
@@ -543,6 +464,7 @@ impl HTTPCache {
                 dirty_hash,
             },
             files,
+            body,
         )))
     }
 
@@ -574,24 +496,6 @@ impl HTTPCache {
             e => e.into(),
         }
     }
-}
-
-/// Yields zero-copy `Bytes` slices of `chunk_size` from an already-in-memory
-/// buffer. Each `.slice()` call is O(1) -- it bumps the `Bytes` refcount
-/// rather than copying data.
-fn chunked_byte_stream(
-    buf: bytes::Bytes,
-    chunk_size: usize,
-) -> impl futures::Stream<Item = Result<bytes::Bytes, turborepo_api_client::Error>> {
-    let len = buf.len();
-    futures::stream::unfold((buf, 0usize), move |(buf, offset)| async move {
-        if offset >= len {
-            return None;
-        }
-        let end = (offset + chunk_size).min(len);
-        let chunk = buf.slice(offset..end);
-        Some((Ok(chunk), (buf, end)))
-    })
 }
 
 #[cfg(test)]

--- a/crates/turborepo-cache/src/lib.rs
+++ b/crates/turborepo-cache/src/lib.rs
@@ -10,11 +10,11 @@
 #![allow(unused_assignments)]
 #![deny(clippy::all)]
 
-/// A wrapper for the cache that uses a worker pool to perform cache operations
-mod async_cache;
 /// A compressed artifact body shared between local and remote cache consumers
 /// so archives are built exactly once.
 pub(crate) mod artifact_body;
+/// A wrapper for the cache that uses a worker pool to perform cache operations
+mod async_cache;
 /// The core cache creation and restoration logic.
 pub mod cache_archive;
 pub mod config;

--- a/crates/turborepo-cache/src/lib.rs
+++ b/crates/turborepo-cache/src/lib.rs
@@ -12,6 +12,9 @@
 
 /// A wrapper for the cache that uses a worker pool to perform cache operations
 mod async_cache;
+/// A compressed artifact body shared between local and remote cache consumers
+/// so archives are built exactly once.
+pub(crate) mod artifact_body;
 /// The core cache creation and restoration logic.
 pub mod cache_archive;
 pub mod config;

--- a/crates/turborepo-cache/src/multiplexer.rs
+++ b/crates/turborepo-cache/src/multiplexer.rs
@@ -137,6 +137,32 @@ impl CacheMultiplexer {
         // info. This is a no-op when the state is already resolved.
         self.scm_state.get_resolved().await;
 
+        // When both destinations are written, build and compress the archive
+        // exactly once, then install it locally and upload the same bytes.
+        if self.cache_config.local.write
+            && self.cache_config.remote.write
+            && let Some(fs) = &self.fs
+            && let Some(http) = self.get_http_cache()
+        {
+            let body = crate::artifact_body::ArtifactBody::from_files(anchor, files)?;
+
+            fs.put_archive(anchor, key, files, &body, duration)?;
+            let http_result = http.put_body(key, body, duration).await;
+
+            return match http_result {
+                Err(CacheError::ApiClientError(
+                    box turborepo_api_client::Error::CacheDisabled { .. },
+                    ..,
+                )) => {
+                    warn!("failed to put to http cache: cache disabled");
+                    self.should_use_http_cache.store(false, Ordering::Relaxed);
+                    Ok(())
+                }
+                Err(e) => Err(e),
+                Ok(()) => Ok(()),
+            };
+        }
+
         if self.cache_config.local.write {
             self.fs
                 .as_ref()
@@ -200,19 +226,26 @@ impl CacheMultiplexer {
 
         if self.cache_config.remote.read
             && let Some(http) = self.get_http_cache()
-            && let Ok(Some((hit_metadata, files))) = http.fetch(key).await
         {
-            // Store this into fs cache. We can ignore errors here because we know
-            // we have previously successfully stored in HTTP cache, and so the overall
-            // result is a success at fetching. Storing in lower-priority caches is an
-            // optimization.
+            // When the remote hit is also written to the local cache, install
+            // the verified archive bytes directly instead of restoring and
+            // then re-reading/re-compressing every output file.
             if self.cache_config.local.write
                 && let Some(fs) = &self.fs
             {
-                let _ = fs.put(anchor, key, &files, hit_metadata.time_saved);
+                if let Ok(Some((hit_metadata, files, body))) = http.fetch_with_archive(key).await {
+                    // We can ignore errors here because we know we have
+                    // previously successfully fetched from the HTTP cache, and
+                    // so the overall result is a success. Storing in
+                    // lower-priority caches is an optimization. The archive
+                    // passed signature verification before any restore ran, so
+                    // a rejected download never becomes a local hit.
+                    let _ = fs.put_archive(anchor, key, &files, &body, hit_metadata.time_saved);
+                    return Ok(Some((hit_metadata, files)));
+                }
+            } else if let Ok(Some((hit_metadata, files))) = http.fetch(key).await {
+                return Ok(Some((hit_metadata, files)));
             }
-
-            return Ok(Some((hit_metadata, files)));
         }
 
         Ok(None)
@@ -245,5 +278,177 @@ impl CacheMultiplexer {
         }
 
         Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use anyhow::Result;
+    use tempfile::tempdir;
+    use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
+    use turborepo_api_client::{APIAuth, APIClient};
+    use turborepo_types::SecretString;
+    use turborepo_vercel_api_mock::start_test_server;
+
+    use super::*;
+    use crate::{CacheActions, CacheSource, RemoteCacheOpts};
+
+    fn both_write_opts() -> CacheOpts {
+        CacheOpts {
+            cache_dir: ".turbo/cache".into(),
+            cache: CacheConfig {
+                local: CacheActions {
+                    read: true,
+                    write: true,
+                },
+                remote: CacheActions {
+                    read: true,
+                    write: true,
+                },
+            },
+            workers: 0,
+            remote_cache_opts: Some(RemoteCacheOpts {
+                unused_team_id: Some("my-team".to_string()),
+                signature: false,
+                enforce_signature_key_length: false,
+            }),
+            cache_max_age: None,
+            cache_max_size: None,
+        }
+    }
+
+    fn test_multiplexer(
+        opts: &CacheOpts,
+        repo_root: &AbsoluteSystemPathBuf,
+        port: u16,
+    ) -> CacheMultiplexer {
+        CacheMultiplexer::new(
+            opts,
+            repo_root,
+            Some(
+                APIClient::new(
+                    format!("http://localhost:{port}"),
+                    Some(Duration::from_secs(200)),
+                    None,
+                    "2.0.0",
+                    true,
+                )
+                .unwrap(),
+            ),
+            Some(APIAuth {
+                team_id: Some("my-team".to_string()),
+                token: SecretString::new("my-token".to_string()),
+                team_slug: None,
+            }),
+            None,
+            LazyScmState::resolved(None),
+        )
+        .unwrap()
+    }
+
+    async fn start_mock() -> (u16, tokio::task::JoinHandle<Result<()>>) {
+        let port = port_scanner::request_open_port().unwrap();
+        let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+        let handle = tokio::spawn(start_test_server(port, Some(ready_tx)));
+        tokio::time::timeout(Duration::from_secs(5), ready_rx)
+            .await
+            .expect("test server start timed out")
+            .expect("test server failed to start");
+        (port, handle)
+    }
+
+    async fn remote_bytes(port: u16, hash: &str) -> Vec<u8> {
+        reqwest::get(format!("http://localhost:{port}/v8/artifacts/{hash}"))
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap()
+            .to_vec()
+    }
+
+    /// With local and remote writes both enabled, one canonical archive must
+    /// be built: the bytes installed locally are exactly the bytes uploaded.
+    #[tokio::test]
+    async fn test_put_builds_one_archive_for_local_and_remote() -> Result<()> {
+        let (port, handle) = start_mock().await;
+
+        let repo_root = tempdir()?;
+        let repo_root_path = AbsoluteSystemPathBuf::try_from(repo_root.path())?;
+        let file = AnchoredSystemPathBuf::from_raw("out/output.txt")?;
+        std::fs::create_dir_all(repo_root_path.resolve(&file).parent().unwrap())?;
+        std::fs::write(repo_root_path.resolve(&file), "shared archive contents")?;
+
+        let hash = "shared-put-hash";
+        let cache = test_multiplexer(&both_write_opts(), &repo_root_path, port);
+        cache
+            .put(&repo_root_path, hash, std::slice::from_ref(&file), 42)
+            .await?;
+
+        let local_bytes = std::fs::read(
+            repo_root_path.join_components(&[".turbo", "cache", &format!("{hash}.tar.zst")]),
+        )?;
+        let uploaded = remote_bytes(port, hash).await;
+
+        assert!(!uploaded.is_empty());
+        assert_eq!(
+            local_bytes, uploaded,
+            "local and remote destinations must contain the same archive bytes"
+        );
+
+        handle.abort();
+        Ok(())
+    }
+
+    /// A remote hit with local writes enabled installs the verified remote
+    /// archive bytes locally instead of re-encoding restored files.
+    #[tokio::test]
+    async fn test_fetch_installs_remote_archive_bytes() -> Result<()> {
+        let (port, handle) = start_mock().await;
+
+        let repo_root = tempdir()?;
+        let repo_root_path = AbsoluteSystemPathBuf::try_from(repo_root.path())?;
+        let file = AnchoredSystemPathBuf::from_raw("out/output.txt")?;
+        std::fs::create_dir_all(repo_root_path.resolve(&file).parent().unwrap())?;
+        std::fs::write(repo_root_path.resolve(&file), "fetch install contents")?;
+
+        let hash = "shared-fetch-hash";
+        let cache = test_multiplexer(&both_write_opts(), &repo_root_path, port);
+        cache
+            .put(&repo_root_path, hash, std::slice::from_ref(&file), 42)
+            .await?;
+
+        let uploaded = remote_bytes(port, hash).await;
+
+        // Remove the local archive and the outputs so the fetch must be a
+        // remote hit that restores and re-installs.
+        std::fs::remove_file(
+            repo_root_path.join_components(&[".turbo", "cache", &format!("{hash}.tar.zst")]),
+        )?;
+        std::fs::remove_file(repo_root_path.resolve(&file))?;
+
+        let (metadata, files) = cache
+            .fetch(&repo_root_path, hash)
+            .await?
+            .expect("remote hit expected");
+        assert_eq!(metadata.source, CacheSource::Remote);
+        assert_eq!(files, vec![file.clone()]);
+        assert_eq!(
+            std::fs::read(repo_root_path.resolve(&file))?,
+            b"fetch install contents"
+        );
+
+        let local_bytes = std::fs::read(
+            repo_root_path.join_components(&[".turbo", "cache", &format!("{hash}.tar.zst")]),
+        )?;
+        assert_eq!(
+            local_bytes, uploaded,
+            "locally installed archive must be the downloaded bytes, not a re-encode"
+        );
+
+        handle.abort();
+        Ok(())
     }
 }

--- a/crates/turborepo-cache/src/multiplexer.rs
+++ b/crates/turborepo-cache/src/multiplexer.rs
@@ -387,9 +387,11 @@ mod tests {
             .put(&repo_root_path, hash, std::slice::from_ref(&file), 42)
             .await?;
 
-        let local_bytes = std::fs::read(
-            repo_root_path.join_components(&[".turbo", "cache", &format!("{hash}.tar.zst")]),
-        )?;
+        let local_bytes = std::fs::read(repo_root_path.join_components(&[
+            ".turbo",
+            "cache",
+            &format!("{hash}.tar.zst"),
+        ]))?;
         let uploaded = remote_bytes(port, hash).await;
 
         assert!(!uploaded.is_empty());
@@ -424,9 +426,11 @@ mod tests {
 
         // Remove the local archive and the outputs so the fetch must be a
         // remote hit that restores and re-installs.
-        std::fs::remove_file(
-            repo_root_path.join_components(&[".turbo", "cache", &format!("{hash}.tar.zst")]),
-        )?;
+        std::fs::remove_file(repo_root_path.join_components(&[
+            ".turbo",
+            "cache",
+            &format!("{hash}.tar.zst"),
+        ]))?;
         std::fs::remove_file(repo_root_path.resolve(&file))?;
 
         let (metadata, files) = cache
@@ -440,9 +444,11 @@ mod tests {
             b"fetch install contents"
         );
 
-        let local_bytes = std::fs::read(
-            repo_root_path.join_components(&[".turbo", "cache", &format!("{hash}.tar.zst")]),
-        )?;
+        let local_bytes = std::fs::read(repo_root_path.join_components(&[
+            ".turbo",
+            "cache",
+            &format!("{hash}.tar.zst"),
+        ]))?;
         assert_eq!(
             local_bytes, uploaded,
             "locally installed archive must be the downloaded bytes, not a re-encode"


### PR DESCRIPTION
## Summary

Closes TURBO-5986. Builds on the spooled-artifact transfer work merged in #14011.

With both local and remote cache writes enabled, output files were opened, read, and compressed twice: `FSCache::put` built its own archive while `HTTPCache::put` built a second copy for upload. The fetch direction had the mirror problem: a remote hit restored files and then `FSCache::put` re-read and re-compressed every restored output to populate the local cache.

## Changes

- New shared `ArtifactBody` (in `artifact_body.rs`): the canonical compressed archive, held in memory below 8 MiB and spooled to an anonymous temp file above it. Built once via `ArtifactBody::from_files`; every consumer gets a fresh positioned reader or bounded stream over identical bytes.
- `CacheMultiplexer::put` with local+remote writes now builds the archive once, atomically installs it into the local cache (temp + rename, 1 MiB-buffered copy, same publication semantics as `CacheWriter::create`), and uploads the same bytes. Single-destination paths are unchanged.
- `CacheMultiplexer::fetch` on a remote hit with local writes installs the *downloaded* archive bytes (signature verification gates any restore or local install) instead of re-encoding the restored files. A rejected download can never become a local hit.
- `HTTPCache::put` splits into archive construction and `put_body`; `fetch_with_archive` returns the verified body alongside restored files. Signing is unchanged: the tag covers exactly the uploaded bytes.

## Benchmarks

End-to-end through `AsyncCache` against the repo's mock remote as a separate process; debug build; macOS. Five interleaved runs per scenario (order alternated), medians reported. Harness was temporary and is not committed. Debug-build disk I/O on this machine is noisy; the many-small-files case is the most deterministic and the multi-hundred-MiB case is dominated by page-cache variance, so phase timings from an instrumented run are included for the large case.

| Scenario | Phase | Before | After | Change |
| --- | --- | --- | --- | --- |
| 10,000 × 100 B files | put (local+remote) | 1,980 ms | 916 ms | −54% |
| 10,000 × 100 B files | remote-hit fetch + local install | 2,125 ms | 1,395 ms | −34% |
| 100 × 1 MiB files | put (local+remote) | 207 ms | 148–263 ms (noisy) | ~wash to −29% |
| 100 × 1 MiB files | remote-hit fetch + local install | 254 ms | 197 ms | −22% |
| 1 × 512 MiB file | put (local+remote) | 3,460 ms | 2,498 ms | −28% |
| 1 × 512 MiB file | remote-hit fetch + local install | 4,156–4,530 ms | 3,222–3,672 ms | −14 to −25% |

Instrumented phase breakdown, 512 MiB remote-hit fetch: local archive install (buffered copy of verified bytes) 338–641 ms, replacing a full read + zstd re-encode of restored outputs (~1.1–1.2 s in the same environment). Restore time dominates and is identical in both paths.

## Correctness preserved

- Local publication stays atomic (temp file + rename); metadata/manifest sidecars are written exactly as before.
- Signing still covers exactly the uploaded bytes; retries after token refresh resend byte-identical content.
- New tests: local install and remote upload are byte-identical after a combined put; a remote-hit fetch installs byte-identical archive bytes locally.
- `cargo test -p turborepo-cache`: 159 passed, 0 failed. `cargo clippy -p turborepo-cache`: clean.