### PR TITLE
perf: Move synchronous cache archiving off Tokio runtime workers

### DIFF
--- a/crates/turborepo-cache/src/http.rs
+++ b/crates/turborepo-cache/src/http.rs
@@ -186,9 +186,14 @@ impl HTTPCache {
     ) -> Result<(), CacheError> {
         // Spool the compressed artifact: small artifacts stay in memory while
         // large ones roll to an anonymous temporary file, so retained memory
-        // is bounded regardless of artifact size.
-        let body = ArtifactBody::from_files(anchor, files)?;
-        self.put_body(hash, body, duration).await
+        // is bounded regardless of artifact size. Building it reads and
+        // compresses every output file, so it runs on the blocking pool
+        // rather than occupying a Tokio runtime worker.
+        let anchor = anchor.to_owned();
+        let files = files.to_vec();
+        let body = tokio::task::spawn_blocking(move || ArtifactBody::from_files(&anchor, &files))
+            .await??;
+        self.put_body(hash, Arc::new(body), duration).await
     }
 
     /// Uploads an already-built archive. Shared with the local cache so a
@@ -198,10 +203,9 @@ impl HTTPCache {
     pub(crate) async fn put_body(
         &self,
         hash: &str,
-        body: ArtifactBody,
+        body: Arc<ArtifactBody>,
         duration: u64,
     ) -> Result<(), CacheError> {
-        let body = Arc::new(body);
         let body_len = body.len();
 
         let tag = self
@@ -453,7 +457,13 @@ impl HTTPCache {
 
         spool.seek(SeekFrom::Start(0))?;
         let body = ArtifactBody::from_spool(spool)?;
-        let files = Self::restore_tar(&self.repo_root, body.reader()?)?;
+        // Decompression and extraction are synchronous CPU and filesystem
+        // work; run them on the blocking pool so a large restore does not
+        // occupy a runtime worker.
+        let repo_root = self.repo_root.clone();
+        let reader = body.reader()?;
+        let files =
+            tokio::task::spawn_blocking(move || Self::restore_tar(&repo_root, reader)).await??;
 
         self.log_fetch(analytics::CacheEvent::Hit, hash, duration);
         Ok(Some((

--- a/crates/turborepo-cache/src/lib.rs
+++ b/crates/turborepo-cache/src/lib.rs
@@ -101,6 +101,8 @@ pub enum CacheError {
     MetadataWriteFailure(serde_json::Error, #[backtrace] Backtrace),
     #[error("Unable to perform write as cache is shutting down")]
     CacheShuttingDown,
+    #[error("blocking cache archive task failed to complete: {0}")]
+    BlockingTask(#[from] tokio::task::JoinError),
     #[error("Invalid restore manifest: {0}")]
     InvalidManifest(String),
     #[error("Unable to determine config cache base")]

--- a/crates/turborepo-cache/src/multiplexer.rs
+++ b/crates/turborepo-cache/src/multiplexer.rs
@@ -24,8 +24,8 @@ pub struct CacheMultiplexer {
     // being read-only
     should_print_skipping_remote_put: AtomicBool,
     cache_config: CacheConfig,
-    fs: Option<FSCache>,
-    http: Option<HTTPCache>,
+    fs: Option<Arc<FSCache>>,
+    http: Option<Arc<HTTPCache>>,
     scm_state: LazyScmState,
 }
 
@@ -65,6 +65,7 @@ impl CacheMultiplexer {
                     analytics_recorder.clone(),
                     scm_state.clone(),
                 )
+                .map(Arc::new)
             })
             .transpose()?;
 
@@ -86,14 +87,14 @@ impl CacheMultiplexer {
 
         let http_cache = if use_http_cache {
             match (api_client, api_auth) {
-                (Some(api_client), Some(api_auth)) => Some(HTTPCache::new(
+                (Some(api_client), Some(api_auth)) => Some(Arc::new(HTTPCache::new(
                     api_client,
                     opts,
                     repo_root.to_owned(),
                     api_auth,
                     analytics_recorder.clone(),
                     scm_state.clone(),
-                )?),
+                )?)),
                 _ => None,
             }
         } else {
@@ -112,7 +113,7 @@ impl CacheMultiplexer {
 
     // This is technically a TOCTOU bug, but at worst it'll cause
     // a few extra cache requests.
-    fn get_http_cache(&self) -> Option<&HTTPCache> {
+    fn get_http_cache(&self) -> Option<&Arc<HTTPCache>> {
         if self.should_use_http_cache.load(Ordering::Relaxed) {
             self.http.as_ref()
         } else {
@@ -144,9 +145,28 @@ impl CacheMultiplexer {
             && let Some(fs) = &self.fs
             && let Some(http) = self.get_http_cache()
         {
-            let body = crate::artifact_body::ArtifactBody::from_files(anchor, files)?;
+            // Archive construction reads and compresses every output file;
+            // keep that synchronous work off the Tokio runtime workers.
+            let body = Arc::new({
+                let anchor = anchor.to_owned();
+                let files = files.to_vec();
+                tokio::task::spawn_blocking(move || {
+                    crate::artifact_body::ArtifactBody::from_files(&anchor, &files)
+                })
+                .await??
+            });
 
-            fs.put_archive(anchor, key, files, &body, duration)?;
+            {
+                let fs = fs.clone();
+                let anchor = anchor.to_owned();
+                let key = key.to_owned();
+                let files = files.to_vec();
+                let body = body.clone();
+                tokio::task::spawn_blocking(move || {
+                    fs.put_archive(&anchor, &key, &files, &body, duration)
+                })
+                .await??;
+            }
             let http_result = http.put_body(key, body, duration).await;
 
             return match http_result {
@@ -163,11 +183,16 @@ impl CacheMultiplexer {
             };
         }
 
-        if self.cache_config.local.write {
-            self.fs
-                .as_ref()
-                .map(|fs| fs.put(anchor, key, files, duration))
-                .transpose()?;
+        if self.cache_config.local.write
+            && let Some(fs) = &self.fs
+        {
+            // Synchronous archive I/O + compression belongs on the blocking
+            // pool; the AsyncCache semaphore bounds concurrency.
+            let fs = fs.clone();
+            let anchor = anchor.to_owned();
+            let key = key.to_owned();
+            let files = files.to_vec();
+            tokio::task::spawn_blocking(move || fs.put(&anchor, &key, &files, duration)).await??;
         }
 
         let http_result = match self.get_http_cache() {
@@ -219,9 +244,18 @@ impl CacheMultiplexer {
     ) -> Result<Option<(CacheHitMetadata, Vec<AnchoredSystemPathBuf>)>, CacheError> {
         if self.cache_config.local.read
             && let Some(fs) = &self.fs
-            && let response @ Ok(Some(_)) = fs.fetch(anchor, key)
         {
-            return response;
+            // Local restore (decompression + extraction) is synchronous; keep
+            // it off the runtime workers.
+            let fs = fs.clone();
+            let anchor = anchor.to_owned();
+            let key = key.to_owned();
+            let response = tokio::task::spawn_blocking(move || fs.fetch(&anchor, &key)).await?;
+            if let response @ Ok(Some(_)) = response {
+                return response;
+            }
+            // Ok(None) or Err: fall through to the remote cache, matching
+            // previous behavior.
         }
 
         if self.cache_config.remote.read
@@ -240,7 +274,16 @@ impl CacheMultiplexer {
                     // lower-priority caches is an optimization. The archive
                     // passed signature verification before any restore ran, so
                     // a rejected download never becomes a local hit.
-                    let _ = fs.put_archive(anchor, key, &files, &body, hit_metadata.time_saved);
+                    let _ = {
+                        let fs = fs.clone();
+                        let anchor = anchor.to_owned();
+                        let key = key.to_owned();
+                        let files = files.clone();
+                        tokio::task::spawn_blocking(move || {
+                            fs.put_archive(&anchor, &key, &files, &body, hit_metadata.time_saved)
+                        })
+                        .await
+                    };
                     return Ok(Some((hit_metadata, files)));
                 }
             } else if let Ok(Some((hit_metadata, files))) = http.fetch(key).await {


### PR DESCRIPTION
## Summary

Closes TURBO-6051.

`AsyncCache` spawned ordinary Tokio tasks whose `CacheMultiplexer::put` ran synchronous archive I/O and zstd compression inline: `FSCache::put` is fully synchronous, and the HTTP path's archive construction was synchronous inside an `async` fn. Large artifacts occupying runtime workers starved unrelated process/output/network/timer work. Restores had the same problem on the fetch path, which runs inline on the calling task rather than on the cache worker pool.

## Changes

- `CacheMultiplexer::put` / `fetch`: local-cache reads, writes, restores, and shared-archive installs now run inside `tokio::task::spawn_blocking` (sub-caches are `Arc`-shared). Local fetch errors still fall through to the remote cache exactly as before.
- `HTTPCache::put`: artifact body construction (read + compress + spool, shared with #14012 as `ArtifactBody::from_files`) runs on the blocking pool; the upload itself stays async. The combined local+remote write path in the multiplexer builds the shared archive on the blocking pool as well.
- `HTTPCache::fetch` / `fetch_with_archive`: tar extraction runs on the blocking pool; the verified spool is dropped (and its temp file cleaned up) there.

Concurrency bounds are unchanged: the existing `AsyncCache` worker semaphore still limits concurrent cache jobs, so blocking-pool fanout stays bounded by the configured cache workers on the write path. Error propagation and shutdown draining (workers are awaited to completion) are preserved; join failures surface as a new `CacheError::BlockingTask` variant.

## Benchmarks

4 concurrent 64 MiB incompressible artifact puts (local + remote) against the repo's mock server as a separate process, while a 5 ms heartbeat task ticks on the same runtime. Debug build, macOS. Temporary harness, not committed.

| Tokio runtime workers | Before: total / worst heartbeat gap | After: total / worst heartbeat gap |
| --- | --- | --- |
| 1 | 2.26 s / **1.1 s** | 1.35 s / **6.3 ms** |
| 2 | 2.33 s / **1.4 s** | 1.38 s / **6.1 ms** |
| 8 | 2.72 s / 6.1 ms | 1.30 s / 6.1 ms |

Before: with 1–2 workers the heartbeat stalled for over a second (5 ms target cadence). After: worst gap stays at ~6 ms regardless of worker count, and total cache-save time improves even at 8 workers (archiving no longer competes with upload progress/runtime work).

## Verification

- `cargo test -p turborepo-cache`: 159 passed, 0 failed (includes the worker/shutdown draining tests in `async_cache.rs` and the shared-archive round-trips from #14012).
- `cargo clippy -p turborepo-cache --all-targets`: clean.
- Rebased onto `main` after #14012 merged; conflicts resolved by composing the two changes (shared `ArtifactBody` + blocking-pool execution).