### PR TITLE
perf: Share source text across boundaries diagnostics instead of copying it per error

### DIFF
--- a/crates/turborepo-boundaries/src/imports.rs
+++ b/crates/turborepo-boundaries/src/imports.rs
@@ -1,4 +1,7 @@
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use camino::Utf8Path;
 use miette::{NamedSource, SourceSpan};
@@ -74,7 +77,7 @@ fn check_import_as_tsconfig_path_alias(
     package_root: &AbsoluteSystemPath,
     span: SourceSpan,
     file_path: &AbsoluteSystemPath,
-    file_content: &str,
+    file_content: &Arc<str>,
     import: &str,
 ) -> Result<(bool, Option<BoundariesDiagnostic>), Error> {
     // Safety guard — relative imports are resolved as file imports elsewhere.
@@ -177,7 +180,7 @@ pub(crate) fn check_import(
     span: &Span,
     statement_span: &Span,
     file_path: &AbsoluteSystemPath,
-    file_content: &str,
+    file_content: &Arc<str>,
     dependency_locations: DependencyLocations<'_>,
     resolver: &Resolver,
 ) -> Result<(), Error> {
@@ -274,7 +277,7 @@ pub(crate) fn check_file_import(
     import: &str,
     resolved_import_path: &AbsoluteSystemPath,
     source_span: SourceSpan,
-    file_content: &str,
+    file_content: &Arc<str>,
 ) -> Result<Option<BoundariesDiagnostic>, Error> {
     // We have to check for this case because `relation_to_path` returns `Parent` if
     // the paths are equal and there's nothing wrong with importing the
@@ -310,7 +313,7 @@ pub(crate) fn check_file_import(
             resolved_import_path,
             package_name: package_name.to_owned(),
             span: source_span,
-            text: NamedSource::new(file_path.as_str(), file_content.to_string()),
+            text: NamedSource::new(file_path.as_str(), file_content.clone()),
         }))
     } else {
         Ok(None)
@@ -365,7 +368,7 @@ pub(crate) fn check_package_import(
     import_type: ImportType,
     span: SourceSpan,
     file_path: &AbsoluteSystemPath,
-    file_content: &str,
+    file_content: &Arc<str>,
     dependency_locations: DependencyLocations<'_>,
     resolver: &Resolver,
 ) -> Option<BoundariesDiagnostic> {
@@ -376,7 +379,7 @@ pub(crate) fn check_package_import(
             path: file_path.to_owned(),
             import: import.to_string(),
             span,
-            text: NamedSource::new(file_path.as_str(), file_content.to_string()),
+            text: NamedSource::new(file_path.as_str(), file_content.clone()),
         });
     }
     let package_node = PackageNode::Workspace(PackageName::Other(package_name.to_string()));
@@ -403,7 +406,7 @@ pub(crate) fn check_package_import(
                     path: file_path.to_owned(),
                     import: import.to_string(),
                     span,
-                    text: NamedSource::new(file_path.as_str(), file_content.to_string()),
+                    text: NamedSource::new(file_path.as_str(), file_content.clone()),
                 }),
             };
         }
@@ -412,7 +415,7 @@ pub(crate) fn check_package_import(
             path: file_path.to_owned(),
             name: package_node.to_string(),
             span,
-            text: NamedSource::new(file_path.as_str(), file_content.to_string()),
+            text: NamedSource::new(file_path.as_str(), file_content.clone()),
         });
     }
 
@@ -516,11 +519,17 @@ mod test {
 
     fn make_tsconfig_alias_test_args(
         import: &str,
-    ) -> (Resolver, PackageName, SourceSpan, String, BoundariesResult) {
+    ) -> (
+        Resolver,
+        PackageName,
+        SourceSpan,
+        Arc<str>,
+        BoundariesResult,
+    ) {
         let resolver = Tracer::create_resolver(None);
         let package_name = PackageName::from("test-pkg");
         let span = SourceSpan::new(0.into(), 0);
-        let file_content = format!("import {{ x }} from \"{import}\";");
+        let file_content: Arc<str> = format!("import {{ x }} from \"{import}\";").into();
         let result = BoundariesResult::default();
         (resolver, package_name, span, file_content, result)
     }
@@ -541,7 +550,7 @@ mod test {
         let tmp = tempfile::tempdir().unwrap();
         let package_root = AbsoluteSystemPath::new(tmp.path().to_str().unwrap()).unwrap();
         let file_path = package_root.join_component("index.ts");
-        std::fs::write(file_path.as_std_path(), &file_content).unwrap();
+        std::fs::write(file_path.as_std_path(), &file_content.as_bytes()).unwrap();
 
         let (resolved, diag) = check_import_as_tsconfig_path_alias(
             &resolver,
@@ -570,7 +579,7 @@ mod test {
         let tmp = tempfile::tempdir().unwrap();
         let package_root = AbsoluteSystemPath::new(tmp.path().to_str().unwrap()).unwrap();
         let file_path = package_root.join_component("index.ts");
-        std::fs::write(file_path.as_std_path(), &file_content).unwrap();
+        std::fs::write(file_path.as_std_path(), &file_content.as_bytes()).unwrap();
 
         let (resolved, diag) = check_import_as_tsconfig_path_alias(
             &resolver,
@@ -595,8 +604,8 @@ mod test {
         let tmp = tempfile::tempdir().unwrap();
         let root = AbsoluteSystemPath::new(tmp.path().to_str().unwrap()).unwrap();
         let file_path = root.join_component("index.ts");
-        let file_content = "import { $, which } from \"bun\";";
-        std::fs::write(file_path.as_std_path(), file_content).unwrap();
+        let file_content: Arc<str> = "import { $, which } from \"bun\";".into();
+        std::fs::write(file_path.as_std_path(), file_content.as_bytes()).unwrap();
 
         let resolver = Tracer::create_resolver(None);
         let package_name = PackageName::from("my-app");
@@ -628,7 +637,7 @@ mod test {
             ImportType::Value,
             span,
             &file_path,
-            file_content,
+            &file_content,
             dependency_locations,
             &resolver,
         );
@@ -644,8 +653,8 @@ mod test {
         let tmp = tempfile::tempdir().unwrap();
         let root = AbsoluteSystemPath::new(tmp.path().to_str().unwrap()).unwrap();
         let file_path = root.join_component("extension.ts");
-        let file_content = "import { window, commands } from \"vscode\";";
-        std::fs::write(file_path.as_std_path(), file_content).unwrap();
+        let file_content: Arc<str> = "import { window, commands } from \"vscode\";".into();
+        std::fs::write(file_path.as_std_path(), file_content.as_bytes()).unwrap();
 
         let resolver = Tracer::create_resolver(None);
         let package_name = PackageName::from("my-vscode-ext");
@@ -676,7 +685,7 @@ mod test {
             ImportType::Value,
             span,
             &file_path,
-            file_content,
+            &file_content,
             dependency_locations,
             &resolver,
         );
@@ -692,8 +701,8 @@ mod test {
         let tmp = tempfile::tempdir().unwrap();
         let root = AbsoluteSystemPath::new(tmp.path().to_str().unwrap()).unwrap();
         let file_path = root.join_component("index.ts");
-        let file_content = "import { Ship } from \"ship\";";
-        std::fs::write(file_path.as_std_path(), file_content).unwrap();
+        let file_content: Arc<str> = "import { Ship } from \"ship\";".into();
+        std::fs::write(file_path.as_std_path(), file_content.as_bytes()).unwrap();
 
         let resolver = Tracer::create_resolver(None);
         let package_name = PackageName::from("my-app");
@@ -725,7 +734,7 @@ mod test {
             ImportType::Value,
             span,
             &file_path,
-            file_content,
+            &file_content,
             dependency_locations,
             &resolver,
         );
@@ -758,8 +767,8 @@ mod test {
         std::fs::write(root.join("utils").join("helper.ts"), "export const x = 1;").unwrap();
 
         // Create the source file
-        let file_content = "import { x } from \"@/utils/helper\";";
-        std::fs::write(root.join("index.ts"), file_content).unwrap();
+        let file_content: Arc<str> = "import { x } from \"@/utils/helper\";".into();
+        std::fs::write(root.join("index.ts"), file_content.as_bytes()).unwrap();
 
         let package_root = AbsoluteSystemPath::new(root.to_str().unwrap()).unwrap();
         let tsconfig_path = AbsoluteSystemPath::new(tsconfig.to_str().unwrap()).unwrap();
@@ -775,7 +784,7 @@ mod test {
             package_root,
             span,
             &file_path,
-            file_content,
+            &file_content,
             "@/utils/helper",
         )
         .unwrap();
@@ -819,8 +828,8 @@ mod test {
         .unwrap();
 
         // Create the source file that imports via the alias
-        let file_content = "import { featureA } from \"features/feature-a\";";
-        std::fs::write(root.join("index.ts"), file_content).unwrap();
+        let file_content: Arc<str> = "import { featureA } from \"features/feature-a\";".into();
+        std::fs::write(root.join("index.ts"), file_content.as_bytes()).unwrap();
 
         let package_root = AbsoluteSystemPath::new(root.to_str().unwrap()).unwrap();
         let tsconfig_path = AbsoluteSystemPath::new(tsconfig.to_str().unwrap()).unwrap();
@@ -836,7 +845,7 @@ mod test {
             package_root,
             span,
             &file_path,
-            file_content,
+            &file_content,
             "features/feature-a",
         )
         .unwrap();
@@ -882,8 +891,8 @@ mod test {
         std::fs::create_dir_all(root.join("utils")).unwrap();
         std::fs::write(root.join("utils").join("helper.ts"), "export const x = 1;").unwrap();
 
-        let file_content = "import { x } from \"@/utils/helper\";";
-        std::fs::write(root.join("index.ts"), file_content).unwrap();
+        let file_content: Arc<str> = "import { x } from \"@/utils/helper\";".into();
+        std::fs::write(root.join("index.ts"), file_content.as_bytes()).unwrap();
 
         let package_root = AbsoluteSystemPath::new(root.to_str().unwrap()).unwrap();
         let tsconfig_path = AbsoluteSystemPath::new(tsconfig.to_str().unwrap()).unwrap();
@@ -899,7 +908,7 @@ mod test {
             package_root,
             span,
             &file_path,
-            file_content,
+            &file_content,
             "@/utils/helper",
         )
         .unwrap();
@@ -946,8 +955,8 @@ mod test {
         )
         .unwrap();
 
-        let file_content = r#"import { x } from "some-pkg";"#;
-        std::fs::write(root.join("index.ts"), file_content).unwrap();
+        let file_content: Arc<str> = r#"import { x } from "some-pkg";"#.into();
+        std::fs::write(root.join("index.ts"), file_content.as_bytes()).unwrap();
 
         let package_root = AbsoluteSystemPath::new(root.to_str().unwrap()).unwrap();
         let tsconfig_path = AbsoluteSystemPath::new(tsconfig.to_str().unwrap()).unwrap();
@@ -963,7 +972,7 @@ mod test {
             package_root,
             span,
             &file_path,
-            file_content,
+            &file_content,
             "some-pkg",
         )
         .unwrap();
@@ -999,8 +1008,8 @@ mod test {
         )
         .unwrap();
 
-        let file_content = r#"import { x } from "@shared/utils";"#;
-        std::fs::write(pkg_dir.join("index.ts"), file_content).unwrap();
+        let file_content: Arc<str> = r#"import { x } from "@shared/utils";"#.into();
+        std::fs::write(pkg_dir.join("index.ts"), file_content.as_bytes()).unwrap();
 
         let package_root = AbsoluteSystemPath::new(pkg_dir.to_str().unwrap()).unwrap();
         let tsconfig_path = AbsoluteSystemPath::new(tsconfig.to_str().unwrap()).unwrap();
@@ -1016,7 +1025,7 @@ mod test {
             package_root,
             span,
             &file_path,
-            file_content,
+            &file_content,
             "@shared/utils",
         )
         .unwrap();
@@ -1054,8 +1063,8 @@ mod test {
             .expect("create target directory");
         std::fs::write(&target_path, "export const x = 1;").expect("write target file");
 
-        let file_content = format!(r#"import {{ x }} from "{import}";"#);
-        std::fs::write(root.join("index.ts"), &file_content).expect("write source file");
+        let file_content: Arc<str> = format!(r#"import {{ x }} from "{import}";"#).into();
+        std::fs::write(root.join("index.ts"), &file_content.as_bytes()).expect("write source file");
 
         let package_root = AbsoluteSystemPath::new(root.to_str().expect("root path is utf-8"))
             .expect("root path is absolute");
@@ -1116,7 +1125,7 @@ mod test {
             "../../../../node_modules/@sveltejs/kit/src/runtime/components/error.svelte",
             &resolved_import_path,
             SourceSpan::new(0.into(), 0),
-            "",
+            &Arc::from(""),
         )
         .expect("check file import");
 
@@ -1146,7 +1155,7 @@ mod test {
             "../docs/utils",
             &resolved_import_path,
             SourceSpan::new(0.into(), 0),
-            "",
+            &Arc::from(""),
         )
         .expect("check file import");
 
@@ -1154,5 +1163,52 @@ mod test {
             matches!(diag, Some(BoundariesDiagnostic::ImportLeavesPackage { .. })),
             "imports resolving outside the package should still be flagged"
         );
+    }
+
+    /// Every diagnostic produced for a file must share the same source
+    /// allocation, so retaining N errors costs one copy of the file, not N.
+    #[test]
+    fn diagnostics_share_file_source() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::new(tmp.path().to_str().unwrap()).unwrap();
+        let file_path = root.join_component("index.ts");
+        let file_content: Arc<str> =
+            "import { a } from \"undeclared-a\"; import { b } from \"undeclared-b\";".into();
+
+        let resolver = Tracer::create_resolver(None);
+        let package_name = PackageName::from("my-app");
+        let package_json = PackageJson::default();
+        let internal_deps = HashSet::new();
+        let implicit_deps = HashMap::new();
+        let global_implicit_deps = HashMap::new();
+        let declarations = declarations(&package_json);
+        let dependency_locations = DependencyLocations {
+            package: &package_name,
+            internal_dependencies: &internal_deps,
+            external_declarations: PackageExternalDeclarations::new(&declarations, "my-app"),
+            implicit_dependencies: &implicit_deps,
+            global_implicit_dependencies: &global_implicit_deps,
+        };
+
+        let mut sources = Vec::new();
+        for import in ["undeclared-a", "undeclared-b"] {
+            if let Some(diag) = check_package_import(
+                import,
+                ImportType::Value,
+                SourceSpan::new(0.into(), 0),
+                &file_path,
+                &file_content,
+                dependency_locations,
+                &resolver,
+            ) {
+                let BoundariesDiagnostic::PackageNotFound { text, .. } = diag else {
+                    panic!("expected PackageNotFound");
+                };
+                sources.push(text);
+            }
+        }
+
+        assert_eq!(sources.len(), 2);
+        assert!(Arc::ptr_eq(sources[0].inner(), sources[1].inner()));
     }
 }

--- a/crates/turborepo-boundaries/src/imports.rs
+++ b/crates/turborepo-boundaries/src/imports.rs
@@ -550,7 +550,7 @@ mod test {
         let tmp = tempfile::tempdir().unwrap();
         let package_root = AbsoluteSystemPath::new(tmp.path().to_str().unwrap()).unwrap();
         let file_path = package_root.join_component("index.ts");
-        std::fs::write(file_path.as_std_path(), &file_content.as_bytes()).unwrap();
+        std::fs::write(file_path.as_std_path(), file_content.as_bytes()).unwrap();
 
         let (resolved, diag) = check_import_as_tsconfig_path_alias(
             &resolver,
@@ -579,7 +579,7 @@ mod test {
         let tmp = tempfile::tempdir().unwrap();
         let package_root = AbsoluteSystemPath::new(tmp.path().to_str().unwrap()).unwrap();
         let file_path = package_root.join_component("index.ts");
-        std::fs::write(file_path.as_std_path(), &file_content.as_bytes()).unwrap();
+        std::fs::write(file_path.as_std_path(), file_content.as_bytes()).unwrap();
 
         let (resolved, diag) = check_import_as_tsconfig_path_alias(
             &resolver,
@@ -1064,7 +1064,7 @@ mod test {
         std::fs::write(&target_path, "export const x = 1;").expect("write target file");
 
         let file_content: Arc<str> = format!(r#"import {{ x }} from "{import}";"#).into();
-        std::fs::write(root.join("index.ts"), &file_content.as_bytes()).expect("write source file");
+        std::fs::write(root.join("index.ts"), file_content.as_bytes()).expect("write source file");
 
         let package_root = AbsoluteSystemPath::new(root.to_str().expect("root path is utf-8"))
             .expect("root path is absolute");

--- a/crates/turborepo-boundaries/src/lib.rs
+++ b/crates/turborepo-boundaries/src/lib.rs
@@ -10,6 +10,7 @@ use std::{
     collections::{BTreeMap, HashMap, HashSet},
     fs::OpenOptions,
     io::Write,
+    sync::Arc,
 };
 
 pub use config::{BoundariesConfig, Permissions, Rule, RulesMap};
@@ -128,6 +129,16 @@ pub struct BoundariesContext<'a, G: PackageGraphProvider, T: TurboJsonProvider> 
     pub filtered_pkgs: &'a HashSet<PackageName>,
 }
 
+/// Converts an owned `String`-backed source (produced by
+/// `Spanned::span_and_text` for configuration files) into the shared
+/// `Arc<str>`-backed representation used by all diagnostics, so retaining N
+/// diagnostics never retains N copies of the text.
+pub(crate) fn into_shared_source(source: NamedSource<String>) -> NamedSource<Arc<str>> {
+    let name = source.name().to_string();
+    let text: Arc<str> = source.inner().as_str().into();
+    NamedSource::new(name, text)
+}
+
 #[derive(Clone, Debug, Error, Diagnostic)]
 pub enum SecondaryDiagnostic {
     #[error("package `{package} is defined here")]
@@ -136,21 +147,21 @@ pub enum SecondaryDiagnostic {
         #[label]
         package_span: Option<SourceSpan>,
         #[source_code]
-        package_text: NamedSource<String>,
+        package_text: NamedSource<Arc<str>>,
     },
     #[error("consider adding one of the following tags listed here")]
     Allowlist {
         #[label]
         span: Option<SourceSpan>,
         #[source_code]
-        text: NamedSource<String>,
+        text: NamedSource<Arc<str>>,
     },
     #[error("denylist defined here")]
     Denylist {
         #[label]
         span: Option<SourceSpan>,
         #[source_code]
-        text: NamedSource<String>,
+        text: NamedSource<Arc<str>>,
     },
 }
 
@@ -161,7 +172,7 @@ pub enum BoundariesDiagnostic {
         #[label("tags defined here")]
         span: Option<SourceSpan>,
         #[source_code]
-        text: NamedSource<String>,
+        text: NamedSource<Arc<str>>,
     },
     #[error("Tag `{tag}` cannot share the same name as package `{package}`")]
     TagSharesPackageName {
@@ -170,7 +181,7 @@ pub enum BoundariesDiagnostic {
         #[label("tag defined here")]
         tag_span: Option<SourceSpan>,
         #[source_code]
-        tag_text: NamedSource<String>,
+        tag_text: NamedSource<Arc<str>>,
         #[related]
         secondary: [SecondaryDiagnostic; 1],
     },
@@ -190,7 +201,7 @@ pub enum BoundariesDiagnostic {
         #[help]
         help: Option<String>,
         #[source_code]
-        text: NamedSource<String>,
+        text: NamedSource<Arc<str>>,
         #[related]
         secondary: [SecondaryDiagnostic; 1],
     },
@@ -205,7 +216,7 @@ pub enum BoundariesDiagnostic {
         #[label("tag found here")]
         span: Option<SourceSpan>,
         #[source_code]
-        text: NamedSource<String>,
+        text: NamedSource<Arc<str>>,
         #[related]
         secondary: [SecondaryDiagnostic; 1],
     },
@@ -220,7 +231,7 @@ pub enum BoundariesDiagnostic {
         #[label("package imported here")]
         span: SourceSpan,
         #[source_code]
-        text: NamedSource<String>,
+        text: NamedSource<Arc<str>>,
     },
     #[error("cannot import package `{name}` because it is not a dependency")]
     PackageNotFound {
@@ -229,7 +240,7 @@ pub enum BoundariesDiagnostic {
         #[label("package imported here")]
         span: SourceSpan,
         #[source_code]
-        text: NamedSource<String>,
+        text: NamedSource<Arc<str>>,
     },
     #[error("import `{import}` leaves the package")]
     #[diagnostic(help(
@@ -243,7 +254,7 @@ pub enum BoundariesDiagnostic {
         #[label("file imported here")]
         span: SourceSpan,
         #[source_code]
-        text: NamedSource<String>,
+        text: NamedSource<Arc<str>>,
     },
     #[error("failed to parse file {0}: {1}")]
     ParseError(AbsoluteSystemPathBuf, String),
@@ -784,9 +795,14 @@ impl BoundariesChecker {
         dependency_locations: DependencyLocations<'_>,
         resolver: &Resolver,
     ) -> Result<(Vec<BoundariesDiagnostic>, Vec<String>), Error> {
-        let file_content = file_path
+        // Read the file once and share it across every diagnostic it
+        // produces. Each emitted error keeps an Arc clone instead of a fresh
+        // copy of the whole source, so retained memory scales with the file
+        // size rather than file size times error count.
+        let file_content: Arc<str> = file_path
             .read_to_string()
-            .map_err(|_| Error::FileNotFound(file_path.to_owned()))?;
+            .map_err(|_| Error::FileNotFound(file_path.to_owned()))?
+            .into();
 
         let (imports, comments) = match parse_with_comments(file_path, &file_content) {
             Some(result) => result,

--- a/crates/turborepo-boundaries/src/tags.rs
+++ b/crates/turborepo-boundaries/src/tags.rs
@@ -1,4 +1,7 @@
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use miette::NamedSource;
 use tracing::info_span;
@@ -80,9 +83,13 @@ where
     {
         let (span, text) = package_name_source
             .map(|name| name.span_and_text("package.json"))
-            .unwrap_or_else(|| (None, NamedSource::new("package.json", String::new())));
+            .map(|(span, text)| (span, crate::into_shared_source(text)))
+            .unwrap_or_else(|| (None, NamedSource::new("package.json", Arc::from(""))));
         let deny_list_spanned = deny_list.to(());
-        let (deny_list_span, deny_list_text) = deny_list_spanned.span_and_text("turbo.json");
+        let (deny_list_span, deny_list_text) = {
+            let (span, text) = deny_list_spanned.span_and_text("turbo.json");
+            (span, crate::into_shared_source(text))
+        };
 
         return Ok(Some(BoundariesDiagnostic::DeniedTag {
             source_package_name: package_name.clone(),
@@ -107,9 +114,15 @@ where
         if let Some(deny_list) = deny_list
             && deny_list.contains(tag.as_inner())
         {
-            let (span, text) = tag.span_and_text("turbo.json");
+            let (span, text) = {
+                let (span, text) = tag.span_and_text("turbo.json");
+                (span, crate::into_shared_source(text))
+            };
             let deny_list_spanned = deny_list.to(());
-            let (deny_list_span, deny_list_text) = deny_list_spanned.span_and_text("turbo.json");
+            let (deny_list_span, deny_list_text) = {
+                let (span, text) = deny_list_spanned.span_and_text("turbo.json");
+                (span, crate::into_shared_source(text))
+            };
 
             return Ok(Some(BoundariesDiagnostic::DeniedTag {
                 source_package_name: package_name.clone(),
@@ -126,7 +139,10 @@ where
     }
 
     if !has_tag_in_allowlist {
-        let (span, text) = tags_span.span_and_text("turbo.json");
+        let (span, text) = {
+            let (span, text) = tags_span.span_and_text("turbo.json");
+            (span, crate::into_shared_source(text))
+        };
         let help = span.is_none().then(|| {
             format!("`{relation_package_name}` doesn't any tags defined in its `turbo.json` file")
         });
@@ -134,7 +150,10 @@ where
         let allow_list_spanned = allow_list
             .map(|allow_list| allow_list.to(()))
             .unwrap_or_default();
-        let (allow_list_span, allow_list_text) = allow_list_spanned.span_and_text("turbo.json");
+        let (allow_list_span, allow_list_text) = {
+            let (span, text) = allow_list_spanned.span_and_text("turbo.json");
+            (span, crate::into_shared_source(text))
+        };
 
         return Ok(Some(BoundariesDiagnostic::NoTagInAllowlist {
             source_package_name: package_name.clone(),
@@ -223,10 +242,14 @@ fn check_if_package_name_is_tag(
     package_name_source: Option<&Spanned<()>>,
 ) -> Option<BoundariesDiagnostic> {
     let rule = tags_rules.get(pkg.as_package_name().as_str())?;
-    let (tag_span, tag_text) = rule.span.span_and_text("turbo.json");
+    let (tag_span, tag_text) = {
+        let (span, text) = rule.span.span_and_text("turbo.json");
+        (span, crate::into_shared_source(text))
+    };
     let (package_span, package_text) = package_name_source
         .map(|name| name.span_and_text("package.json"))
-        .unwrap_or_else(|| (None, NamedSource::new("package.json", "".into())));
+        .map(|(span, text)| (span, crate::into_shared_source(text)))
+        .unwrap_or_else(|| (None, NamedSource::new("package.json", Arc::from(""))));
     Some(BoundariesDiagnostic::TagSharesPackageName {
         tag: pkg.as_package_name().to_string(),
         package: pkg.as_package_name().to_string(),
@@ -362,7 +385,10 @@ where
 
     if let Some(boundaries) = package_boundaries {
         if let Some(tags) = &boundaries.tags {
-            let (span, text) = tags.span_and_text("turbo.json");
+            let (span, text) = {
+                let (span, text) = tags.span_and_text("turbo.json");
+                (span, crate::into_shared_source(text))
+            };
             diagnostics.push(BoundariesDiagnostic::PackageBoundariesHasTags { span, text });
         }
         let dependencies = boundaries


### PR DESCRIPTION
## Summary

Closes TURBO-6050.

Every invalid-import diagnostic owned a fresh copy of the complete source file via `NamedSource::new(path, file_content.to_string())`. `process_file` accumulates all diagnostics for a file and package/repository results retain them until emission, so E errors in an S-byte file retained O(E × S) source bytes — broad dependency migrations or generated files could turn a small input into hundreds of MB.

## Changes

- All boundaries diagnostic structs now hold `NamedSource<Arc<str>>` (miette implements `SourceCode` for `Arc<T: SourceCode>`, so rendering is identical).
- `process_file` reads the file once into an `Arc<str>`; every diagnostic from that file keeps an `Arc` clone. Retained source memory is O(S) per file regardless of error count.
- The four import-check entry points (`check_import`, `check_file_import`, `check_package_import`, `check_import_as_tsconfig_path_alias`) take the shared source instead of copying it per error.
- Configuration-file sources produced by `Spanned::span_and_text` (package.json / turbo.json texts, owned `String`) are converted once at construction via `into_shared_source` — that helper stays in this crate, so the shared `turborepo-errors` API and other crates' diagnostics are untouched.
- New regression test: two diagnostics from one file must share the same `Arc` allocation (`Arc::ptr_eq`).

## Benchmarks

2,000 undeclared imports in one 173,780-byte source file, all diagnostics retained (the `process_file` accumulation scenario). Peak RSS of the test process, macOS `/usr/bin/time -l`, single test thread. Harness was temporary and is not committed.

| Metric | Before | After | Change |
| --- | --- | --- | --- |
| Peak RSS, 2,000 retained diagnostics | 367,673,344 B (350.7 MiB) | 7,045,120 B (6.7 MiB) | −98.1% |
| Retained source bytes (structural) | 2,000 × 173,780 B = 347.6 MB | 173,780 B (one shared allocation) | −99.95% |

## Verification

- `cargo test -p turborepo-boundaries`: 73 passed, 0 failed.
- `cargo test -p turbo --test boundaries`: 4 passed, 0 failed (end-to-end CLI output unchanged).
- `cargo clippy -p turborepo-boundaries`: clean.