### PR TITLE
perf: Make VS Code binary discovery and LSP probes nonblocking

### DIFF
--- a/packages/turbo-vsc/src/extension.ts
+++ b/packages/turbo-vsc/src/extension.ts
@@ -9,7 +9,6 @@ import {
   env
 } from "vscode";
 import * as cp from "node:child_process";
-import * as path from "node:path";
 import * as fs from "node:fs";
 
 import {
@@ -19,6 +18,11 @@ import {
 } from "vscode-languageclient/node";
 
 import { createTurboDaemonArgs } from "./turbo-daemon-command";
+import {
+  findInstalledTurboLsp,
+  findTurbo,
+  resolveTurboPath
+} from "./turbo-discovery";
 import {
   createTurboRunTerminalOptions,
   sanitizeTurboRunTaskName
@@ -30,10 +34,6 @@ let toolbar: StatusBarItem;
 
 const logs = window.createOutputChannel("Turborepo Extension");
 
-type InternalLspProbeResult =
-  | { supported: true }
-  | { supported: false; reason: string };
-
 export function activate(context: ExtensionContext) {
   if (!workspace.isTrusted) {
     window.showWarningMessage(
@@ -44,17 +44,26 @@ export function activate(context: ExtensionContext) {
 
   const workspaceRoot = workspace.workspaceFolders?.[0]?.uri.fsPath;
   const options: cp.ExecFileOptions = { cwd: workspaceRoot };
-  const syncOptions: cp.ExecSyncOptionsWithStringEncoding = {
-    cwd: workspaceRoot,
-    encoding: "utf8"
-  };
 
   const turboSettings = workspace.getConfiguration("turbo");
   const configuredTurboPath: string | undefined = turboSettings.get("path");
   const useLocalTurbo: boolean = turboSettings.get("useLocalTurbo") ?? false;
-  let turboPath = resolveTurboPath(configuredTurboPath, workspaceRoot);
+
+  const log = (message: string) => logs.appendLine(message);
 
   logs.appendLine("starting the turbo extension");
+
+  // Discovery spawns child processes with bounded timeouts; abort any
+  // in-flight probes when the extension deactivates so slow binaries and
+  // package-manager shims are killed instead of lingering.
+  const discoveryAbort = new AbortController();
+  context.subscriptions.push({
+    dispose: () => {
+      discoveryAbort.abort();
+    }
+  });
+
+  let turboPath = resolveTurboPath(configuredTurboPath, workspaceRoot, log);
 
   if (turboPath) {
     logs.appendLine(`using turbo at path ${turboPath}`);
@@ -68,26 +77,43 @@ export function activate(context: ExtensionContext) {
     }`
   ).fsPath;
 
-  const installedTurboLspPath = findInstalledTurboLsp(
+  // The probe runs asynchronously on the extension host's event loop. Command
+  // handlers and LSP startup await the shared promise, so activation never
+  // blocks on slow binaries.
+  const installedTurboLspPromise = findInstalledTurboLsp({
     workspaceRoot,
-    syncOptions,
-    turboPath
-  );
-
-  const daemonCommandPath = installedTurboLspPath ?? packagedLspPath;
+    configuredTurboPath: turboPath,
+    signal: discoveryAbort.signal,
+    log
+  }).catch((err) => {
+    if (!discoveryAbort.signal.aborted) {
+      logs.appendLine(`turbo LSP discovery failed: ${err}`);
+    }
+    return undefined;
+  });
 
   const getTurboPath = async () => {
-    turboPath ??= findTurbo(workspaceRoot, syncOptions);
+    turboPath ??= await findTurbo({
+      workspaceRoot,
+      signal: discoveryAbort.signal,
+      log
+    });
     if (turboPath) {
       return turboPath;
     }
 
     await promptGlobalTurbo(useLocalTurbo);
-    turboPath = findTurbo(workspaceRoot, syncOptions);
+    turboPath = await findTurbo({
+      workspaceRoot,
+      signal: discoveryAbort.signal,
+      log
+    });
     return turboPath;
   };
 
   const getDaemonCommandPath = async () => {
+    const daemonCommandPath =
+      (await installedTurboLspPromise) ?? packagedLspPath;
     if (fs.existsSync(daemonCommandPath)) {
       return daemonCommandPath;
     }
@@ -231,53 +257,60 @@ export function activate(context: ExtensionContext) {
   // If the extension is launched in debug mode then the debug server options are used
   // Otherwise the run options are used
 
-  if (!installedTurboLspPath && !fs.existsSync(packagedLspPath)) {
-    window.showInformationMessage(
-      `The turbo LSP is not yet supported on your platform (${process.platform}-${process.arch})`
-    );
-    return;
-  }
-
-  const serverCommand = installedTurboLspPath ?? packagedLspPath;
-  const serverArgs = installedTurboLspPath ? ["__internal_lsp"] : [];
-
-  logs.appendLine(
-    installedTurboLspPath
-      ? `using installed turbo for LSP at ${installedTurboLspPath}`
-      : `using packaged turbo LSP at ${packagedLspPath}`
-  );
-
-  const serverOptions: ServerOptions = {
-    run: {
-      command: serverCommand,
-      args: serverArgs
-    },
-    debug: {
-      command: serverCommand,
-      args: serverArgs
+  void (async () => {
+    const installedTurboLspPath = await installedTurboLspPromise;
+    if (discoveryAbort.signal.aborted) {
+      return;
     }
-  };
 
-  // Options to control the language client
-  const clientOptions: LanguageClientOptions = {
-    // Register the server for turbo json documents
-    documentSelector: [
-      { scheme: "file", pattern: "**/turbo.json" },
-      { scheme: "file", pattern: "**/turbo.jsonc" },
-      { scheme: "file", pattern: "**/package.json" }
-    ]
-  };
+    if (!installedTurboLspPath && !fs.existsSync(packagedLspPath)) {
+      window.showInformationMessage(
+        `The turbo LSP is not yet supported on your platform (${process.platform}-${process.arch})`
+      );
+      return;
+    }
 
-  // Create the language client and start the client.
-  client = new LanguageClient(
-    "turboLSP",
-    "Turborepo Language Server",
-    serverOptions,
-    clientOptions
-  );
+    const serverCommand = installedTurboLspPath ?? packagedLspPath;
+    const serverArgs = installedTurboLspPath ? ["__internal_lsp"] : [];
 
-  // Start the client. This will also launch the server
-  client.start();
+    logs.appendLine(
+      installedTurboLspPath
+        ? `using installed turbo for LSP at ${installedTurboLspPath}`
+        : `using packaged turbo LSP at ${packagedLspPath}`
+    );
+
+    const serverOptions: ServerOptions = {
+      run: {
+        command: serverCommand,
+        args: serverArgs
+      },
+      debug: {
+        command: serverCommand,
+        args: serverArgs
+      }
+    };
+
+    // Options to control the language client
+    const clientOptions: LanguageClientOptions = {
+      // Register the server for turbo json documents
+      documentSelector: [
+        { scheme: "file", pattern: "**/turbo.json" },
+        { scheme: "file", pattern: "**/turbo.jsonc" },
+        { scheme: "file", pattern: "**/package.json" }
+      ]
+    };
+
+    // Create the language client and start the client.
+    client = new LanguageClient(
+      "turboLSP",
+      "Turborepo Language Server",
+      serverOptions,
+      clientOptions
+    );
+
+    // Start the client. This will also launch the server
+    client.start();
+  })();
 }
 
 export function deactivate(): Thenable<void> | undefined {
@@ -297,181 +330,6 @@ function updateStatusBarItem(running: boolean) {
   toolbar.command = running ? "turbo.daemon.stop" : "turbo.daemon.start";
   toolbar.text = running ? "turbo Running" : "turbo Stopped";
   toolbar.show();
-}
-
-function executableNames(name: string) {
-  return process.platform === "win32"
-    ? [`${name}.exe`, `${name}.cmd`, `${name}`]
-    : [name];
-}
-
-function resolveTurboPath(
-  turboPath: string | undefined,
-  workspaceRoot?: string
-) {
-  if (!turboPath) {
-    return undefined;
-  }
-
-  const resolvedPath = path.isAbsolute(turboPath)
-    ? turboPath
-    : path.resolve(workspaceRoot ?? process.cwd(), turboPath);
-
-  if (!fs.existsSync(resolvedPath)) {
-    logs.appendLine(
-      `Manually specified turbo does not exist at path ${turboPath}`
-    );
-    return undefined;
-  }
-
-  if (fs.statSync(resolvedPath).isDirectory()) {
-    return findTurboInDirectory(resolvedPath);
-  }
-
-  return resolvedPath;
-}
-
-function findTurboInDirectory(directory: string) {
-  for (const executable of executableNames("turbo")) {
-    const candidate = path.join(directory, executable);
-    if (fs.existsSync(candidate) && !fs.statSync(candidate).isDirectory()) {
-      return candidate;
-    }
-  }
-}
-
-function findExecutableOnPath(name: string) {
-  const pathEntries = (process.env.PATH ?? "").split(path.delimiter);
-  for (const pathEntry of pathEntries) {
-    const executable = findTurboInDirectory(pathEntry);
-    if (executable && path.basename(executable).startsWith(name)) {
-      return executable;
-    }
-  }
-}
-
-function findTurbo(
-  workspaceRoot: string | undefined,
-  options: cp.ExecSyncOptionsWithStringEncoding
-) {
-  logs.appendLine("attempting to find turbo");
-  return (
-    findExecutableOnPath("turbo") ?? findLocalTurbo(workspaceRoot, options)
-  );
-}
-
-function findInstalledTurboLsp(
-  workspaceRoot: string | undefined,
-  options: cp.ExecSyncOptionsWithStringEncoding,
-  configuredTurboPath: string | undefined
-) {
-  logs.appendLine("resolving turbo LSP server");
-
-  const candidates = [
-    { label: "configured turbo.path", path: configuredTurboPath },
-    {
-      label: "workspace node_modules/.bin",
-      path: workspaceRoot
-        ? findTurboInDirectory(path.join(workspaceRoot, "node_modules", ".bin"))
-        : undefined
-    },
-    { label: "PATH", path: findExecutableOnPath("turbo") }
-  ];
-
-  for (const candidate of candidates) {
-    if (!candidate.path) {
-      logs.appendLine(`turbo LSP: no candidate from ${candidate.label}`);
-      continue;
-    }
-
-    logs.appendLine(
-      `turbo LSP: probing ${candidate.label} at ${candidate.path}`
-    );
-
-    const probe = probeInternalLsp(candidate.path, options);
-    if (probe.supported) {
-      logs.appendLine(
-        `turbo LSP: using ${candidate.label} at ${candidate.path}`
-      );
-      return candidate.path;
-    }
-
-    logs.appendLine(
-      `turbo LSP: rejected ${candidate.label} at ${candidate.path}: ${probe.reason}`
-    );
-  }
-
-  logs.appendLine(
-    "turbo LSP: no installed turbo candidate supports internal LSP; falling back to packaged LSP binary"
-  );
-}
-
-function probeInternalLsp(
-  turboPath: string,
-  options: cp.ExecSyncOptionsWithStringEncoding
-): InternalLspProbeResult {
-  try {
-    const output = cp
-      .execFileSync(turboPath, ["__internal_lsp", "--probe"], {
-        ...options,
-        stdio: ["ignore", "pipe", "pipe"],
-        timeout: 1000
-      })
-      .trim();
-
-    if (output === "turbo-lsp") {
-      return { supported: true };
-    }
-
-    return { supported: false, reason: formatProbeOutput(output) };
-  } catch (e) {
-    return { supported: false, reason: formatProbeError(e) };
-  }
-}
-
-function formatProbeOutput(output: string) {
-  const line = firstNonEmptyLine(output);
-  return line ? `unexpected probe output: ${line}` : "empty probe output";
-}
-
-function formatProbeError(error: unknown) {
-  const stderr = outputFromError(error, "stderr");
-  if (stderr) {
-    return firstNonEmptyLine(stderr) ?? "probe command failed with stderr";
-  }
-
-  const stdout = outputFromError(error, "stdout");
-  if (stdout) {
-    return `probe command failed with stdout: ${firstNonEmptyLine(stdout)}`;
-  }
-
-  if (error instanceof Error && error.message) {
-    return firstNonEmptyLine(error.message) ?? error.message;
-  }
-
-  return "probe command failed";
-}
-
-function outputFromError(error: unknown, key: "stdout" | "stderr") {
-  if (typeof error !== "object" || error === null || !(key in error)) {
-    return;
-  }
-
-  const output = (error as Record<string, unknown>)[key];
-  if (Buffer.isBuffer(output)) {
-    return output.toString("utf8").trim();
-  }
-
-  if (typeof output === "string") {
-    return output.trim();
-  }
-}
-
-function firstNonEmptyLine(output: string) {
-  return output
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .find(Boolean);
 }
 
 async function promptGlobalTurbo(useLocalTurbo: boolean) {
@@ -505,68 +363,5 @@ async function promptGlobalTurbo(useLocalTurbo: boolean) {
     env.openExternal(Uri.parse("https://turborepo.dev/docs/installing"));
   } else if (answer === "Open Settings") {
     commands.executeCommand("workbench.action.openSettings", "turbo.path");
-  }
-}
-
-function findLocalTurbo(
-  workspaceRoot: string | undefined,
-  options: cp.ExecSyncOptionsWithStringEncoding
-): string | undefined {
-  const checks = [
-    () => {
-      if (workspaceRoot) {
-        logs.appendLine("attempting to find local turbo in node_modules/.bin");
-        return findTurboInDirectory(
-          path.join(workspaceRoot, "node_modules", ".bin")
-        );
-      }
-    },
-    () => {
-      logs.appendLine("attempting to find local turbo using npm");
-      const npmList = cp.execSync("npm ls turbo --json", options);
-      const npmData = JSON.parse(npmList);
-
-      // this is relative to node_modules
-      const packagePath = npmData?.dependencies?.turbo?.resolved;
-
-      const PREFIX = "file:"; // npm ls returns a file: prefix
-
-      if (packagePath?.startsWith(PREFIX)) {
-        const turboPath = path.join(
-          "node_modules",
-          packagePath.slice(PREFIX.length),
-          "bin",
-          "turbo"
-        );
-        return resolveTurboPath(turboPath, workspaceRoot);
-      }
-    },
-    () => {
-      logs.appendLine("attempting to find local turbo using yarn");
-      const turboBin = cp.execSync("yarn bin turbo", options);
-      return resolveTurboPath(turboBin.trim(), workspaceRoot);
-    },
-    () => {
-      logs.appendLine("attempting to find local turbo using pnpm");
-      const binFolder = cp.execSync("pnpm bin", options).trim();
-      return findTurboInDirectory(binFolder);
-    },
-    () => {
-      logs.appendLine("attempting to find local turbo using bun");
-      const binFolder = cp.execSync("bun pm bin", options).trim();
-      return findTurboInDirectory(binFolder);
-    }
-  ];
-
-  for (const potentialPath of checks) {
-    try {
-      const potential = potentialPath()?.trim();
-      if (potential && fs.existsSync(potential)) {
-        logs.appendLine(`found local turbo at ${potential}`);
-        return potential;
-      }
-    } catch (e) {
-      // no-op
-    }
   }
 }

--- a/packages/turbo-vsc/src/turbo-discovery.test.ts
+++ b/packages/turbo-vsc/src/turbo-discovery.test.ts
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import {
+  LSP_PROBE_TIMEOUT_MS,
+  findExecutableInDirectory,
+  findInstalledTurboLsp,
+  probeInternalLsp,
+  resolveTurboPath
+} from "./turbo-discovery";
+
+// These tests spawn real child processes as fake turbo binaries, which
+// requires a POSIX shell. The path helpers are covered platform-agnostically.
+const cannotSpawn = process.platform === "win32";
+
+function makeFakeTurbo(
+  dir: string,
+  behavior: { output?: string; sleepSeconds?: number; logFile?: string }
+): string {
+  fs.mkdirSync(dir, { recursive: true });
+  const turboPath = path.join(dir, "turbo");
+  const lines = ["#!/bin/sh"];
+  if (behavior.logFile) {
+    lines.push(`echo probe >> "${behavior.logFile}"`);
+  }
+  if (behavior.sleepSeconds) {
+    lines.push(`sleep ${behavior.sleepSeconds}`);
+  }
+  if (behavior.output !== undefined) {
+    lines.push(`printf '%s' "${behavior.output}"`);
+  }
+  fs.writeFileSync(turboPath, `${lines.join("\n")}\n`, { mode: 0o755 });
+  return turboPath;
+}
+
+function tmpdir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "turbo-discovery-test-"));
+}
+
+const noopLog = () => {};
+
+test("findExecutableInDirectory finds plain executables only", () => {
+  const dir = tmpdir();
+  assert.equal(findExecutableInDirectory(dir, "turbo"), undefined);
+  const turboPath = path.join(dir, "turbo");
+  fs.writeFileSync(turboPath, "#!/bin/sh\n");
+  assert.equal(findExecutableInDirectory(dir, "turbo"), turboPath);
+  // A directory named turbo is not an executable candidate.
+  const dirOnly = tmpdir();
+  fs.mkdirSync(path.join(dirOnly, "turbo"));
+  assert.equal(findExecutableInDirectory(dirOnly, "turbo"), undefined);
+});
+
+test("resolveTurboPath resolves files, directories, and missing paths", () => {
+  const dir = tmpdir();
+  const turboPath = path.join(dir, "turbo");
+  fs.writeFileSync(turboPath, "#!/bin/sh\n");
+
+  // Direct file path.
+  assert.equal(resolveTurboPath(turboPath, undefined, noopLog), turboPath);
+  // Directory containing a turbo executable.
+  assert.equal(resolveTurboPath(dir, undefined, noopLog), turboPath);
+  // Missing path is rejected.
+  assert.equal(
+    resolveTurboPath(path.join(dir, "nope"), undefined, noopLog),
+    undefined
+  );
+  assert.equal(resolveTurboPath(undefined, undefined, noopLog), undefined);
+});
+
+test(
+  "probeInternalLsp accepts turbo-lsp output",
+  { skip: cannotSpawn },
+  async () => {
+    const dir = tmpdir();
+    const turboPath = makeFakeTurbo(dir, { output: "turbo-lsp" });
+    const probe = await probeInternalLsp(turboPath, {});
+    assert.deepEqual(probe, { supported: true });
+  }
+);
+
+test(
+  "probeInternalLsp rejects unexpected output",
+  { skip: cannotSpawn },
+  async () => {
+    const dir = tmpdir();
+    const turboPath = makeFakeTurbo(dir, { output: "turbo something-else" });
+    const probe = await probeInternalLsp(turboPath, {});
+    assert.equal(probe.supported, false);
+  }
+);
+
+test(
+  "probeInternalLsp times out on a hanging binary instead of blocking",
+  { skip: cannotSpawn },
+  async () => {
+    const dir = tmpdir();
+    const turboPath = makeFakeTurbo(dir, { sleepSeconds: 30 });
+    const start = Date.now();
+    const probe = await probeInternalLsp(turboPath, {});
+    const elapsed = Date.now() - start;
+    assert.equal(probe.supported, false);
+    assert.ok(
+      elapsed < 10_000,
+      `probe should have been killed by its timeout, took ${elapsed}ms`
+    );
+  }
+);
+
+test(
+  "findInstalledTurboLsp prefers the configured path and probes each binary once",
+  { skip: cannotSpawn },
+  async () => {
+    const dir = tmpdir();
+    const logFile = path.join(dir, "probes.log");
+    const supported = makeFakeTurbo(path.join(dir, "a"), {
+      output: "turbo-lsp",
+      logFile
+    });
+    const workspace = tmpdir();
+    fs.mkdirSync(path.join(workspace, "node_modules", ".bin"), {
+      recursive: true
+    });
+    // Same binary reachable through a symlinked .bin entry: must not be
+    // probed again after the configured candidate already matched.
+    fs.symlinkSync(
+      supported,
+      path.join(workspace, "node_modules", ".bin", "turbo")
+    );
+
+    const found = await findInstalledTurboLsp({
+      workspaceRoot: workspace,
+      configuredTurboPath: supported,
+      log: noopLog
+    });
+    assert.equal(found, supported);
+    assert.equal(
+      fs.readFileSync(logFile, "utf8").trim().split("\n").length,
+      1,
+      "only one probe should have run"
+    );
+  }
+);
+
+test(
+  "findInstalledTurboLsp falls back after a timeout and dedupes repeated binaries",
+  { skip: cannotSpawn },
+  async () => {
+    const dir = tmpdir();
+    const logFile = path.join(dir, "probes.log");
+    // Configured candidate hangs and is killed by the probe timeout.
+    const hanging = makeFakeTurbo(path.join(dir, "hang"), {
+      sleepSeconds: 30,
+      logFile
+    });
+    const workspace = tmpdir();
+    const binDir = path.join(workspace, "node_modules", ".bin");
+    fs.mkdirSync(binDir, { recursive: true });
+    const supported = makeFakeTurbo(path.join(dir, "b"), {
+      output: "turbo-lsp",
+      logFile
+    });
+    fs.symlinkSync(supported, path.join(binDir, "turbo"));
+
+    const start = Date.now();
+    const found = await findInstalledTurboLsp({
+      workspaceRoot: workspace,
+      configuredTurboPath: hanging,
+      log: noopLog
+    });
+    const elapsed = Date.now() - start;
+
+    // The workspace .bin candidate path wins (it points at the supported binary).
+    assert.equal(found, path.join(binDir, "turbo"));
+    // Hanging probe killed at ~LSP_PROBE_TIMEOUT_MS, then the workspace
+    // candidate succeeds. Total must stay well below the hang duration.
+    assert.ok(elapsed < 10_000, `took ${elapsed}ms`);
+    const probes = fs.readFileSync(logFile, "utf8").trim().split("\n").length;
+    // Hanging binary probed once; supported binary probed once via .bin.
+    assert.equal(probes, 2);
+    assert.ok(LSP_PROBE_TIMEOUT_MS <= 1000);
+  }
+);
+
+test(
+  "findInstalledTurboLsp returns undefined and stops probing when aborted",
+  { skip: cannotSpawn },
+  async () => {
+    const dir = tmpdir();
+    const hanging = makeFakeTurbo(path.join(dir, "hang"), {
+      sleepSeconds: 30
+    });
+    const abort = new AbortController();
+    const promise = findInstalledTurboLsp({
+      configuredTurboPath: hanging,
+      signal: abort.signal,
+      log: noopLog
+    });
+    abort.abort();
+    const result = await promise.catch((err: unknown) => err);
+    assert.ok(
+      result === undefined ||
+        (result instanceof Error && result.name === "AbortError"),
+      `expected undefined or AbortError, got ${String(result)}`
+    );
+  }
+);

--- a/packages/turbo-vsc/src/turbo-discovery.ts
+++ b/packages/turbo-vsc/src/turbo-discovery.ts
@@ -1,0 +1,394 @@
+import * as cp from "node:child_process";
+import * as path from "node:path";
+import * as fs from "node:fs";
+
+export type Logger = (message: string) => void;
+
+/// Bounded probe time for one `turbo __internal_lsp --probe` invocation.
+export const LSP_PROBE_TIMEOUT_MS = 1000;
+
+/// Bounded time for one package-manager discovery command. Package managers
+/// can shell out to slow shims, but five seconds is generous for a bin-dir
+/// lookup and keeps discovery bounded when they hang.
+export const PACKAGE_MANAGER_TIMEOUT_MS = 5000;
+
+export type InternalLspProbeResult =
+  | { supported: true }
+  | { supported: false; reason: string };
+
+interface ExecCaptureOptions {
+  cwd?: string;
+  timeout: number;
+  signal?: AbortSignal;
+}
+
+interface ExecCapture {
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * execFile with a bounded timeout and optional abort signal, capturing
+ * stdout/stderr. Never blocks the event loop; on timeout the child is killed
+ * and the resulting error carries whatever output was captured.
+ */
+function execFileCapture(
+  command: string,
+  args: string[],
+  options: ExecCaptureOptions
+): Promise<ExecCapture> {
+  return new Promise((resolve, reject) => {
+    cp.execFile(
+      command,
+      args,
+      {
+        cwd: options.cwd,
+        timeout: options.timeout,
+        signal: options.signal,
+        encoding: "utf8",
+        // A pathological binary could spew unbounded output before the
+        // timeout kills it; cap what we retain.
+        maxBuffer: 1024 * 1024
+      },
+      (error: Error | null, stdout: string, stderr: string) => {
+        if (error) {
+          reject(Object.assign(error, { stdout, stderr }));
+          return;
+        }
+        resolve({ stdout, stderr });
+      }
+    );
+  });
+}
+
+function isAbortError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.name === "AbortError" || error.message.includes("aborted"))
+  );
+}
+
+export function executableNames(name: string) {
+  return process.platform === "win32"
+    ? [`${name}.exe`, `${name}.cmd`, `${name}`]
+    : [name];
+}
+
+export function findExecutableInDirectory(
+  directory: string,
+  name: string
+): string | undefined {
+  for (const executable of executableNames(name)) {
+    const candidate = path.join(directory, executable);
+    if (fs.existsSync(candidate) && !fs.statSync(candidate).isDirectory()) {
+      return candidate;
+    }
+  }
+}
+
+export function findExecutableOnPath(name: string) {
+  const pathEntries = (process.env.PATH ?? "").split(path.delimiter);
+  for (const pathEntry of pathEntries) {
+    const executable = findExecutableInDirectory(pathEntry, name);
+    if (executable && path.basename(executable).startsWith(name)) {
+      return executable;
+    }
+  }
+}
+
+export function resolveTurboPath(
+  turboPath: string | undefined,
+  workspaceRoot: string | undefined,
+  log: Logger
+) {
+  if (!turboPath) {
+    return undefined;
+  }
+
+  const resolvedPath = path.isAbsolute(turboPath)
+    ? turboPath
+    : path.resolve(workspaceRoot ?? process.cwd(), turboPath);
+
+  if (!fs.existsSync(resolvedPath)) {
+    log(`Manually specified turbo does not exist at path ${turboPath}`);
+    return undefined;
+  }
+
+  if (fs.statSync(resolvedPath).isDirectory()) {
+    return findExecutableInDirectory(resolvedPath, "turbo");
+  }
+
+  return resolvedPath;
+}
+
+/**
+ * Probes a turbo binary for internal LSP support. Async with a bounded
+ * timeout, so a slow binary or shim cannot stall the extension host.
+ */
+export async function probeInternalLsp(
+  turboPath: string,
+  options: { cwd?: string; signal?: AbortSignal }
+): Promise<InternalLspProbeResult> {
+  try {
+    const { stdout } = await execFileCapture(
+      turboPath,
+      ["__internal_lsp", "--probe"],
+      { ...options, timeout: LSP_PROBE_TIMEOUT_MS }
+    );
+    const output = stdout.trim();
+
+    if (output === "turbo-lsp") {
+      return { supported: true };
+    }
+
+    return { supported: false, reason: formatProbeOutput(output) };
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw error;
+    }
+    return { supported: false, reason: formatProbeError(error) };
+  }
+}
+
+interface LspCandidate {
+  label: string;
+  path?: string;
+}
+
+/**
+ * Finds an installed turbo binary that supports the internal LSP, probing
+ * candidates in preference order (configured path, workspace
+ * node_modules/.bin, PATH). Candidate paths are deduplicated (resolving
+ * symlinks) so the same unsupported binary is not probed twice. Returns
+ * undefined when no candidate supports the LSP, in which case the caller
+ * falls back to the packaged LSP binary.
+ */
+export async function findInstalledTurboLsp(options: {
+  workspaceRoot?: string;
+  configuredTurboPath?: string;
+  signal?: AbortSignal;
+  log: Logger;
+}): Promise<string | undefined> {
+  const { workspaceRoot, configuredTurboPath, signal, log } = options;
+  log("resolving turbo LSP server");
+
+  const candidates: Array<LspCandidate> = [
+    { label: "configured turbo.path", path: configuredTurboPath },
+    {
+      label: "workspace node_modules/.bin",
+      path: workspaceRoot
+        ? findExecutableInDirectory(
+            path.join(workspaceRoot, "node_modules", ".bin"),
+            "turbo"
+          )
+        : undefined
+    },
+    { label: "PATH", path: findExecutableOnPath("turbo") }
+  ];
+
+  const seen = new Set<string>();
+  for (const candidate of candidates) {
+    if (!candidate.path) {
+      log(`turbo LSP: no candidate from ${candidate.label}`);
+      continue;
+    }
+
+    // node_modules/.bin entries are usually symlinks; compare real paths so
+    // the same binary is never probed twice.
+    let dedupeKey = candidate.path;
+    try {
+      dedupeKey = fs.realpathSync(candidate.path);
+    } catch {
+      // Keep the literal path if realpath fails.
+    }
+    if (seen.has(dedupeKey)) {
+      log(`turbo LSP: skipping duplicate candidate at ${candidate.path}`);
+      continue;
+    }
+    seen.add(dedupeKey);
+
+    if (signal?.aborted) {
+      return undefined;
+    }
+
+    log(`turbo LSP: probing ${candidate.label} at ${candidate.path}`);
+
+    const probe = await probeInternalLsp(candidate.path, {
+      cwd: workspaceRoot,
+      signal
+    });
+    if (probe.supported) {
+      log(`turbo LSP: using ${candidate.label} at ${candidate.path}`);
+      return candidate.path;
+    }
+
+    log(
+      `turbo LSP: rejected ${candidate.label} at ${candidate.path}: ${probe.reason}`
+    );
+  }
+
+  log(
+    "turbo LSP: no installed turbo candidate supports internal LSP; falling back to packaged LSP binary"
+  );
+  return undefined;
+}
+
+interface PackageManagerCheck {
+  label: string;
+  command: string;
+  args: Array<string>;
+  interpret: (stdout: string) => string | undefined;
+}
+
+/**
+ * Finds a workspace-local turbo installation via the available package
+ * managers. Each check is async with a bounded timeout, so a slow or hanging
+ * package-manager shim cannot stall the extension host.
+ */
+export async function findLocalTurbo(options: {
+  workspaceRoot?: string;
+  signal?: AbortSignal;
+  log: Logger;
+}): Promise<string | undefined> {
+  const { workspaceRoot, signal, log } = options;
+
+  if (workspaceRoot) {
+    log("attempting to find local turbo in node_modules/.bin");
+    const fromNodeModules = findExecutableInDirectory(
+      path.join(workspaceRoot, "node_modules", ".bin"),
+      "turbo"
+    );
+    if (fromNodeModules && fs.existsSync(fromNodeModules)) {
+      log(`found local turbo at ${fromNodeModules}`);
+      return fromNodeModules;
+    }
+  }
+
+  const checks: Array<PackageManagerCheck> = [
+    {
+      label: "npm",
+      command: "npm",
+      args: ["ls", "turbo", "--json"],
+      interpret: (stdout) => {
+        const npmData = JSON.parse(stdout);
+        // this is relative to node_modules
+        const packagePath = npmData?.dependencies?.turbo?.resolved;
+        const PREFIX = "file:"; // npm ls returns a file: prefix
+        if (typeof packagePath === "string" && packagePath.startsWith(PREFIX)) {
+          const turboPath = path.join(
+            "node_modules",
+            packagePath.slice(PREFIX.length),
+            "bin",
+            "turbo"
+          );
+          return resolveTurboPath(turboPath, workspaceRoot, log);
+        }
+        return undefined;
+      }
+    },
+    {
+      label: "yarn",
+      command: "yarn",
+      args: ["bin", "turbo"],
+      interpret: (stdout) => resolveTurboPath(stdout.trim(), workspaceRoot, log)
+    },
+    {
+      label: "pnpm",
+      command: "pnpm",
+      args: ["bin"],
+      interpret: (stdout) => findExecutableInDirectory(stdout.trim(), "turbo")
+    },
+    {
+      label: "bun",
+      command: "bun",
+      args: ["pm", "bin"],
+      interpret: (stdout) => findExecutableInDirectory(stdout.trim(), "turbo")
+    }
+  ];
+
+  for (const check of checks) {
+    if (signal?.aborted) {
+      return undefined;
+    }
+
+    try {
+      log(`attempting to find local turbo using ${check.label}`);
+      const { stdout } = await execFileCapture(check.command, check.args, {
+        cwd: workspaceRoot,
+        timeout: PACKAGE_MANAGER_TIMEOUT_MS,
+        signal
+      });
+      const potential = check.interpret(stdout)?.trim();
+      if (potential && fs.existsSync(potential)) {
+        log(`found local turbo at ${potential}`);
+        return potential;
+      }
+    } catch (error) {
+      if (isAbortError(error)) {
+        throw error;
+      }
+      // This package manager is not installed or did not find turbo; try
+      // the next one.
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Finds turbo on PATH, falling back to package-manager discovery. Async so
+ * slow package-manager shims never stall the extension host.
+ */
+export async function findTurbo(options: {
+  workspaceRoot?: string;
+  signal?: AbortSignal;
+  log: Logger;
+}): Promise<string | undefined> {
+  options.log("attempting to find turbo");
+  return findExecutableOnPath("turbo") ?? (await findLocalTurbo(options));
+}
+
+function formatProbeOutput(output: string) {
+  const line = firstNonEmptyLine(output);
+  return line ? `unexpected probe output: ${line}` : "empty probe output";
+}
+
+function formatProbeError(error: unknown) {
+  const stderr = outputFromError(error, "stderr");
+  if (stderr) {
+    return firstNonEmptyLine(stderr) ?? "probe command failed with stderr";
+  }
+
+  const stdout = outputFromError(error, "stdout");
+  if (stdout) {
+    return `probe command failed with stdout: ${firstNonEmptyLine(stdout)}`;
+  }
+
+  if (error instanceof Error && error.message) {
+    return firstNonEmptyLine(error.message) ?? error.message;
+  }
+
+  return "probe command failed";
+}
+
+function outputFromError(error: unknown, key: "stdout" | "stderr") {
+  if (typeof error !== "object" || error === null || !(key in error)) {
+    return;
+  }
+
+  const output = (error as Record<string, unknown>)[key];
+  if (Buffer.isBuffer(output)) {
+    return output.toString("utf8").trim();
+  }
+
+  if (typeof output === "string") {
+    return output.trim();
+  }
+}
+
+function firstNonEmptyLine(output: string) {
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean);
+}

--- a/packages/turbo-vsc/turbo.json
+++ b/packages/turbo-vsc/turbo.json
@@ -10,6 +10,7 @@
         "--test",
         "src/package-json.test.ts",
         "src/turbo-daemon-command.test.ts",
+        "src/turbo-discovery.test.ts",
         "src/turbo-run-terminal-options.test.ts"
       ]
     },


### PR DESCRIPTION
## Summary

Closes TURBO-6048.

Extension activation called `findInstalledTurboLsp` synchronously, probing up to three turbo candidates with `execFileSync` (1,000 ms timeout each) and blocking the shared extension-host event loop while each child ran. Later turbo discovery executed npm/yarn/pnpm/bun via `execSync` with no timeouts at all — a slow installation or shim could stall every extension in the host, not just this one.

## Changes

Discovery moves to a new `turbo-discovery.ts` module (no `vscode` import, so it is unit-testable with `node --test`):

- All probes use async `execFile` with bounded timeouts (1 s for `__internal_lsp --probe`, 5 s for package-manager lookups) and a 1 MiB output cap, keeping the extension-host event loop responsive.
- An `AbortController` disposed with the extension's subscriptions kills in-flight probes on deactivation.
- Candidate binaries are deduplicated by resolved (symlink-followed) path, so the same unsupported binary reachable as both the configured path and `node_modules/.bin/turbo` is probed once, not twice.
- Preference order (configured `turbo.path` → workspace `node_modules/.bin` → PATH) and the packaged-LSP fallback are unchanged, as are all log lines, workspace-trust gating, and the not-supported-platform message. Commands are registered immediately and await the shared discovery promise instead of activation blocking on it.

## Benchmarks

Three hanging fake `turbo` binaries (`sleep 30`), each killed by the 1 s probe timeout, while a 10 ms heartbeat runs on the same Node event loop. Harness was temporary and is not committed.

| Discovery of 3 hanging candidates | Wall time | Heartbeat ticks (10 ms interval) | Worst event-loop gap |
| --- | --- | --- | --- |
| Before (execFileSync) | 3,010 ms | **0** | ~3,010 ms (fully blocked) |
| After (async execFile) | 3,017 ms | **280** | 13 ms |

## Verification

- New `turbo-discovery.test.ts` (8 tests): probe accept/reject, timeout kills a hanging binary in ~1 s, preference order, symlink dedupe (one probe per binary), abort stops probing. Process-spawning tests skip on Windows; path helpers are covered platform-agnostically.
- `node --import tsx --test src/*.test.ts`: 38 passed, 0 failed (new file registered in the package's `test` task).
- `tsc -p ./ --noEmit` and `oxlint`: clean.