### PR TITLE
perf: Avoid serializing ASTs for path-only file dependency queries

### DIFF
--- a/crates/turbo-trace/src/tracer.rs
+++ b/crates/turbo-trace/src/tracer.rs
@@ -33,6 +33,7 @@ pub struct Tracer {
     cwd: AbsoluteSystemPathBuf,
     errors: Vec<TraceError>,
     import_type: ImportTraceType,
+    include_ast: bool,
 }
 
 #[derive(Clone, Debug, Error, Diagnostic)]
@@ -203,6 +204,7 @@ impl Tracer {
             cwd,
             import_type: ImportTraceType::All,
             errors: Vec::new(),
+            include_ast: true,
         }
     }
 
@@ -211,25 +213,38 @@ impl Tracer {
         self.import_type = import_type;
     }
 
+    /// Controls whether every traced file's AST is serialized to JSON.
+    ///
+    /// Defaults to true. Callers that only need dependency *paths* should set
+    /// this to false: serializing the parsed program and decoding it into
+    /// `serde_json::Value` is by far the most expensive part of tracing a
+    /// file, and path-only consumers discard the result.
+    #[allow(dead_code)]
+    pub fn set_include_ast(&mut self, include_ast: bool) {
+        self.include_ast = include_ast;
+    }
+
     #[tracing::instrument(skip(errors))]
     pub async fn get_imports_from_file(
         errors: &mut Vec<TraceError>,
         resolver: &Resolver,
         file_path: &AbsoluteSystemPath,
         import_type: ImportTraceType,
+        include_ast: bool,
     ) -> Option<(Vec<AbsoluteSystemPathBuf>, SeenFile)> {
         let Ok(file_content) = tokio::fs::read_to_string(&file_path).await else {
             errors.push(TraceError::FileNotFound(file_path.to_owned()));
             return None;
         };
 
-        let (imports, ast_json) = match parse_file(file_path, &file_content, import_type, true) {
-            Ok(result) => result,
-            Err(msg) => {
-                errors.push(TraceError::ParseError(file_path.to_owned(), msg));
-                return None;
-            }
-        };
+        let (imports, ast_json) =
+            match parse_file(file_path, &file_content, import_type, include_ast) {
+                Ok(result) => result,
+                Err(msg) => {
+                    errors.push(TraceError::ParseError(file_path.to_owned(), msg));
+                    return None;
+                }
+            };
 
         let mut files = Vec::new();
         for ImportResult {
@@ -332,9 +347,14 @@ impl Tracer {
             return;
         }
 
-        let Some((imports, seen_file)) =
-            Self::get_imports_from_file(&mut self.errors, resolver, &file_path, self.import_type)
-                .await
+        let Some((imports, seen_file)) = Self::get_imports_from_file(
+            &mut self.errors,
+            resolver,
+            &file_path,
+            self.import_type,
+            self.include_ast,
+        )
+        .await
         else {
             return;
         };
@@ -526,6 +546,7 @@ impl Tracer {
                     resolver,
                     &file,
                     shared_self.import_type,
+                    shared_self.include_ast,
                 )
                 .await
                 else {

--- a/crates/turborepo-query/src/file.rs
+++ b/crates/turborepo-query/src/file.rs
@@ -166,6 +166,7 @@ impl File {
 
     async fn dependencies(
         &self,
+        ctx: &async_graphql::Context<'_>,
         depth: Option<usize>,
         ts_config: Option<String>,
         import_type: Option<ImportType>,
@@ -175,6 +176,17 @@ impl File {
             self.run.repo_root().to_owned(),
             vec![self.path.clone()],
             ts_config.map(Utf8PathBuf::from),
+        );
+
+        // Only serialize every traced file's AST when the query actually
+        // selects it; path-only selections skip the most expensive part of
+        // tracing entirely.
+        tracer.set_include_ast(
+            ctx.look_ahead()
+                .field("files")
+                .field("items")
+                .field("ast")
+                .exists(),
         );
 
         if let Some(import_type) = import_type {
@@ -191,6 +203,7 @@ impl File {
 
     async fn dependents(
         &self,
+        ctx: &async_graphql::Context<'_>,
         ts_config: Option<String>,
         import_type: Option<ImportType>,
     ) -> Result<TraceResult, Error> {
@@ -198,6 +211,16 @@ impl File {
             self.run.repo_root().to_owned(),
             vec![self.path.clone()],
             ts_config.map(Utf8PathBuf::from),
+        );
+
+        // Reverse tracing parses every candidate file; only pay for AST
+        // serialization when the selection asks for it.
+        tracer.set_include_ast(
+            ctx.look_ahead()
+                .field("files")
+                .field("items")
+                .field("ast")
+                .exists(),
         );
 
         if let Some(import_type) = import_type {

--- a/crates/turborepo/tests/query.rs
+++ b/crates/turborepo/tests/query.rs
@@ -52,6 +52,7 @@ fn test_ast() -> Result<(), anyhow::Error> {
         "npm@10.5.0",
         "query",
         "get `main.ts` with ast" => ["query { file(path: \"main.ts\") { path ast } }"],
+        "get `main.ts` with dependencies including ast" => ["query { file(path: \"main.ts\") { path dependencies { files { items { path ast } } } } }"],
     );
 
     Ok(())

--- a/crates/turborepo/tests/snapshots/query__turbo_trace_get_`main.ts`_with_dependencies_including_ast_(npm@10.5.0).snap
+++ b/crates/turborepo/tests/snapshots/query__turbo_trace_get_`main.ts`_with_dependencies_including_ast_(npm@10.5.0).snap
@@ -1,0 +1,599 @@
+---
+source: crates/turborepo/tests/query.rs
+assertion_line: 50
+expression: query_output
+---
+{
+  "data": {
+    "file": {
+      "path": "main.ts",
+      "dependencies": {
+        "files": {
+          "items": [
+            {
+              "path": "bar.js",
+              "ast": {
+                "type": "Program",
+                "body": [
+                  {
+                    "type": "ExportDefaultDeclaration",
+                    "declaration": {
+                      "type": "FunctionDeclaration",
+                      "id": {
+                        "type": "Identifier",
+                        "decorators": [],
+                        "name": "bar",
+                        "optional": false,
+                        "typeAnnotation": null,
+                        "start": 24,
+                        "end": 27
+                      },
+                      "generator": false,
+                      "async": false,
+                      "declare": false,
+                      "typeParameters": null,
+                      "params": [],
+                      "returnType": null,
+                      "body": {
+                        "type": "BlockStatement",
+                        "body": [
+                          {
+                            "type": "ExpressionStatement",
+                            "expression": {
+                              "type": "CallExpression",
+                              "callee": {
+                                "type": "MemberExpression",
+                                "object": {
+                                  "type": "Identifier",
+                                  "decorators": [],
+                                  "name": "console",
+                                  "optional": false,
+                                  "typeAnnotation": null,
+                                  "start": 34,
+                                  "end": 41
+                                },
+                                "property": {
+                                  "type": "Identifier",
+                                  "decorators": [],
+                                  "name": "log",
+                                  "optional": false,
+                                  "typeAnnotation": null,
+                                  "start": 42,
+                                  "end": 45
+                                },
+                                "optional": false,
+                                "computed": false,
+                                "start": 34,
+                                "end": 45
+                              },
+                              "typeArguments": null,
+                              "arguments": [
+                                {
+                                  "type": "Literal",
+                                  "value": "bar",
+                                  "raw": "\"bar\"",
+                                  "start": 46,
+                                  "end": 51
+                                }
+                              ],
+                              "optional": false,
+                              "start": 34,
+                              "end": 52
+                            },
+                            "directive": null,
+                            "start": 34,
+                            "end": 53
+                          }
+                        ],
+                        "start": 30,
+                        "end": 55
+                      },
+                      "expression": false,
+                      "start": 15,
+                      "end": 55
+                    },
+                    "exportKind": "value",
+                    "start": 0,
+                    "end": 55
+                  }
+                ],
+                "sourceType": "module",
+                "hashbang": null,
+                "start": 0,
+                "end": 56
+              }
+            },
+            {
+              "path": "button.css",
+              "ast": {
+                "type": "Program",
+                "body": [],
+                "sourceType": "module",
+                "hashbang": null,
+                "start": 0,
+                "end": 0
+              }
+            },
+            {
+              "path": "button.json",
+              "ast": {
+                "type": "Program",
+                "body": [],
+                "sourceType": "module",
+                "hashbang": null,
+                "start": 0,
+                "end": 0
+              }
+            },
+            {
+              "path": "button.tsx",
+              "ast": {
+                "type": "Program",
+                "body": [
+                  {
+                    "type": "ImportDeclaration",
+                    "specifiers": [],
+                    "source": {
+                      "type": "Literal",
+                      "value": "./button.css",
+                      "raw": "\"./button.css\"",
+                      "start": 7,
+                      "end": 21
+                    },
+                    "phase": null,
+                    "attributes": [],
+                    "importKind": "value",
+                    "start": 0,
+                    "end": 22
+                  },
+                  {
+                    "type": "ImportDeclaration",
+                    "specifiers": [],
+                    "source": {
+                      "type": "Literal",
+                      "value": "./button.json",
+                      "raw": "\"./button.json\"",
+                      "start": 30,
+                      "end": 45
+                    },
+                    "phase": null,
+                    "attributes": [
+                      {
+                        "type": "ImportAttribute",
+                        "key": {
+                          "type": "Identifier",
+                          "decorators": [],
+                          "name": "type",
+                          "optional": false,
+                          "typeAnnotation": null,
+                          "start": 53,
+                          "end": 57
+                        },
+                        "value": {
+                          "type": "Literal",
+                          "value": "json",
+                          "raw": "\"json\"",
+                          "start": 59,
+                          "end": 65
+                        },
+                        "start": 53,
+                        "end": 65
+                      }
+                    ],
+                    "importKind": "value",
+                    "start": 23,
+                    "end": 68
+                  },
+                  {
+                    "type": "ExportNamedDeclaration",
+                    "declaration": {
+                      "type": "VariableDeclaration",
+                      "kind": "const",
+                      "declarations": [
+                        {
+                          "type": "VariableDeclarator",
+                          "id": {
+                            "type": "Identifier",
+                            "decorators": [],
+                            "name": "Button",
+                            "optional": false,
+                            "typeAnnotation": null,
+                            "start": 83,
+                            "end": 89
+                          },
+                          "init": {
+                            "type": "ArrowFunctionExpression",
+                            "expression": false,
+                            "async": false,
+                            "typeParameters": null,
+                            "params": [
+                              {
+                                "type": "ObjectPattern",
+                                "decorators": [],
+                                "properties": [
+                                  {
+                                    "type": "Property",
+                                    "kind": "init",
+                                    "key": {
+                                      "type": "Identifier",
+                                      "decorators": [],
+                                      "name": "children",
+                                      "optional": false,
+                                      "typeAnnotation": null,
+                                      "start": 95,
+                                      "end": 103
+                                    },
+                                    "value": {
+                                      "type": "Identifier",
+                                      "decorators": [],
+                                      "name": "children",
+                                      "optional": false,
+                                      "typeAnnotation": null,
+                                      "start": 95,
+                                      "end": 103
+                                    },
+                                    "method": false,
+                                    "shorthand": true,
+                                    "computed": false,
+                                    "optional": false,
+                                    "start": 95,
+                                    "end": 103
+                                  }
+                                ],
+                                "optional": false,
+                                "typeAnnotation": {
+                                  "type": "TSTypeAnnotation",
+                                  "typeAnnotation": {
+                                    "type": "TSTypeLiteral",
+                                    "members": [
+                                      {
+                                        "type": "TSPropertySignature",
+                                        "computed": false,
+                                        "optional": false,
+                                        "readonly": false,
+                                        "key": {
+                                          "type": "Identifier",
+                                          "decorators": [],
+                                          "name": "children",
+                                          "optional": false,
+                                          "typeAnnotation": null,
+                                          "start": 109,
+                                          "end": 117
+                                        },
+                                        "typeAnnotation": {
+                                          "type": "TSTypeAnnotation",
+                                          "typeAnnotation": {
+                                            "type": "TSTypeReference",
+                                            "typeName": {
+                                              "type": "TSQualifiedName",
+                                              "left": {
+                                                "type": "Identifier",
+                                                "decorators": [],
+                                                "name": "React",
+                                                "optional": false,
+                                                "typeAnnotation": null,
+                                                "start": 119,
+                                                "end": 124
+                                              },
+                                              "right": {
+                                                "type": "Identifier",
+                                                "decorators": [],
+                                                "name": "ReactNode",
+                                                "optional": false,
+                                                "typeAnnotation": null,
+                                                "start": 125,
+                                                "end": 134
+                                              },
+                                              "start": 119,
+                                              "end": 134
+                                            },
+                                            "typeArguments": null,
+                                            "start": 119,
+                                            "end": 134
+                                          },
+                                          "start": 117,
+                                          "end": 134
+                                        },
+                                        "accessibility": null,
+                                        "static": false,
+                                        "start": 109,
+                                        "end": 134
+                                      }
+                                    ],
+                                    "start": 107,
+                                    "end": 136
+                                  },
+                                  "start": 105,
+                                  "end": 136
+                                },
+                                "start": 93,
+                                "end": 136
+                              }
+                            ],
+                            "returnType": null,
+                            "body": {
+                              "type": "BlockStatement",
+                              "body": [
+                                {
+                                  "type": "ReturnStatement",
+                                  "argument": {
+                                    "type": "JSXElement",
+                                    "openingElement": {
+                                      "type": "JSXOpeningElement",
+                                      "name": {
+                                        "type": "JSXIdentifier",
+                                        "name": "button",
+                                        "start": 153,
+                                        "end": 159
+                                      },
+                                      "typeArguments": null,
+                                      "attributes": [],
+                                      "selfClosing": false,
+                                      "start": 152,
+                                      "end": 160
+                                    },
+                                    "children": [
+                                      {
+                                        "type": "JSXExpressionContainer",
+                                        "expression": {
+                                          "type": "Identifier",
+                                          "decorators": [],
+                                          "name": "children",
+                                          "optional": false,
+                                          "typeAnnotation": null,
+                                          "start": 161,
+                                          "end": 169
+                                        },
+                                        "start": 160,
+                                        "end": 170
+                                      }
+                                    ],
+                                    "closingElement": {
+                                      "type": "JSXClosingElement",
+                                      "name": {
+                                        "type": "JSXIdentifier",
+                                        "name": "button",
+                                        "start": 172,
+                                        "end": 178
+                                      },
+                                      "start": 170,
+                                      "end": 179
+                                    },
+                                    "start": 152,
+                                    "end": 179
+                                  },
+                                  "start": 145,
+                                  "end": 180
+                                }
+                              ],
+                              "start": 141,
+                              "end": 182
+                            },
+                            "id": null,
+                            "generator": false,
+                            "start": 92,
+                            "end": 182
+                          },
+                          "definite": false,
+                          "start": 83,
+                          "end": 182
+                        }
+                      ],
+                      "declare": false,
+                      "start": 77,
+                      "end": 183
+                    },
+                    "specifiers": [],
+                    "source": null,
+                    "exportKind": "value",
+                    "attributes": [],
+                    "start": 70,
+                    "end": 183
+                  }
+                ],
+                "sourceType": "module",
+                "hashbang": null,
+                "start": 0,
+                "end": 184
+              }
+            },
+            {
+              "path": "foo.js",
+              "ast": {
+                "type": "Program",
+                "body": [
+                  {
+                    "type": "ImportDeclaration",
+                    "specifiers": [
+                      {
+                        "type": "ImportSpecifier",
+                        "imported": {
+                          "type": "Identifier",
+                          "decorators": [],
+                          "name": "bar",
+                          "optional": false,
+                          "typeAnnotation": null,
+                          "start": 9,
+                          "end": 12
+                        },
+                        "local": {
+                          "type": "Identifier",
+                          "decorators": [],
+                          "name": "bar",
+                          "optional": false,
+                          "typeAnnotation": null,
+                          "start": 9,
+                          "end": 12
+                        },
+                        "importKind": "value",
+                        "start": 9,
+                        "end": 12
+                      }
+                    ],
+                    "source": {
+                      "type": "Literal",
+                      "value": "./bar",
+                      "raw": "\"./bar\"",
+                      "start": 20,
+                      "end": 27
+                    },
+                    "phase": null,
+                    "attributes": [
+                      {
+                        "type": "ImportAttribute",
+                        "key": {
+                          "type": "Identifier",
+                          "decorators": [],
+                          "name": "type",
+                          "optional": false,
+                          "typeAnnotation": null,
+                          "start": 35,
+                          "end": 39
+                        },
+                        "value": {
+                          "type": "Literal",
+                          "value": "js",
+                          "raw": "\"js\"",
+                          "start": 41,
+                          "end": 45
+                        },
+                        "start": 35,
+                        "end": 45
+                      }
+                    ],
+                    "importKind": "value",
+                    "start": 0,
+                    "end": 48
+                  },
+                  {
+                    "type": "ExportDefaultDeclaration",
+                    "declaration": {
+                      "type": "FunctionDeclaration",
+                      "id": {
+                        "type": "Identifier",
+                        "decorators": [],
+                        "name": "foo",
+                        "optional": false,
+                        "typeAnnotation": null,
+                        "start": 74,
+                        "end": 77
+                      },
+                      "generator": false,
+                      "async": false,
+                      "declare": false,
+                      "typeParameters": null,
+                      "params": [],
+                      "returnType": null,
+                      "body": {
+                        "type": "BlockStatement",
+                        "body": [
+                          {
+                            "type": "IfStatement",
+                            "test": {
+                              "type": "UnaryExpression",
+                              "operator": "!",
+                              "argument": {
+                                "type": "MemberExpression",
+                                "object": {
+                                  "type": "MemberExpression",
+                                  "object": {
+                                    "type": "Identifier",
+                                    "decorators": [],
+                                    "name": "process",
+                                    "optional": false,
+                                    "typeAnnotation": null,
+                                    "start": 89,
+                                    "end": 96
+                                  },
+                                  "property": {
+                                    "type": "Identifier",
+                                    "decorators": [],
+                                    "name": "env",
+                                    "optional": false,
+                                    "typeAnnotation": null,
+                                    "start": 97,
+                                    "end": 100
+                                  },
+                                  "optional": false,
+                                  "computed": false,
+                                  "start": 89,
+                                  "end": 100
+                                },
+                                "property": {
+                                  "type": "Identifier",
+                                  "decorators": [],
+                                  "name": "IS_CI",
+                                  "optional": false,
+                                  "typeAnnotation": null,
+                                  "start": 101,
+                                  "end": 106
+                                },
+                                "optional": false,
+                                "computed": false,
+                                "start": 89,
+                                "end": 106
+                              },
+                              "prefix": true,
+                              "start": 88,
+                              "end": 106
+                            },
+                            "consequent": {
+                              "type": "BlockStatement",
+                              "body": [
+                                {
+                                  "type": "ReturnStatement",
+                                  "argument": {
+                                    "type": "Literal",
+                                    "value": "bar",
+                                    "raw": "\"bar\"",
+                                    "start": 121,
+                                    "end": 126
+                                  },
+                                  "start": 114,
+                                  "end": 127
+                                }
+                              ],
+                              "start": 108,
+                              "end": 131
+                            },
+                            "alternate": null,
+                            "start": 84,
+                            "end": 131
+                          },
+                          {
+                            "type": "ReturnStatement",
+                            "argument": {
+                              "type": "Literal",
+                              "value": "foo",
+                              "raw": "\"foo\"",
+                              "start": 141,
+                              "end": 146
+                            },
+                            "start": 134,
+                            "end": 147
+                          }
+                        ],
+                        "start": 80,
+                        "end": 149
+                      },
+                      "expression": false,
+                      "start": 65,
+                      "end": 149
+                    },
+                    "exportKind": "value",
+                    "start": 50,
+                    "end": 149
+                  }
+                ],
+                "sourceType": "module",
+                "hashbang": null,
+                "start": 0,
+                "end": 150
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes TURBO-6046.

`Tracer::get_imports_from_file` always requested AST capture: every successfully parsed file was serialized to ESTree JSON text and decoded into `serde_json::Value`, even when the GraphQL query selected only file paths. Reverse (dependents) tracing paid this for every scanned file, including non-matches discarded immediately afterward.

## Changes

- `Tracer` gains an `include_ast` flag (default `true`, preserving behavior for existing callers) threaded into both the forward (`trace_file`) and reverse (`reverse_trace`) paths.
- The GraphQL `dependencies`/`dependents` resolvers inspect the selection set via `ctx.look_ahead()` and skip AST capture unless `files { items { ast } }` is actually selected. The existing lazy `File::ast` fallback (parse on demand when no captured AST is present) remains for any file without one.
- New snapshot test: selecting `ast` inside `dependencies` still returns full ASTs for traced files (capture is selection-aware, not removed).

## Benchmarks

Synthetic 1,000-file TypeScript repo (sparse chained imports), debug `turbo` binary, `turbo query` wall time, median of 5 runs. macOS. Harness repo was generated in /tmp and is not committed.

| Query (1,000 files) | Before | After | Change |
| --- | --- | --- | --- |
| `dependencies`, paths only | 2.47 s | 0.25 s | −90% |
| `dependents`, paths only | 0.33 s | 0.07 s | −79% |
| `dependencies` with `ast` selected | 6.12 s | 6.00 s | unchanged (capture retained) |

The with-AST row shows the serialized AST work dominates tracing (~24× the path-only cost) and is paid only when the query selects it.

## Verification

- `cargo test -p turbo --test query`: 7 passed, 0 failed (all existing path/error snapshots identical; new AST-in-dependencies snapshot added).
- `cargo test -p turbo-trace`: 17 passed, 0 failed.
- `cargo clippy -p turbo-trace -p turborepo-query`: clean.