### PR TITLE
docs: Document a focused Cargo build for CLI-only development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,13 @@ In general, there are two major areas in the repository:
 ## Building Turborepo
 
 1. Run `pnpm install` at the root of the repository
-2. Run `cargo build`
+2. Run `cargo build -p turbo`
+
+The focused `cargo build -p turbo` builds just the `turbo` CLI and its
+dependencies, skipping the workspace's other top-level targets (such as the
+LSP, schema generator, and N-API addon) that you don't need for CLI
+development. Use a plain `cargo build` when you want to build and verify every
+workspace member.
 
 ### TLS Implementation
 


### PR DESCRIPTION
## Summary

Closes TURBO-6043.

CONTRIBUTING.md prescribed a root `cargo build`, which selects all 65 default members of the virtual workspace — including the unrelated top-level LSP, schema-generator, and N-API targets a CLI contributor doesn't need. The established `cargo build -p turbo` (already used by the root `package.json` scripts) produces the working CLI without building those targets. Workspace defaults and CI coverage are unchanged.

## Benchmarks

Clean debug builds in separate `CARGO_TARGET_DIR`s, macOS. `turbo` binary verified runnable from the focused build.

| Build command | Wall time | CPU (user+sys) | Target dir size |
| --- | --- | --- | --- |
| `cargo build` (all 65 default members) | 135.7 s | 622 s | 4.7 GB |
| `cargo build -p turbo` (focused) | 118.1 s | 460 s | 3.8 GB |
| **Change** | **−13%** | **−26%** | **−19%** |

Much of the dependency closure is shared, so the win is the extra top-level targets; the focused command also narrows the recompile surface for iteration.