### PR TITLE
perf: Run the docs MDX generator once per quality task graph

### DIFF
--- a/apps/docs/turbo.json
+++ b/apps/docs/turbo.json
@@ -60,7 +60,7 @@
       "command": ["pnpm", "exec", "fumadocs-mdx"]
     },
     "lint": {
-      "command": ["pnpm", "exec", "fumadocs-mdx"]
+      "dependsOn": ["check-types:mdx"]
     },
     "check-openapi": {
       "command": [


### PR DESCRIPTION
## Summary

Closes TURBO-6042.

`docs#lint` and `docs#check-types:mdx` both invoked exactly `pnpm exec fumadocs-mdx` with no ordering between them, so a cold or invalidated `quality` run scheduled the same generator twice — concurrently.

## Changes

`docs#lint` becomes a commandless alias that depends on `docs#check-types:mdx`. The generator node is now shared by both selectors, so it runs exactly once per graph. Standalone `turbo run lint --filter=docs` still generates the required MDX files (through the dependency), and the `check-types` → `check-types:mdx` → `check-types:next` chain is untouched.

## Benchmarks

`turbo run quality --dry=json`, tasks invoking `fumadocs-mdx`:

| | Generator tasks in quality graph |
| --- | --- |
| Before | `docs#check-types:mdx`, `docs#lint` (2 invocations, unordered) |
| After | `docs#check-types:mdx` (1 invocation) |

Wall time of the affected slice (`turbo run lint check-types --filter=docs --force`, macOS, 3 interleaved runs):

| | run 1 | run 2 | run 3 | median |
| --- | --- | --- | --- | --- |
| Before | 5.18 s | 2.38 s | 2.23 s | 2.38 s |
| After | 2.13 s | 2.01 s | 2.23 s | 2.13 s |

The generator itself is fast on this repo (~6.5 ms per invocation); the saving is one fewer scheduled task and its process spawn, and removing the possibility of the two nodes writing concurrently.

## Verification

- Dry-run graph shows exactly one generator invocation; `docs#lint` resolves with `dependencies: ["docs#check-types:mdx"]` and no command.
- `turbo run lint check-types --filter=docs --force`: all tasks pass, including `check-types` (tsc), `check-types:next` (typegen), and links/OpenAPI checks in the full `quality` graph.