### PR TITLE
perf: Keep package bundling inside a cacheable build boundary

### DIFF
--- a/packages/eslint-plugin-turbo/package.json
+++ b/packages/eslint-plugin-turbo/package.json
@@ -24,6 +24,9 @@
   ],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsdown && tsc -p tsconfig.build.json"
+  },
   "dependencies": {
     "dotenv": "16.0.3"
   },

--- a/packages/eslint-plugin-turbo/turbo.json
+++ b/packages/eslint-plugin-turbo/turbo.json
@@ -3,13 +3,9 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": ["build:bundle"],
-      "command": ["pnpm", "exec", "tsc", "-p", "tsconfig.build.json"]
-    },
-    "build:bundle": {
-      "cache": false,
       "dependsOn": ["^build"],
-      "command": ["pnpm", "exec", "tsdown"]
+      "outputs": ["dist/**"],
+      "command": ["pnpm", "run", "build"]
     },
     "test": {
       "dependsOn": ["build"],

--- a/packages/turbo-gen/package.json
+++ b/packages/turbo-gen/package.json
@@ -20,6 +20,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "scripts": {
+    "build": "tsdown && tsc -p tsconfig.build.json"
+  },
   "dependencies": {
     "@inquirer/prompts": "^7.10.1",
     "esbuild": "^0.28.1"

--- a/packages/turbo-gen/turbo.json
+++ b/packages/turbo-gen/turbo.json
@@ -15,14 +15,9 @@
       "command": ["pnpm", "exec", "jest"]
     },
     "build": {
-      "dependsOn": ["build:bundle"],
-      "outputs": ["dist/**"],
-      "command": ["pnpm", "exec", "tsc", "-p", "tsconfig.build.json"]
-    },
-    "build:bundle": {
-      "cache": false,
       "dependsOn": ["^build", "build:embed"],
-      "command": ["pnpm", "exec", "tsdown"]
+      "outputs": ["dist/**"],
+      "command": ["pnpm", "run", "build"]
     }
   }
 }

--- a/packages/turbo-workspaces/package.json
+++ b/packages/turbo-workspaces/package.json
@@ -22,6 +22,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "scripts": {
+    "build": "tsdown && tsc -p tsconfig.build.json"
+  },
   "dependencies": {
     "@inquirer/prompts": "^7.10.1",
     "commander": "10.0.0",

--- a/packages/turbo-workspaces/turbo.json
+++ b/packages/turbo-workspaces/turbo.json
@@ -3,13 +3,9 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": ["build:bundle"],
-      "command": ["pnpm", "exec", "tsc", "-p", "tsconfig.build.json"]
-    },
-    "build:bundle": {
-      "cache": false,
       "dependsOn": ["^build"],
-      "command": ["pnpm", "exec", "tsdown"]
+      "outputs": ["dist/**"],
+      "command": ["pnpm", "run", "build"]
     },
     "dev": {
       "command": ["pnpm", "exec", "tsdown", "--watch"]


### PR DESCRIPTION
## Summary

Closes TURBO-6041.

`@turbo/workspaces`, `eslint-plugin-turbo`, and `@turbo/gen` each split their build into a cached `build` (declaration generation via `tsc`) depending on an uncached `build:bundle` (`tsdown`). The uncached prerequisite re-executed on every run — even when the parent build restored from cache — so unchanged local and CI builds paid full bundling cost, and the split created two writers of `dist` that could not both be cached safely.

## Changes

Each package now has a single cached `build` that runs bundling and declaration generation together (`tsdown && tsc -p tsconfig.build.json` as the package's `build` script, `dist/**` as its outputs). The `build:bundle` task is removed. Prerequisites are preserved: `^build` everywhere, plus `build:embed` for `@turbo/gen`. Dev watch mode (`tsdown --watch`) is unchanged.

## Benchmarks

`turbo run build --filter=@turbo/workspaces --filter=eslint-plugin-turbo --filter=@turbo/gen`, macOS, interleaved runs. Task counts prove the behavioral contract; timings from turbo's own summary.

| Build | Before | After |
| --- | --- | --- |
| Cold (`--force`) | 1.99 s | 1.62 s (−19%) |
| Warm, no changes | 1.33 s — 5/8 tasks cached, 3 × `tsdown` re-executed | 0.59 s — 5/5 cached, zero `tsdown`/`tsc` processes (−55%) |

Deleting `dist` and rebuilding restores all artifacts from cache (all 20 declaration files included for @turbo/workspaces), and each package's Jest suite passes (@turbo/workspaces, @turbo/gen green; eslint-plugin-turbo shows the same `npm install` network/auth failures on clean `main` in this environment — unrelated to this change).

## Verification

- Cold and warm builds verified above; dist restore reproduces JS + declarations.
- `oxfmt` check clean on all touched files (pre-push hook runs the repo format suite).