### PR TITLE
perf: Replace repeated deferred-hash scans with dependency-driven readiness

### DIFF
--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -355,25 +355,6 @@ impl<'a> Visitor<'a> {
         })
     }
 
-    fn dependency_hashes_available(
-        &self,
-        engine: &Engine,
-        task_id: &TaskId<'static>,
-    ) -> Result<bool, Error> {
-        let dependency_set = engine
-            .dependencies(task_id)
-            .ok_or(Error::MissingDefinition)?;
-        let task_hash_tracker = self.task_hasher.task_hash_tracker();
-
-        Ok(dependency_set.iter().all(|dependency| {
-            let TaskNode::Task(dependency_task_id) = dependency else {
-                return true;
-            };
-
-            task_hash_tracker.hash(dependency_task_id).is_some()
-        }))
-    }
-
     fn dependency_output_hashes(
         &self,
         engine: &Engine,
@@ -484,35 +465,56 @@ impl<'a> Visitor<'a> {
     ) -> Result<(), Error> {
         use rayon::prelude::*;
 
-        loop {
-            let ready_to_hash = precomputed
-                .iter()
-                .filter_map(|(task_id, precomputed_task)| {
-                    if !matches!(precomputed_task, PrecomputedTask::Deferred) {
-                        return None;
-                    }
+        // Build incremental readiness once: an unresolved-dependency count
+        // per deferred task and reverse edges from each unhashed dependency
+        // to the deferred tasks waiting on it. Hashing a task then touches
+        // only its dependents instead of rescanning every candidate each
+        // round.
+        let task_hash_tracker = self.task_hasher.task_hash_tracker();
+        let mut pending_deps: HashMap<TaskId<'static>, usize> = HashMap::new();
+        let mut waiting_on: HashMap<TaskId<'static>, Vec<TaskId<'static>>> = HashMap::new();
+        let mut ready: Vec<TaskId<'static>> = Vec::new();
 
-                    let Some(task_definition) = engine.task_definition(task_id) else {
-                        return Some(Err(Error::MissingDefinition));
-                    };
-                    if task_definition.inputs.has_deferred_inputs() {
-                        return None;
-                    }
-
-                    match self.dependency_hashes_available(engine, task_id) {
-                        Ok(true) => Some(Ok(task_id.clone())),
-                        Ok(false) => None,
-                        Err(err) => Some(Err(err)),
-                    }
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-
-            if ready_to_hash.is_empty() {
-                return Ok(());
+        for (task_id, precomputed_task) in precomputed.iter() {
+            if !matches!(precomputed_task, PrecomputedTask::Deferred) {
+                continue;
             }
 
+            let Some(task_definition) = engine.task_definition(task_id) else {
+                return Err(Error::MissingDefinition);
+            };
+            if task_definition.inputs.has_deferred_inputs() {
+                continue;
+            }
+
+            let mut pending = 0;
+            for dependency in engine
+                .dependencies(task_id)
+                .ok_or(Error::MissingDefinition)?
+                .iter()
+            {
+                let TaskNode::Task(dependency_task_id) = dependency else {
+                    continue;
+                };
+                if task_hash_tracker.hash(dependency_task_id).is_none() {
+                    pending += 1;
+                    waiting_on
+                        .entry(dependency_task_id.clone())
+                        .or_default()
+                        .push(task_id.clone());
+                }
+            }
+
+            if pending == 0 {
+                ready.push(task_id.clone());
+            } else {
+                pending_deps.insert(task_id.clone(), pending);
+            }
+        }
+
+        while !ready.is_empty() {
             type HashResult = Result<(TaskId<'static>, PrecomputedTask), Error>;
-            let hash_results: Vec<HashResult> = ready_to_hash
+            let hash_results: Vec<HashResult> = ready
                 .par_iter()
                 .map(|task_id| {
                     self.precompute_ready_task_hash(engine, telemetry, task_id)
@@ -520,11 +522,30 @@ impl<'a> Visitor<'a> {
                 })
                 .collect();
 
+            let mut next_ready = Vec::new();
             for result in hash_results {
                 let (task_id, precomputed_task) = result?;
-                precomputed.insert(task_id, precomputed_task);
+                precomputed.insert(task_id.clone(), precomputed_task);
+
+                // Unblock the deferred tasks that were waiting only on this
+                // hash (among others they still wait for).
+                if let Some(waiters) = waiting_on.remove(&task_id) {
+                    for waiter in waiters {
+                        let Some(pending) = pending_deps.get_mut(&waiter) else {
+                            continue;
+                        };
+                        *pending -= 1;
+                        if *pending == 0 {
+                            pending_deps.remove(&waiter);
+                            next_ready.push(waiter);
+                        }
+                    }
+                }
             }
+            ready = next_ready;
         }
+
+        Ok(())
     }
 
     fn precompute_task_hashes(


### PR DESCRIPTION
## Summary

Closes TURBO-5983.

`precompute_unblocked_deferred_hashes` repeatedly scanned the complete precomputed-task map after every round of hashing: collect all newly-ready deferred tasks, hash them in parallel, rescan. Long deferred chains or layered deferred graphs approached O(D × N) readiness checks, each walking the task's dependencies and materializing adjacency through engine neighbor helpers.

## Changes

Readiness is now built once per invocation:

- an unresolved-deferred-dependency count per deferred task, and
- reverse edges from each unhashed dependency to the deferred tasks waiting on it,
- a ready queue populated when a count reaches zero.

Hashing a task then unblocks only its dependents. Missing-definition errors, deferred-input (JIT/dependencyOutputs) exclusion, round-based hashing, and tracker semantics are unchanged; a deferred task whose dependency is itself deferred-but-excluded still never resolves in the loop, exactly as before.

## Benchmarks

Source-exact model of the old scan loop vs the new readiness structure over synthetic deferred task graphs (hashing modeled as free — it is identical in both), release-mode harness, macOS. Not committed.

| Deferred graph | Before (checks / wall) | After (checks / wall) | Change |
| --- | --- | --- | --- |
| Chain, 100 tasks | 5,049 / 55.8 µs | 198 / 21.5 µs | −96% checks, −61% |
| Chain, 1,000 tasks | 500,499 / 3.77 ms | 1,998 / 160 µs | −99.6% checks, −96% |
| Chain, 5,000 tasks | 12.5M / 91.7 ms | 9,998 / 778 µs | −99.92% checks, −99.2% |
| Chain, 10,000 tasks | 50.0M / 419 ms | 19,998 / 1.75 ms | −99.96% checks, −99.6% |
| Diamond layers, 10,000 tasks (50-wide) | 1.25M / 14.1 ms | 519K / 4.7 ms | −59% checks, −67% |
| Dense layered, 10,000 tasks (100-wide, fully connected layers) | 1.49M / 11.7 ms | 1.98M / 15.5 ms | +33% checks, +32% wall — see note |

Note: for pathologically dense graphs (every task depending on an entire 100-task layer), counting every edge costs more than scan-with-early-exit. Real deferred/JIT graphs are chains and small diamonds, where the win is 2–3 orders of magnitude; small chains are also faster (bookkeeping does not exceed scan cost).

## Verification

- `cargo test -p turborepo-lib`: 498 passed, 0 failed.
- Deferred-hash integration tests pass: `test_dependency_outputs_dry_run_reports_deferred_hash`, `test_structured_jit_with_defaults_uses_deferred_default_inputs` (and the deferred watch test module).
- `cargo clippy -p turborepo-lib --all-targets`: clean (only the pre-existing proc-macro-error2 future-incompat note, also present on main).