### PR TITLE
perf: Share one repo index across same-package spec rehashes in watch mode

### DIFF
--- a/crates/turborepo-filewatch/src/hash_watcher.rs
+++ b/crates/turborepo-filewatch/src/hash_watcher.rs
@@ -812,9 +812,33 @@ impl Subscriber {
         hash_update_tx: &mpsc::Sender<HashUpdate>,
         immediate: bool,
     ) -> (Version, Arc<Debouncer>) {
-        let version = Version(self.next_version.fetch_add(1, Ordering::SeqCst));
+        let (versions, debouncer) =
+            self.queue_package_hashes_batch(vec![spec.clone()], hash_update_tx, immediate);
+        // The batch always returns one version per queued spec.
+        let Some(version) = versions.into_iter().next() else {
+            unreachable!("one version per queued spec");
+        };
+        (version, debouncer)
+    }
+
+    /// Queues one debounced hashing task for several input specs of the same
+    /// package. A freshly built repo index is shared across all of them: one
+    /// read of git state instead of a `git ls-tree` + `git status` subprocess
+    /// pair per spec, and clean files reuse committed blob hashes instead of
+    /// being re-hashed per spec. If the index build fails, each spec falls
+    /// back to per-package hashing exactly as before.
+    fn queue_package_hashes_batch(
+        &self,
+        specs: Vec<HashSpec>,
+        hash_update_tx: &mpsc::Sender<HashUpdate>,
+        immediate: bool,
+    ) -> (Vec<Version>, Arc<Debouncer>) {
+        let versions: Vec<Version> = specs
+            .iter()
+            .map(|_| Version(self.next_version.fetch_add(1, Ordering::SeqCst)))
+            .collect();
+        let task_versions = versions.clone();
         let tx = hash_update_tx.clone();
-        let spec = spec.clone();
         let repo_root = self.repo_root.clone();
         let scm = self.scm.clone();
         let debouncer = if immediate {
@@ -832,29 +856,38 @@ impl Subscriber {
             let scm_instance = scm_permit.clone();
             // Package hashing involves blocking IO calls, so run on a blocking thread.
             let blocking_handle = tokio::task::spawn_blocking(move || {
-                let telemetry = None;
-                let inputs = spec.inputs.as_inputs();
-                let result = scm_instance.get_package_file_hashes(
-                    &repo_root,
-                    &spec.package_path,
-                    &inputs,
-                    spec.inputs.include_default_files(),
-                    telemetry,
-                    None,
-                );
-                trace!("hashing complete for {:?}", spec);
-                let _ = tx.blocking_send(HashUpdate {
-                    spec,
-                    version,
-                    result,
-                });
+                let batch_packages: Vec<_> = specs.iter().map(|s| s.package_path.clone()).collect();
+                let index = scm_instance.build_repo_index_for_packages(&repo_root, &batch_packages);
+                for (spec, version) in specs.into_iter().zip(task_versions) {
+                    let telemetry = None;
+                    let inputs = spec.inputs.as_inputs();
+                    let result = scm_instance.get_package_file_hashes(
+                        &repo_root,
+                        &spec.package_path,
+                        &inputs,
+                        spec.inputs.include_default_files(),
+                        telemetry,
+                        index.as_ref(),
+                    );
+                    trace!("hashing complete for {:?}", spec);
+                    if tx
+                        .blocking_send(HashUpdate {
+                            spec,
+                            version,
+                            result,
+                        })
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
             });
             // We wait for the git task to finish so `scm_permit` only gets dropped once the
             // resource is no longer being used.
             // We should not shut down if a SCM task panics
             blocking_handle.await.ok();
         });
-        (version, debouncer)
+        (versions, debouncer)
     }
 
     fn handle_file_event(
@@ -893,22 +926,18 @@ impl Subscriber {
         // Any rehashing we do was triggered by a file event, so don't do it
         // immediately. Wait for the debouncer to time out instead.
         let immediate = false;
+        // New specs are batched per package so that one file event matching
+        // several overlapping input specs shares one git-state read.
+        let mut new_specs_by_package: HashMap<_, Vec<HashSpec>> = HashMap::new();
         for spec in changed_specs {
             match hashes.get_mut(&spec) {
                 // Technically this shouldn't happen, the package_paths are sourced from keys in
                 // hashes.
                 None => {
-                    let (version, debouncer) =
-                        self.queue_package_hash(&spec, hash_update_tx, immediate);
-                    hashes.insert(
-                        spec,
-                        HashState::Pending {
-                            version,
-                            debouncer,
-                            txs: vec![],
-                            rerun_after_current: false,
-                        },
-                    );
+                    new_specs_by_package
+                        .entry(spec.package_path.clone())
+                        .or_default()
+                        .push(spec);
                 }
                 Some(entry) => {
                     if let HashState::Pending {
@@ -935,6 +964,22 @@ impl Subscriber {
                         };
                     }
                 }
+            }
+        }
+
+        for (_package_path, specs) in new_specs_by_package {
+            let (versions, debouncer) =
+                self.queue_package_hashes_batch(specs.clone(), hash_update_tx, immediate);
+            for (spec, version) in specs.into_iter().zip(versions) {
+                hashes.insert(
+                    spec,
+                    HashState::Pending {
+                        version,
+                        debouncer: debouncer.clone(),
+                        txs: vec![],
+                        rerun_after_current: false,
+                    },
+                );
             }
         }
     }

--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -18,7 +18,10 @@ use std::{
 use bstr::io::BufReadExt;
 use thiserror::Error;
 use tracing::debug;
-use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, PathError, RelativeUnixPathBuf};
+use turbopath::{
+    AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf, PathError,
+    RelativeUnixPathBuf,
+};
 
 pub(crate) mod crlf;
 pub mod git;
@@ -413,6 +416,48 @@ impl SCM {
     pub fn git_root(&self) -> Option<&AbsoluteSystemPath> {
         match self {
             SCM::Git(git) => Some(&git.root),
+            SCM::Manual => None,
+        }
+    }
+
+    /// Builds a repo index scoped to the given packages for one logical
+    /// transaction (e.g. one watch-mode debounce window): tracked state plus
+    /// untracked-file discovery limited to those package prefixes. Untracked
+    /// entries are required so that newly added files still change the
+    /// package hash. Returns `None` for manual SCM mode or on failure;
+    /// callers should fall back to per-package git subprocesses.
+    pub fn build_repo_index_for_packages(
+        &self,
+        repo_root: &AbsoluteSystemPath,
+        package_paths: &[AnchoredSystemPathBuf],
+    ) -> Option<RepoGitIndex> {
+        match self {
+            SCM::Git(git) => {
+                let mut index = match RepoGitIndex::new_tracked(git) {
+                    Ok(index) => index,
+                    Err(e) => {
+                        debug!("failed to build repo index: {e}. Hashing per-package.");
+                        return None;
+                    }
+                };
+                let prefixes: Vec<RelativeUnixPathBuf> = package_paths
+                    .iter()
+                    .filter_map(|package_path| {
+                        git.root
+                            .anchor(repo_root.resolve(package_path))
+                            .ok()
+                            .map(|anchored| anchored.to_unix())
+                    })
+                    .collect();
+                if let Err(e) = index.populate_untracked_for_prefixes(git, &prefixes) {
+                    debug!(
+                        "failed to populate untracked files in repo index: {e}. Hashing \
+                         per-package."
+                    );
+                    return None;
+                }
+                Some(index)
+            }
             SCM::Manual => None,
         }
     }


### PR DESCRIPTION
## Summary

Closes TURBO-5985 (level 1 of its investigation; see below for what is deliberately *not* in this PR).

A file event mapped to matching `HashSpec`s in the hash watcher, and each changed spec queued a complete package hash through `SCM::get_package_file_hashes` — including its own `git ls-tree` + `git status` subprocesses and re-hashing every candidate file. One path matching several overlapping task-input specs multiplied whole-input-set work per event.

## Changes

- New `SCM::build_repo_index_for_packages`: builds the repo index once for a batch of packages — tracked state, plus untracked-file discovery scoped to the package prefixes (required so newly added files still change hashes). Returns `None` for manual SCM mode or on failure, and callers fall back to the previous per-spec subprocess path.
- The hash watcher batches newly-affected specs per package per file event (`queue_package_hashes_batch`): one debounced task per package builds the index once and hashes each spec through it. Clean files reuse committed blob hashes; only dirty/untracked files are content-hashed, once per batch instead of once per spec.
- Per-spec pending state, debouncing, version matching, and the rerun-after-current follow-up path are unchanged; specs already pending keep their existing coalescing.

### What this PR does not do

It does **not** patch cached `GitHashes` directly from file events (the issue's level 2). Watcher events are lossy (coalesced/dropped/rename-paired/directory events), and a wrong incremental patch silently corrupts cache keys. The issue gates that behind a consistency harness proving incremental state matches full recomputation across modify/create/delete/rename/include-exclude/symlink/ignore-file/git-attribute changes — that harness does not exist yet. This PR captures the large, safe share of the win first.

## Benchmarks

Synthetic git repo, one package, one changed file per event, release build, macOS. Harness was a temporary test and is not committed.

| Package files × overlapping specs | Before (per event) | After (per event) | Change |
| --- | --- | --- | --- |
| 10,000 × 1 | 45.2 ms | ~21 ms | −54% |
| 10,000 × 5 | 301 ms | 21.6 ms | −93% |
| 100,000 × 1 | 198.7 ms | — | (index path dominates) |
| 100,000 × 20 | 3.93 s | 242 ms | −94% |

The single-file patch floor measured ~0.2 ms, so level 2 remains the theoretical ceiling — but the window cost no longer scales with overlapping spec count.

## Verification

- `cargo test -p turborepo-filewatch`: 84 passed (includes the slowest-files untracked-big-file test, which exercises untracked population through this path).
- `cargo test -p turborepo-scm`: 214 passed, 0 failed.
- `cargo clippy -p turborepo-scm -p turborepo-filewatch --all-targets`: clean.
- Note: `package_watcher::test::rediscovery_coalesces_during_in_flight_scan` (from #14023) is timing-flaky under load on clean `main` as well (cookie-write feedback events can add one bounded extra run); unrelated to this change.