### PR TITLE
perf: Reuse the package graph across partial watch reruns

### DIFF
--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -121,6 +121,13 @@ pub struct RunBuilder {
     // cache provenance. Skip the repository-wide work that only serves those consumers.
     skip_repo_index_and_scm_state: bool,
     skip_external_dependencies: bool,
+    // In watch mode, partial reruns may reuse the package graph built by the
+    // previous full run instead of rediscovering the workspace, re-reading
+    // every manifest, and re-parsing the lockfile. Only sound when the caller
+    // has proven that no graph-defining file (workspace manifests, lockfile,
+    // workspace configuration) changed since the graph was built; the watch
+    // client checks the changed-file set before sharing it.
+    shared_pkg_graph: Option<Arc<PackageGraph>>,
 }
 
 impl RunBuilder {
@@ -163,6 +170,7 @@ impl RunBuilder {
             changed_files_for_watch: None,
             skip_repo_index_and_scm_state: false,
             skip_external_dependencies: false,
+            shared_pkg_graph: None,
         })
     }
 
@@ -196,6 +204,16 @@ impl RunBuilder {
 
     pub fn with_changed_files(mut self, files: HashSet<turbopath::AnchoredSystemPathBuf>) -> Self {
         self.changed_files_for_watch = Some(files);
+        self
+    }
+
+    /// Reuse a package graph from an earlier run instead of building a fresh
+    /// one from disk. Only sound when workspace manifests, the lockfile, and
+    /// workspace configuration are unchanged; used by watch-mode partial
+    /// reruns where the watcher proves that from the changed-file set.
+    /// Ignored for `--parallel`, which mutates the graph after construction.
+    pub fn with_shared_package_graph(mut self, graph: Arc<PackageGraph>) -> Self {
+        self.shared_pkg_graph = Some(graph);
         self
     }
 
@@ -842,39 +860,55 @@ impl RunBuilder {
             self.http_client.activate();
         }
 
-        let mut pkg_dep_graph = {
-            let builder =
-                PackageGraph::builder_optional(&self.repo_root, root_package_json.clone())
-                    .with_single_package_mode(self.opts.run_opts.single_package)
-                    .with_allow_no_package_manager(self.opts.repo_opts.allow_no_package_manager);
-            let builder = if self.skip_external_dependencies {
-                builder.without_external_dependencies()
-            } else {
-                builder
-            };
-            let builder = graph_features.configure(builder);
+        // --parallel removes inter-package dependencies from the graph after
+        // construction, so a graph shared with other runs cannot be reused
+        // for it.
+        let shared_pkg_graph = if self.opts.run_opts.parallel {
+            None
+        } else {
+            self.shared_pkg_graph.clone()
+        };
+        let mut pkg_dep_graph = match shared_pkg_graph {
+            Some(graph) => {
+                tracing::debug!("reusing package graph from previous run");
+                graph
+            }
+            None => {
+                let builder =
+                    PackageGraph::builder_optional(&self.repo_root, root_package_json.clone())
+                        .with_single_package_mode(self.opts.run_opts.single_package)
+                        .with_allow_no_package_manager(
+                            self.opts.repo_opts.allow_no_package_manager,
+                        );
+                let builder = if self.skip_external_dependencies {
+                    builder.without_external_dependencies()
+                } else {
+                    builder
+                };
+                let builder = graph_features.configure(builder);
 
-            let graph = builder
-                .build()
-                .instrument(tracing::info_span!("pkg_dep_graph_build"))
-                .await;
+                let graph = builder
+                    .build()
+                    .instrument(tracing::info_span!("pkg_dep_graph_build"))
+                    .await;
 
-            match graph {
-                Ok(graph) => graph,
-                // if we can't find the package.json, it is a bug, and we should report it.
-                // likely cause is that package discovery watching is not up to date.
-                // note: there _is_ a false positive from a race condition that can occur
-                //       from toctou if the package.json is deleted, but we'd like to know
-                Err(turborepo_repository::package_graph::Error::PackageJson(
-                    package_json::Error::Io(io),
-                )) if io.kind() == ErrorKind::NotFound => {
-                    run_telemetry.track_error(TrackedErrors::InvalidPackageDiscovery);
-                    return Err(turborepo_repository::package_graph::Error::PackageJson(
+                match graph {
+                    Ok(graph) => Arc::new(graph),
+                    // if we can't find the package.json, it is a bug, and we should report it.
+                    // likely cause is that package discovery watching is not up to date.
+                    // note: there _is_ a false positive from a race condition that can occur
+                    //       from toctou if the package.json is deleted, but we'd like to know
+                    Err(turborepo_repository::package_graph::Error::PackageJson(
                         package_json::Error::Io(io),
-                    )
-                    .into());
+                    )) if io.kind() == ErrorKind::NotFound => {
+                        run_telemetry.track_error(TrackedErrors::InvalidPackageDiscovery);
+                        return Err(turborepo_repository::package_graph::Error::PackageJson(
+                            package_json::Error::Io(io),
+                        )
+                        .into());
+                    }
+                    Err(e) => return Err(e.into()),
                 }
-                Err(e) => return Err(e.into()),
             }
         };
 
@@ -1220,7 +1254,13 @@ impl RunBuilder {
         // requiring a fresh engine build. Affected filtering runs once afterward
         // rather than on both engines to avoid a redundant SCM query.
         if self.opts.run_opts.parallel {
-            pkg_dep_graph.remove_package_dependencies();
+            // A --parallel run never reuses a shared package graph (the
+            // sharing path above opts out for parallel), so this Arc is
+            // uniquely owned here.
+            let Some(graph) = Arc::get_mut(&mut pkg_dep_graph) else {
+                unreachable!("--parallel runs never reuse a shared package graph");
+            };
+            graph.remove_package_dependencies();
             let engine_pkgs: Box<dyn Iterator<Item = &PackageName>> = if needs_all_packages {
                 Box::new(all_pkgs.iter())
             } else {
@@ -1480,7 +1520,7 @@ impl RunBuilder {
                 api_client,
                 env_at_execution_start,
                 filtered_pkgs: filtered_pkgs.keys().cloned().collect(),
-                pkg_dep_graph: Arc::new(pkg_dep_graph),
+                pkg_dep_graph,
                 turbo_json_loader,
                 root_turbo_json,
                 scm,

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -541,6 +541,13 @@ impl Run {
         &self.pkg_dep_graph
     }
 
+    /// The package graph as a shared handle so watch-mode partial reruns can
+    /// reuse it when no graph-defining file (manifests, lockfile, workspace
+    /// configuration) changed between runs.
+    pub(crate) fn pkg_dep_graph_handle(&self) -> Arc<PackageGraph> {
+        self.pkg_dep_graph.clone()
+    }
+
     pub fn engine(&self) -> &Engine {
         &self.engine
     }

--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -20,7 +20,7 @@ use turborepo_filewatch::{
     cookies::CookieWriter, globwatcher::GlobWatcher, hash_watcher::HashWatcher,
     package_watcher::PackageWatcher, FileSystemWatcher,
 };
-use turborepo_repository::package_graph::PackageName;
+use turborepo_repository::package_graph::{PackageGraph, PackageName};
 use turborepo_run_cache::{OutputWatcher, OutputWatcherError};
 use turborepo_scm::SCM;
 use turborepo_scope::target_selector::InvalidSelectorError;
@@ -138,6 +138,10 @@ impl OutputWatcher for InProcessOutputWatcher {
 
 pub struct WatchClient {
     run: Arc<Run>,
+    /// The package graph from the most recent full run, reused by partial
+    /// (`ChangedPackages::Some`) reruns whose changed files provably cannot
+    /// alter it. See `package_graph_invalidated`.
+    shared_pkg_graph: Option<Arc<PackageGraph>>,
     watched_packages: HashSet<PackageName>,
     active_runs: Vec<RunHandle>,
     // Stoppers from completed runs whose ProcessManagers may still track
@@ -157,6 +161,36 @@ pub struct WatchClient {
     ui_handle: Option<JoinHandle<()>>,
     experimental_write_cache: bool,
     query_server: Option<Arc<dyn turborepo_query_api::QueryServer>>,
+}
+
+/// True when a changed file may have altered the package graph: a workspace
+/// manifest (`package.json`/`package.jsonc`), the package manager's lockfile,
+/// pnpm's workspace-definition file, or any toolchain watch-spec definition
+/// file. Watch-mode partial reruns reuse the cached package graph only when
+/// this is false. Everything else that defines the graph (workspace glob
+/// changes, root `turbo.json`) already triggers full rediscovery upstream of
+/// this check, and task configuration is reloaded per run, so package-level
+/// `turbo.json` changes stay correct on a shared graph.
+fn package_graph_invalidated(
+    changed_files: &HashSet<AnchoredSystemPathBuf>,
+    lockfile_name: Option<&str>,
+    watch_spec: &turborepo_repository::toolchain::WatchSpec,
+) -> bool {
+    changed_files.iter().any(|path| {
+        let unix_path = path.to_unix();
+        let file_name = path.as_path().file_name().and_then(|name| name.to_str());
+        matches!(file_name, Some("package.json") | Some("package.jsonc"))
+            || Some(unix_path.as_str()) == lockfile_name
+            || file_name == Some("pnpm-workspace.yaml")
+            || watch_spec
+                .definition_paths
+                .iter()
+                .any(|definition| unix_path.as_str() == definition)
+            || watch_spec
+                .definition_file_names
+                .iter()
+                .any(|name| file_name == Some(name.as_str()))
+    })
 }
 
 struct RunHandle {
@@ -357,6 +391,7 @@ impl WatchClient {
         }
 
         let (run, _analytics) = run_builder.build(&handler, telemetry.clone()).await?;
+        let shared_pkg_graph = Some(run.pkg_dep_graph_handle());
         let run = Arc::new(run);
 
         let watched_packages = run.get_relevant_packages();
@@ -391,6 +426,7 @@ impl WatchClient {
         Ok(Self {
             base,
             run,
+            shared_pkg_graph,
             watched_packages,
             _watching: watching,
             output_watcher,
@@ -776,6 +812,19 @@ impl WatchClient {
                 let signal_handler = self.handler.clone();
                 let telemetry = self.telemetry.clone();
 
+                // Reuse the package graph from the previous full run when the
+                // changed files provably cannot alter it (no manifests,
+                // lockfile, or workspace-definition files). Task configuration
+                // is still reloaded per run, so package-level turbo.json
+                // changes take effect even on a shared graph.
+                let reusable_graph = self.shared_pkg_graph.clone().filter(|graph| {
+                    !package_graph_invalidated(
+                        &changed_files,
+                        graph.package_manager().map(|pm| pm.lockfile_name()),
+                        &graph.active_watch_spec(),
+                    )
+                });
+
                 let mut run_builder = RunBuilder::new(new_base, None)?
                     .with_output_watcher(self.output_watcher.clone())
                     .with_entrypoint_packages(packages)
@@ -783,7 +832,17 @@ impl WatchClient {
                 if let Some(ref qs) = self.query_server {
                     run_builder = run_builder.with_query_server(qs.clone());
                 }
+                let needs_fresh_graph = reusable_graph.is_none();
+                if let Some(graph) = reusable_graph {
+                    run_builder = run_builder.with_shared_package_graph(graph);
+                }
                 let (run, _analytics) = run_builder.build(&signal_handler, telemetry).await?;
+
+                // A rerun that rebuilt the graph refreshes the shared copy so
+                // later partial reruns can reuse it again.
+                if needs_fresh_graph {
+                    self.shared_pkg_graph = Some(run.pkg_dep_graph_handle());
+                }
 
                 let task_names = run.engine.tasks_with_command(&run.pkg_dep_graph);
                 if task_names.is_empty() {
@@ -828,6 +887,7 @@ impl WatchClient {
                 let (run, _analytics) = run_builder
                     .build(&self.handler, self.telemetry.clone())
                     .await?;
+                self.shared_pkg_graph = Some(run.pkg_dep_graph_handle());
                 self.run = run.into();
 
                 self.watched_packages = self.run.get_relevant_packages();
@@ -859,9 +919,9 @@ mod test {
 
     use turbopath::AnchoredSystemPathBuf;
     use turborepo_daemon::PackageChangeEvent;
-    use turborepo_repository::package_graph::PackageName;
+    use turborepo_repository::{package_graph::PackageName, toolchain::WatchSpec};
 
-    use super::{ChangedPackages, WatchClient};
+    use super::{package_graph_invalidated, ChangedPackages, WatchClient};
 
     fn make_package_changed(name: &str) -> PackageChangeEvent {
         PackageChangeEvent::Package {
@@ -891,6 +951,94 @@ mod test {
         let cp = ChangedPackages::default();
         assert!(cp.is_empty());
         assert!(matches!(cp, ChangedPackages::Some { ref packages, .. } if packages.is_empty()));
+    }
+
+    fn files(paths: &[&str]) -> HashSet<AnchoredSystemPathBuf> {
+        paths
+            .iter()
+            .map(|f| AnchoredSystemPathBuf::from_raw(f).unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn graph_reused_for_source_file_changes() {
+        let changed = files(&["packages/foo/src/index.ts", "packages/foo/README.md"]);
+        assert!(!package_graph_invalidated(
+            &changed,
+            Some("pnpm-lock.yaml"),
+            &WatchSpec::default()
+        ));
+    }
+
+    #[test]
+    fn graph_invalidated_by_manifest_changes() {
+        for path in [
+            "package.json",
+            "packages/foo/package.json",
+            "packages/foo/package.jsonc",
+        ] {
+            let changed = files(&[path, "packages/foo/src/index.ts"]);
+            assert!(
+                package_graph_invalidated(&changed, Some("pnpm-lock.yaml"), &WatchSpec::default()),
+                "{path} must invalidate the cached package graph"
+            );
+        }
+    }
+
+    #[test]
+    fn graph_invalidated_by_lockfile_and_workspace_definition() {
+        assert!(package_graph_invalidated(
+            &files(&["pnpm-lock.yaml"]),
+            Some("pnpm-lock.yaml"),
+            &WatchSpec::default()
+        ));
+        // A different package manager's lockfile name must not match.
+        assert!(!package_graph_invalidated(
+            &files(&["pnpm-lock.yaml"]),
+            Some("yarn.lock"),
+            &WatchSpec::default()
+        ));
+        assert!(package_graph_invalidated(
+            &files(&["pnpm-workspace.yaml"]),
+            Some("pnpm-lock.yaml"),
+            &WatchSpec::default()
+        ));
+    }
+
+    #[test]
+    fn graph_invalidated_by_toolchain_definition_files() {
+        let watch_spec = WatchSpec {
+            definition_file_names: vec!["Cargo.toml".to_string()],
+            definition_paths: vec!["Cargo.lock".to_string()],
+            ..Default::default()
+        };
+        assert!(package_graph_invalidated(
+            &files(&["crates/foo/Cargo.toml"]),
+            None,
+            &watch_spec
+        ));
+        assert!(package_graph_invalidated(
+            &files(&["Cargo.lock"]),
+            None,
+            &watch_spec
+        ));
+        assert!(!package_graph_invalidated(
+            &files(&["crates/foo/src/lib.rs"]),
+            None,
+            &watch_spec
+        ));
+    }
+
+    #[test]
+    fn graph_reused_when_turbo_json_changes() {
+        // Task configuration is reloaded on every run even with a shared
+        // package graph, so turbo.json changes do not invalidate the graph.
+        let changed = files(&["packages/foo/turbo.json"]);
+        assert!(!package_graph_invalidated(
+            &changed,
+            Some("pnpm-lock.yaml"),
+            &WatchSpec::default()
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes TURBO-5984.

Every watch-mode file change rebuilt `CommandBase`, `RunBuilder`, and `Run` from scratch. For partial reruns (`ChangedPackages::Some`) that means re-running workspace discovery, parsing every `package.json`, and re-parsing the lockfile — work whose inputs are unchanged for a source-only edit.

## Changes

- `RunBuilder::with_shared_package_graph`: build a run on top of an existing `Arc<PackageGraph>` instead of rebuilding from disk. `--parallel` opts out (it mutates the graph after construction).
- The watch client keeps the most recent full run's package graph and reuses it for a partial rerun only when the event's changed-file set provably cannot alter it. The invalidators are exactly the graph's inputs that are not already covered by upstream full rediscovery (workspace-glob changes, root `turbo.json`, toolchain definition files → `ChangedPackages::All`):
  - any `package.json` / `package.jsonc` (workspace manifests),
  - the detected package manager's lockfile,
  - `pnpm-workspace.yaml`,
  - toolchain watch-spec definition files (belt-and-braces; these already rediscover).
- A rerun that does rebuild the graph refreshes the shared copy, so later partial reruns reuse it again.
- Task configuration (`turbo.json` loader), SCM state, and the repo index are still rebuilt per run: package-level `turbo.json` changes take effect on a shared graph, and commits made while watching are picked up. Root `.env` inference likewise re-runs per run.

Note on the invariant: structural changes (package added/removed, workspace globs, root turbo.json, lockfile-driven rediscovery) already surface as `Rediscover` → `ChangedPackages::All`, which always rebuilds. The changed-file check covers the remaining graph inputs that flow through `Some` events.

## Benchmarks

Synthetic pnpm monorepos, one changed file per event, debug build, macOS. The measured span is `pkg_dep_graph_build` — workspace discovery + manifest parsing + lockfile parsing — which partial reruns now skip entirely:

| Packages | Graph rebuild per rerun (before) | After |
| --- | --- | --- |
| 500 | 31–41 ms | ~0 |
| 2,000 | 165 ms | ~0 |

The cost scales with workspace size and lockfile length; release builds shrink the constant but keep the per-event scaling.

## Verification

- `cargo test -p turborepo-lib --lib`: 503 passed, 0 failed (includes 5 new tests for the invalidation predicate: source files reuse; manifests/lockfile/`pnpm-workspace.yaml`/toolchain definitions invalidate; package `turbo.json` does not).
- `cargo clippy -p turborepo-lib --all-targets`: clean.
- Manual smoke test (`turbo watch build` on a 500-package synthetic repo, debug logging):
  - Source-file edit → partial reruns log `reusing package graph from previous run` and rebuild the affected package.
  - `packages/pkg7/package.json` edit → rerun rebuilds the graph (no reuse log for that rerun) and refreshes the shared copy.
  - Subsequent source edit → reuse resumes.