### PR TITLE
test: Deflake rediscovery_coalesces_during_in_flight_scan

### DIFF
--- a/crates/turborepo-filewatch/src/package_watcher.rs
+++ b/crates/turborepo-filewatch/src/package_watcher.rs
@@ -883,12 +883,34 @@ mod test {
             }
         }
 
-        // The burst must not produce a pile-up: one in-flight discovery plus
-        // exactly one coalesced follow-up.
-        assert_eq!(
-            calls.load(Ordering::SeqCst),
-            2,
-            "expected initial scan + one coalesced follow-up"
+        // Wait for quiescence before asserting: file events from the burst
+        // are delivered asynchronously, and one may still be in flight when
+        // the coalesced follow-up runs.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        let mut last_calls = 0;
+        let mut stable_since = tokio::time::Instant::now();
+        loop {
+            let current = calls.load(Ordering::SeqCst);
+            if current != last_calls || in_flight.load(Ordering::SeqCst) > 0 {
+                last_calls = current;
+                stable_since = tokio::time::Instant::now();
+            } else if stable_since.elapsed() > Duration::from_millis(300) {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "discoveries never settled"
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        // The burst must not produce a pile-up proportional to its size: one
+        // in-flight discovery, one coalesced follow-up, and at most one extra
+        // scan if a straggler event lands while the follow-up runs.
+        let total = calls.load(Ordering::SeqCst);
+        assert!(
+            total <= 3,
+            "20 invalidations must coalesce into at most 3 scans, got {total}"
         );
         assert_eq!(
             max_in_flight.load(Ordering::SeqCst),


### PR DESCRIPTION
## Summary

Follow-up to #14023. Its test asserted exactly two discoveries (initial scan + one coalesced follow-up), but file events from the 20-write burst are delivered asynchronously by the OS watcher. Under load, one straggler event can land while the follow-up scan runs, setting the rerun flag and producing a third bounded scan (observed: `calls == 3`, `max_in_flight == 1`). That is still correct coalescing — the guarantee is one follow-up per event observed mid-scan, never a pile-up proportional to the burst.

The test now waits for quiescence (no scan in flight and the call count stable across a settle window) and asserts the actual guarantee: at most three scans total, and discoveries never overlap.

## Verification

- The test previously failed about 1 in 6 runs under load on clean `main`; with this change it passed 12/12 runs, and `cargo test -p turborepo-filewatch` is green twice in a row (84 passed).
- `cargo clippy -p turborepo-filewatch --all-targets`: clean.