### PR TITLE
docs: Verify Rust cache reuse for a docs-only change

### DIFF
--- a/apps/docs/content/docs/guides/tools/rust.mdx
+++ b/apps/docs/content/docs/guides/tools/rust.mdx
@@ -152,7 +152,7 @@ The built-in `format` task also includes `rustfmt.toml`, `.rustfmt.toml`, and `R
 
 Project-specific hashing inputs must be accounted for manually. This includes:
 
-- Environment variables must read by build scripts still need to be declared in the task's [`env`](/docs/reference/configuration#env) configuration
+- Environment variables read by build scripts still need to be declared in the task's [`env`](/docs/reference/configuration#env) configuration
 - File inputs that are not included by default. Use [`inputs`](/docs/reference/configuration#inputs) to define your own file inputs and [`$TURBO_DEFAULT$`](/docs/reference/configuration#turbo_default) to preserve zero-configuration file inputs
 
 ### Output caching


### PR DESCRIPTION
## Summary

- Fix a wording error in the Rust guide, with no changes outside `apps/docs/content/docs/guides/tools/rust.mdx`.
- Use this draft PR to verify that a docs-only change reuses the Rust test task cache across all three operating systems and both shards.

## CI experiment

- Branch from main at `171a0a3882ea028b6e823cd36ebcde57a45badd0`, whose six Rust test jobs completed successfully in run https://github.com/vercel/turborepo/actions/runs/34429739554.
- Leave Rust sources, lockfiles, task configuration, and CI workflows unchanged.
- Inspect each Rust job for an actual task cache hit; successful tests alone are not proof of cache reuse.
- Results are pending. Keep this PR in draft while collecting evidence.