### PR TITLE
test: Deflake Go watch CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,19 +44,18 @@ jobs:
         with:
           persist-credentials: false
 
-      - parallel:
-          - name: Setup Rust
-            uses: ./.github/actions/setup-rust
-            with:
-              shared-cache-key: turborepo-debug-build
-              save-cache: true
-              github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          shared-cache-key: turborepo-debug-build
+          save-cache: true
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-          - name: Setup Zig
-            uses: ./.github/actions/setup-zig
+      - name: Setup Zig
+        uses: ./.github/actions/setup-zig
 
-          - name: Setup capnproto
-            uses: ./.github/actions/setup-capnproto
+      - name: Setup capnproto
+        uses: ./.github/actions/setup-capnproto
 
       - name: Run cargo clippy
         run: cargo lint
@@ -91,15 +90,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - parallel:
-          - name: Set up Turborepo Remote Cache
-            if: github.event.pull_request.head.repo.full_name == github.repository
-            uses: vercel/setup-turborepo-remote-cache-action@49d7b1b46ba4c9251e1977986bfe18336feabc8f # v1.1.0
-            with:
-              team: ${{ vars.TURBO_TEAM }}
+      - name: Set up Turborepo Remote Cache
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: vercel/setup-turborepo-remote-cache-action@49d7b1b46ba4c9251e1977986bfe18336feabc8f # v1.1.0
+        with:
+          team: ${{ vars.TURBO_TEAM }}
 
-          - name: "Setup Node"
-            uses: ./.github/actions/setup-node
+      - name: "Setup Node"
+        uses: ./.github/actions/setup-node
 
       - name: Install Global Turbo
         uses: ./.github/actions/install-global-turbo

--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -85,19 +85,18 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install bash capnp
 
-      - parallel:
-          - name: Setup capnproto
-            if: runner.os != 'macOS'
-            uses: ./.github/actions/setup-capnproto
+      - name: Setup capnproto
+        if: runner.os != 'macOS'
+        uses: ./.github/actions/setup-capnproto
 
-          - name: Rust Setup
-            uses: ./.github/actions/setup-rust
-            with:
-              github-token: ${{ github.token }}
-              targets: ${{ matrix.settings.target }}
+      - name: Rust Setup
+        uses: ./.github/actions/setup-rust
+        with:
+          github-token: ${{ github.token }}
+          targets: ${{ matrix.settings.target }}
 
-          - name: Setup Zig
-            uses: ./.github/actions/setup-zig
+      - name: Setup Zig
+        uses: ./.github/actions/setup-zig
 
       - name: Build Setup
         shell: bash
@@ -138,47 +137,46 @@ jobs:
             exit 1
           fi
 
-      - parallel:
-          - name: Setup Node
-            uses: ./.github/actions/setup-node
-            with:
-              extra-flags: "--frozen-lockfile"
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
+        with:
+          extra-flags: "--frozen-lockfile"
 
-          - name: Download darwin arm64 LSP
-            uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-            with:
-              name: turborepo-lsp-aarch64-apple-darwin
-              path: packages/turbo-vsc/out/artifacts/turborepo-lsp-aarch64-apple-darwin
+      - name: Download darwin arm64 LSP
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: turborepo-lsp-aarch64-apple-darwin
+          path: packages/turbo-vsc/out/artifacts/turborepo-lsp-aarch64-apple-darwin
 
-          - name: Download darwin x64 LSP
-            uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-            with:
-              name: turborepo-lsp-x86_64-apple-darwin
-              path: packages/turbo-vsc/out/artifacts/turborepo-lsp-x86_64-apple-darwin
+      - name: Download darwin x64 LSP
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: turborepo-lsp-x86_64-apple-darwin
+          path: packages/turbo-vsc/out/artifacts/turborepo-lsp-x86_64-apple-darwin
 
-          - name: Download linux arm64 LSP
-            uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-            with:
-              name: turborepo-lsp-aarch64-unknown-linux-musl
-              path: packages/turbo-vsc/out/artifacts/turborepo-lsp-aarch64-unknown-linux-musl
+      - name: Download linux arm64 LSP
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: turborepo-lsp-aarch64-unknown-linux-musl
+          path: packages/turbo-vsc/out/artifacts/turborepo-lsp-aarch64-unknown-linux-musl
 
-          - name: Download linux x64 LSP
-            uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-            with:
-              name: turborepo-lsp-x86_64-unknown-linux-musl
-              path: packages/turbo-vsc/out/artifacts/turborepo-lsp-x86_64-unknown-linux-musl
+      - name: Download linux x64 LSP
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: turborepo-lsp-x86_64-unknown-linux-musl
+          path: packages/turbo-vsc/out/artifacts/turborepo-lsp-x86_64-unknown-linux-musl
 
-          - name: Download win32 arm64 LSP
-            uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-            with:
-              name: turborepo-lsp-aarch64-pc-windows-msvc
-              path: packages/turbo-vsc/out/artifacts/turborepo-lsp-aarch64-pc-windows-msvc
+      - name: Download win32 arm64 LSP
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: turborepo-lsp-aarch64-pc-windows-msvc
+          path: packages/turbo-vsc/out/artifacts/turborepo-lsp-aarch64-pc-windows-msvc
 
-          - name: Download win32 x64 LSP
-            uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-            with:
-              name: turborepo-lsp-x86_64-pc-windows-msvc
-              path: packages/turbo-vsc/out/artifacts/turborepo-lsp-x86_64-pc-windows-msvc
+      - name: Download win32 x64 LSP
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: turborepo-lsp-x86_64-pc-windows-msvc
+          path: packages/turbo-vsc/out/artifacts/turborepo-lsp-x86_64-pc-windows-msvc
 
       - name: Stamp extension version
         id: version
@@ -314,17 +312,16 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
           persist-credentials: false
 
-      - parallel:
-          - name: Setup Node
-            uses: ./.github/actions/setup-node
-            with:
-              extra-flags: "--frozen-lockfile"
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
+        with:
+          extra-flags: "--frozen-lockfile"
 
-          - name: Download VSIX
-            uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-            with:
-              name: turbo-vsc-${{ needs.package-vscode.outputs.version }}
-              path: packages/turbo-vsc
+      - name: Download VSIX
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: turbo-vsc-${{ needs.package-vscode.outputs.version }}
+          path: packages/turbo-vsc
 
       - name: Publish VSIX
         working-directory: packages/turbo-vsc

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -119,22 +119,21 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - parallel:
-          - name: Set up Turborepo Remote Cache
-            if: github.event.pull_request.head.repo.full_name == github.repository
-            uses: vercel/setup-turborepo-remote-cache-action@49d7b1b46ba4c9251e1977986bfe18336feabc8f # v1.1.0
-            with:
-              team: ${{ vars.TURBO_TEAM }}
+      - name: Set up Turborepo Remote Cache
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: vercel/setup-turborepo-remote-cache-action@49d7b1b46ba4c9251e1977986bfe18336feabc8f # v1.1.0
+        with:
+          team: ${{ vars.TURBO_TEAM }}
 
-          - name: "Setup Node"
-            uses: ./.github/actions/setup-node
-            with:
-              node-version: ${{ matrix.node-version }}
-            env:
-              PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - name: "Setup Node"
+        uses: ./.github/actions/setup-node
+        with:
+          node-version: ${{ matrix.node-version }}
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
 
-          - name: Install Bun
-            uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - name: Install Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install Global Turbo
         uses: ./.github/actions/install-global-turbo

--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -130,23 +130,22 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install bash capnp
 
-      - parallel:
-          - name: Setup Rust
-            uses: ./.github/actions/setup-rust
-            with:
-              targets: ${{ matrix.settings.target }}
-              github-token: ${{ github.token }}
-            if: ${{ !matrix.settings.install }}
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          targets: ${{ matrix.settings.target }}
+          github-token: ${{ github.token }}
+        if: ${{ !matrix.settings.install }}
 
-          - name: Setup Node
-            uses: ./.github/actions/setup-node
-            if: ${{ !matrix.settings.install }}
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
+        if: ${{ !matrix.settings.install }}
 
-          - name: Setup capnproto
-            if: runner.os != 'macOS'
-            uses: ./.github/actions/setup-capnproto
-            with:
-              use-cache: ${{ !matrix.settings.install }}
+      - name: Setup capnproto
+        if: runner.os != 'macOS'
+        uses: ./.github/actions/setup-capnproto
+        with:
+          use-cache: ${{ !matrix.settings.install }}
 
       - name: Setup toolchain
         run: ${{ matrix.settings.setup }}
@@ -184,16 +183,15 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - parallel:
-          - name: Setup Node
-            uses: ./.github/actions/setup-node
-            with:
-              package-install: false
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
+        with:
+          package-install: false
 
-          - name: Download Artifacts
-            uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-            with:
-              path: ${{ runner.temp }}/native-packages
+      - name: Download Artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          path: ${{ runner.temp }}/native-packages
 
       - name: Configure npm
         run: |

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -163,43 +163,42 @@ jobs:
             exit 1
           fi
 
-      - parallel:
-          - name: Setup Node
-            uses: ./.github/actions/setup-node
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
 
-          - name: Get base SHA
-            id: base-sha
-            run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+      - name: Get base SHA
+        id: base-sha
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
-          - name: Get previous tag
-            id: previous-tag
-            env:
-              INCREMENT: ${{ github.event_name == 'schedule' && 'prerelease' || inputs.increment }}
-            run: |
-              # For minor/major releases, compare against the previous minor/major
-              # release (vX.Y.0) so notes include all patches since then.
-              # For patch releases, compare against the latest stable tag.
-              # For canary releases, compare against the latest canary tag.
-              if [[ "$INCREMENT" == "minor" || "$INCREMENT" == "major" ]]; then
-                PREV_TAG=$(git ls-remote --tags origin 'refs/tags/v*' \
-                  | awk '{print $2}' | sed 's|refs/tags/||' | grep -v '\^{}$' \
-                  | grep -v canary | grep -E 'v[0-9]+\.[0-9]+\.0$' | sort -V | tail -n 1)
-              elif [[ "$INCREMENT" == "patch" ]]; then
-                PREV_TAG=$(git ls-remote --tags origin 'refs/tags/v*' \
-                  | awk '{print $2}' | sed 's|refs/tags/||' | grep -v '\^{}$' \
-                  | grep -v canary | sort -V | tail -n 1)
-              else
-                PREV_TAG=$(git ls-remote --tags origin 'refs/tags/v*-canary.*' \
-                  | awk '{print $2}' | sed 's|refs/tags/||' | grep -v '\^{}$' \
-                  | sort -V | tail -n 1)
-                if [ -z "$PREV_TAG" ]; then
-                  PREV_TAG=$(git ls-remote --tags origin 'refs/tags/v*' \
-                    | awk '{print $2}' | sed 's|refs/tags/||' | grep -v '\^{}$' \
-                    | grep -v canary | sort -V | tail -n 1)
-                fi
-              fi
-              echo "tag=$PREV_TAG" >> $GITHUB_OUTPUT
-              echo "Previous tag: $PREV_TAG"
+      - name: Get previous tag
+        id: previous-tag
+        env:
+          INCREMENT: ${{ github.event_name == 'schedule' && 'prerelease' || inputs.increment }}
+        run: |
+          # For minor/major releases, compare against the previous minor/major
+          # release (vX.Y.0) so notes include all patches since then.
+          # For patch releases, compare against the latest stable tag.
+          # For canary releases, compare against the latest canary tag.
+          if [[ "$INCREMENT" == "minor" || "$INCREMENT" == "major" ]]; then
+            PREV_TAG=$(git ls-remote --tags origin 'refs/tags/v*' \
+              | awk '{print $2}' | sed 's|refs/tags/||' | grep -v '\^{}$' \
+              | grep -v canary | grep -E 'v[0-9]+\.[0-9]+\.0$' | sort -V | tail -n 1)
+          elif [[ "$INCREMENT" == "patch" ]]; then
+            PREV_TAG=$(git ls-remote --tags origin 'refs/tags/v*' \
+              | awk '{print $2}' | sed 's|refs/tags/||' | grep -v '\^{}$' \
+              | grep -v canary | sort -V | tail -n 1)
+          else
+            PREV_TAG=$(git ls-remote --tags origin 'refs/tags/v*-canary.*' \
+              | awk '{print $2}' | sed 's|refs/tags/||' | grep -v '\^{}$' \
+              | sort -V | tail -n 1)
+            if [ -z "$PREV_TAG" ]; then
+              PREV_TAG=$(git ls-remote --tags origin 'refs/tags/v*' \
+                | awk '{print $2}' | sed 's|refs/tags/||' | grep -v '\^{}$' \
+                | grep -v canary | sort -V | tail -n 1)
+            fi
+          fi
+          echo "tag=$PREV_TAG" >> $GITHUB_OUTPUT
+          echo "Previous tag: $PREV_TAG"
 
       - name: Build release tool
         run: pnpm --filter @turbo/releaser build
@@ -335,16 +334,15 @@ jobs:
           filter: blob:none
           persist-credentials: false
 
-      - parallel:
-          - name: Setup Node
-            uses: ./.github/actions/setup-node
-            with:
-              extra-flags: "--no-frozen-lockfile"
-            env:
-              PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
+        with:
+          extra-flags: "--no-frozen-lockfile"
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
 
-          - name: Install Bun
-            uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - name: Install Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install Global Turbo
         uses: ./.github/actions/install-global-turbo
@@ -393,28 +391,27 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install bash capnp
 
-      - parallel:
-          - name: Setup Protoc
-            uses: ./.github/actions/setup-protoc
-            with:
-              version: "26.x"
-              github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Protoc
+        uses: ./.github/actions/setup-protoc
+        with:
+          version: "26.x"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-          - name: Setup capnproto
-            if: runner.os != 'macOS'
-            uses: ./.github/actions/setup-capnproto
+      - name: Setup capnproto
+        if: runner.os != 'macOS'
+        uses: ./.github/actions/setup-capnproto
 
-          - name: Rust Setup
-            uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
-            with:
-              target: ${{ matrix.settings.target }}
-              # needed to not make it override the defaults
-              rustflags: ""
-              # we want more specific settings
-              cache: false
+      - name: Rust Setup
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
+        with:
+          target: ${{ matrix.settings.target }}
+          # needed to not make it override the defaults
+          rustflags: ""
+          # we want more specific settings
+          cache: false
 
-          - name: Setup Zig
-            uses: ./.github/actions/setup-zig
+      - name: Setup Zig
+        uses: ./.github/actions/setup-zig
 
       - name: Build Setup
         if: ${{ matrix.settings.setup }}
@@ -427,48 +424,47 @@ jobs:
         if: ${{ contains(matrix.settings.target, 'apple-darwin') }}
         run: cargo install apple-codesign --version 0.29.0 --locked
 
-      - parallel:
-          - name: Write Apple signing certificate
-            if: ${{ contains(matrix.settings.target, 'apple-darwin') }}
-            shell: bash
-            env:
-              APPLE_CERT_DATA: ${{ secrets.APPLE_CERT_DATA }}
-              APPLE_CERT_PATH: ${{ runner.temp }}/apple-certificate.p12
-            run: |
-              set -euo pipefail
-              umask 077
-              if [[ -z "$APPLE_CERT_DATA" ]]; then
-                echo "::error::APPLE_CERT_DATA secret is empty or unavailable"
-                exit 1
-              fi
-              printf '%s' "$APPLE_CERT_DATA" | base64 --decode > "$APPLE_CERT_PATH"
-              chmod 600 "$APPLE_CERT_PATH"
-              if [[ ! -s "$APPLE_CERT_PATH" ]]; then
-                echo "::error::Decoded Apple certificate is empty"
-                exit 1
-              fi
-              echo "APPLE_CERT_PATH=$APPLE_CERT_PATH" >> "$GITHUB_ENV"
+      - name: Write Apple signing certificate
+        if: ${{ contains(matrix.settings.target, 'apple-darwin') }}
+        shell: bash
+        env:
+          APPLE_CERT_DATA: ${{ secrets.APPLE_CERT_DATA }}
+          APPLE_CERT_PATH: ${{ runner.temp }}/apple-certificate.p12
+        run: |
+          set -euo pipefail
+          umask 077
+          if [[ -z "$APPLE_CERT_DATA" ]]; then
+            echo "::error::APPLE_CERT_DATA secret is empty or unavailable"
+            exit 1
+          fi
+          printf '%s' "$APPLE_CERT_DATA" | base64 --decode > "$APPLE_CERT_PATH"
+          chmod 600 "$APPLE_CERT_PATH"
+          if [[ ! -s "$APPLE_CERT_PATH" ]]; then
+            echo "::error::Decoded Apple certificate is empty"
+            exit 1
+          fi
+          echo "APPLE_CERT_PATH=$APPLE_CERT_PATH" >> "$GITHUB_ENV"
 
-          - name: Write Apple notarization API key
-            if: ${{ contains(matrix.settings.target, 'apple-darwin') }}
-            shell: bash
-            env:
-              APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
-              APPLE_API_KEY_PATH: ${{ runner.temp }}/apple-api-key.json
-            run: |
-              set -euo pipefail
-              umask 077
-              if [[ -z "$APPLE_API_KEY" ]]; then
-                echo "::error::APPLE_API_KEY secret is empty or unavailable"
-                exit 1
-              fi
-              printf '%s' "$APPLE_API_KEY" | base64 --decode > "$APPLE_API_KEY_PATH"
-              chmod 600 "$APPLE_API_KEY_PATH"
-              if [[ ! -s "$APPLE_API_KEY_PATH" ]]; then
-                echo "::error::Decoded Apple API key is empty"
-                exit 1
-              fi
-              echo "APPLE_API_KEY_PATH=$APPLE_API_KEY_PATH" >> "$GITHUB_ENV"
+      - name: Write Apple notarization API key
+        if: ${{ contains(matrix.settings.target, 'apple-darwin') }}
+        shell: bash
+        env:
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_PATH: ${{ runner.temp }}/apple-api-key.json
+        run: |
+          set -euo pipefail
+          umask 077
+          if [[ -z "$APPLE_API_KEY" ]]; then
+            echo "::error::APPLE_API_KEY secret is empty or unavailable"
+            exit 1
+          fi
+          printf '%s' "$APPLE_API_KEY" | base64 --decode > "$APPLE_API_KEY_PATH"
+          chmod 600 "$APPLE_API_KEY_PATH"
+          if [[ ! -s "$APPLE_API_KEY_PATH" ]]; then
+            echo "::error::Decoded Apple API key is empty"
+            exit 1
+          fi
+          echo "APPLE_API_KEY_PATH=$APPLE_API_KEY_PATH" >> "$GITHUB_ENV"
 
       - name: Sign macOS binary
         if: ${{ contains(matrix.settings.target, 'apple-darwin') }}
@@ -545,32 +541,30 @@ jobs:
           filter: blob:none
           persist-credentials: false
 
-      - parallel:
-          - name: Setup Node
-            uses: ./.github/actions/setup-node
-            with:
-              extra-flags: "--no-frozen-lockfile"
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
+        with:
+          extra-flags: "--no-frozen-lockfile"
 
-          - name: Download Rust artifacts
-            uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-            with:
-              path: rust-artifacts
+      - name: Download Rust artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          path: rust-artifacts
 
-      - parallel:
-          - name: Install Global Turbo
-            uses: ./.github/actions/install-global-turbo
-            with:
-              turbo-version: ${{ inputs.ci-tag-override || '' }}
+      - name: Install Global Turbo
+        uses: ./.github/actions/install-global-turbo
+        with:
+          turbo-version: ${{ inputs.ci-tag-override || '' }}
 
-          - name: Move Rust artifacts into place
-            run: |
-              mkdir release-artifacts
-              mv rust-artifacts/turbo-aarch64-apple-darwin release-artifacts/dist-darwin-arm64
-              mv rust-artifacts/turbo-aarch64-unknown-linux-musl release-artifacts/dist-linux-arm64
-              cp -r rust-artifacts/turbo-x86_64-pc-windows-msvc release-artifacts/dist-windows-arm64
-              mv rust-artifacts/turbo-x86_64-unknown-linux-musl release-artifacts/dist-linux-x64
-              mv rust-artifacts/turbo-x86_64-apple-darwin release-artifacts/dist-darwin-x64
-              mv rust-artifacts/turbo-x86_64-pc-windows-msvc release-artifacts/dist-windows-x64
+      - name: Move Rust artifacts into place
+        run: |
+          mkdir release-artifacts
+          mv rust-artifacts/turbo-aarch64-apple-darwin release-artifacts/dist-darwin-arm64
+          mv rust-artifacts/turbo-aarch64-unknown-linux-musl release-artifacts/dist-linux-arm64
+          cp -r rust-artifacts/turbo-x86_64-pc-windows-msvc release-artifacts/dist-windows-arm64
+          mv rust-artifacts/turbo-x86_64-unknown-linux-musl release-artifacts/dist-linux-x64
+          mv rust-artifacts/turbo-x86_64-apple-darwin release-artifacts/dist-darwin-x64
+          mv rust-artifacts/turbo-x86_64-pc-windows-msvc release-artifacts/dist-windows-x64
 
       - name: Ensure npm version
         run: npm install -g npm@11.5.1
@@ -705,18 +699,17 @@ jobs:
           filter: blob:none
           persist-credentials: false
 
-      - parallel:
-          - name: Get version and compute subdomain
-            id: version
-            run: |
-              VERSION=$(head -n 1 version.txt)
-              # Transform version to valid subdomain (replace dots with dashes, prepend v)
-              SUBDOMAIN=$(echo "v${VERSION}" | tr '.' '-')
-              echo "version=${VERSION}" >> $GITHUB_OUTPUT
-              echo "subdomain=${SUBDOMAIN}" >> $GITHUB_OUTPUT
+      - name: Get version and compute subdomain
+        id: version
+        run: |
+          VERSION=$(head -n 1 version.txt)
+          # Transform version to valid subdomain (replace dots with dashes, prepend v)
+          SUBDOMAIN=$(echo "v${VERSION}" | tr '.' '-')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "subdomain=${SUBDOMAIN}" >> $GITHUB_OUTPUT
 
-          - name: Install Vercel CLI
-            run: npm install -g vercel@53.1.0
+      - name: Install Vercel CLI
+        run: npm install -g vercel@53.1.0
 
       - name: Find Vercel deployment for SHA
         id: find-deployment

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -107,30 +107,29 @@ jobs:
         with:
           persist-credentials: false
 
-      - parallel:
-          - name: Set up Turborepo Remote Cache
-            if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-            uses: vercel/setup-turborepo-remote-cache-action@49d7b1b46ba4c9251e1977986bfe18336feabc8f # v1.1.0
-            with:
-              team: ${{ vars.TURBO_TEAM }}
+      - name: Set up Turborepo Remote Cache
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: vercel/setup-turborepo-remote-cache-action@49d7b1b46ba4c9251e1977986bfe18336feabc8f # v1.1.0
+        with:
+          team: ${{ vars.TURBO_TEAM }}
 
-          - name: Setup Node
-            uses: ./.github/actions/setup-node
-            env:
-              PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
 
-          - name: Setup Rust
-            uses: ./.github/actions/setup-rust
-            with:
-              shared-cache-key: turborepo-debug-build
-              save-cache: true
-              github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          shared-cache-key: turborepo-debug-build
+          save-cache: true
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-          - name: Setup Zig
-            uses: ./.github/actions/setup-zig
+      - name: Setup Zig
+        uses: ./.github/actions/setup-zig
 
-          - name: Setup capnproto
-            uses: ./.github/actions/setup-capnproto
+      - name: Setup capnproto
+        uses: ./.github/actions/setup-capnproto
 
       - name: Install Global Turbo
         uses: ./.github/actions/install-global-turbo
@@ -204,80 +203,78 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install bash capnp
 
-      - parallel:
-          # Exchanges a GitHub OIDC token for a short-lived Remote Cache access
-          # token, exported as TURBO_TOKEN/TURBO_TEAM for subsequent steps.
-          # Pushes and same-repository PRs can mint OIDC tokens. Fork PRs remain
-          # local-only. With credentials present, turbo caches the test task
-          # remotely; Cargo reuses state from the target-cache restore below.
-          - name: Set up Turborepo Remote Cache
-            if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-            uses: vercel/setup-turborepo-remote-cache-action@49d7b1b46ba4c9251e1977986bfe18336feabc8f # v1.1.0
-            with:
-              team: ${{ vars.TURBO_TEAM }}
+      # Exchanges a GitHub OIDC token for a short-lived Remote Cache access
+      # token, exported as TURBO_TOKEN/TURBO_TEAM for subsequent steps.
+      # Pushes and same-repository PRs can mint OIDC tokens. Fork PRs remain
+      # local-only. With credentials present, turbo caches the test task
+      # remotely; Cargo reuses state from the target-cache restore below.
+      - name: Set up Turborepo Remote Cache
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: vercel/setup-turborepo-remote-cache-action@49d7b1b46ba4c9251e1977986bfe18336feabc8f # v1.1.0
+        with:
+          team: ${{ vars.TURBO_TEAM }}
 
-          - name: Setup Node
-            uses: ./.github/actions/setup-node
-            with:
-              node-version: "18.20.2"
-              package-install: "false"
-            env:
-              PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
+        with:
+          node-version: "18.20.2"
+          package-install: "false"
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
 
-          - name: Setup Rust
-            uses: ./.github/actions/setup-rust
-            with:
-              shared-cache-key: turborepo-debug-build
-              save-cache: true
-              cache: "false"
-              github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          shared-cache-key: turborepo-debug-build
+          save-cache: true
+          cache: "false"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-          - name: Setup Zig
-            uses: ./.github/actions/setup-zig
+      - name: Setup Zig
+        uses: ./.github/actions/setup-zig
 
-          - name: Setup capnproto
-            if: runner.os != 'macOS'
-            uses: ./.github/actions/setup-capnproto
+      - name: Setup capnproto
+        if: runner.os != 'macOS'
+        uses: ./.github/actions/setup-capnproto
 
-          - name: Restore Cargo target
-            id: cargo-target-restore
-            uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-            with:
-              path: target
-              key: cargo-target-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml', '.cargo/config.toml', 'Cargo.lock') }}-${{ hashFiles('Cargo.toml', 'crates/**', 'packages/turbo-repository/rust/**', 'version.txt') }}
-              restore-keys: |
-                cargo-target-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml', '.cargo/config.toml', 'Cargo.lock') }}-
+      - name: Restore Cargo target
+        id: cargo-target-restore
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: target
+          key: cargo-target-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml', '.cargo/config.toml', 'Cargo.lock') }}-${{ hashFiles('Cargo.toml', 'crates/**', 'packages/turbo-repository/rust/**', 'version.txt') }}
+          restore-keys: |
+            cargo-target-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml', '.cargo/config.toml', 'Cargo.lock') }}-
 
-          - name: Install Bun
-            uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
+      - name: Install Bun
+        uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
 
-          - name: Setup uv
-            uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-            with:
-              version: "0.12.0"
-              enable-cache: false
+      - name: Setup uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.12.0"
+          enable-cache: false
 
-      - parallel:
-          - name: Install cargo-nextest
-            if: runner.os == 'Windows'
-            shell: cmd
-            run: |
-              curl -L -o "%TEMP%\nextest.zip" "https://get.nexte.st/latest/windows"
-              tar -xf "%TEMP%\nextest.zip" -C "%USERPROFILE%\.cargo\bin"
+      - name: Install cargo-nextest
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: |
+          curl -L -o "%TEMP%\nextest.zip" "https://get.nexte.st/latest/windows"
+          tar -xf "%TEMP%\nextest.zip" -C "%USERPROFILE%\.cargo\bin"
 
-          - name: Install cargo-nextest
-            if: runner.os != 'Windows'
-            uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532
-            with:
-              tool: nextest
+      - name: Install cargo-nextest
+        if: runner.os != 'Windows'
+        uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532
+        with:
+          tool: nextest
 
-          - name: Configure Insta workspace root
-            if: runner.os == 'Windows'
-            shell: bash
-            run: echo "INSTA_WORKSPACE_ROOT=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
+      - name: Configure Insta workspace root
+        if: runner.os == 'Windows'
+        shell: bash
+        run: echo "INSTA_WORKSPACE_ROOT=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
 
-          - name: Install Global Turbo
-            uses: ./.github/actions/install-global-turbo
+      - name: Install Global Turbo
+        uses: ./.github/actions/install-global-turbo
 
       # The nextest invocation (and its excludes) lives in turbo.json as
       # the turborepo-crates#test command; dogfooding the task command
@@ -315,21 +312,20 @@ jobs:
         with:
           persist-credentials: false
 
-      - parallel:
-          # Exchanges a GitHub OIDC token for a short-lived Remote Cache access
-          # token, exported as TURBO_TOKEN/TURBO_TEAM for subsequent steps.
-          - name: Set up Turborepo Remote Cache
-            uses: vercel/setup-turborepo-remote-cache-action@49d7b1b46ba4c9251e1977986bfe18336feabc8f # v1.1.0
-            with:
-              team: ${{ vars.TURBO_TEAM }}
+      # Exchanges a GitHub OIDC token for a short-lived Remote Cache access
+      # token, exported as TURBO_TOKEN/TURBO_TEAM for subsequent steps.
+      - name: Set up Turborepo Remote Cache
+        uses: vercel/setup-turborepo-remote-cache-action@49d7b1b46ba4c9251e1977986bfe18336feabc8f # v1.1.0
+        with:
+          team: ${{ vars.TURBO_TEAM }}
 
-          - name: Setup Node.js
-            uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-            with:
-              node-version: "20"
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "20"
 
-          - name: Setup pnpm
-            uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
 
       - name: Install dependencies
         run: pnpm install
@@ -364,46 +360,45 @@ jobs:
         with:
           persist-credentials: false
 
-      - parallel:
-          # Exchanges a GitHub OIDC token for a short-lived Remote Cache access
-          # token, exported as TURBO_TOKEN/TURBO_TEAM for subsequent steps.
-          # Pushes and same-repository PRs can mint OIDC tokens. Fork PRs remain
-          # local-only.
-          - name: Set up Turborepo Remote Cache
-            if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-            uses: vercel/setup-turborepo-remote-cache-action@49d7b1b46ba4c9251e1977986bfe18336feabc8f # v1.1.0
-            with:
-              team: ${{ vars.TURBO_TEAM }}
+      # Exchanges a GitHub OIDC token for a short-lived Remote Cache access
+      # token, exported as TURBO_TOKEN/TURBO_TEAM for subsequent steps.
+      # Pushes and same-repository PRs can mint OIDC tokens. Fork PRs remain
+      # local-only.
+      - name: Set up Turborepo Remote Cache
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: vercel/setup-turborepo-remote-cache-action@49d7b1b46ba4c9251e1977986bfe18336feabc8f # v1.1.0
+        with:
+          team: ${{ vars.TURBO_TEAM }}
 
-          - name: Setup Node
-            uses: ./.github/actions/setup-node
-            env:
-              PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
 
-          - name: Setup Rust
-            uses: ./.github/actions/setup-rust
-            with:
-              shared-cache-key: turborepo-debug-build
-              save-cache: true
-              cache: "false"
-              github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          shared-cache-key: turborepo-debug-build
+          save-cache: true
+          cache: "false"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-          - name: Setup Zig
-            uses: ./.github/actions/setup-zig
+      - name: Setup Zig
+        uses: ./.github/actions/setup-zig
 
-          - name: Setup capnproto
-            uses: ./.github/actions/setup-capnproto
+      - name: Setup capnproto
+        uses: ./.github/actions/setup-capnproto
 
-          - name: Restore Cargo target
-            uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-            with:
-              path: target
-              key: cargo-target-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml', '.cargo/config.toml', 'Cargo.lock') }}-${{ hashFiles('Cargo.toml', 'crates/**', 'packages/turbo-repository/rust/**', 'version.txt') }}
-              restore-keys: |
-                cargo-target-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml', '.cargo/config.toml', 'Cargo.lock') }}-
+      - name: Restore Cargo target
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: target
+          key: cargo-target-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml', '.cargo/config.toml', 'Cargo.lock') }}-${{ hashFiles('Cargo.toml', 'crates/**', 'packages/turbo-repository/rust/**', 'version.txt') }}
+          restore-keys: |
+            cargo-target-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('rust-toolchain.toml', '.cargo/config.toml', 'Cargo.lock') }}-
 
-          - name: Install Bun
-            uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
+      - name: Install Bun
+        uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
 
       - name: Install Global Turbo
         uses: ./.github/actions/install-global-turbo
@@ -445,43 +440,42 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install bash capnp
 
-      - parallel:
-          # Exchanges a GitHub OIDC token for a short-lived Remote Cache access
-          # token, exported as TURBO_TOKEN/TURBO_TEAM for subsequent steps.
-          # Pushes and same-repository PRs can mint OIDC tokens. Fork PRs remain
-          # local-only.
-          - name: Set up Turborepo Remote Cache
-            if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-            uses: vercel/setup-turborepo-remote-cache-action@49d7b1b46ba4c9251e1977986bfe18336feabc8f # v1.1.0
-            with:
-              team: ${{ vars.TURBO_TEAM }}
+      # Exchanges a GitHub OIDC token for a short-lived Remote Cache access
+      # token, exported as TURBO_TOKEN/TURBO_TEAM for subsequent steps.
+      # Pushes and same-repository PRs can mint OIDC tokens. Fork PRs remain
+      # local-only.
+      - name: Set up Turborepo Remote Cache
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: vercel/setup-turborepo-remote-cache-action@49d7b1b46ba4c9251e1977986bfe18336feabc8f # v1.1.0
+        with:
+          team: ${{ vars.TURBO_TEAM }}
 
-          - name: Setup Node
-            uses: ./.github/actions/setup-node
-            with:
-              node-version: ${{ matrix.node-version }}
-            env:
-              PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
+        with:
+          node-version: ${{ matrix.node-version }}
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
 
-          - name: Setup Rust
-            uses: ./.github/actions/setup-rust
-            with:
-              shared-cache-key: turborepo-debug-build
-              save-cache: true
-              github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          shared-cache-key: turborepo-debug-build
+          save-cache: true
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-          - name: Setup Zig
-            uses: ./.github/actions/setup-zig
+      - name: Setup Zig
+        uses: ./.github/actions/setup-zig
 
-          - name: Setup uv
-            uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-            with:
-              version: "0.12.0"
-              enable-cache: false
+      - name: Setup uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.12.0"
+          enable-cache: false
 
-          - name: Setup capnproto
-            if: runner.os != 'macOS'
-            uses: ./.github/actions/setup-capnproto
+      - name: Setup capnproto
+        if: runner.os != 'macOS'
+        uses: ./.github/actions/setup-capnproto
 
       - name: Install Global Turbo
         uses: ./.github/actions/install-global-turbo

--- a/.github/workflows/update-examples-on-release.yml
+++ b/.github/workflows/update-examples-on-release.yml
@@ -24,15 +24,14 @@ jobs:
           filter: blob:none
           persist-credentials: false
 
-      - parallel:
-          - name: Setup Node
-            uses: ./.github/actions/setup-node
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
 
-          - name: Make branch
-            id: branch
-            run: |
-              git checkout -b post-release-bump-examples
-              echo "STAGE_BRANCH=$(git branch --show-current)" >> $GITHUB_OUTPUT
+      - name: Make branch
+        id: branch
+        run: |
+          git checkout -b post-release-bump-examples
+          echo "STAGE_BRANCH=$(git branch --show-current)" >> $GITHUB_OUTPUT
 
       - name: Run upgrade script
         run: bash scripts/update-examples-dep.sh

--- a/crates/turborepo/tests/go_workspace_test.rs
+++ b/crates/turborepo/tests/go_workspace_test.rs
@@ -207,27 +207,27 @@ fn go_version_shim_path(dir: &Path) -> String {
 }
 
 #[cfg(unix)]
-fn wait_for_path(path: &Path, timeout: Duration) -> bool {
-    let started = std::time::Instant::now();
-    while started.elapsed() < timeout {
-        if path.exists() {
-            return true;
-        }
-        std::thread::sleep(Duration::from_millis(100));
-    }
-    path.exists()
+fn publish_go_work(path: &Path, contents: &[u8]) {
+    use std::io::Write;
+
+    // Stage on the same filesystem so persist replaces the manifest atomically.
+    let mut staged = tempfile::NamedTempFile::new_in(path.parent().unwrap()).unwrap();
+    staged.write_all(contents).unwrap();
+    staged.persist(path).unwrap();
 }
 
 #[cfg(unix)]
-struct GoWatchGuard(Option<Child>);
+struct GoWatchGuard {
+    child: Child,
+    // Keep diagnostics/config outside the watched repository: logging must not
+    // itself generate file events or become a task input.
+    diagnostics: tempfile::TempDir,
+}
 
 #[cfg(unix)]
 impl GoWatchGuard {
     fn spawn(dir: &Path) -> Self {
-        use std::os::unix::process::CommandExt;
-
         let mut command = std::process::Command::new(assert_cmd::cargo::cargo_bin("turbo"));
-        command.process_group(0);
         for name in AMBIENT_GO_ENV {
             command.env_remove(name);
         }
@@ -244,11 +244,84 @@ impl GoWatchGuard {
             .env("TURBO_GLOBAL_WARNING_DISABLED", "1")
             .env("TURBO_PRINT_VERSION_DISABLED", "1")
             .env("DO_NOT_TRACK", "1")
-            .current_dir(dir)
+            .env_remove("CI")
+            .env_remove("GITHUB_ACTIONS")
+            .current_dir(dir);
+        Self::spawn_command(command)
+    }
+
+    fn spawn_command(mut command: std::process::Command) -> Self {
+        use std::os::unix::process::CommandExt;
+
+        let diagnostics = tempfile::tempdir().expect("create watch diagnostics directory");
+        let stdout = fs::File::create(diagnostics.path().join("stdout.log")).unwrap();
+        let stderr = fs::File::create(diagnostics.path().join("stderr.log")).unwrap();
+        // Files avoid pipe backpressure and reader threads that can outlive the
+        // child. The guard keeps both the logs and isolated config alive.
+        let child = command
+            .process_group(0)
+            .env("TURBO_CONFIG_DIR_PATH", diagnostics.path().join("config"))
             .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null());
-        Self(Some(command.spawn().expect("failed to spawn turbo watch")))
+            .stdout(stdout)
+            .stderr(stderr)
+            .spawn()
+            .expect("failed to spawn watch command");
+        Self { child, diagnostics }
+    }
+
+    fn output(&self) -> String {
+        use std::io::{Read, Seek, SeekFrom};
+
+        let read = |name| -> std::io::Result<String> {
+            // Keep a noisy child from overwhelming the test failure report.
+            const MAX_BYTES: u64 = 64 * 1024;
+            let mut file = fs::File::open(self.diagnostics.path().join(name))?;
+            let skipped = file.metadata()?.len().saturating_sub(MAX_BYTES);
+            file.seek(SeekFrom::Start(skipped))?;
+            let mut bytes = Vec::new();
+            file.take(MAX_BYTES).read_to_end(&mut bytes)?;
+            let text = String::from_utf8_lossy(&bytes);
+            Ok(if skipped > 0 {
+                format!("[omitted {skipped} bytes]\n{text}")
+            } else {
+                text.into_owned()
+            })
+        };
+        let log =
+            |name| read(name).unwrap_or_else(|error| format!("failed to read {name}: {error}"));
+        format!(
+            "stdout:\n{}\nstderr:\n{}",
+            log("stdout.log"),
+            log("stderr.log")
+        )
+    }
+
+    fn wait_for_path(&mut self, path: &Path, timeout: Duration) -> Result<(), String> {
+        let started = std::time::Instant::now();
+        loop {
+            match self.child.try_wait() {
+                Ok(Some(status)) => {
+                    return Err(format!(
+                        "watch exited with {status} while waiting for {path:?}\n{}",
+                        self.output()
+                    ));
+                }
+                Err(error) => {
+                    return Err(format!("polling watch failed: {error}\n{}", self.output()));
+                }
+                Ok(None) => {}
+            }
+            if path.exists() {
+                return Ok(());
+            }
+            if started.elapsed() >= timeout {
+                return Err(format!(
+                    "timed out after {timeout:?} waiting for {path:?}\n{}",
+                    self.output()
+                ));
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
     }
 }
 
@@ -260,9 +333,13 @@ impl Drop for GoWatchGuard {
             unistd::Pid,
         };
 
-        let Some(mut child) = self.0.take() else {
-            return;
-        };
+        let child = &mut self.child;
+        // Avoid signaling a recycled process-group ID if a prior wait already
+        // observed and reaped the child.
+        match child.try_wait() {
+            Ok(Some(_)) | Err(_) => return,
+            Ok(None) => {}
+        }
         let group = Pid::from_raw(-(child.id() as i32));
         let _ = signal::kill(group, Signal::SIGTERM);
         let started = std::time::Instant::now();
@@ -274,6 +351,117 @@ impl Drop for GoWatchGuard {
         }
         let _ = signal::kill(group, Signal::SIGKILL);
         let _ = child.wait();
+    }
+}
+
+#[cfg(unix)]
+mod go_watch_harness_tests {
+    use super::*;
+
+    #[test]
+    fn atomic_publication_never_exposes_partial_go_work() {
+        use std::sync::{Barrier, mpsc};
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("go.work");
+        let old = format!(
+            "go 1.22\nuse ./apps/api\n{}",
+            "// old workspace\n".repeat(16384)
+        );
+        let new = format!(
+            "go 1.22\nuse ./apps/worker\n{}",
+            "// new workspace\n".repeat(16384)
+        );
+        fs::write(&path, &old).unwrap();
+        let ready = Barrier::new(2);
+        std::thread::scope(|scope| {
+            // Dropping the sender also stops the reader if publication panics.
+            let (done, completed) = mpsc::channel::<()>();
+            let (first_read, observed_first_read) = mpsc::channel::<()>();
+            let reader = scope.spawn({
+                let (path, old, new, ready) = (&path, &old, &new, &ready);
+                move || {
+                    ready.wait();
+                    let mut first = true;
+                    loop {
+                        let observed = fs::read(path).unwrap();
+                        assert!(
+                            observed == old.as_bytes() || observed == new.as_bytes(),
+                            "reader observed a partial go.work ({} bytes)",
+                            observed.len()
+                        );
+                        if first {
+                            first_read.send(()).unwrap();
+                            first = false;
+                        }
+                        if !matches!(completed.try_recv(), Err(mpsc::TryRecvError::Empty)) {
+                            break;
+                        }
+                    }
+                }
+            });
+            ready.wait();
+            observed_first_read.recv().unwrap();
+            for _ in 0..100 {
+                publish_go_work(&path, new.as_bytes());
+                publish_go_work(&path, old.as_bytes());
+            }
+            drop(done);
+            reader.join().unwrap();
+        });
+    }
+
+    #[test]
+    fn wait_reports_exit_even_if_output_file_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("output");
+        fs::write(&path, "not proof of a live watcher").unwrap();
+        let mut command = std::process::Command::new("sh");
+        command.args([
+            "-c",
+            "printf 'watch stdout'; printf 'watch stderr' >&2; exit 7",
+        ]);
+        let mut watch = GoWatchGuard::spawn_command(command);
+        // Synchronize on exit rather than racing the child's final instructions.
+        watch.child.wait().unwrap();
+        let error = watch
+            .wait_for_path(&path, Duration::from_secs(30))
+            .unwrap_err();
+        assert!(error.contains("exit status: 7"), "{error}");
+        assert!(error.contains("watch stdout"), "{error}");
+        assert!(error.contains("watch stderr"), "{error}");
+        assert!(error.contains(path.to_str().unwrap()), "{error}");
+    }
+
+    #[test]
+    fn noisy_child_does_not_block_and_timeout_includes_log_tails() {
+        let dir = tempfile::tempdir().unwrap();
+        let ready = dir.path().join("ready");
+        let mut command = std::process::Command::new("sh");
+        command
+            .args([
+                "-c",
+                concat!(
+                    "i=0; while [ $i -lt 8192 ]; do ",
+                    "printf 'verbose watch output\\n'; printf 'verbose watch error\\n' >&2; ",
+                    "i=$((i+1)); done; ",
+                    "printf '\\377stdout tail\\n'; printf 'stderr tail\\n' >&2; ",
+                    "touch \"$1\"; exec sleep 60"
+                ),
+                "watch-test",
+            ])
+            .arg(&ready);
+        let mut watch = GoWatchGuard::spawn_command(command);
+        watch
+            .wait_for_path(&ready, Duration::from_secs(30))
+            .unwrap();
+        let missing = dir.path().join("missing");
+        let error = watch.wait_for_path(&missing, Duration::ZERO).unwrap_err();
+        assert!(error.contains("timed out"), "{error}");
+        assert!(error.contains("stdout tail"), "{error}");
+        assert!(error.contains("stderr tail"), "{error}");
+        assert!(error.contains("[omitted "), "{error}");
+        assert!(error.len() < 132 * 1024, "diagnostics must be bounded");
     }
 }
 
@@ -1116,12 +1304,11 @@ fn test_go_watch_rediscovers_workspace_members_with_repository_local_caches() {
     }
     let tempdir = tempfile::tempdir().unwrap();
     setup_go_pure_workspace(tempdir.path());
-    let _watch = GoWatchGuard::spawn(tempdir.path());
+    let mut watch = GoWatchGuard::spawn(tempdir.path());
     let api_binary = tempdir.path().join("apps/api/dist/api");
-    assert!(
-        wait_for_path(&api_binary, Duration::from_secs(30)),
-        "initial Go watch build did not produce {api_binary:?}"
-    );
+    watch
+        .wait_for_path(&api_binary, Duration::from_secs(30))
+        .unwrap_or_else(|error| panic!("initial Go watch build failed: {error}"));
 
     let worker = tempdir.path().join("apps/worker");
     fs::create_dir_all(&worker).unwrap();
@@ -1135,11 +1322,13 @@ fn test_go_watch_rediscovers_workspace_members_with_repository_local_caches() {
         "package main\n\nfunc main() { println(\"worker\") }\n",
     )
     .unwrap();
-    fs::write(
-        tempdir.path().join("go.work"),
-        "go 1.22\n\nuse (\n\t./apps/api\n\t./apps/worker\n\t./packages/lib\n)\n",
-    )
-    .unwrap();
+    // This test exercises rediscovery of a valid workspace, not recovery from
+    // a partially written manifest. fs::write truncates go.work before writing;
+    // the watcher can observe an empty workspace and exit before the write ends.
+    publish_go_work(
+        &tempdir.path().join("go.work"),
+        b"go 1.22\n\nuse (\n\t./apps/api\n\t./apps/worker\n\t./packages/lib\n)\n",
+    );
     common::git(
         tempdir.path(),
         &[
@@ -1155,10 +1344,9 @@ fn test_go_watch_rediscovers_workspace_members_with_repository_local_caches() {
     );
 
     let worker_binary = worker.join("dist/worker");
-    assert!(
-        wait_for_path(&worker_binary, Duration::from_secs(60)),
-        "turbo watch did not rediscover and build {worker_binary:?}"
-    );
+    watch
+        .wait_for_path(&worker_binary, Duration::from_secs(60))
+        .unwrap_or_else(|error| panic!("Go watch workspace rediscovery failed: {error}"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Run CI setup and artifact steps sequentially to avoid cross-step setup races.
- Publish `go.work` atomically so the watch test cannot observe a partially written workspace manifest.
- Capture bounded watch diagnostics, detect early child exits, and make process cleanup safer.
- Add focused coverage for atomic publication, noisy child output, and early watch exits.

## Verification

The Go workspace rediscovery test passed three consecutive runs, and the new watch harness tests passed.
