### PR TITLE
docs: Group experimental languages and link the Go RFC

### DIFF
--- a/apps/docs/content/docs/guides/tools/go.mdx
+++ b/apps/docs/content/docs/guides/tools/go.mdx
@@ -17,7 +17,8 @@ Turborepo can discover modules in a repository-root [`go.work`](https://go.dev/r
 
 <Callout type="warn">
   Native Go workspace support is experimental and can change at any time. The
-  initial supported range is Go 1.22 and newer.
+  initial supported range is Go 1.22 and newer. Please provide feedback on the [Go
+  RFC](https://github.com/vercel/turborepo/discussions/14033).
 </Callout>
 
 ## Enable Go workspaces

--- a/apps/docs/content/docs/guides/tools/meta.json
+++ b/apps/docs/content/docs/guides/tools/meta.json
@@ -1,3 +1,16 @@
 {
-  "pages": ["..."]
+  "pages": [
+    "index",
+    "biome",
+    "docker",
+    "eslint",
+    "jest",
+    "oxc",
+    "playwright",
+    "prisma",
+    "go",
+    "python",
+    "rust",
+    "..."
+  ]
 }


### PR DESCRIPTION
### Description

- Move Go immediately before Python and Rust in the tools sidebar so the experimental languages appear together.
- Add the Go RFC link to its experimental warning banner. Python and Rust already link to their respective RFCs.

### Testing Instructions

- Open the tools sidebar and confirm Go, Python, and Rust appear consecutively after Prisma.
- Open each experimental language page and confirm its warning banner links to the corresponding language RFC.