### PR TITLE
fix: Restore leading flags for implicit run commands

### DIFF
--- a/crates/turborepo-lib/src/cli/args.rs
+++ b/crates/turborepo-lib/src/cli/args.rs
@@ -657,7 +657,10 @@ impl Args {
             .take_while(|arg| *arg != "--")
             .any(|arg| matches!(arg.to_str(), Some("-h" | "--help")));
         if help_requested {
-            let help_args: Vec<_> = os_args.into_iter().skip(1).collect();
+            let (_, words) = Self::remove_single_package(os_args);
+            let mut words: Vec<_> = words.collect();
+            Self::normalize_leading_run_flags(&mut words);
+            let help_args: Vec<_> = words.into_iter().skip(1).collect();
             if let usage::embedded::Outcome::Exit(exit) = Args::embedded_outcome(&help_args) {
                 print_help(&exit.text);
                 exit_with_heap_profile(exit.code);
@@ -783,6 +786,7 @@ impl Args {
             words.pop();
             words.insert(1, OsString::from("__turbo_config_options"));
         }
+        Self::normalize_leading_run_flags(&mut words);
         Self::reject_duplicate_scalar_flags(&words)?;
         for word in &words {
             if matches!(
@@ -853,6 +857,45 @@ impl Args {
         }
 
         Ok(args)
+    }
+
+    /// usage-rs selects the default command on a positional, not on a flag.
+    /// Restore `turbo -F web build` without making run flags global or
+    /// accepting them before explicit subcommands. Let the parser consume
+    /// flag values and short bundles rather than guessing which word is the
+    /// task name.
+    fn normalize_leading_run_flags(words: &mut Vec<OsString>) {
+        let root = Self::command();
+        let Some(run) = root.default_subcommand else {
+            return;
+        };
+        let flags: Vec<_> = root.flags.iter().chain(run.flags).copied().collect();
+        let probe = usage::Command {
+            flags: &flags,
+            args: run.args,
+            default_subcommand: None,
+            ..*root
+        };
+        let argv: Vec<_> = words.iter().skip(1).map(OsString::as_os_str).collect();
+        let mut parser = usage::Parser::new(&probe, &argv);
+        let mut leading_run_flag = false;
+        while let Some(event) = parser.next_event() {
+            match event {
+                Ok(usage::Event::Flag { flag, .. }) => {
+                    leading_run_flag |= run
+                        .flags
+                        .iter()
+                        .any(|run_flag| std::ptr::eq(*run_flag, flag));
+                }
+                Ok(usage::Event::Arg { .. }) => break,
+                // A named command (including an alias) must retain its own
+                // flag scope. Leave malformed argv to the normal parser too.
+                _ => return,
+            }
+        }
+        if leading_run_flag && !parser.double_dash_seen() {
+            words.insert(1, OsString::from("run"));
+        }
     }
 
     fn reject_duplicate_scalar_flags(words: &[OsString]) -> Result<(), String> {

--- a/crates/turborepo-lib/src/cli/test.rs
+++ b/crates/turborepo-lib/src/cli/test.rs
@@ -65,6 +65,65 @@ fn run_args_summarize_parses_optional_boolean(args: Vec<&str>, expected: Option<
     assert_eq!(run_args.summarize(), expected);
 }
 
+#[test_case::test_case(&["-F", "api-proxy", "test:integration"] ; "short filter")]
+#[test_case::test_case(&["-Fapi-proxy", "test:integration"] ; "attached short filter")]
+#[test_case::test_case(&["-F=api-proxy", "test:integration"] ; "equals short filter")]
+#[test_case::test_case(&["--filter", "api-proxy", "test:integration"] ; "long filter")]
+#[test_case::test_case(&["--filter=api-proxy", "test:integration"] ; "equals long filter")]
+#[test_case::test_case(&["-F", "api-proxy", "test:integration", "--env-mode", "loose", "--output-logs=errors-only", "--log-order=stream"] ; "api integration regression")]
+#[test_case::test_case(&["--cwd", "run", "-F", "api-proxy", "build"] ; "global flag before filter")]
+#[test_case::test_case(&["-F", "run", "--cwd", "watch", "build"] ; "command names as flag values")]
+#[test_case::test_case(&["-vFapi-proxy", "build"] ; "bundled global and run flags")]
+#[test_case::test_case(&["-F", "web", "-F", "api", "build", "test"] ; "repeated filters and tasks")]
+#[test_case::test_case(&["--affected", "build"] ; "execution switch")]
+#[test_case::test_case(&["--concurrency", "2", "build"] ; "execution value")]
+#[test_case::test_case(&["--force=true", "build"] ; "run boolean")]
+#[test_case::test_case(&["--dry=json", "build"] ; "run alias")]
+#[test_case::test_case(&["--graph", "run", "build"] ; "optional value")]
+#[test_case::test_case(&["--affected", "build", "run"] ; "command name after task")]
+#[test_case::test_case(&["-F", "web", "build", "--", "-F", "untouched", "--help"] ; "pass through")]
+#[test_case::test_case(&["--single-package", "-F", "web", "build"] ; "legacy single package")]
+#[test_case::test_case(&["--affected"] ; "flags only")]
+fn leading_run_flags_match_explicit_run(words: &[&str]) {
+    let explicit = parse_args(["turbo", "run"].into_iter().chain(words.iter().copied())).unwrap();
+    let implicit = parse_args(["turbo"].into_iter().chain(words.iter().copied())).unwrap();
+    assert_eq!(implicit, explicit);
+}
+
+#[test_case::test_case(&["-F", "web", "run", "build"] ; "explicit run")]
+#[test_case::test_case(&["-F", "web", "watch", "build"] ; "explicit watch")]
+#[test_case::test_case(&["--filter=web", "boundaries"] ; "explicit boundaries")]
+#[test_case::test_case(&["--affected", "g"] ; "explicit alias")]
+#[test_case::test_case(&["-F"] ; "missing value")]
+#[test_case::test_case(&["-Z", "build"] ; "unknown short flag")]
+#[test_case::test_case(&["--unknown", "build"] ; "unknown long flag")]
+#[test_case::test_case(&["--env-mode=invalid", "build"] ; "invalid value")]
+#[test_case::test_case(&["--concurrency=1", "--concurrency=2", "build"] ; "duplicate scalar")]
+fn leading_run_flags_preserve_errors(words: &[&str]) {
+    assert!(parse_args(["turbo"].into_iter().chain(words.iter().copied())).is_err());
+}
+
+#[test_case::test_case(&["build"], None ; "absent")]
+#[test_case::test_case(&["build", "--force"], Some(true) ; "bare flag after task")]
+#[test_case::test_case(&["--force=true", "build"], Some(true) ; "attached true before task")]
+#[test_case::test_case(&["--force=false", "build"], Some(false) ; "attached false before task")]
+#[test_case::test_case(&["--force", "true", "build"], Some(true) ; "detached true before task")]
+#[test_case::test_case(&["--force", "false", "build"], Some(false) ; "detached false before task")]
+fn force_preserves_optional_boolean_semantics(words: &[&str], expected: Option<bool>) {
+    for prefix in [&["turbo"][..], &["turbo", "run"][..]] {
+        let args = parse_args(prefix.iter().chain(words).copied()).unwrap();
+        let Command::Run {
+            run_args,
+            execution_args,
+        } = args.command.unwrap()
+        else {
+            panic!("expected run command");
+        };
+        assert_eq!(run_args.force.flatten(), expected);
+        assert_eq!(execution_args.tasks, ["build"]);
+    }
+}
+
 #[test]
 fn config_accepts_run_configuration_flags_before_command() {
     let args = parse_args([

--- a/crates/turborepo/tests/command_test.rs
+++ b/crates/turborepo/tests/command_test.rs
@@ -70,6 +70,49 @@ fn test_parser_exits_before_starting_worker_pools() {
 }
 
 #[test]
+fn test_leading_run_flags_execute_task() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "-F",
+            "my-app",
+            "build",
+            "--env-mode",
+            "loose",
+            "--output-logs=errors-only",
+            "--log-order=stream",
+        ],
+    );
+    let combined = common::combined_output(&output);
+    assert_eq!(output.status.code(), Some(0), "{combined}");
+    assert!(combined.contains("1 successful, 1 total"), "{combined}");
+}
+
+#[test]
+fn test_leading_run_flags_help() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let explicit = run_turbo(tempdir.path(), &["run", "--help"]);
+    assert!(explicit.status.success());
+    for args in [
+        vec!["-F", "web", "build", "--help"],
+        vec!["--filter=web", "build", "--help"],
+        vec!["--filter=web", "--help"],
+        vec!["--single-package", "-F", "web", "build", "--help"],
+    ] {
+        let output = run_turbo(tempdir.path(), &args);
+        assert_eq!(
+            output.status.code(),
+            Some(0),
+            "{args:?}: {}",
+            common::combined_output(&output)
+        );
+        assert_eq!(output.stdout, explicit.stdout, "{args:?}");
+    }
+}
+
+#[test]
 fn test_short_v_flag_errors() {
     let tempdir = tempfile::tempdir().unwrap();
     let output = run_turbo(tempdir.path(), &["-v"]);


### PR DESCRIPTION
### Description

Fix a parsing regression introduced by the usage-rs migration in #13890. Implicit runs such as `turbo -F web build` reject run-local flags before reaching the task name because usage-rs selects its default subcommand only on a positional argument.

- Normalize leading run flags into an explicit run using the existing parser metadata, including short bundles and attached or detached values.
- Preserve explicit subcommand flag scopes, aliases, global options, and arguments after `--`.
- Apply the same normalization to help requests.
- Add parser and binary regression coverage for leading filters, task execution, help, and the existing optional-boolean behavior of `--force`.

The optional-value behavior of `--force` is unchanged: a bare flag after the task and explicit boolean values are supported. A bare `--force` immediately before a task already consumed the task as its value under clap.

### Testing Instructions

Exercise implicit runs with filters before the task, including short and long forms and mixed global options. Confirm the selected task executes and help resolves to run help. Check that explicit subcommand restrictions and forwarded task arguments remain unchanged.