### PR TITLE
fix: Avoid duplicate interrupts during task shutdown

### DIFF
--- a/crates/turborepo-process/src/child/handle.rs
+++ b/crates/turborepo-process/src/child/handle.rs
@@ -25,7 +25,7 @@ pub(super) struct ChildHandle {
     #[cfg(unix)]
     pty_controller_fd: Option<libc::c_int>,
     #[cfg(unix)]
-    graceful_descendant_pids: Vec<libc::pid_t>,
+    graceful_descendants: Vec<GracefulDescendant>,
     #[cfg(windows)]
     _job: Option<crate::job_object::JobObject>,
     #[cfg(windows)]
@@ -102,6 +102,90 @@ impl ShutdownSemantics {
     }
 }
 
+/// Per-descendant bookkeeping captured immediately before the initial graceful
+/// interrupt.
+///
+/// We remember which captured descendants the initial interrupt already
+/// targeted (directly or through their process group) so the
+/// remaining-descendant fallback does not deliver a duplicate signal to them
+/// while still draining every captured survivor.
+#[cfg(unix)]
+#[derive(Debug, Clone, Copy)]
+pub(super) struct GracefulDescendant {
+    pub(super) pid: libc::pid_t,
+    /// The descendant's process group at capture time, when resolvable. `None`
+    /// leaves the descendant eligible for the direct fallback.
+    pub(super) process_group_id: Option<libc::pid_t>,
+    /// Whether a successful initial signal request targeted this descendant.
+    /// This does not imply its signal handler has run.
+    pub(super) initially_signaled: bool,
+}
+
+#[cfg(unix)]
+impl GracefulDescendant {
+    fn captured(pid: libc::pid_t) -> Self {
+        let process_group_id = unsafe { libc::getpgid(pid) };
+        Self {
+            pid,
+            process_group_id: (process_group_id != -1).then_some(process_group_id),
+            initially_signaled: false,
+        }
+    }
+
+    fn mark_initially_signaled(&mut self) {
+        self.initially_signaled = true;
+    }
+
+    /// Record a direct PID delivery. The flag is only set when the kill
+    /// syscall was accepted, so a failed delivery stays eligible for the
+    /// fallback.
+    pub(super) fn record_direct_delivery(&mut self, delivered: bool) {
+        if delivered {
+            self.mark_initially_signaled();
+        }
+    }
+}
+
+#[cfg(unix)]
+fn capture_descendants(root_pid: libc::pid_t) -> Vec<GracefulDescendant> {
+    descendant_pids(root_pid)
+        .into_iter()
+        .map(GracefulDescendant::captured)
+        .collect()
+}
+
+/// Mark the captured descendants that belong to the process group that just
+/// accepted the initial signal.
+///
+/// This must only run after the group kill syscall succeeds and only against
+/// the membership snapshot taken before delivery, so a failed delivery leaves
+/// every descendant eligible for the fallback.
+#[cfg(unix)]
+pub(super) fn mark_group_targets(
+    descendants: &mut [GracefulDescendant],
+    delivered_process_group_id: libc::pid_t,
+) {
+    for descendant in descendants {
+        if descendant.process_group_id == Some(delivered_process_group_id) {
+            descendant.mark_initially_signaled();
+        }
+    }
+}
+
+/// Surviving captured descendants that the initial interrupt did not target,
+/// and which the fallback should therefore signal directly.
+#[cfg(unix)]
+pub(super) fn descendants_needing_fallback(
+    descendants: &[GracefulDescendant],
+    mut is_alive: impl FnMut(libc::pid_t) -> bool,
+) -> Vec<libc::pid_t> {
+    descendants
+        .iter()
+        .filter(|descendant| !descendant.initially_signaled && is_alive(descendant.pid))
+        .map(|descendant| descendant.pid)
+        .collect()
+}
+
 #[cfg(unix)]
 #[derive(Debug, Clone, Copy)]
 pub(super) struct TargetIdentity {
@@ -147,8 +231,8 @@ pub(super) fn process_group_matches_identity(
 }
 
 #[cfg(unix)]
-pub(super) fn signal_process_group(process_group_id: libc::pid_t, signal: libc::c_int) {
-    let _ = unsafe { libc::kill(-process_group_id, signal) };
+pub(super) fn signal_process_group(process_group_id: libc::pid_t, signal: libc::c_int) -> bool {
+    unsafe { libc::kill(-process_group_id, signal) == 0 }
 }
 
 #[cfg(windows)]
@@ -351,7 +435,7 @@ impl ChildHandle {
                 #[cfg(unix)]
                 pty_controller_fd: None,
                 #[cfg(unix)]
-                graceful_descendant_pids: Vec::new(),
+                graceful_descendants: Vec::new(),
                 #[cfg(windows)]
                 _job: job,
                 #[cfg(windows)]
@@ -504,7 +588,7 @@ impl ChildHandle {
                 #[cfg(unix)]
                 pty_controller_fd,
                 #[cfg(unix)]
-                graceful_descendant_pids: Vec::new(),
+                graceful_descendants: Vec::new(),
                 #[cfg(windows)]
                 _job: job,
                 #[cfg(windows)]
@@ -531,12 +615,6 @@ impl ChildHandle {
     }
 
     #[cfg(unix)]
-    fn graceful_process_group_id(&self) -> Option<libc::pid_t> {
-        self.foreground_process_group_id()
-            .or_else(|| self.process_group_id())
-    }
-
-    #[cfg(unix)]
     fn foreground_process_group_id(&self) -> Option<libc::pid_t> {
         self.pty_controller_fd
             .and_then(|fd| match unsafe { libc::tcgetpgrp(fd) } {
@@ -545,22 +623,43 @@ impl ChildHandle {
             })
     }
 
+    /// Deliver the initial graceful signal to a resolved process group.
+    ///
+    /// Descendant membership was snapshotted before this call. Descendants are
+    /// marked as already targeted only after the kernel accepts the group
+    /// signal; a failed delivery leaves them unmarked so the
+    /// remaining-descendant fallback can retry them directly.
     #[cfg(unix)]
-    fn send_signal_to_process_group(&self, pid: libc::pid_t, signal: libc::c_int) {
-        let Some(process_group_id) = self.graceful_process_group_id() else {
-            debug!("missing process group id for child {pid}");
+    fn signal_initial_process_group(
+        &mut self,
+        process_group_id: Option<libc::pid_t>,
+        signal: libc::c_int,
+    ) {
+        let Some(process_group_id) = process_group_id else {
+            debug!("missing process group id for graceful interrupt");
             return;
         };
 
         debug!("sending signal {signal} to process group -{process_group_id}");
-        signal_process_group(process_group_id, signal);
+        if !signal_process_group(process_group_id, signal) {
+            debug!("failed to send signal {signal} to process group -{process_group_id}");
+            return;
+        }
+
+        mark_group_targets(&mut self.graceful_descendants, process_group_id);
     }
 
     #[cfg(unix)]
     pub(super) fn send_graceful_interrupt(&mut self, pid: libc::pid_t) {
         let child_process_group_id = self.process_group_id();
         let foreground_process_group_id = self.foreground_process_group_id();
-        self.graceful_descendant_pids = descendant_pids(pid);
+        let graceful_process_group_id = foreground_process_group_id.or(child_process_group_id);
+        self.graceful_descendants = capture_descendants(pid);
+        let captured_pids = self
+            .graceful_descendants
+            .iter()
+            .map(|descendant| descendant.pid)
+            .collect::<Vec<_>>();
 
         debug!(
             "graceful interrupt target={:?}, child pid={pid}, child pgid={:?}, pty foreground \
@@ -568,26 +667,27 @@ impl ChildHandle {
             self.shutdown_semantics.graceful_interrupt_target,
             child_process_group_id,
             foreground_process_group_id,
-            self.graceful_descendant_pids
+            captured_pids
         );
 
         match self.shutdown_semantics.graceful_interrupt_target {
             GracefulInterruptTarget::DirectChild => {
-                if self.graceful_descendant_pids.len() > 1 {
+                if self.graceful_descendants.len() > 1 {
                     debug!(
                         "sending SIGINT to process group because PTY child has nested descendants"
                     );
-                    self.send_signal_to_process_group(pid, libc::SIGINT);
+                    self.signal_initial_process_group(graceful_process_group_id, libc::SIGINT);
                     return;
                 }
 
-                if !self.graceful_descendant_pids.is_empty() {
-                    debug!(
-                        "sending SIGINT to descendant processes {:?}",
-                        self.graceful_descendant_pids
-                    );
-                    for descendant_pid in &self.graceful_descendant_pids {
-                        let _ = unsafe { libc::kill(*descendant_pid, libc::SIGINT) };
+                if !self.graceful_descendants.is_empty() {
+                    debug!("sending SIGINT to descendant processes {:?}", captured_pids);
+                    for descendant in &mut self.graceful_descendants {
+                        let delivered = unsafe { libc::kill(descendant.pid, libc::SIGINT) } == 0;
+                        descendant.record_direct_delivery(delivered);
+                        if !delivered {
+                            debug!("failed to send SIGINT to descendant {}", descendant.pid);
+                        }
                     }
                     return;
                 }
@@ -609,7 +709,7 @@ impl ChildHandle {
                 }
             }
             GracefulInterruptTarget::ProcessGroup => {
-                self.send_signal_to_process_group(pid, libc::SIGINT);
+                self.signal_initial_process_group(graceful_process_group_id, libc::SIGINT);
             }
         }
     }
@@ -623,46 +723,39 @@ impl ChildHandle {
             return false;
         }
 
-        let remaining_descendants = self
-            .graceful_descendant_pids
-            .iter()
-            .copied()
-            .filter(|pid| is_pid_alive(*pid))
-            .collect::<Vec<_>>();
+        let remaining_descendants =
+            descendants_needing_fallback(&self.graceful_descendants, is_pid_alive);
 
-        if remaining_descendants.is_empty() {
-            return false;
+        if !remaining_descendants.is_empty() {
+            debug!(
+                "sending SIGINT to remaining descendant processes {:?}",
+                remaining_descendants
+            );
+            for pid in remaining_descendants {
+                let _ = unsafe { libc::kill(pid, libc::SIGINT) };
+            }
         }
 
-        debug!(
-            "sending SIGINT to remaining descendant processes {:?}",
-            remaining_descendants
-        );
-        for pid in remaining_descendants {
-            let _ = unsafe { libc::kill(pid, libc::SIGINT) };
-        }
-
-        true
+        // Descendants the initial interrupt already reached may still be
+        // running cleanup, so the caller must drain every captured survivor
+        // even when no fallback signal was necessary.
+        self.has_running_descendants()
     }
 
     #[cfg(unix)]
     fn has_running_descendants(&self) -> bool {
-        self.graceful_descendant_pids
+        self.graceful_descendants
             .iter()
-            .copied()
-            .any(is_pid_alive)
+            .any(|descendant| is_pid_alive(descendant.pid))
     }
 
     #[cfg(unix)]
     fn kill_remaining_descendants(&self) {
-        for pid in self
-            .graceful_descendant_pids
-            .iter()
-            .copied()
-            .filter(|pid| is_pid_alive(*pid))
-        {
-            debug!("killing remaining descendant process {pid}");
-            let _ = unsafe { libc::kill(pid, libc::SIGKILL) };
+        for descendant in &self.graceful_descendants {
+            if is_pid_alive(descendant.pid) {
+                debug!("killing remaining descendant process {}", descendant.pid);
+                let _ = unsafe { libc::kill(descendant.pid, libc::SIGKILL) };
+            }
         }
     }
 

--- a/crates/turborepo-process/src/child/test.rs
+++ b/crates/turborepo-process/src/child/test.rs
@@ -13,6 +13,9 @@ use tokio::{
 use tracing_test::traced_test;
 use turbopath::AbsoluteSystemPathBuf;
 
+#[cfg(unix)]
+mod shutdown_adversarial;
+
 use super::{Child, ChildInput, ChildOutput, ChildStdin, Command};
 use crate::{
     PtySize,

--- a/crates/turborepo-process/src/child/test/shutdown_adversarial.rs
+++ b/crates/turborepo-process/src/child/test/shutdown_adversarial.rs
@@ -1,0 +1,905 @@
+//! Adversarial graceful-shutdown contracts for piped and PTY children.
+//!
+//! These tests drive `ChildHandle::send_graceful_interrupt` and its
+//! `send_interrupt_to_remaining_descendants` follow-up through the
+//! deterministic `test/scripts/shutdown_fixture.js` fixture.
+//!
+//! What we actually promise, and therefore assert:
+//!
+//! * Given a cooperative worker, our shutdown delivers at least one interrupt
+//!   it can act on, and `Child::stop` does not report completion until the
+//!   worker has recorded that its cleanup finished.
+//! * The owned process group is gone before the test returns.
+//! * No fixture watchdog fired and no unexpected IO error occurred.
+//! * The final cleanup line is captured for pipe children and for PTY children
+//!   whose session leader stays alive.
+//!
+//! What we deliberately do not promise: an exact signal count when arbitrary
+//! wrappers forward. Turborepo signals the process group on the pipe path, and
+//! a wrapper may forward that signal to its child on top of the group delivery.
+//! Duplicate SIGINTs are therefore legitimate and are kept as observations.
+//!
+//! Capture scope is separate from the counts. A PTY session leader that exits
+//! early hangs up the terminal for the rest of the group; the worker tolerates
+//! SIGHUP and still proves cleanup through its file marker, but output written
+//! after the hangup is not a guarantee. Those cases are process-tree completion
+//! tests. Pipe cases, and PTY cases whose session leader stays alive, still
+//! require the final cleanup output.
+//!
+//! One focused regression pins down a duplicate that is ours, not a wrapper's:
+//! nested nonforwarding wrappers under PTY get the group SIGINT and then our
+//! remaining-descendant fallback signals the worker a second time. With every
+//! wrapper known nonforwarding, an exact-one worker assertion is legitimate.
+
+use std::{
+    assert_matches,
+    ffi::OsString,
+    fs,
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
+    time::{Duration, Instant},
+};
+
+use test_case::test_case;
+use tracing_test::traced_test;
+
+use super::{ObservedOutput, TEST_PTY, find_script_dir};
+use crate::{
+    Child, Command, PtySize,
+    child::{
+        ChildExit, ShutdownStyle,
+        handle::{GracefulDescendant, descendants_needing_fallback, mark_group_targets},
+    },
+};
+
+const READY_LIMIT: Duration = Duration::from_secs(15);
+const FINISH_LIMIT: Duration = Duration::from_secs(15);
+const GRACE_TIMEOUT: Duration = Duration::from_secs(8);
+const SLOW_CLEANUP_MS: u64 = 1500;
+const FAST_CLEANUP_MS: u64 = 200;
+const FORWARD_DELAY_MS: u64 = 300;
+const FIXTURE_WATCHDOG_MS: u64 = 30_000;
+
+static NEXT_STATE_DIR: AtomicU64 = AtomicU64::new(0);
+
+fn unique_state_dir(label: &str) -> PathBuf {
+    loop {
+        let id = NEXT_STATE_DIR.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "turbo-shutdown-{}-{id}-{label}",
+            std::process::id()
+        ));
+        match fs::create_dir(&dir) {
+            Ok(()) => return dir,
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(err) => panic!(
+                "failed to create fixture state dir {}: {err}",
+                dir.display()
+            ),
+        }
+    }
+}
+
+/// Kills the fixture's process group and removes the state dir even if the test
+/// panics. The root is its own group leader on Unix (`process_group(0)` for
+/// piped children, a fresh session for PTY children) and descendants inherit
+/// that group, so one `kill(-pgid, SIGKILL)` signals whatever is left.
+struct CleanupGuard {
+    pgid: Option<libc::pid_t>,
+    state_dir: PathBuf,
+}
+
+impl CleanupGuard {
+    fn new(state_dir: PathBuf) -> Self {
+        Self {
+            pgid: None,
+            state_dir,
+        }
+    }
+
+    /// Drop the panic-path kill; `Drop` still removes the state dir.
+    fn disarm(&mut self) {
+        self.pgid = None;
+    }
+}
+
+impl Drop for CleanupGuard {
+    fn drop(&mut self) {
+        if let Some(pgid) = self.pgid {
+            unsafe {
+                libc::kill(-pgid, libc::SIGKILL);
+            }
+        }
+        let _ = fs::remove_dir_all(&self.state_dir);
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Forward {
+    /// Never signal the child.
+    None,
+    /// Forward after a delay, on top of whatever the group delivery did.
+    Delayed,
+}
+
+impl Forward {
+    fn as_arg(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Delayed => "delayed",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum ExitMode {
+    /// Exit as soon as the interrupt is handled.
+    Now,
+    /// Stay alive until the child exits.
+    AfterChild,
+    /// Nonforwarding only: wait for the worker's file acknowledgment, then
+    /// exit. This is the readiness barrier that makes our fallback re-signal a
+    /// distinct delivery instead of a coalesced one.
+    AfterAck,
+}
+
+impl ExitMode {
+    fn as_arg(self) -> &'static str {
+        match self {
+            Self::Now => "now",
+            Self::AfterChild => "after-child",
+            Self::AfterAck => "after-ack",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct FixtureSpec {
+    /// When false the fixture launches a plain worker (no wrapper).
+    wrapper: bool,
+    /// Number of wrapper levels above the worker.
+    depth: u32,
+    forward: Forward,
+    forward_delay_ms: u64,
+    exit_mode: ExitMode,
+    worker_cleanup_ms: u64,
+}
+
+/// How the test asks the child to shut down.
+#[derive(Clone, Copy, Debug)]
+enum Driver {
+    /// One `Child::stop` using the gracefully-configured style.
+    Stop,
+    /// Several `Child::shutdown(Graceful)` requests issued while the worker
+    /// cleans up; only internal command idempotency is under test here.
+    RepeatedGraceful(u32),
+}
+
+struct Outcome {
+    use_pty: bool,
+    exit: Option<ChildExit>,
+    output: String,
+    worker_sigint_count: u32,
+    worker_cleanup_complete: bool,
+    /// True when shutdown reported completion before the worker recorded its
+    /// cleanup marker.
+    stop_finished_before_cleanup: bool,
+    state_dir: PathBuf,
+    _guard: CleanupGuard,
+}
+
+impl Outcome {
+    fn marker_present(&self, name: &str) -> bool {
+        self.state_dir.join(name).exists()
+    }
+
+    /// True when the root wrapper exited before worker cleanup finished; the
+    /// scenario assertion for declared early-exit cases.
+    fn early_exit_observed(&self) -> bool {
+        self.marker_present("root-exited")
+    }
+
+    /// Any fixture process wrote a watchdog marker instead of shutting down.
+    fn watchdog_fired(&self) -> bool {
+        self.marker_contains("watchdog")
+    }
+
+    /// A fixture process hit a stream error we do not consider expected.
+    fn io_error_fired(&self) -> bool {
+        self.marker_contains("io-error")
+    }
+
+    fn marker_contains(&self, needle: &str) -> bool {
+        fs::read_dir(&self.state_dir)
+            .map(|entries| {
+                entries
+                    .flatten()
+                    .any(|entry| entry.file_name().to_string_lossy().contains(needle))
+            })
+            .unwrap_or(false)
+    }
+
+    fn diagnostic(&self, scenario: &str) -> String {
+        use std::fmt::Write as _;
+
+        let mode = if self.use_pty { "pty" } else { "pipe" };
+        let mut report = String::new();
+        let _ = writeln!(report, "=== shutdown adversarial: {scenario} ({mode}) ===");
+        let _ = writeln!(report, "root_exit={:?}", self.exit);
+        let _ = writeln!(report, "worker_sigint_count={}", self.worker_sigint_count);
+        let _ = writeln!(
+            report,
+            "worker_cleanup_complete={}",
+            self.worker_cleanup_complete
+        );
+        let _ = writeln!(
+            report,
+            "stop_finished_before_cleanup={}",
+            self.stop_finished_before_cleanup
+        );
+        let _ = writeln!(report, "early_exit_observed={}", self.early_exit_observed());
+        let _ = writeln!(report, "--- captured output ---\n{}", self.output);
+        let _ = writeln!(report, "--- state files ---");
+
+        match fs::read_dir(&self.state_dir) {
+            Ok(entries) => {
+                let mut files: Vec<PathBuf> = entries.flatten().map(|e| e.path()).collect();
+                files.sort();
+                for path in files {
+                    let name = path
+                        .file_name()
+                        .unwrap_or_default()
+                        .to_string_lossy()
+                        .to_string();
+                    let contents = fs::read_to_string(&path)
+                        .map(|c| c.trim().to_string())
+                        .unwrap_or_else(|err| format!("<unreadable: {err}>"));
+                    report.push_str(&format!("  {name}={contents}\n"));
+                }
+            }
+            Err(err) => report.push_str(&format!("  <failed to list state dir: {err}>\n")),
+        }
+
+        report
+    }
+
+    /// The owned group must actually be gone. This is an assertion, not a
+    /// tolerated wait: a lingering descendant fails the test, and the panic
+    /// path still kills the group via `CleanupGuard`.
+    async fn assert_owned_group_gone(&mut self) {
+        let Some(pgid) = self._guard.pgid else {
+            return;
+        };
+        let deadline = Instant::now() + FINISH_LIMIT;
+        while Instant::now() < deadline && !process_group_gone(pgid) {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        let diag = self.diagnostic("owned group teardown");
+        assert!(
+            process_group_gone(pgid),
+            "owned process group {pgid} survived stop(){diag}"
+        );
+        self._guard.disarm();
+    }
+}
+
+async fn wait_for_file(path: &Path, limit: Duration) -> bool {
+    let deadline = Instant::now() + limit;
+    loop {
+        if path.exists() {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+/// Wait until the worker file records at least one SIGINT.
+async fn wait_for_worker_ack(state_dir: &Path, limit: Duration) -> bool {
+    let path = state_dir.join("worker-sigint-count");
+    let deadline = Instant::now() + limit;
+    loop {
+        if let Ok(contents) = fs::read_to_string(&path)
+            && contents.trim().parse::<u32>().is_ok_and(|count| count >= 1)
+        {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+}
+
+/// True once no process remains in the group. `kill(-pgid, 0)` only probes the
+/// group; it never delivers a signal.
+fn process_group_gone(pgid: libc::pid_t) -> bool {
+    let result = unsafe { libc::kill(-pgid, 0) };
+    result != 0 && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
+}
+
+fn fixture_args(spec: FixtureSpec, state_dir: &Path) -> Vec<OsString> {
+    let script = find_script_dir().join_component("shutdown_fixture.js");
+    let script_arg = script.as_std_path().as_os_str().to_os_string();
+    let state_arg = state_dir.as_os_str().to_os_string();
+
+    if spec.wrapper {
+        vec![
+            script_arg,
+            OsString::from("wrapper"),
+            state_arg,
+            OsString::from("1"),
+            OsString::from(spec.depth.to_string()),
+            OsString::from(spec.forward.as_arg()),
+            OsString::from(spec.forward_delay_ms.to_string()),
+            OsString::from(spec.exit_mode.as_arg()),
+            OsString::from(spec.worker_cleanup_ms.to_string()),
+            OsString::from(FIXTURE_WATCHDOG_MS.to_string()),
+        ]
+    } else {
+        vec![
+            script_arg,
+            OsString::from("worker"),
+            state_arg,
+            OsString::from(spec.worker_cleanup_ms.to_string()),
+            OsString::from(FIXTURE_WATCHDOG_MS.to_string()),
+        ]
+    }
+}
+
+async fn run_fixture(use_pty: bool, label: &str, spec: FixtureSpec, driver: Driver) -> Outcome {
+    let state_dir = unique_state_dir(label);
+    let mut guard = CleanupGuard::new(state_dir.clone());
+
+    let mut cmd = Command::new("node");
+    cmd.args(fixture_args(spec, &state_dir));
+    cmd.open_stdin();
+
+    let child = Child::spawn(
+        cmd,
+        ShutdownStyle::Graceful(Some(GRACE_TIMEOUT)),
+        use_pty.then(PtySize::default),
+    )
+    .expect("failed to spawn shutdown fixture");
+    guard.pgid = child.pid().map(|pid| pid as libc::pid_t);
+
+    let ready_marker = if spec.wrapper { "tree-ready" } else { "ready" };
+    assert!(
+        wait_for_file(&state_dir.join(ready_marker), READY_LIMIT).await,
+        "fixture tree never became ready (pid={:?})",
+        child.pid()
+    );
+
+    let mut output_child = child.clone();
+    let (mut observer, output, _ready_rx) = ObservedOutput::new();
+    let output_task =
+        tokio::spawn(async move { output_child.wait_with_piped_outputs(&mut observer).await });
+
+    child.set_closing();
+    let cleanup_path = state_dir.join("worker-cleanup-complete");
+    let mut stop_tasks = Vec::new();
+    match driver {
+        Driver::Stop => {
+            let mut stop_child = child.clone();
+            stop_tasks.push(tokio::spawn(async move { stop_child.stop().await }));
+        }
+        Driver::RepeatedGraceful(requests) => {
+            let mut first = child.clone();
+            stop_tasks.push(tokio::spawn(async move {
+                first
+                    .shutdown(ShutdownStyle::Graceful(Some(GRACE_TIMEOUT)))
+                    .await
+            }));
+            assert!(
+                wait_for_worker_ack(&state_dir, READY_LIMIT).await,
+                "worker never acknowledged the first graceful interrupt"
+            );
+            // Duplicate requests only exercise in-flight idempotency if the
+            // first request is still pending and cleanup has not yet finished.
+            assert!(
+                !stop_tasks[0].is_finished(),
+                "first graceful request completed before duplicates were issued"
+            );
+            assert!(
+                !cleanup_path.exists(),
+                "worker cleanup completed before duplicates were issued"
+            );
+            for _ in 1..requests {
+                let mut extra = child.clone();
+                stop_tasks.push(tokio::spawn(async move {
+                    extra
+                        .shutdown(ShutdownStyle::Graceful(Some(GRACE_TIMEOUT)))
+                        .await
+                }));
+            }
+        }
+    }
+
+    // Watch that shutdown does not report completion while the worker is still
+    // alive and cleaning up. The worker writes its completion marker
+    // immediately before exiting, so the marker must appear first.
+    let deadline = Instant::now() + FINISH_LIMIT;
+    let mut stop_finished_before_cleanup = false;
+    while !cleanup_path.exists() {
+        if Instant::now() >= deadline {
+            break;
+        }
+        if stop_tasks.iter().all(|task| task.is_finished()) {
+            // The marker can land between the `exists()` probe and the finished
+            // check; recheck before concluding shutdown outraced cleanup.
+            if !cleanup_path.exists() {
+                stop_finished_before_cleanup = true;
+            }
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    let output_exit = tokio::time::timeout(FINISH_LIMIT, output_task)
+        .await
+        .expect("output drain did not finish")
+        .expect("output task panicked")
+        .expect("output reader failed");
+
+    for task in &mut stop_tasks {
+        let stop_exit = tokio::time::timeout(FINISH_LIMIT, task)
+            .await
+            .expect("stop() did not finish")
+            .expect("stop task panicked");
+        assert_eq!(
+            stop_exit, output_exit,
+            "output reader and a shutdown request disagreed on the child exit ({label})"
+        );
+    }
+
+    let worker_sigint_count = fs::read_to_string(state_dir.join("worker-sigint-count"))
+        .ok()
+        .and_then(|s| s.trim().parse::<u32>().ok())
+        .unwrap_or(0);
+    let worker_cleanup_complete = cleanup_path.exists();
+    let output = String::from_utf8_lossy(&output.lock().unwrap().clone()).into_owned();
+
+    let mut outcome = Outcome {
+        use_pty,
+        exit: output_exit,
+        output,
+        worker_sigint_count,
+        worker_cleanup_complete,
+        stop_finished_before_cleanup,
+        state_dir,
+        _guard: guard,
+    };
+
+    outcome.assert_owned_group_gone().await;
+
+    println!(
+        "shutdown observation: label={label} mode={} sigint_count={} cleanup_complete={} \
+         final_output_present={} early_exit={} stop_before_cleanup={}",
+        if use_pty { "pty" } else { "pipe" },
+        outcome.worker_sigint_count,
+        outcome.worker_cleanup_complete,
+        outcome.output.contains("worker cleanup complete"),
+        outcome.early_exit_observed(),
+        outcome.stop_finished_before_cleanup,
+    );
+
+    outcome
+}
+
+/// Contracts that hold for every scenario, independent of capture scope.
+fn assert_clean_teardown(outcome: &Outcome, scenario: &str) {
+    let diag = outcome.diagnostic(scenario);
+    assert!(
+        outcome.worker_cleanup_complete,
+        "worker never proved cleanup completed{diag}"
+    );
+    assert!(
+        outcome.output.contains("worker started") || outcome.worker_sigint_count > 0,
+        "worker produced no evidence that it ever ran{diag}"
+    );
+    assert!(
+        !outcome.stop_finished_before_cleanup,
+        "shutdown reported complete while a tracked descendant was still cleaning up{diag}"
+    );
+    assert!(
+        !outcome.watchdog_fired(),
+        "a fixture watchdog fired instead of a clean shutdown{diag}"
+    );
+    assert!(
+        !outcome.io_error_fired(),
+        "a fixture process hit an unexpected stream error{diag}"
+    );
+}
+
+fn assert_interrupted(outcome: &Outcome, scenario: &str) {
+    let diag = outcome.diagnostic(scenario);
+    assert_matches!(outcome.exit, Some(ChildExit::Interrupted), "{diag}");
+}
+
+/// Capture is a guarantee only for pipe children and for PTY children whose
+/// session leader stays alive until the worker exits.
+fn assert_final_cleanup_captured(outcome: &Outcome, scenario: &str) {
+    let diag = outcome.diagnostic(scenario);
+    assert!(
+        outcome.output.contains("worker cleanup complete"),
+        "final cleanup output was not captured, but capture is in scope for this scenario{diag}"
+    );
+}
+
+/// Legitimate when no arbitrary forwarding is involved: the plain worker and
+/// the known-nonforwarding regression.
+fn assert_exactly_one_interrupt(outcome: &Outcome, scenario: &str) {
+    let diag = outcome.diagnostic(scenario);
+    assert_eq!(
+        outcome.worker_sigint_count, 1,
+        "expected exactly one intended interruption{diag}"
+    );
+}
+
+/// The real contract for forwarding wrappers. Turborepo signals the process
+/// group on the pipe path and the worker's own wrapper may forward on top of
+/// that; both are valid deliveries, so we only require that the worker saw at
+/// least one interrupt it could act on.
+fn assert_at_least_one_interrupt(outcome: &Outcome, scenario: &str) {
+    let diag = outcome.diagnostic(scenario);
+    assert!(
+        outcome.worker_sigint_count >= 1,
+        "worker observed no interrupt{diag}"
+    );
+}
+
+#[test_case(false)]
+#[test_case(TEST_PTY)]
+#[tokio::test]
+#[traced_test]
+async fn test_shutdown_control_plain_worker_observes_single_interrupt(use_pty: bool) {
+    let outcome = run_fixture(
+        use_pty,
+        "control-plain-worker",
+        FixtureSpec {
+            wrapper: false,
+            depth: 0,
+            forward: Forward::None,
+            forward_delay_ms: 0,
+            exit_mode: ExitMode::AfterChild,
+            worker_cleanup_ms: FAST_CLEANUP_MS,
+        },
+        Driver::Stop,
+    )
+    .await;
+
+    assert_clean_teardown(&outcome, "control plain worker");
+    assert_interrupted(&outcome, "control plain worker");
+    assert_exactly_one_interrupt(&outcome, "control plain worker");
+    assert_final_cleanup_captured(&outcome, "control plain worker");
+}
+
+/// A forwarding wrapper stays alive until a slow worker finishes cleanup. The
+/// session leader never exits early, so final output capture is in scope for
+/// both modes. The worker may see the group SIGINT plus the wrapper's forward.
+#[test_case(false)]
+#[test_case(TEST_PTY)]
+#[tokio::test]
+#[traced_test]
+async fn test_shutdown_forwarding_wrapper_waits_for_slow_cleanup(use_pty: bool) {
+    let outcome = run_fixture(
+        use_pty,
+        "forwarding-wrapper-slow-cleanup",
+        FixtureSpec {
+            wrapper: true,
+            depth: 0,
+            forward: Forward::Delayed,
+            forward_delay_ms: FORWARD_DELAY_MS,
+            exit_mode: ExitMode::AfterChild,
+            worker_cleanup_ms: SLOW_CLEANUP_MS,
+        },
+        Driver::Stop,
+    )
+    .await;
+
+    assert_clean_teardown(&outcome, "forwarding wrapper waits for slow cleanup");
+    assert_interrupted(&outcome, "forwarding wrapper waits for slow cleanup");
+    assert_at_least_one_interrupt(&outcome, "forwarding wrapper waits for slow cleanup");
+    assert_final_cleanup_captured(&outcome, "forwarding wrapper waits for slow cleanup");
+}
+
+/// A forwarding wrapper may exit while the worker is still cleaning up.
+///
+/// Whether the wrapper exits early is an observation about the current
+/// target-selection heuristics, not a shutdown invariant. The final cleanup
+/// output is required whenever the session leader keeps the terminal usable:
+/// on pipes, and on PTY when the wrapper did not exit early. When a PTY
+/// session leader does exit early the terminal hangs up, so late output is not
+/// guaranteed and only process-tree completion is asserted.
+#[test_case(false)]
+#[test_case(TEST_PTY)]
+#[tokio::test]
+#[traced_test]
+async fn test_shutdown_forwarding_wrapper_exits_before_worker_cleanup(use_pty: bool) {
+    let outcome = run_fixture(
+        use_pty,
+        "forwarding-wrapper-exits-early",
+        FixtureSpec {
+            wrapper: true,
+            depth: 0,
+            forward: Forward::Delayed,
+            forward_delay_ms: FORWARD_DELAY_MS,
+            exit_mode: ExitMode::Now,
+            worker_cleanup_ms: SLOW_CLEANUP_MS,
+        },
+        Driver::Stop,
+    )
+    .await;
+
+    let scenario = "forwarding wrapper exits before cleanup";
+    assert_clean_teardown(&outcome, scenario);
+    assert_interrupted(&outcome, scenario);
+    assert_at_least_one_interrupt(&outcome, scenario);
+
+    if !use_pty || !outcome.early_exit_observed() {
+        assert_final_cleanup_captured(&outcome, scenario);
+    }
+}
+
+/// Nested forwarding wrappers: with two descendants Turborepo targets the
+/// process group on both paths, and each wrapper forwards on top of it, so the
+/// leaf worker can observe the interruption several times. Counts are
+/// observations.
+#[test_case(false)]
+#[test_case(TEST_PTY)]
+#[tokio::test]
+#[traced_test]
+async fn test_shutdown_nested_forwarding_wrappers(use_pty: bool) {
+    let outcome = run_fixture(
+        use_pty,
+        "nested-forwarding-wrappers",
+        FixtureSpec {
+            wrapper: true,
+            depth: 1,
+            forward: Forward::Delayed,
+            forward_delay_ms: FORWARD_DELAY_MS,
+            exit_mode: ExitMode::AfterChild,
+            worker_cleanup_ms: SLOW_CLEANUP_MS,
+        },
+        Driver::Stop,
+    )
+    .await;
+
+    assert_clean_teardown(&outcome, "nested forwarding wrappers");
+    assert_interrupted(&outcome, "nested forwarding wrappers");
+    assert_at_least_one_interrupt(&outcome, "nested forwarding wrappers");
+    assert_final_cleanup_captured(&outcome, "nested forwarding wrappers");
+}
+
+/// Nested forwarding wrappers where the root exits before worker cleanup.
+/// On PTY the extra nesting forces the group target, so the root is really
+/// interrupted and its early exit is exercised. That exit hangs up the
+/// terminal, so this is a process-tree completion test, not a capture test.
+/// On pipe the terminal is not hung up and cleanup output remains in scope.
+#[test_case(false)]
+#[test_case(TEST_PTY)]
+#[tokio::test]
+#[traced_test]
+async fn test_shutdown_nested_forwarding_wrapper_exits_before_worker_cleanup(use_pty: bool) {
+    let outcome = run_fixture(
+        use_pty,
+        "nested-forwarding-wrapper-exits-early",
+        FixtureSpec {
+            wrapper: true,
+            depth: 1,
+            forward: Forward::Delayed,
+            forward_delay_ms: FORWARD_DELAY_MS,
+            exit_mode: ExitMode::Now,
+            worker_cleanup_ms: SLOW_CLEANUP_MS,
+        },
+        Driver::Stop,
+    )
+    .await;
+
+    let scenario = "nested forwarding wrapper exits before cleanup";
+    assert_clean_teardown(&outcome, scenario);
+    assert_interrupted(&outcome, scenario);
+    assert_at_least_one_interrupt(&outcome, scenario);
+    assert!(
+        outcome.early_exit_observed(),
+        "root wrapper was expected to exit before worker cleanup{}",
+        outcome.diagnostic(scenario)
+    );
+
+    if !use_pty {
+        assert_final_cleanup_captured(&outcome, scenario);
+    }
+}
+
+/// Focused regression for OUR duplicate send. Nested nonforwarding wrappers
+/// under PTY receive the group SIGINT, then the root exits and
+/// `send_interrupt_to_remaining_descendants` signals the still-cleaning worker
+/// again. Because no wrapper forwards, the only way the worker sees a second
+/// SIGINT is our fallback. The root waits on the worker's file acknowledgment
+/// before exiting, so the second delivery cannot be coalesced with the first.
+/// Expected to stay red until the fallback stops re-signaling.
+#[tokio::test]
+#[traced_test]
+async fn test_nonforwarding_wrappers_resignal_worker_under_pty() {
+    let outcome = run_fixture(
+        true,
+        "nonforwarding-pty-resignal",
+        FixtureSpec {
+            wrapper: true,
+            depth: 1,
+            forward: Forward::None,
+            forward_delay_ms: 0,
+            exit_mode: ExitMode::AfterAck,
+            worker_cleanup_ms: SLOW_CLEANUP_MS,
+        },
+        Driver::Stop,
+    )
+    .await;
+
+    let scenario = "nonforwarding wrappers re-signal under PTY";
+    assert_clean_teardown(&outcome, scenario);
+    assert_interrupted(&outcome, scenario);
+    assert!(
+        outcome.early_exit_observed(),
+        "nonforwarding root was expected to exit after acknowledging the worker{}",
+        outcome.diagnostic(scenario)
+    );
+    assert_exactly_one_interrupt(&outcome, scenario);
+}
+
+/// Passing pipe counterpart of the regression above. The process-group target
+/// makes `send_interrupt_to_remaining_descendants` a no-op, so the worker sees
+/// the group signal exactly once.
+#[tokio::test]
+#[traced_test]
+async fn test_nonforwarding_wrappers_pipe_counterpart() {
+    let outcome = run_fixture(
+        false,
+        "nonforwarding-pipe-counterpart",
+        FixtureSpec {
+            wrapper: true,
+            depth: 1,
+            forward: Forward::None,
+            forward_delay_ms: 0,
+            exit_mode: ExitMode::AfterAck,
+            worker_cleanup_ms: SLOW_CLEANUP_MS,
+        },
+        Driver::Stop,
+    )
+    .await;
+
+    let scenario = "nonforwarding wrappers pipe counterpart";
+    assert_clean_teardown(&outcome, scenario);
+    assert_interrupted(&outcome, scenario);
+    assert_exactly_one_interrupt(&outcome, scenario);
+    assert_final_cleanup_captured(&outcome, scenario);
+}
+
+/// Repeated internal graceful shutdown requests while the worker cleans up must
+/// be idempotent at the Child layer: they must not deliver a second OS
+/// interrupt. (Repeated *OS* signals are a different escalation policy and are
+/// not what this exercises.) The worker acknowledges the first interrupt before
+/// the extra requests are issued, and cleanup is slow enough to overlap them.
+#[test_case(false)]
+#[test_case(TEST_PTY)]
+#[tokio::test]
+#[traced_test]
+async fn test_repeated_graceful_shutdown_requests_are_idempotent(use_pty: bool) {
+    let outcome = run_fixture(
+        use_pty,
+        "repeated-graceful-shutdown",
+        FixtureSpec {
+            wrapper: false,
+            depth: 0,
+            forward: Forward::None,
+            forward_delay_ms: 0,
+            exit_mode: ExitMode::AfterChild,
+            worker_cleanup_ms: SLOW_CLEANUP_MS,
+        },
+        Driver::RepeatedGraceful(4),
+    )
+    .await;
+
+    let scenario = "repeated graceful shutdown requests";
+    assert_clean_teardown(&outcome, scenario);
+    assert_interrupted(&outcome, scenario);
+    assert_exactly_one_interrupt(&outcome, scenario);
+    assert_final_cleanup_captured(&outcome, scenario);
+}
+
+fn descendant(
+    pid: libc::pid_t,
+    process_group_id: Option<libc::pid_t>,
+    initially_signaled: bool,
+) -> GracefulDescendant {
+    GracefulDescendant {
+        pid,
+        process_group_id,
+        initially_signaled,
+    }
+}
+
+/// Group delivery must only mark the members of the process group that
+/// actually accepted the signal, so descendants outside the signaled group
+/// (for example a PTY descendant that moved itself) stay eligible for the
+/// direct fallback.
+#[test]
+fn group_delivery_marks_only_signaled_group_members() {
+    let mut descendants = vec![
+        descendant(101, Some(50), false),
+        descendant(102, Some(50), false),
+        descendant(103, Some(60), false),
+        descendant(104, None, false),
+    ];
+
+    mark_group_targets(&mut descendants, 50);
+
+    assert!(descendants[0].initially_signaled);
+    assert!(descendants[1].initially_signaled);
+    assert!(!descendants[2].initially_signaled);
+    assert!(!descendants[3].initially_signaled);
+}
+
+/// A failed group delivery never reaches `mark_group_targets`, so every
+/// surviving descendant remains available for the fallback to retry directly.
+#[test]
+fn failed_group_delivery_leaves_all_descendants_untargeted() {
+    let descendants = vec![
+        descendant(201, Some(70), false),
+        descendant(202, None, false),
+    ];
+
+    let fallback = descendants_needing_fallback(&descendants, |_| true);
+
+    assert_eq!(fallback, vec![201, 202]);
+}
+
+/// The fallback must skip descendants the initial interrupt already reached
+/// while preserving an initially untargeted survivor.
+#[test]
+fn fallback_skips_targeted_descendants_and_preserves_untargeted() {
+    let descendants = vec![
+        descendant(301, Some(80), true),
+        descendant(302, Some(81), false),
+        descendant(303, Some(80), true),
+    ];
+
+    let fallback = descendants_needing_fallback(&descendants, |_| true);
+
+    assert_eq!(fallback, vec![302]);
+}
+
+/// Direct-target delivery marks each descendant only when its own kill
+/// syscall was accepted; a sibling captured in the same snapshot stays
+/// eligible for the fallback.
+#[test]
+fn direct_target_delivery_marks_only_accepted_pids() {
+    let mut descendants = vec![
+        descendant(401, Some(90), false),
+        descendant(402, Some(90), false),
+    ];
+
+    descendants[0].record_direct_delivery(true);
+    descendants[1].record_direct_delivery(false);
+
+    assert!(descendants[0].initially_signaled);
+    assert!(!descendants[1].initially_signaled);
+
+    let fallback = descendants_needing_fallback(&descendants, |_| true);
+    assert_eq!(fallback, vec![402]);
+}
+
+/// Dead descendants are filtered before the fallback signals anything.
+#[test]
+fn fallback_filters_dead_descendants() {
+    let descendants = vec![
+        descendant(501, Some(95), false),
+        descendant(502, Some(95), false),
+    ];
+
+    let fallback = descendants_needing_fallback(&descendants, |pid| pid != 501);
+
+    assert_eq!(fallback, vec![502]);
+}

--- a/crates/turborepo-process/test/scripts/shutdown_fixture.js
+++ b/crates/turborepo-process/test/scripts/shutdown_fixture.js
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+"use strict";
+
+// Deterministic wrapper/worker fixture for the adversarial graceful-shutdown
+// tests in crates/turborepo-process/src/child/test/shutdown_adversarial.rs.
+//
+// Every process installs a SIGINT handler that records each delivery, so a
+// wrapper forwarding on top of Turborepo's group signal is an observation
+// rather than a silent kill. SIGINT counts and cleanup completion are written
+// to files in <stateDir>; the tests treat counts as observations and use the
+// file markers as the actual contract.
+//
+// Usage:
+//   worker:  node shutdown_fixture.js worker  <stateDir> <cleanupMs> <watchdogMs>
+//   wrapper: node shutdown_fixture.js wrapper <stateDir> <root:0|1> <depth> \
+//              <forward:none|delayed> <forwardDelayMs> \
+//              <exit:now|after-child|after-ack> <cleanupMs> <watchdogMs>
+//
+// A wrapper with depth > 0 spawns another wrapper; depth 0 spawns the worker.
+// Exit modes:
+//   now         record that this wrapper exited and exit immediately.
+//   after-child stay alive until the child exits, then mirror its status.
+//   after-ack   nonforwarding only: wait until the worker has acknowledged the
+//               group SIGINT, then exit. This is a file readiness barrier, not
+//               a sleep, so a subsequent remaining-descendant re-signal cannot
+//               be coalesced with the original delivery.
+//
+// Readiness: every process writes "ready"/"wrapper-ready-<depth>" after its
+// handlers are installed, and the outermost wrapper (root=1) writes
+// "tree-ready" once the whole tree is ready. Tests await that marker so they
+// never signal before every handler exists.
+
+const fs = require("fs");
+const path = require("path");
+const { spawn } = require("child_process");
+
+// During shutdown Turborepo may stop draining our stdout, and a PTY session
+// leader exiting hangs up the terminal for its process group. Those teardown
+// errors (EPIPE/EIO/ERR_STREAM_DESTROYED) are expected and swallowed. Any other
+// stream error is recorded and aborts the fixture so it cannot be hidden.
+for (const stream of [process.stdout, process.stderr]) {
+  stream.on("error", (err) => {
+    const code = err && err.code;
+    if (
+      code === "EPIPE" ||
+      code === "EIO" ||
+      code === "ERR_STREAM_DESTROYED" ||
+      code === "ERR_STREAM_WRITE_AFTER_END"
+    ) {
+      return;
+    }
+    write(`io-error-${process.pid}`, `${code || err}\n`);
+    process.exit(70);
+  });
+}
+
+// PTY children run as session leaders. When one exits the kernel can deliver
+// SIGHUP to the remaining process group, which would otherwise cut a worker's
+// file-based cleanup proof short. The handler keeps a hangup from ending a
+// fixture process and records it per process. SIGHUP is deliberately not
+// treated as a shutdown signal.
+process.on("SIGHUP", () => {
+  write(`sighup-${process.pid}`, "1\n");
+});
+
+const [, , role, stateDir, ...rest] = process.argv;
+
+function write(file, contents) {
+  fs.writeFileSync(path.join(stateDir, file), contents);
+}
+
+function log(line) {
+  console.log(line);
+}
+
+function keepAlive() {
+  setInterval(() => {}, 1000);
+}
+
+function worker(cleanupMs, watchdogMs) {
+  let sigints = 0;
+  let cleaning = false;
+
+  process.on("SIGINT", () => {
+    sigints += 1;
+    write("worker-sigint-count", `${sigints}\n`);
+    log(`worker sigint count=${sigints}`);
+    if (cleaning) return;
+    cleaning = true;
+    setTimeout(() => {
+      // Marker first, log second: the file is the proof even if the terminal
+      // has already been hung up.
+      write("worker-cleanup-complete", `${sigints}\n`);
+      log("worker cleanup complete");
+      process.exit(0);
+    }, cleanupMs);
+  });
+
+  setTimeout(() => {
+    write("worker-watchdog", "1\n");
+    process.exit(3);
+  }, watchdogMs);
+
+  write("worker-sigint-count", "0\n");
+  write("ready", `${process.pid}\n`);
+  log(`worker started pid=${process.pid}`);
+
+  keepAlive();
+}
+
+function wrapper(root, depth, forward, forwardDelayMs, exitMode, cleanupMs, watchdogMs) {
+  const childArgs =
+    depth === 0
+      ? [__filename, "worker", stateDir, String(cleanupMs), String(watchdogMs)]
+      : [
+          __filename,
+          "wrapper",
+          stateDir,
+          "0",
+          String(depth - 1),
+          forward,
+          String(forwardDelayMs),
+          exitMode,
+          String(cleanupMs),
+          String(watchdogMs),
+        ];
+
+  const child = spawn(process.execPath, childArgs, { stdio: "inherit" });
+  let sigints = 0;
+  let acted = false;
+
+  const markExit = (reason) => {
+    write(`wrapper-exited-${depth}`, "1\n");
+    if (root === "1") write("root-exited", "1\n");
+    log(`wrapper exit pid=${process.pid} depth=${depth} reason=${reason}`);
+    process.exit(0);
+  };
+
+  // File readiness barrier: only leave once the worker has recorded the first
+  // interrupt, so the remaining-descendant re-signal is a distinct delivery.
+  const waitForWorkerAck = (onAck) => {
+    const ackPath = path.join(stateDir, "worker-sigint-count");
+    const deadline = Date.now() + 5000;
+    const timer = setInterval(() => {
+      let acked = false;
+      try {
+        acked = Number.parseInt(fs.readFileSync(ackPath, "utf8").trim(), 10) >= 1;
+      } catch (_err) {
+        acked = false;
+      }
+      if (acked) {
+        clearInterval(timer);
+        onAck();
+      } else if (Date.now() > deadline) {
+        clearInterval(timer);
+        write(`wrapper-ack-timeout-${depth}`, "1\n");
+        log(`wrapper ack timeout pid=${process.pid} depth=${depth}`);
+        process.exit(2);
+      }
+    }, 5);
+  };
+
+  process.on("SIGINT", () => {
+    sigints += 1;
+    write(`wrapper-${process.pid}-sigint-count`, `${sigints}\n`);
+    log(`wrapper sigint pid=${process.pid} depth=${depth} count=${sigints}`);
+    if (acted) return;
+    acted = true;
+
+    if (forward === "delayed") {
+      setTimeout(() => {
+        write(`wrapper-${process.pid}-forwarded`, "1\n");
+        child.kill("SIGINT");
+        if (exitMode === "now") markExit("forwarded-early");
+      }, forwardDelayMs);
+      return;
+    }
+
+    // forward === "none": this wrapper never signals its child.
+    if (exitMode === "now") {
+      markExit("nonforwarding-early");
+    } else if (exitMode === "after-ack") {
+      waitForWorkerAck(() => markExit("nonforwarding-after-ack"));
+    }
+  });
+
+  child.on("exit", (code, signal) => {
+    log(`wrapper child exit pid=${process.pid} code=${code} signal=${signal}`);
+    process.exit(code ?? (signal ? 1 : 0));
+  });
+
+  write(`wrapper-ready-${depth}`, `${process.pid}\n`);
+  log(`wrapper ready pid=${process.pid} depth=${depth}`);
+
+  if (root === "1") {
+    const readyPath = path.join(stateDir, "ready");
+    const wrappersReady = () =>
+      Array.from({ length: depth + 1 }, (_, d) =>
+        fs.existsSync(path.join(stateDir, `wrapper-ready-${d}`)),
+      ).every(Boolean);
+    const readyDeadline = Date.now() + 10000;
+    const readyTimer = setInterval(() => {
+      if (fs.existsSync(readyPath) && wrappersReady()) {
+        clearInterval(readyTimer);
+        write("tree-ready", `${process.pid}\n`);
+        log("tree ready");
+      } else if (Date.now() > readyDeadline) {
+        clearInterval(readyTimer);
+        log(`wrapper ready timeout pid=${process.pid}`);
+        process.exit(2);
+      }
+    }, 10);
+  }
+
+  setTimeout(() => {
+    write(`wrapper-${process.pid}-watchdog`, "1\n");
+    process.exit(3);
+  }, watchdogMs);
+
+  keepAlive();
+}
+
+if (role === "worker") {
+  worker(Number(rest[0]), Number(rest[1]));
+} else if (role === "wrapper") {
+  const [root, depth, forward, forwardDelayMs, exitMode, cleanupMs, watchdogMs] = rest;
+  wrapper(
+    root,
+    Number(depth),
+    forward,
+    Number(forwardDelayMs),
+    exitMode,
+    Number(cleanupMs),
+    Number(watchdogMs),
+  );
+} else {
+  console.error(`unknown role: ${role}`);
+  process.exit(64);
+}

--- a/crates/turborepo-signals/src/lib.rs
+++ b/crates/turborepo-signals/src/lib.rs
@@ -315,6 +315,73 @@ mod test {
         handler.done().await;
     }
 
+    /// COUNTER-CHARACTERIZATION, not a correctness proof: pins how the worker
+    /// currently folds an ordered SIGINT-then-SIGTERM sequence into the
+    /// retained signal count while a shutdown guard is held. The count drops
+    /// signal type and source, so SIGINT+SIGTERM reaching the same threshold as
+    /// two SIGINTs is the observed behavior. This documents the input the
+    /// worker sees today; it does not assert that collapsing the two signals is
+    /// the desired OS signal policy.
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn test_followup_ordered_interrupt_then_terminate_is_retained() {
+        // Gate the second signal on the test observing the first so delivery
+        // order is explicit rather than scheduler-dependent.
+        let gate = Arc::new(Notify::new());
+        let stream_gate = gate.clone();
+        let handler = SignalHandler::new(stream::unfold(0u8, move |state| {
+            let gate = stream_gate.clone();
+            async move {
+                match state {
+                    0 => Some((Some(Signal::Interrupt), 1)),
+                    1 => {
+                        gate.notified().await;
+                        Some((Some(Signal::Terminate), 2))
+                    }
+                    _ => None,
+                }
+            }
+        }));
+        let subscriber = handler.subscribe().unwrap();
+        let guard = subscriber.listen().await.unwrap();
+        let mut signals = handler.subscribe_signals();
+
+        // Retain the first signal before allowing the second to be delivered.
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if *signals.borrow_and_update() >= 1 {
+                    return;
+                }
+                signals.changed().await.unwrap();
+            }
+        })
+        .await
+        .expect("the first SIGINT should be retained while a guard is held");
+
+        gate.notify_one();
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if *signals.borrow_and_update() >= 2 {
+                    return;
+                }
+                signals.changed().await.unwrap();
+            }
+        })
+        .await
+        .expect("ordered SIGINT then SIGTERM should both be retained while a guard is held");
+
+        assert_eq!(
+            *signals.borrow_and_update(),
+            2,
+            "the retained count should be exactly the two delivered signals"
+        );
+        assert_eq!(handler.shutdown_reason(), Some(ShutdownReason::Signal));
+
+        drop(guard);
+        handler.done().await;
+    }
+
     #[tokio::test]
     async fn test_subscribers_triggered_from_close() {
         let (_tx, rx) = oneshot::channel::<()>();

--- a/crates/turborepo/tests/graceful_shutdown_test.rs
+++ b/crates/turborepo/tests/graceful_shutdown_test.rs
@@ -17,7 +17,7 @@ mod unix {
 
     use nix::{
         sys::signal::{self, Signal},
-        unistd::Pid,
+        unistd::{Pid, getpgid},
     };
     use portable_pty::{CommandBuilder, PtySize, native_pty_system};
     use serde_json::{Value, json};
@@ -28,6 +28,10 @@ mod unix {
     const START_TIMEOUT: Duration = Duration::from_secs(15);
     const EXIT_TIMEOUT: Duration = Duration::from_secs(20);
     const MAX_PTY_OUTPUT_BYTES: usize = 256 * 1024;
+    /// Upper bound on how long a fixture process may run before it kills its
+    /// own process group. This is a hang backstop, not a pass condition: the
+    /// graceful tests still finish only after the release file is written.
+    const FIXTURE_WATCHDOG_SECS: u64 = 60;
 
     struct ChildGuard {
         child: Option<Child>,
@@ -102,6 +106,78 @@ mod unix {
                 .expect("child guard consumed")
                 .wait_with_output()
                 .expect("failed waiting for child output")
+        }
+
+        /// Assert turbo is still running. Used to prove the CLI waits for
+        /// in-flight task cleanup instead of exiting as soon as it forwards a
+        /// shutdown request.
+        fn assert_still_running(&mut self) {
+            let status = self
+                .child_mut()
+                .try_wait()
+                .expect("failed waiting for child exit");
+            assert!(
+                status.is_none(),
+                "turbo exited while task cleanup was still blocked: {status:?}"
+            );
+        }
+    }
+
+    /// Writes a blocked task's `release` file on drop so a failed assertion
+    /// cannot leave the task tree waiting forever.
+    struct ReleaseGuard {
+        path: PathBuf,
+    }
+
+    impl ReleaseGuard {
+        fn new(test_dir: &Path) -> Self {
+            Self {
+                path: test_dir.join("apps/app-a/release"),
+            }
+        }
+    }
+
+    impl Drop for ReleaseGuard {
+        fn drop(&mut self) {
+            let _ = fs::write(&self.path, b"");
+        }
+    }
+
+    /// Kills the task's own process group if the test fails before the run
+    /// reaches its normal teardown. Turborepo gives each task its own group, so
+    /// one group kill terminates the task and any looping descendants that
+    /// would otherwise keep turbo's inherited output pipes open on the panic
+    /// path. The kill only terminates those processes; it does not reap them.
+    /// The resolved group is checked against our own so a misresolved pgid can
+    /// never signal the test runner.
+    struct TaskTreeGuard {
+        pgid: Option<i32>,
+    }
+
+    impl TaskTreeGuard {
+        /// Resolve the task child's process group after its PID is readable.
+        /// A missing, non-positive, or own-group pgid is discarded.
+        fn new(task_pid: i32) -> Self {
+            let own_group = getpgid(None).map(Pid::as_raw).unwrap_or(0);
+            let pgid = getpgid(Some(Pid::from_raw(task_pid)))
+                .ok()
+                .map(Pid::as_raw)
+                .filter(|pgid| *pgid > 0 && *pgid != own_group);
+            Self { pgid }
+        }
+
+        /// Stop the panic-path kill once the task tree has drained, so a
+        /// recycled process group is never signaled after normal teardown.
+        fn disarm(&mut self) {
+            self.pgid = None;
+        }
+    }
+
+    impl Drop for TaskTreeGuard {
+        fn drop(&mut self) {
+            if let Some(pgid) = self.pgid.take() {
+                let _ = signal::kill(Pid::from_raw(-pgid), Signal::SIGKILL);
+            }
         }
     }
 
@@ -283,6 +359,48 @@ mod unix {
         .expect("failed to update turbo.json");
 
         (tempdir, test_dir)
+    }
+
+    /// A task that only finishes its SIGINT cleanup once the test writes a
+    /// `release` file. The task owns its background descendant: on shutdown it
+    /// waits for the external `release`, signals the private
+    /// `descendant.release`, and reaps the child before reporting cleanup done.
+    /// The descendant ignores INT and TERM and only exits when released, so
+    /// cleanup is coordinated by the parent rather than by inherited signals.
+    /// Every loop carries a watchdog deadline and the parent advertises
+    /// readiness only after the descendant has published `descendant.ready`.
+    fn blocked_cleanup_script(label: &str) -> String {
+        format!(
+            r#"#!/usr/bin/env bash
+set -u
+trap 'printf "{label} cleanup start\n"; : > cleanup.started; deadline=$((SECONDS + {watchdog})); while [ ! -f release ]; do if [ "$SECONDS" -ge "$deadline" ]; then kill -KILL 0; fi; sleep 0.1; done; : > descendant.release; wait "$child"; printf "{label} cleanup done\n"; exit 0' INT
+(
+  trap '' INT TERM
+  : > descendant.ready
+  deadline=$((SECONDS + {watchdog}))
+  while [ ! -f descendant.release ]; do
+    if [ "$SECONDS" -ge "$deadline" ]; then kill -KILL 0; fi
+    sleep 0.2 || true
+  done
+) &
+child=$!
+printf '%s\n' "$child" > child.pid
+deadline=$((SECONDS + {watchdog}))
+while [ ! -f descendant.ready ]; do
+  if [ "$SECONDS" -ge "$deadline" ]; then kill -KILL 0; fi
+  sleep 0.05 || true
+done
+printf "{label} ready child=%s\n" "$child"
+: > ready
+deadline=$((SECONDS + {watchdog}))
+while true; do
+  if [ "$SECONDS" -ge "$deadline" ]; then kill -KILL 0; fi
+  sleep 0.2 || true
+done
+"#,
+            label = label,
+            watchdog = FIXTURE_WATCHDOG_SECS,
+        )
     }
 
     fn turbo_bin() -> PathBuf {
@@ -937,5 +1055,204 @@ while true; do sleep 0.2 || true; done
                 .contains("Graceful shutdown timed out. Force killed Turborepo tasks: app-a#dev"),
             "expected auto-force banner after timeout\n{combined}"
         );
+    }
+
+    #[test]
+    fn native_turbo_sigterm_waits_for_graceful_task_cleanup() {
+        let (_tempdir, test_dir) =
+            setup_shutdown_fixture("sigterm-graceful.sh", &blocked_cleanup_script("sigterm"));
+        let app_dir = test_dir.join("apps/app-a");
+        let ready_file = app_dir.join("ready");
+        let cleanup_started_file = app_dir.join("cleanup.started");
+        let child_pid_file = app_dir.join("child.pid");
+
+        let mut child = spawn_noninteractive_turbo(&test_dir);
+        let release = ReleaseGuard::new(&test_dir);
+        child.wait_for_startup_marker(&ready_file, START_TIMEOUT);
+        let task_child_pid = wait_for_pid_file(&child_pid_file, START_TIMEOUT);
+        let mut task_guard = TaskTreeGuard::new(task_child_pid);
+
+        // SIGTERM goes to the native turbo PID. The supervisor turns this into
+        // a graceful SIGINT request to the task; this test asserts boundary
+        // behavior, not byte-for-byte forwarding of the incoming signal.
+        send_signal(child.child_mut().id() as i32, Signal::SIGTERM);
+
+        // Reaching the task trap means turbo accepted the signal and asked the
+        // task to shut down.
+        child.wait_for_startup_marker(&cleanup_started_file, START_TIMEOUT);
+        child.assert_still_running();
+
+        drop(release);
+
+        let output = child.into_output(EXIT_TIMEOUT);
+        let combined = normalize_output(&format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        ));
+
+        assert!(
+            output.status.success(),
+            "graceful shutdown on SIGTERM should exit 0\n{combined}"
+        );
+        let cleanup_start = combined
+            .find("sigterm cleanup start")
+            .expect("expected task cleanup to start after SIGTERM");
+        let cleanup_done = combined
+            .find("sigterm cleanup done")
+            .expect("expected task cleanup to finish before turbo exits");
+        assert!(
+            cleanup_start < cleanup_done,
+            "cleanup completion should be emitted before turbo exits\n{combined}"
+        );
+        assert!(
+            !combined.contains("Force killed Turborepo tasks")
+                && !combined.contains("Graceful shutdown timed out")
+                && !combined.contains("Press CTRL+C again to exit forcefully."),
+            "graceful SIGTERM shutdown should not emit force-shutdown UX\n{combined}"
+        );
+
+        wait_for_process_gone(task_child_pid, Duration::from_secs(5));
+        task_guard.disarm();
+    }
+
+    /// SIGHUP reaches turbo as a process-directed signal while its output pipes
+    /// stay open. This does not model a terminal physically disappearing: the
+    /// supervisor's stdout/stderr are redirected pipes, and a disappearing
+    /// terminal would not close them. It only exercises the supervisor's hangup
+    /// listener.
+    #[test]
+    fn native_turbo_sighup_waits_for_graceful_task_cleanup() {
+        let (_tempdir, test_dir) =
+            setup_shutdown_fixture("sighup-graceful.sh", &blocked_cleanup_script("sighup"));
+        let app_dir = test_dir.join("apps/app-a");
+        let ready_file = app_dir.join("ready");
+        let cleanup_started_file = app_dir.join("cleanup.started");
+        let child_pid_file = app_dir.join("child.pid");
+
+        let mut child = spawn_noninteractive_turbo(&test_dir);
+        let release = ReleaseGuard::new(&test_dir);
+        child.wait_for_startup_marker(&ready_file, START_TIMEOUT);
+        let task_child_pid = wait_for_pid_file(&child_pid_file, START_TIMEOUT);
+        let mut task_guard = TaskTreeGuard::new(task_child_pid);
+
+        send_signal(child.child_mut().id() as i32, Signal::SIGHUP);
+
+        child.wait_for_startup_marker(&cleanup_started_file, START_TIMEOUT);
+        child.assert_still_running();
+
+        drop(release);
+
+        let output = child.into_output(EXIT_TIMEOUT);
+        let combined = normalize_output(&format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        ));
+
+        assert!(
+            output.status.success(),
+            "graceful shutdown on SIGHUP should exit 0\n{combined}"
+        );
+        let cleanup_start = combined
+            .find("sighup cleanup start")
+            .expect("expected task cleanup to start after SIGHUP");
+        let cleanup_done = combined
+            .find("sighup cleanup done")
+            .expect("expected task cleanup to finish before turbo exits");
+        assert!(
+            cleanup_start < cleanup_done,
+            "cleanup completion should be emitted before turbo exits\n{combined}"
+        );
+        assert!(
+            !combined.contains("Force killed Turborepo tasks")
+                && !combined.contains("Graceful shutdown timed out")
+                && !combined.contains("Press CTRL+C again to exit forcefully."),
+            "graceful SIGHUP shutdown should not emit force-shutdown UX\n{combined}"
+        );
+
+        wait_for_process_gone(task_child_pid, Duration::from_secs(5));
+        task_guard.disarm();
+    }
+
+    #[test]
+    fn native_turbo_second_sigint_after_acknowledged_shutdown_force_kills_stubborn_task() {
+        let stubborn_script = format!(
+            r#"#!/usr/bin/env bash
+set -u
+trap 'printf "second sigint shutdown requested\n"; : > cleanup.started' INT
+(
+  trap '' INT TERM
+  : > descendant.ready
+  deadline=$((SECONDS + {watchdog}))
+  while true; do
+    if [ "$SECONDS" -ge "$deadline" ]; then kill -KILL 0; fi
+    sleep 0.2 || true
+  done
+) &
+child=$!
+printf '%s\n' "$child" > child.pid
+deadline=$((SECONDS + {watchdog}))
+while [ ! -f descendant.ready ]; do
+  if [ "$SECONDS" -ge "$deadline" ]; then kill -KILL 0; fi
+  sleep 0.05 || true
+done
+printf "second sigint ready child=%s\n" "$child"
+: > ready
+deadline=$((SECONDS + {watchdog}))
+while true; do
+  if [ "$SECONDS" -ge "$deadline" ]; then kill -KILL 0; fi
+  sleep 0.2 || true
+done
+"#,
+            watchdog = FIXTURE_WATCHDOG_SECS,
+        );
+        let (_tempdir, test_dir) = setup_shutdown_fixture("second-sigint.sh", &stubborn_script);
+        let app_dir = test_dir.join("apps/app-a");
+        let ready_file = app_dir.join("ready");
+        let cleanup_started_file = app_dir.join("cleanup.started");
+        let child_pid_file = app_dir.join("child.pid");
+
+        let mut child = spawn_noninteractive_turbo(&test_dir);
+        child.wait_for_startup_marker(&ready_file, START_TIMEOUT);
+        let task_child_pid = wait_for_pid_file(&child_pid_file, START_TIMEOUT);
+        let mut task_guard = TaskTreeGuard::new(task_child_pid);
+
+        let turbo_pid = child.child_mut().id() as i32;
+        send_signal(turbo_pid, Signal::SIGINT);
+
+        // The stubborn task acknowledges the graceful request but never exits,
+        // so turbo must still be waiting before a second signal arrives. Two OS
+        // signals here are two real signals, not assumed to be two key presses.
+        child.wait_for_startup_marker(&cleanup_started_file, START_TIMEOUT);
+        child.assert_still_running();
+
+        send_signal(turbo_pid, Signal::SIGINT);
+        let output = child.into_output(EXIT_TIMEOUT);
+        let combined = normalize_output(&format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        ));
+
+        assert!(
+            combined.contains("second sigint ready child="),
+            "task output should remain visible until it is force killed\n{combined}"
+        );
+        assert!(
+            combined.contains("Shutting down Turborepo tasks..."),
+            "expected non-interactive shutdown banner before force kill\n{combined}"
+        );
+        assert!(
+            combined.contains("Force killed Turborepo tasks: app-a#dev"),
+            "the second SIGINT should force kill the stubborn task\n{combined}"
+        );
+        assert!(
+            !combined.contains("Graceful shutdown timed out"),
+            "force kill should come from the second signal, not the timeout\n{combined}"
+        );
+
+        wait_for_process_gone(task_child_pid, Duration::from_secs(5));
+        task_guard.disarm();
     }
 }


### PR DESCRIPTION
## Summary

- Track which captured descendants were targeted by successful initial SIGINT requests, including direct PID and process-group delivery.
- Avoid interrupting those descendants again when a PTY wrapper exits, while preserving fallback signaling for initially untargeted survivors, waiting for cleanup, and force-kill behavior.
- Add synchronized process-supervision regressions and native CLI coverage for SIGTERM, SIGHUP, and a second SIGINT after shutdown acknowledgment. Treat child-forwarded interrupts and output after terminal hangup separately from Turborepo's own guarantees.

Related to #14043. This hardens signal delivery within Turborepo; it does not change an external package manager's decision to exit before Turborepo finishes shutting down.
